### PR TITLE
chore: add releasing open VSX

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,17 @@
+name: Setup Node
+description: Setup Node.js Environment
+
+runs:
+  using: composite
+
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '24'
+
+    - name: Install pnpm
+      run: corepack enable
+
+    - name: Install dependencies
+      run: pnpm install --frozen-lockfile

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -11,7 +11,9 @@ runs:
         node-version: '24'
 
     - name: Install pnpm
+      shell: bash
       run: corepack enable
 
     - name: Install dependencies
+      shell: bash
       run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,20 +63,14 @@ jobs:
         with:
           submodules: true
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
           go-version: ${{ matrix.go-version }}
           cache-name: test-node
-      - name: Install pnpm
-        run: corepack enable
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Format
         run: pnpm format:check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,9 @@ jobs:
         run: |
           pnpm -r publish --no-git-checks --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
 
-  publish-extesion:
-    if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
-    name: ${{ inputs.dry_run == true && 'Dry Run - Extensions' || 'Publish Extensions' }}
+  publish-extesion-vscode:
+    if: false
+    name: ${{ inputs.dry_run == true && 'Dry Run - VSCode Extensions' || 'Publish VSCode Extensions' }}
     needs: [build]
     runs-on: rspack-ubuntu-22.04-large
     steps:
@@ -117,15 +117,7 @@ jobs:
           submodules: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-
-      - name: Install pnpm
-        run: corepack enable
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        uses: ./.github/actions/setup-node
 
       - name: Download Artifact
         uses: actions/download-artifact@v4.1.7
@@ -154,9 +146,29 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: packages/vscode-extension/rslint-*.vsix
+
+  publish-extesion-open-vsx:
+    if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
+    name: ${{ inputs.dry_run == true && 'Dry Run - Open VSX Extensions' || 'Publish Open VSX Extensions' }}
+    needs: [build]
+    runs-on: rspack-ubuntu-22.04-large
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.event.inputs.branch }}
+          submodules: true
+
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4.1.7
+        with:
+          path: binaries
+
       - name: Build and publish to Open VSX Registry
-        # TODO fix the timeout problem while publish to Open VSX Registry
-        if: false
         env:
           OVSX_PAT: ${{ secrets.RSLINT_OVSX_PAT }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - Open VSX Extensions' || 'Publish Open VSX Extensions' }}
     needs: [build]
-    runs-on: rspack-ubuntu-22.04-large
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           pnpm -r publish --no-git-checks --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
 
   publish-extesion-vscode:
-    if: false
+    if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - VSCode Extensions' || 'Publish VSCode Extensions' }}
     needs: [build]
     runs-on: rspack-ubuntu-22.04-large

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           pnpm -r publish --no-git-checks --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
 
-  publish-extesion-vscode:
+  publish-extension-vscode:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - VSCode Extensions' || 'Publish VSCode Extensions' }}
     needs: [build]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           path: packages/vscode-extension/rslint-*.vsix
 
-  publish-extesion-open-vsx:
+  publish-extension-open-vsx:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}
     name: ${{ inputs.dry_run == true && 'Dry Run - Open VSX Extensions' || 'Publish Open VSX Extensions' }}
     needs: [build]


### PR DESCRIPTION
1. Move publishing open vsx extenison to a sperated workflow running on github hosted runner.
2. Extract Setup node action to avoid duplication