### PR TITLE
fix(lsp): should load jsonc config as well

### DIFF
--- a/cmd/rslint/lsp_test.go
+++ b/cmd/rslint/lsp_test.go
@@ -19,7 +19,7 @@ func (m *mockFS) FileExists(path string) bool {
 	return exists
 }
 
-// Implement other required methods from vfs.FS interface (not used in findRslintConfig)
+// Stubbed implementations of other vfs.FS interface methods for testing purposes
 func (m *mockFS) UseCaseSensitiveFileNames() bool                                   { return true }
 func (m *mockFS) ReadFile(path string) (string, bool)                               { return "", false }
 func (m *mockFS) WriteFile(path string, data string, writeByteOrderMark bool) error { return nil }

--- a/cmd/rslint/lsp_test.go
+++ b/cmd/rslint/lsp_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
-// mockFS is a simple mock implementation of vfs.FS for testing
+// mockFS is a mock implementation of vfs.FS for testing. Only FileExists is properly implemented;
+// other methods are stubbed with default implementations.
 type mockFS struct {
 	files map[string]bool // path -> exists
 }


### PR DESCRIPTION
fix: editor extension won't work if the config file uses `.jsonc` extension.