### PR TITLE
chore(ci): use lynx cache

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -21,10 +21,24 @@ runs:
 
     - name: Go cache
       uses: actions/cache@v4.2.3
+      if: runner.environment == 'github-hosted'
       with:
         key: setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           setup-go-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          ~/AppData/Local/go-build
+
+    - name: Go cache
+      uses: lynx-infra/cache@5c6160a6a4c7fca80a2f3057bb9dfc9513fcb732
+      if: runner.environment == 'self-hosted'
+      with:
+        key: setup-go-SH-1-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          setup-go-SH-1-${{ runner.os }}-${{ steps.install-go.outputs.go-version }}-${{ inputs.cache-name }}-${{ hashFiles('**/go.sum') }}
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build


### PR DESCRIPTION
0. use lynx cache only when in self-hosted runner
1. lynx cache is much more aggressive so higher cache hit rate
2. lynx cache upload/downloading in self-hosted runner is much faster