### PR TITLE
fix: fix unstable error count

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -172,9 +172,6 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 		programs = append(programs, program)
 	}
 
-	// Find source files from all programs
-	files := []*ast.SourceFile{}
-
 	// Collect diagnostics
 	var diagnostics []api.Diagnostic
 	var diagnosticsLock sync.Mutex
@@ -214,10 +211,10 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	}
 
 	// Run linter
-	err = linter.RunLinter(
+	lintedFilesCount, err := linter.RunLinter(
 		programs,
 		false, // Don't use single-threaded mode for IPC
-		&files,
+		nil,
 		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			return utils.Map(rulesWithOptions, func(r RuleWithOption) linter.ConfiguredRule {
 
@@ -242,7 +239,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	return &api.LintResponse{
 		Diagnostics: diagnostics,
 		ErrorCount:  errorsCount,
-		FileCount:   len(files),
+		FileCount:   int(lintedFilesCount),
 		RuleCount:   len(rulesWithOptions),
 	}, nil
 }

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -430,8 +430,6 @@ func runCMD() int {
 
 	}
 
-	files := []*ast.SourceFile{}
-
 	var wg sync.WaitGroup
 
 	diagnosticsChan := make(chan rule.RuleDiagnostic, 4096)
@@ -477,10 +475,10 @@ func runCMD() int {
 		}
 	}()
 
-	err = linter.RunLinter(
+	lintedfileCount, err := linter.RunLinter(
 		programs,
 		singleThreaded,
-		&files,
+		nil,
 		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			activeRules := rslintconfig.GlobalRuleRegistry.GetEnabledRules(rslintConfig, sourceFile.FileName())
 			return activeRules
@@ -555,7 +553,7 @@ func runCMD() int {
 	}
 
 	filesText := "files"
-	if len(files) == 1 {
+	if lintedfileCount == 1 {
 		filesText = "file"
 	}
 	threadsCount := 1
@@ -576,7 +574,7 @@ func runCMD() int {
 				warningsColorFunc("%d", warningsCount),
 				warningsText,
 				colors.DimText(""),
-				colors.BoldText("%d", len(files)),
+				colors.BoldText("%d", lintedfileCount),
 				filesText,
 				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
 				colors.BoldText("%d", threadsCount),
@@ -593,7 +591,7 @@ func runCMD() int {
 				warningsColorFunc("%d", warningsCount),
 				warningsText,
 				colors.DimText(""),
-				colors.BoldText("%d", len(files)),
+				colors.BoldText("%d", lintedfileCount),
 				filesText,
 				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
 				colors.BoldText("%d", threadsCount),

--- a/cmd/rslint/lsp.go
+++ b/cmd/rslint/lsp.go
@@ -362,12 +362,11 @@ func runLintWithPrograms(uri lsproto.DocumentUri, programs []*compiler.Program, 
 		defer diagnosticsLock.Unlock()
 		diagnostics = append(diagnostics, d)
 	}
-	files := []*ast.SourceFile{}
 	// Run linter with all programs using rule registry
-	err := linter.RunLinter(
+	_, err := linter.RunLinter(
 		programs,
 		false, // Don't use single-threaded mode for LSP
-		&files,
+		nil,
 		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			activeRules := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, sourceFile.FileName())
 			return activeRules

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -76,12 +76,12 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 		program, err := utils.CreateProgram(true, fs, rootDir, tsconfigPath, host)
 		assert.NilError(t, err, "couldn't create program. code: "+code)
 
-		files := []*ast.SourceFile{}
+		files := []*ast.SourceFile{program.GetSourceFile(fileName)}
 
-		err = linter.RunLinter(
+		_, err = linter.RunLinter(
 			[]*compiler.Program{program},
 			true,
-			&files,
+			files,
 			func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 				return []linter.ConfiguredRule{
 					{


### PR DESCRIPTION
The previous implementation is not stable cause which checker will consum the file is random and different checker may return different result for same file https://github.com/web-infra-dev/rslint/pull/133/files#diff-7b5cc5ddc972ad189866a953617e82997f119dc1a89d291fd750971c6992cdfbL36