### PR TITLE
fix: beautify CLI help logs

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -308,19 +308,19 @@ func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathO
 	w.WriteString("\n\n")
 }
 
-const usage = `✨ Rslint - Rocket Speed Linter
+const usage = `🚀 Rslint - Rocket Speed Linter
 
 Usage:
-    rslint [OPTIONS]
+  rslint [OPTIONS]
 
 Options:
-    --config PATH     Which rslint config file to use. Defaults to rslint.json.
-	--list-files      List matched files
-	--format FORMAT   Output format: default | jsonline
-	--ipc             Run in IPC mode (for JS integration)
-	--no-color        Disable colored output
-	--force-color     Force colored output
-	-h, --help        Show help
+  --config PATH     Which rslint config file to use. Defaults to rslint.json.
+  --list-files      List matched files
+  --format FORMAT   Output format: default | jsonline
+  --ipc             Run in IPC mode (for JS integration)
+  --no-color        Disable colored output
+  --force-color     Force colored output
+  -h, --help        Show help
 `
 
 func runCMD() int {


### PR DESCRIPTION
Beautify CLI help logs by unifying the indentation.

- before:

<img width="826" height="291" alt="Screenshot 2025-07-29 at 11 37 37" src="https://github.com/user-attachments/assets/8e8cbb58-8850-4651-845d-a8cd024d7a84" />

- after:

<img width="795" height="291" alt="Screenshot 2025-07-29 at 11 39 13" src="https://github.com/user-attachments/assets/fb84c121-630d-4539-873c-d292a6ee2985" />
