### PR TITLE
feat: update color scheme to output more beautiful logs

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -64,7 +64,7 @@ func setupColors() *ColorScheme {
 	// Create color functions
 	ruleNameColor := color.New(color.FgHiGreen).SprintfFunc()
 	fileNameColor := color.New(color.FgCyan, color.Italic).SprintfFunc()
-	errorTextColor := color.New(color.FgRed, color.Underline).SprintfFunc()
+	errorTextColor := color.New(color.FgRed, color.Bold).SprintfFunc()
 	successColor := color.New(color.FgGreen, color.Bold).SprintfFunc()
 	dimColor := color.New(color.Faint).SprintfFunc()
 	boldColor := color.New(color.Bold).SprintfFunc()
@@ -261,17 +261,18 @@ func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathO
 
 	diagnosticHighlightActive := false
 	lastLineNumber := strconv.Itoa(codeboxEndLine + 1)
+
 	for line := codeboxStartLine; line <= codeboxEndLine; line++ {
 		w.WriteString("  ")
 		w.WriteString(colors.BorderText("│ "))
 		if line == codeboxEndLine {
-			w.WriteString(lastLineNumber)
+			w.WriteString(colors.DimText("%s", lastLineNumber))
 		} else {
 			number := strconv.Itoa(line + 1)
 			if len(number) < len(lastLineNumber) {
 				w.WriteByte(' ')
 			}
-			w.WriteString(number)
+			w.WriteString(colors.DimText("%s", number))
 		}
 		w.WriteString(colors.BorderText(" │"))
 		w.WriteString("  ")
@@ -295,7 +296,7 @@ func printDiagnosticDefault(d rule.RuleDiagnostic, w *bufio.Writer, comparePathO
 
 		if underlineStart != underlineEnd {
 			w.WriteString(text[lineTextStart:underlineStart])
-			w.WriteString(colors.ErrorText("%s", text[underlineStart:underlineEnd]))
+			w.WriteString(severityColor("%s", text[underlineStart:underlineEnd]))
 			w.WriteString(text[underlineEnd:lineTextEnd])
 		} else if lineTextStart != lineTextEnd {
 			w.WriteString(text[lineTextStart:lineTextEnd])

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "pnpm -r test",
     "test:go": "go test ./internal/...",
     "typecheck": "pnpm tsc -b tsconfig.json",
-    "lint": "rslint --config rslint.json"
+    "lint": "rslint"
   },
   "devDependencies": {
     "prettier": "3.5.0",

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -59,8 +59,7 @@
   "scripts": {
     "build": "node scripts/build.js",
     "watch": "node scripts/build.js --watch",
-    "test": "tsc -p tsconfig.spec.json && node .vscode-test-out/runTest.js",
-    "lint": "rslint --tsconfig tsconfig.build.json"
+    "test": "tsc -p tsconfig.spec.json && node .vscode-test-out/runTest.js"
   },
   "devDependencies": {
     "@rslint/core": "workspace:*",


### PR DESCRIPTION
Update color scheme to output more beautiful logs:

- Use `yellow` for warn logs.
- Use `red + bold` for error logs.

## Before

- warn:
<img width="1059" height="229" alt="warn-old" src="https://github.com/user-attachments/assets/7dffe7f8-59c0-4eac-8e43-596f3dcdbb09" />

- error:

<img width="1060" height="233" alt="error-old" src="https://github.com/user-attachments/assets/f69bf0d8-6f8b-4222-b4c4-0b7591633955" />

## After

- warn:

<img width="1060" height="226" alt="warn-new" src="https://github.com/user-attachments/assets/0d4adbcc-ee64-4ad0-87e7-0f1ba7cd82ec" />

- error:

<img width="1064" height="236" alt="error-new" src="https://github.com/user-attachments/assets/c494c82b-328b-4504-94cc-f2377346f51e" />
