### PR TITLE
chore: disable linting for migrated tests

### DIFF
--- a/rslint.json
+++ b/rslint.json
@@ -5,7 +5,8 @@
     "ignores": [
       "node_modules/**",
       "./packages/rslint-test-tools/tests/**/*.test.ts",
-      "packages/rslint/fixtures/**"
+      "packages/rslint/fixtures/**",
+      "packages/rslint-test-tools/tests/**/*.test.ts"
     ],
     "languageOptions": {
       "parserOptions": {


### PR DESCRIPTION
no need to fix migrated tests from typescript-eslint