### PR TITLE
chore: correct guide link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Rslint is a fork of [tsgolint](https://github.com/typescript-eslint/tsgolint), b
 
 ## 🚀 Getting Started
 
-See [Guide](./website/docs/guide/index.md).
+See [Guide](./website/docs/en/guide/index.md).
 
 ## 📖 Architecture Overview
 


### PR DESCRIPTION
## Summary

Update guide link from `./website/docs/guide/index.md` to `./website/docs/en/guide/index.md`