### PR TITLE
chore: fix release tag push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
     needs:
       - test-go
       - test-node
+      - go-lint
     if: always()
     runs-on: ubuntu-latest
     name: CI Done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner:
-          [
+        runner: [
             rspack-ubuntu-22.04-large,
-            rspack-windows-2022-large,
+            # TODO: enable later
+            # rspack-windows-2022-large,
             windows-latest,
             rspack-darwin-14-medium,
           ]
@@ -51,7 +51,7 @@ jobs:
           cache-name: test-go
       - name: Unit Test
         run: |
-          go test -parallel 4 ./internal/...
+          go test -parallel 8 ./internal/...
   go-lint:
     name: Go Lint
     runs-on: rspack-ubuntu-22.04-large

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: 1.25.0
           cache-name: ${{ matrix.node_os }}-${{ matrix.node_arch }}
 
       - name: Install pnpm
@@ -318,7 +318,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: 1.25.0
           cache-name: ${{ matrix.node_os }}-${{ matrix.node_arch }}
 
       - name: Install pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,8 +102,8 @@ jobs:
           pnpm -r publish --no-git-checks --tag ${{ github.event.inputs.npm_tag }} --publish-branch ${{ github.event.inputs.branch }}
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions"
-          echo git tag v$(jq -r .version package.json)
-          git tag v$(jq -r .version package.json)
+          version=$(jq -r .version package.json)
+          git tag v$version -m "v$version"
           git push origin --follow-tags
 
   publish-extension-vscode:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           git config --global user.name "github-actions"
           version=$(jq -r .version package.json)
           git tag v$version -m "v$version"
-          git push origin --follow-tags
+          git push origin v$version
 
   publish-extension-vscode:
     if: ${{ inputs.to_release == 'all' || inputs.to_release == 'extension' }}


### PR DESCRIPTION
1. use `git push origin $tag` to push local tag to remote in release.
2. remove self hosted windows runner
