### PR TITLE
docs: add credits to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ✨ Rslint ✨
 
-Rslint aims to be a drop-in replacement for ESLint and TypeScript-ESLint, just as Rspack serves as a drop-in replacement for Webpack and may integrated into Rspack in the future.
+Rslint aims to be a drop-in replacement for ESLint and TypeScript-ESLint, just as Rspack serves as a drop-in replacement for webpack and may integrated into Rspack in the future.
+
+> [!NOTE]
+> Rslint is a fork of [tsgolint](https://github.com/typescript-eslint/tsgolint), an experimental proof-of-concept typescript-go powered JS/TS linter. We would like to express our heartfelt gratitude to the tsgolint team, especially to [@auvred](https://github.com/auvred) for their pioneering work and innovative approach to TypeScript linting. We decided to fork tsgolint because it serves as a proof-of-concept with no current plans for continued development on this direction in the near term ([reference](https://x.com/bradzacher/status/1943475629376282998)). 
 
 Based on [typescript-go](https://github.com/microsoft/typescript-go) early exploration.
 


### PR DESCRIPTION
Added a note explaining that Rslint is a fork of tsgolint, including a link to the original project and acknowledgment of the tsgolint team for their contributions.