### PR TITLE
refactor: refactor language server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
     name: Test Go
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: false
       matrix:
         runner:
           [
@@ -64,6 +65,7 @@ jobs:
     name: Test npm packages
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [rspack-ubuntu-22.04-large, windows-latest]
         go-version: ['1.24.1']

--- a/cmd/rslint/lsp.go
+++ b/cmd/rslint/lsp.go
@@ -1,40 +1,126 @@
+// modified based on https://github.com/microsoft/typescript-go/blob/cedc0cbe6c188f9bfe6a51af00c79be48c9ab74d/cmd/tsgo/lsp.go#L1
 package main
 
 import (
-	"context"
-	"io"
-	"log"
+	"flag"
+	"fmt"
 	"os"
+	"runtime"
 
-	"github.com/sourcegraph/jsonrpc2"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"github.com/web-infra-dev/rslint/internal/lsp"
+	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-func runLSP() int {
-	log.SetOutput(os.Stderr) // Send logs to stderr so they don't interfere with LSP communication
-
-	server := lsp.NewLSPServer()
-
-	// Create a simple ReadWriteCloser from stdin/stdout
-	stream := &struct {
-		io.Reader
-		io.Writer
-		io.Closer
-	}{
-		Reader: os.Stdin,
-		Writer: os.Stdout,
-		Closer: os.Stdin,
+func runLSP(args []string) int {
+	flag := flag.NewFlagSet("lsp", flag.ContinueOnError)
+	stdio := flag.Bool("stdio", false, "use stdio for communication")
+	pprofDir := flag.String("pprofDir", "", "Generate pprof CPU/memory profiles to the given directory.")
+	pipe := flag.String("pipe", "", "use named pipe for communication")
+	_ = pipe
+	socket := flag.String("socket", "", "use socket for communication")
+	_ = socket
+	if err := flag.Parse(args); err != nil {
+		return 2
 	}
 
-	// Create connection using stdin/stdout
-	conn := jsonrpc2.NewConn(
-		context.Background(),
-		jsonrpc2.NewBufferedStream(stream, jsonrpc2.VSCodeObjectCodec{}),
-		jsonrpc2.HandlerWithError(server.Handle),
-	)
+	if !*stdio {
+		fmt.Fprintln(os.Stderr, "only stdio is supported")
+		return 1
+	}
 
-	// Wait for connection to close
-	<-conn.DisconnectNotify()
+	if *pprofDir != "" {
+		fmt.Fprintf(os.Stderr, "pprof profiles will be written to: %v\n", *pprofDir)
+		//profileSession := pprof.BeginProfiling(*pprofDir, os.Stderr)
+		//defer profileSession.Stop()
+	}
 
+	fs := bundled.WrapFS(osvfs.FS())
+	defaultLibraryPath := bundled.LibPath()
+	typingsLocation := getGlobalTypingsCacheLocation()
+
+	s := lsp.NewServer(&lsp.ServerOptions{
+		In:                 lsp.ToReader(os.Stdin),
+		Out:                lsp.ToWriter(os.Stdout),
+		Err:                os.Stderr,
+		Cwd:                utils.Must(os.Getwd()),
+		FS:                 fs,
+		DefaultLibraryPath: defaultLibraryPath,
+		TypingsLocation:    typingsLocation,
+	})
+
+	if err := s.Run(); err != nil {
+		return 1
+	}
 	return 0
+}
+
+func getGlobalTypingsCacheLocation() string {
+	switch runtime.GOOS {
+	case "windows":
+		return tspath.CombinePaths(tspath.CombinePaths(getWindowsCacheLocation(), "Microsoft/TypeScript"), core.VersionMajorMinor())
+	case "openbsd", "freebsd", "netbsd", "darwin", "linux", "android":
+		return tspath.CombinePaths(tspath.CombinePaths(getNonWindowsCacheLocation(), "typescript"), core.VersionMajorMinor())
+	default:
+		panic("unsupported platform: " + runtime.GOOS)
+	}
+}
+
+func getWindowsCacheLocation() string {
+	basePath, err := os.UserCacheDir()
+	if err != nil {
+		if basePath, err = os.UserConfigDir(); err != nil {
+			if basePath, err = os.UserHomeDir(); err != nil {
+				if userProfile := os.Getenv("USERPROFILE"); userProfile != "" {
+					basePath = userProfile
+				} else if homeDrive, homePath := os.Getenv("HOMEDRIVE"), os.Getenv("HOMEPATH"); homeDrive != "" && homePath != "" {
+					basePath = homeDrive + homePath
+				} else {
+					basePath = os.TempDir()
+				}
+			}
+		}
+	}
+	return basePath
+}
+
+func getNonWindowsCacheLocation() string {
+	if xdgCacheHome := os.Getenv("XDG_CACHE_HOME"); xdgCacheHome != "" {
+		return xdgCacheHome
+	}
+	const platformIsDarwin = runtime.GOOS == "darwin"
+	var usersDir string
+	if platformIsDarwin {
+		usersDir = "Users"
+	} else {
+		usersDir = "home"
+	}
+	homePath, err := os.UserHomeDir()
+	if err != nil {
+		if home := os.Getenv("HOME"); home != "" {
+			homePath = home
+		} else {
+			var userName string
+			if logName := os.Getenv("LOGNAME"); logName != "" {
+				userName = logName
+			} else if user := os.Getenv("USER"); user != "" {
+				userName = user
+			}
+			if userName != "" {
+				homePath = "/" + usersDir + "/" + userName
+			} else {
+				homePath = os.TempDir()
+			}
+		}
+	}
+	var cacheFolder string
+	if platformIsDarwin {
+		cacheFolder = "Library/Caches"
+	} else {
+		cacheFolder = ".cache"
+	}
+	return tspath.CombinePaths(homePath, cacheFolder)
 }

--- a/cmd/rslint/lsp.go
+++ b/cmd/rslint/lsp.go
@@ -2,8 +2,6 @@
 package main
 
 import (
-	"flag"
-	"fmt"
 	"os"
 	"runtime"
 
@@ -16,27 +14,6 @@ import (
 )
 
 func runLSP(args []string) int {
-	flag := flag.NewFlagSet("lsp", flag.ContinueOnError)
-	stdio := flag.Bool("stdio", false, "use stdio for communication")
-	pprofDir := flag.String("pprofDir", "", "Generate pprof CPU/memory profiles to the given directory.")
-	pipe := flag.String("pipe", "", "use named pipe for communication")
-	_ = pipe
-	socket := flag.String("socket", "", "use socket for communication")
-	_ = socket
-	if err := flag.Parse(args); err != nil {
-		return 2
-	}
-
-	if !*stdio {
-		fmt.Fprintln(os.Stderr, "only stdio is supported")
-		return 1
-	}
-
-	if *pprofDir != "" {
-		fmt.Fprintf(os.Stderr, "pprof profiles will be written to: %v\n", *pprofDir)
-		//profileSession := pprof.BeginProfiling(*pprofDir, os.Stderr)
-		//defer profileSession.Stop()
-	}
 
 	fs := bundled.WrapFS(osvfs.FS())
 	defaultLibraryPath := bundled.LibPath()

--- a/cmd/rslint/main.go
+++ b/cmd/rslint/main.go
@@ -20,7 +20,7 @@ func runMain() int {
 		switch args[0] {
 		case "--lsp":
 			// run in LSP mode for Language Server
-			return runLSP()
+			return runLSP(args[1:])
 		case "--api":
 			// run in API mode for JS API
 			return runAPI()

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -1,127 +1,597 @@
+// modified based on https://github.com/microsoft/typescript-go/blob/cedc0cbe6c188f9bfe6a51af00c79be48c9ab74d/internal/lsp/server.go#L1
 package lsp
 
 import (
 	"context"
-	"log"
+	"errors"
+	"fmt"
+	"io"
 	"os"
+	"os/signal"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"syscall"
 
-	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/go-json-experiment/json"
+	"github.com/microsoft/typescript-go/shim/collections"
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/lsp/lsproto"
 	"github.com/microsoft/typescript-go/shim/project"
-
-	// "github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
-	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
-
-	"github.com/sourcegraph/jsonrpc2"
 	"github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/rule"
-	util "github.com/web-infra-dev/rslint/internal/utils"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/text/language"
 )
+
+type ServerOptions struct {
+	In  Reader
+	Out Writer
+	Err io.Writer
+
+	Cwd                string
+	FS                 vfs.FS
+	DefaultLibraryPath string
+	TypingsLocation    string
+
+	ParsedFileCache project.ParsedFileCache
+}
+
+func NewServer(opts *ServerOptions) *Server {
+	if opts.Cwd == "" {
+		panic("Cwd is required")
+	}
+	return &Server{
+		r:                     opts.In,
+		w:                     opts.Out,
+		stderr:                opts.Err,
+		requestQueue:          make(chan *lsproto.RequestMessage, 100),
+		outgoingQueue:         make(chan *lsproto.Message, 100),
+		pendingClientRequests: make(map[lsproto.ID]pendingClientRequest),
+		pendingServerRequests: make(map[lsproto.ID]chan *lsproto.ResponseMessage),
+		cwd:                   opts.Cwd,
+		fs:                    opts.FS,
+		defaultLibraryPath:    opts.DefaultLibraryPath,
+		typingsLocation:       opts.TypingsLocation,
+		parsedFileCache:       opts.ParsedFileCache,
+	}
+}
+
+var (
+	_ project.ServiceHost = (*Server)(nil)
+	_ project.Client      = (*Server)(nil)
+)
+
+type pendingClientRequest struct {
+	req    *lsproto.RequestMessage
+	cancel context.CancelFunc
+}
+
+type Reader interface {
+	Read() (*lsproto.Message, error)
+}
+
+type Writer interface {
+	Write(msg *lsproto.Message) error
+}
+
+type lspReader struct {
+	r *lsproto.BaseReader
+}
+
+type lspWriter struct {
+	w *lsproto.BaseWriter
+}
+
+func (r *lspReader) Read() (*lsproto.Message, error) {
+	data, err := r.r.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	req := &lsproto.Message{}
+	if err := json.Unmarshal(data, req); err != nil {
+		return nil, fmt.Errorf("%w: %w", lsproto.ErrInvalidRequest, err)
+	}
+
+	return req, nil
+}
+
+func ToReader(r io.Reader) Reader {
+	return &lspReader{r: lsproto.NewBaseReader(r)}
+}
+
+func (w *lspWriter) Write(msg *lsproto.Message) error {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal message: %w", err)
+	}
+	return w.w.Write(data)
+}
+
+func ToWriter(w io.Writer) Writer {
+	return &lspWriter{w: lsproto.NewBaseWriter(w)}
+}
+
+var (
+	_ Reader = (*lspReader)(nil)
+	_ Writer = (*lspWriter)(nil)
+)
+
+type Server struct {
+	r Reader
+	w Writer
+
+	stderr io.Writer
+
+	clientSeq               atomic.Int32
+	requestQueue            chan *lsproto.RequestMessage
+	outgoingQueue           chan *lsproto.Message
+	pendingClientRequests   map[lsproto.ID]pendingClientRequest
+	pendingClientRequestsMu sync.Mutex
+	pendingServerRequests   map[lsproto.ID]chan *lsproto.ResponseMessage
+	pendingServerRequestsMu sync.Mutex
+
+	cwd                string
+	fs                 vfs.FS
+	defaultLibraryPath string
+	typingsLocation    string
+
+	initializeParams *lsproto.InitializeParams
+	positionEncoding lsproto.PositionEncodingKind
+	locale           language.Tag
+
+	watchEnabled bool
+	watcherID    atomic.Uint32
+	watchers     collections.SyncSet[project.WatcherHandle]
+
+	logger         *project.Logger
+	projectService *project.Service
+
+	// enables tests to share a cache of parsed source files
+	parsedFileCache project.ParsedFileCache
+
+	// !!! temporary; remove when we have `handleDidChangeConfiguration`/implicit project config support
+	compilerOptionsForInferredProjects *core.CompilerOptions
+
+	// rslint config
+	rslintConfig config.RslintConfig
+	documents    map[lsproto.DocumentUri]string                // URI -> content
+	diagnostics  map[lsproto.DocumentUri][]rule.RuleDiagnostic // URI -> diagnostics
+
+}
+
+// FS implements project.ServiceHost.
+func (s *Server) FS() vfs.FS {
+	return s.fs
+}
+
+// DefaultLibraryPath implements project.ServiceHost.
+func (s *Server) DefaultLibraryPath() string {
+	return s.defaultLibraryPath
+}
+
+// TypingsLocation implements project.ServiceHost.
+func (s *Server) TypingsLocation() string {
+	return s.typingsLocation
+}
+
+// GetCurrentDirectory implements project.ServiceHost.
+func (s *Server) GetCurrentDirectory() string {
+	return s.cwd
+}
+
+// Trace implements project.ServiceHost.
+func (s *Server) Trace(msg string) {
+	s.Log(msg)
+}
+
+// Client implements project.ServiceHost.
+func (s *Server) Client() project.Client {
+	if !s.watchEnabled {
+		return nil
+	}
+	return s
+}
+
+// WatchFiles implements project.Client.
+func (s *Server) WatchFiles(ctx context.Context, watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error) {
+	watcherId := fmt.Sprintf("watcher-%d", s.watcherID.Add(1))
+	_, err := s.sendRequest(ctx, lsproto.MethodClientRegisterCapability, &lsproto.RegistrationParams{
+		Registrations: []*lsproto.Registration{
+			{
+				Id:     watcherId,
+				Method: string(lsproto.MethodWorkspaceDidChangeWatchedFiles),
+				RegisterOptions: ptrTo(any(lsproto.DidChangeWatchedFilesRegistrationOptions{
+					Watchers: watchers,
+				})),
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to register file watcher: %w", err)
+	}
+
+	handle := project.WatcherHandle(watcherId)
+	s.watchers.Add(handle)
+	return handle, nil
+}
+
+// UnwatchFiles implements project.Client.
+func (s *Server) UnwatchFiles(ctx context.Context, handle project.WatcherHandle) error {
+	if s.watchers.Has(handle) {
+		_, err := s.sendRequest(ctx, lsproto.MethodClientUnregisterCapability, &lsproto.UnregistrationParams{
+			Unregisterations: []*lsproto.Unregistration{
+				{
+					Id:     string(handle),
+					Method: string(lsproto.MethodWorkspaceDidChangeWatchedFiles),
+				},
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("failed to unregister file watcher: %w", err)
+		}
+
+		s.watchers.Delete(handle)
+		return nil
+	}
+
+	return fmt.Errorf("no file watcher exists with ID %s", handle)
+}
+
+// RefreshDiagnostics implements project.Client.
+func (s *Server) RefreshDiagnostics(ctx context.Context) error {
+	if s.initializeParams.Capabilities == nil ||
+		s.initializeParams.Capabilities.Workspace == nil ||
+		s.initializeParams.Capabilities.Workspace.Diagnostics == nil ||
+		!ptrIsTrue(s.initializeParams.Capabilities.Workspace.Diagnostics.RefreshSupport) {
+		return nil
+	}
+
+	if _, err := s.sendRequest(ctx, lsproto.MethodWorkspaceDiagnosticRefresh, nil); err != nil {
+		return fmt.Errorf("failed to refresh diagnostics: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Server) Run() error {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error { return s.dispatchLoop(ctx) })
+	g.Go(func() error { return s.writeLoop(ctx) })
+
+	// Don't run readLoop in the group, as it blocks on stdin read and cannot be cancelled.
+	readLoopErr := make(chan error, 1)
+	g.Go(func() error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case err := <-readLoopErr:
+			return err
+		}
+	})
+	go func() { readLoopErr <- s.readLoop(ctx) }()
+
+	if err := g.Wait(); err != nil && !errors.Is(err, io.EOF) && ctx.Err() != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) readLoop(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		msg, err := s.read()
+		if err != nil {
+			if errors.Is(err, lsproto.ErrInvalidRequest) {
+				s.sendError(nil, err)
+				continue
+			}
+			return err
+		}
+
+		if s.initializeParams == nil && msg.Kind == lsproto.MessageKindRequest {
+			req := msg.AsRequest()
+			if req.Method == lsproto.MethodInitialize {
+				resp, err := s.handleInitialize(ctx, req.Params.(*lsproto.InitializeParams))
+				if err != nil {
+					return err
+				}
+				s.sendResult(req.ID, resp)
+			} else {
+				s.sendError(req.ID, lsproto.ErrServerNotInitialized)
+			}
+			continue
+		}
+
+		if msg.Kind == lsproto.MessageKindResponse {
+			resp := msg.AsResponse()
+			s.pendingServerRequestsMu.Lock()
+			if respChan, ok := s.pendingServerRequests[*resp.ID]; ok {
+				respChan <- resp
+				close(respChan)
+				delete(s.pendingServerRequests, *resp.ID)
+			}
+			s.pendingServerRequestsMu.Unlock()
+		} else {
+			req := msg.AsRequest()
+			if req.Method == lsproto.MethodCancelRequest {
+				s.cancelRequest(req.Params.(*lsproto.CancelParams).Id)
+			} else {
+				s.requestQueue <- req
+			}
+		}
+	}
+}
+
+func (s *Server) cancelRequest(rawID lsproto.IntegerOrString) {
+	id := lsproto.NewID(rawID)
+	s.pendingClientRequestsMu.Lock()
+	defer s.pendingClientRequestsMu.Unlock()
+	if pendingReq, ok := s.pendingClientRequests[*id]; ok {
+		pendingReq.cancel()
+		delete(s.pendingClientRequests, *id)
+	}
+}
+
+func (s *Server) read() (*lsproto.Message, error) {
+	return s.r.Read()
+}
+
+func (s *Server) dispatchLoop(ctx context.Context) error {
+	ctx, lspExit := context.WithCancel(ctx)
+	defer lspExit()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case req := <-s.requestQueue:
+			requestCtx := core.WithLocale(ctx, s.locale)
+			if req.ID != nil {
+				var cancel context.CancelFunc
+				requestCtx, cancel = context.WithCancel(core.WithRequestID(requestCtx, req.ID.String()))
+				s.pendingClientRequestsMu.Lock()
+				s.pendingClientRequests[*req.ID] = pendingClientRequest{
+					req:    req,
+					cancel: cancel,
+				}
+				s.pendingClientRequestsMu.Unlock()
+			}
+
+			handle := func() {
+				defer func() {
+					if r := recover(); r != nil {
+						stack := debug.Stack()
+						s.Log("panic handling request", req.Method, r, string(stack))
+						if isBlockingMethod(req.Method) {
+							lspExit()
+						} else {
+							if req.ID != nil {
+								s.sendError(req.ID, fmt.Errorf("%w: panic handling request %s: %v", lsproto.ErrInternalError, req.Method, r))
+							} else {
+								s.Log("unhandled panic in notification", req.Method, r)
+							}
+						}
+					}
+				}()
+				if err := s.handleRequestOrNotification(requestCtx, req); err != nil {
+					if errors.Is(err, context.Canceled) {
+						s.sendError(req.ID, lsproto.ErrRequestCancelled)
+					} else if errors.Is(err, io.EOF) {
+						lspExit()
+					} else {
+						s.sendError(req.ID, err)
+					}
+				}
+
+				if req.ID != nil {
+					s.pendingClientRequestsMu.Lock()
+					delete(s.pendingClientRequests, *req.ID)
+					s.pendingClientRequestsMu.Unlock()
+				}
+			}
+
+			if isBlockingMethod(req.Method) {
+				handle()
+			} else {
+				go handle()
+			}
+		}
+	}
+}
+
+func (s *Server) writeLoop(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg := <-s.outgoingQueue:
+			if err := s.w.Write(msg); err != nil {
+				return fmt.Errorf("failed to write message: %w", err)
+			}
+		}
+	}
+}
+
+func (s *Server) sendRequest(ctx context.Context, method lsproto.Method, params any) (any, error) {
+	id := lsproto.NewIDString(fmt.Sprintf("ts%d", s.clientSeq.Add(1)))
+	req := lsproto.NewRequestMessage(method, id, params)
+
+	responseChan := make(chan *lsproto.ResponseMessage, 1)
+	s.pendingServerRequestsMu.Lock()
+	s.pendingServerRequests[*id] = responseChan
+	s.pendingServerRequestsMu.Unlock()
+
+	s.outgoingQueue <- req.Message()
+
+	select {
+	case <-ctx.Done():
+		s.pendingServerRequestsMu.Lock()
+		defer s.pendingServerRequestsMu.Unlock()
+		if respChan, ok := s.pendingServerRequests[*id]; ok {
+			close(respChan)
+			delete(s.pendingServerRequests, *id)
+		}
+		return nil, ctx.Err()
+	case resp := <-responseChan:
+		if resp.Error != nil {
+			return nil, fmt.Errorf("request failed: %s", resp.Error.String())
+		}
+		return resp.Result, nil
+	}
+}
+
+func (s *Server) sendResult(id *lsproto.ID, result any) {
+	s.sendResponse(&lsproto.ResponseMessage{
+		ID:     id,
+		Result: result,
+	})
+}
+
+func (s *Server) sendError(id *lsproto.ID, err error) {
+	code := lsproto.ErrInternalError.Code
+	if errCode := (*lsproto.ErrorCode)(nil); errors.As(err, &errCode) {
+		code = errCode.Code
+	}
+	// TODO(jakebailey): error data
+	s.sendResponse(&lsproto.ResponseMessage{
+		ID: id,
+		Error: &lsproto.ResponseError{
+			Code:    code,
+			Message: err.Error(),
+		},
+	})
+}
+
+func (s *Server) sendResponse(resp *lsproto.ResponseMessage) {
+	s.outgoingQueue <- resp.Message()
+}
+
+func (s *Server) handleRequestOrNotification(ctx context.Context, req *lsproto.RequestMessage) error {
+	if handler := handlers()[req.Method]; handler != nil {
+		return handler(s, ctx, req)
+	}
+	s.Log("unknown method", req.Method)
+	if req.ID != nil {
+		s.sendError(req.ID, lsproto.ErrInvalidRequest)
+	}
+	return nil
+}
+
+type handlerMap map[lsproto.Method]func(*Server, context.Context, *lsproto.RequestMessage) error
+
+var handlers = sync.OnceValue(func() handlerMap {
+	handlers := make(handlerMap)
+
+	registerRequestHandler(handlers, lsproto.InitializeInfo, (*Server).handleInitialize)
+	registerNotificationHandler(handlers, lsproto.InitializedInfo, (*Server).handleInitialized)
+	registerRequestHandler(handlers, lsproto.ShutdownInfo, (*Server).handleShutdown)
+	registerNotificationHandler(handlers, lsproto.ExitInfo, (*Server).handleExit)
+
+	registerNotificationHandler(handlers, lsproto.TextDocumentDidOpenInfo, (*Server).handleDidOpen)
+	registerNotificationHandler(handlers, lsproto.TextDocumentDidChangeInfo, (*Server).handleDidChange)
+	registerNotificationHandler(handlers, lsproto.TextDocumentDidSaveInfo, (*Server).handleDidSave)
+	registerRequestHandler(handlers, lsproto.TextDocumentDiagnosticInfo, (*Server).handleDocumentDiagnostic)
+	registerRequestHandler(handlers, lsproto.TextDocumentCodeActionInfo, (*Server).handleCodeAction)
+	return handlers
+})
+
+func registerNotificationHandler[Req any](handlers handlerMap, info lsproto.NotificationInfo[Req], fn func(*Server, context.Context, Req) error) {
+	handlers[info.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
+		var params Req
+		// Ignore empty params; all generated params are either pointers or any.
+		if req.Params != nil {
+			params = req.Params.(Req)
+		}
+		if err := fn(s, ctx, params); err != nil {
+			return err
+		}
+		return ctx.Err()
+	}
+}
+
+func registerRequestHandler[Req, Resp any](handlers handlerMap, info lsproto.RequestInfo[Req, Resp], fn func(*Server, context.Context, Req) (Resp, error)) {
+	handlers[info.Method] = func(s *Server, ctx context.Context, req *lsproto.RequestMessage) error {
+		var params Req
+		// Ignore empty params.
+		if req.Params != nil {
+			params = req.Params.(Req)
+		}
+		resp, err := fn(s, ctx, params)
+		if err != nil {
+			return err
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		s.sendResult(req.ID, resp)
+		return nil
+	}
+}
+
+func (s *Server) handleShutdown(ctx context.Context, params any) (lsproto.ShutdownResponse, error) {
+	s.projectService.Close()
+	return lsproto.ShutdownResponse{}, nil
+}
+
+func (s *Server) handleExit(ctx context.Context, params any) error {
+	return io.EOF
+}
+
+func (s *Server) Log(msg ...any) {
+	fmt.Fprintln(s.stderr, msg...)
+}
+
+// !!! temporary; remove when we have `handleDidChangeConfiguration`/implicit project config support
+func (s *Server) SetCompilerOptionsForInferredProjects(options *core.CompilerOptions) {
+	s.compilerOptionsForInferredProjects = options
+	if s.projectService != nil {
+		s.projectService.SetCompilerOptionsForInferredProjects(options)
+	}
+}
+
+func isBlockingMethod(method lsproto.Method) bool {
+	switch method {
+	case lsproto.MethodInitialize,
+		lsproto.MethodInitialized,
+		lsproto.MethodTextDocumentDidOpen,
+		lsproto.MethodTextDocumentDidChange,
+		lsproto.MethodTextDocumentDidSave,
+		lsproto.MethodTextDocumentDidClose,
+		lsproto.MethodWorkspaceDidChangeWatchedFiles:
+		return true
+	}
+	return false
+}
 
 func ptrTo[T any](v T) *T {
 	return &v
 }
 
-// LSP Server implementation
-type LSPServer struct {
-	conn        *jsonrpc2.Conn
-	documents   map[lsproto.DocumentUri]string                // URI -> content
-	diagnostics map[lsproto.DocumentUri][]rule.RuleDiagnostic // URI -> diagnostics
-	// align with https://github.com/microsoft/typescript-go/blob/5cdf239b02006783231dd4da8ca125cef398cd27/internal/lsp/server.go#L147
-	//nolint
-	projectService *project.Service
-	//nolint
-	logger             *project.Logger
-	fs                 vfs.FS
-	defaultLibraryPath string
-	typingsLocation    string
-	cwd                string
-	rslintConfig       config.RslintConfig
-}
-
-func (s *LSPServer) FS() vfs.FS {
-	return s.fs
-}
-func (s *LSPServer) DefaultLibraryPath() string {
-	return s.defaultLibraryPath
-}
-func (s *LSPServer) TypingsLocation() string {
-	return s.typingsLocation
-}
-func (s *LSPServer) GetCurrentDirectory() string {
-	return s.cwd
-}
-func (s *LSPServer) Client() project.Client {
-	return nil
-}
-
-// FIXME: support watcher in the future
-func (s *LSPServer) WatchFiles(ctx context.Context, watchers []*lsproto.FileSystemWatcher) (project.WatcherHandle, error) {
-	return "", nil
-}
-
-func NewLSPServer() *LSPServer {
-	log.Printf("cwd: %v", util.Must(os.Getwd()))
-	return &LSPServer{
-		documents:   make(map[lsproto.DocumentUri]string),
-		diagnostics: make(map[lsproto.DocumentUri][]rule.RuleDiagnostic),
-		fs:          bundled.WrapFS(osvfs.FS()),
-		cwd:         util.Must(os.Getwd()),
+func ptrIsTrue(v *bool) bool {
+	if v == nil {
+		return false
 	}
+	return *v
 }
 
-func (s *LSPServer) Handle(requestCtx context.Context, conn *jsonrpc2.Conn, req *jsonrpc2.Request) (interface{}, error) {
-	// FIXME: implement cancel logic
-	ctx := core.WithRequestID(requestCtx, req.ID.String())
-
-	s.conn = conn
-	switch req.Method {
-	case "initialize":
-		return s.handleInitialize(ctx, req)
-	case "initialized":
-		return s.handleInitialized(ctx, req)
-	case "textDocument/didOpen":
-		if s.rslintConfig == nil {
-			return nil, nil
-		}
-		s.handleDidOpen(ctx, req)
-		return nil, nil
-	case "textDocument/didChange":
-		if s.rslintConfig == nil {
-			return nil, nil
-		}
-		s.handleDidChange(ctx, req)
-		return nil, nil
-	case "textDocument/didSave":
-		if s.rslintConfig == nil {
-			return nil, nil
-		}
-		s.handleDidSave(ctx, req)
-		return nil, nil
-	case "textDocument/diagnostic":
-		if s.rslintConfig == nil {
-			return nil, nil
-		}
-		s.handleDidSave(ctx, req)
-		return nil, nil
-	case "textDocument/codeAction":
-		if s.rslintConfig == nil {
-			return nil, nil
-		}
-		return s.handleCodeAction(ctx, req)
-	case "shutdown":
-		return s.handleShutdown(ctx, req)
-
-	case "exit":
-		os.Exit(0)
-		return nil, nil
-	default:
-		// Respond with method not found for unhandled methods
-		return nil, &jsonrpc2.Error{
-			Code:    jsonrpc2.CodeMethodNotFound,
-			Message: "method not found: " + req.Method,
-		}
+func shouldEnableWatch(params *lsproto.InitializeParams) bool {
+	if params == nil || params.Capabilities == nil || params.Capabilities.Workspace == nil {
+		return false
 	}
+	return params.Capabilities.Workspace.DidChangeWatchedFiles != nil &&
+		ptrIsTrue(params.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration)
+}
+
+func getCompletionClientCapabilities(params *lsproto.InitializeParams) *lsproto.CompletionClientCapabilities {
+	if params == nil || params.Capabilities == nil || params.Capabilities.TextDocument == nil {
+		return nil
+	}
+	return params.Capabilities.TextDocument.Completion
 }

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -55,6 +55,8 @@ func NewServer(opts *ServerOptions) *Server {
 		defaultLibraryPath:    opts.DefaultLibraryPath,
 		typingsLocation:       opts.TypingsLocation,
 		parsedFileCache:       opts.ParsedFileCache,
+		documents:             make(map[lsproto.DocumentUri]string),
+		diagnostics:           make(map[lsproto.DocumentUri][]rule.RuleDiagnostic),
 	}
 }
 
@@ -145,7 +147,7 @@ type Server struct {
 	watchEnabled bool
 	watcherID    atomic.Uint32
 	watchers     collections.SyncSet[project.WatcherHandle]
-
+	//nolint
 	logger         *project.Logger
 	projectService *project.Service
 
@@ -579,19 +581,4 @@ func ptrIsTrue(v *bool) bool {
 		return false
 	}
 	return *v
-}
-
-func shouldEnableWatch(params *lsproto.InitializeParams) bool {
-	if params == nil || params.Capabilities == nil || params.Capabilities.Workspace == nil {
-		return false
-	}
-	return params.Capabilities.Workspace.DidChangeWatchedFiles != nil &&
-		ptrIsTrue(params.Capabilities.Workspace.DidChangeWatchedFiles.DynamicRegistration)
-}
-
-func getCompletionClientCapabilities(params *lsproto.InitializeParams) *lsproto.CompletionClientCapabilities {
-	if params == nil || params.Capabilities == nil || params.Capabilities.TextDocument == nil {
-		return nil
-	}
-	return params.Capabilities.TextDocument.Completion
 }

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -28,6 +28,7 @@ import (
 )
 
 func (s *Server) handleInitialize(ctx context.Context, params *lsproto.InitializeParams) (lsproto.InitializeResponse, error) {
+	log.Printf("handle initialize with pid: %d\n", os.Getpid())
 	if s.initializeParams != nil {
 		return nil, lsproto.ErrInvalidRequest
 	}
@@ -63,6 +64,9 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 				Options: &lsproto.DiagnosticOptions{
 					InterFileDependencies: true,
 				},
+			},
+			CodeActionProvider: &lsproto.BooleanOrCodeActionOptions{
+				Boolean: ptrTo(true),
 			},
 		},
 	}

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -51,7 +51,7 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 			TextDocumentSync: &lsproto.TextDocumentSyncOptionsOrKind{
 				Options: &lsproto.TextDocumentSyncOptions{
 					OpenClose: ptrTo(true),
-					Change:    ptrTo(lsproto.TextDocumentSyncKindIncremental),
+					Change:    ptrTo(lsproto.TextDocumentSyncKindFull),
 					Save: &lsproto.BooleanOrSaveOptions{
 						SaveOptions: &lsproto.SaveOptions{
 							IncludeText: ptrTo(true),
@@ -59,49 +59,10 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 					},
 				},
 			},
-			HoverProvider: &lsproto.BooleanOrHoverOptions{
-				Boolean: ptrTo(true),
-			},
-			DefinitionProvider: &lsproto.BooleanOrDefinitionOptions{
-				Boolean: ptrTo(true),
-			},
-			TypeDefinitionProvider: &lsproto.BooleanOrTypeDefinitionOptionsOrTypeDefinitionRegistrationOptions{
-				Boolean: ptrTo(true),
-			},
-			ReferencesProvider: &lsproto.BooleanOrReferenceOptions{
-				Boolean: ptrTo(true),
-			},
-			ImplementationProvider: &lsproto.BooleanOrImplementationOptionsOrImplementationRegistrationOptions{
-				Boolean: ptrTo(true),
-			},
 			DiagnosticProvider: &lsproto.DiagnosticOptionsOrRegistrationOptions{
 				Options: &lsproto.DiagnosticOptions{
 					InterFileDependencies: true,
 				},
-			},
-			CompletionProvider: &lsproto.CompletionOptions{
-				TriggerCharacters: &ls.TriggerCharacters,
-				ResolveProvider:   ptrTo(true),
-				// !!! other options
-			},
-			SignatureHelpProvider: &lsproto.SignatureHelpOptions{
-				TriggerCharacters: &[]string{"(", ","},
-			},
-			DocumentFormattingProvider: &lsproto.BooleanOrDocumentFormattingOptions{
-				Boolean: ptrTo(true),
-			},
-			DocumentRangeFormattingProvider: &lsproto.BooleanOrDocumentRangeFormattingOptions{
-				Boolean: ptrTo(true),
-			},
-			DocumentOnTypeFormattingProvider: &lsproto.DocumentOnTypeFormattingOptions{
-				FirstTriggerCharacter: "{",
-				MoreTriggerCharacter:  &[]string{"}", ";", "\n"},
-			},
-			WorkspaceSymbolProvider: &lsproto.BooleanOrWorkspaceSymbolOptions{
-				Boolean: ptrTo(true),
-			},
-			DocumentSymbolProvider: &lsproto.BooleanOrDocumentSymbolOptions{
-				Boolean: ptrTo(true),
 			},
 		},
 	}
@@ -110,7 +71,7 @@ func (s *Server) handleInitialize(ctx context.Context, params *lsproto.Initializ
 }
 func (s *Server) handleInitialized(ctx context.Context, params *lsproto.InitializedParams) error {
 	s.projectService = project.NewService(s, project.ServiceOptions{
-		Logger:           project.NewLogger([]io.Writer{os.Stderr}, "", project.LogLevelVerbose),
+		Logger:           project.NewLogger([]io.Writer{}, "", project.LogLevelVerbose),
 		PositionEncoding: lsproto.PositionEncodingKindUTF8,
 	})
 	// Try to find rslint configuration files with multiple strategies
@@ -199,7 +160,6 @@ func (s *Server) handleCodeAction(ctx context.Context, params *lsproto.CodeActio
 		}
 	}
 
-	//var codeActions []*lsproto.CodeAction
 	var codeActions []lsproto.CommandOrCodeAction
 
 	// Find diagnostics that overlap with the requested range

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -113,3 +113,10 @@ GOEXE
 stub
 llms
 unstub
+USERPROFILE
+LOGNAME
+errgroup
+Unwatch
+Unregistration
+Unregisterations
+jakebailey


### PR DESCRIPTION
align rslint lsp implementation with tsgo lsp
the previous implementation has a fundamental flaw that jsonrpc2 use [`encoding/json`](https://github.com/sourcegraph/jsonrpc2/blob/v0.2.1/response.go#L4) while tsgo use [go-json-experiment](https://github.com/microsoft/typescript-go/blob/main/internal/lsp/lsproto/jsonrpc.go#L9)
which has subtle difference behavior for same message which cause edge bugs