### PR TITLE
fix: fix bin path in windows

### DIFF
--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -12,8 +12,8 @@
     "url": "https://github.com/web-infra-dev/rslint"
   },
   "scripts": {
-    "build:bin": "go build -v -o \"bin/rslint$(go env GOEXE)\" ../../cmd/rslint",
-    "build:debug": "GOEXPERIMENT=noregabi go build -v -gcflags='all=-N -l' -o \"bin/rslint$(go env GOEXE)\" ../../cmd/rslint ",
+    "build:bin": "go build -v -o bin/ ../../cmd/rslint",
+    "build:debug": "GOEXPERIMENT=noregabi go build -v -gcflags='all=-N -l' -o bin/ ../../cmd/rslint ",
     "build:js": "tsc -b tsconfig.build.json --force",
     "dev": "tsc -b tsconfig.build.json --force --watch",
     "build": "pnpm build:bin && pnpm build:js",


### PR DESCRIPTION
`\"bin/rslint$(go env GOEXE)\"` have compatible problems in windows and go compiler will auto add .exe for bin in windows if we don't specify bin name