### PR TITLE
chore: fix no-confusing-void-expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   "engines": {
     "pnpm": ">=10"
   },
-  "files": []
+  "files": [],
+  "dependencies": {
+    "@types/react": "^19.1.9"
+  }
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/fixtures/tsconfig.json
+++ b/packages/rslint-test-tools/tests/typescript-eslint/fixtures/tsconfig.json
@@ -1,10 +1,25 @@
 {
   "compilerOptions": {
-    "strictNullChecks": true,
-    "isolatedModules": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": [
+      "es2015",
+      "es2017",
+      "esnext"
+    ],
+    "experimentalDecorators": true,
   },
   "include": [
-    "src/**/*.ts"
+    "file.ts",
+    "consistent-type-exports.ts",
+    "deprecated.ts",
+    "mixed-enums-decl.ts",
+    "react.tsx",
+    "var-declaration.ts",
+    "errors.ts",
+    "switch-exhaustiveness-check.ts"
   ]
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/fixtures/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/typescript-eslint/fixtures/tsconfig.virtual.json
@@ -1,9 +1,20 @@
 {
   "compilerOptions": {
-    "strictNullChecks": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": [
+      "es2015",
+      "es2017",
+      "esnext"
+    ],
+    "experimentalDecorators": true
   },
   "include": [
-    "src/virtual.ts"
+    "src/virtual.tsx",
+    "src/virtual.ts",
+    
   ]
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-confusing-void-expression.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-confusing-void-expression.test.ts
@@ -298,8 +298,6 @@ const test: Foo = () => console.log('foo');
     },
     {
       code: 'const foo = <button onClick={() => console.log()} />;',
-      // FIXME: it seems jsx is not supported in tsgo yet
-      skip: true, 
       languageOptions: {
         parserOptions: {
           ecmaFeatures: {

--- a/packages/rule-tester/src/index.ts
+++ b/packages/rule-tester/src/index.ts
@@ -147,7 +147,7 @@ export class RuleTester {
         this.options.languageOptions?.parserOptions?.tsconfigRootDir ||
         process.cwd();
       const config = path.resolve(cwd, './rslint.json');
-      let virtual_entry = path.resolve(cwd, 'src/virtual.ts');
+
       // test whether case has only
       let hasOnly =
         cases.valid.some(x => {
@@ -157,6 +157,7 @@ export class RuleTester {
             return false;
           }
         }) || cases.invalid.some(x => x.only);
+      let virtual_entry = path.resolve(cwd, 'src/virtual.ts');
       test('valid', async () => {
         for (const validCase of cases.valid) {
           if (typeof validCase === 'object' && validCase.skip) {
@@ -172,10 +173,17 @@ export class RuleTester {
           }
           const code =
             typeof validCase === 'string' ? validCase : validCase.code;
+          const isJSX =
+            typeof validCase === 'string'
+              ? false
+              : validCase.languageOptions?.parserOptions?.ecmaFeatures?.jsx;
 
           const options =
             typeof validCase === 'string' ? [] : validCase.options || [];
-
+          let virtual_entry = path.resolve(
+            cwd,
+            isJSX ? 'src/virtual.tsx' : 'src/virtual.ts',
+          );
           // workaround for this hardcoded path https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-floating-promises.test.ts#L712
           if (Array.isArray(options)) {
             for (const opt of options) {
@@ -230,6 +238,7 @@ export class RuleTester {
               [ruleName]: options,
             },
           });
+
           expect(diags).toMatchSnapshot();
 
           assert(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      '@types/react':
+        specifier: ^19.1.9
+        version: 19.1.9
     devDependencies:
       '@rslint/core':
         specifier: workspace:*
@@ -773,6 +777,9 @@ packages:
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
+  '@types/react@19.1.9':
+    resolution: {integrity: sha512-WmdoynAX8Stew/36uTSVMcLJJ1KRh6L3IZRx1PZ7qJtBqT3dYTgyDTx8H1qoRghErydW7xw9mSJ3wS//tCRpFA==}
+
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
@@ -1156,6 +1163,9 @@ packages:
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
+
+  csstype@3.1.3:
+    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -3224,6 +3234,10 @@ snapshots:
 
   '@types/normalize-package-data@2.4.4': {}
 
+  '@types/react@19.1.9':
+    dependencies:
+      csstype: 3.1.3
+
   '@types/sarif@2.1.7': {}
 
   '@types/vscode@1.102.0': {}
@@ -3696,6 +3710,8 @@ snapshots:
       nth-check: 2.1.1
 
   css-what@6.2.2: {}
+
+  csstype@3.1.3: {}
 
   debug@4.4.1(supports-color@8.1.1):
     dependencies:


### PR DESCRIPTION
missing @types/react cause calculate wrong type of jsx expression which cause wrong result for no-confusing-void-expression case https://github.com/web-infra-dev/rslint/pull/174/files#diff-f813ca0327e29a5118f9ed313da5e467153aaab685466e0520c331e36e17ffc5R300
