### PR TITLE
fix: eslint-plugin-import rules url

### DIFF
--- a/website/theme/components/RuleStates/rule.tsx
+++ b/website/theme/components/RuleStates/rule.tsx
@@ -57,6 +57,14 @@ const fetcher = async (url: string): Promise<RuleManifest> => {
   return response.json();
 };
 
+function getRuleUrl(rule: Rule): string {
+  if (rule.group === '@typescript-eslint/eslint-plugin') {
+    return `https://typescript-eslint.io/rules/${rule.name}`;
+  }
+  // https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-self-import.md
+  return `https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/${rule.name}.md`;
+}
+
 // Statistics card component
 const StatCard: React.FC<{ item: RuleStateDescribe }> = ({ item }) => {
   const getTextColor = (style: RuleStateDescribe['style']): string => {
@@ -218,10 +226,7 @@ const RuleImplementationStatus: React.FC = () => {
                       <Button
                         variant="link"
                         onClick={() => {
-                          window.open(
-                            `https://typescript-eslint.io/rules/${rule.name}`,
-                            '_blank',
-                          );
+                          window.open(getRuleUrl(rule), '_blank');
                         }}
                         className="p-0"
                       >
@@ -242,7 +247,7 @@ const RuleImplementationStatus: React.FC = () => {
                           {rule.failing_case.map((caseItem, index) => (
                             <Button
                               variant="link"
-                              className="cursor-pointer p-0 items-start justify-start h-4"
+                              className="cursor-pointer p-0 justify-start h-4"
                               key={caseItem.url}
                               onClick={() => {
                                 window.open(


### PR DESCRIPTION
This pull request improves the way rule documentation links are generated and used in the `RuleStates` component, making the code more maintainable and extensible. The main focus is on centralizing the logic for building rule URLs and ensuring the correct links are used throughout the UI.

**Rule documentation link improvements:**

* Added a new `getRuleUrl` function to generate rule documentation URLs based on the rule's group, supporting both `@typescript-eslint/eslint-plugin` and `eslint-plugin-import` rules.
* Updated the rule documentation button to use the new `getRuleUrl` function, ensuring the correct URL is opened for each rule.

**UI consistency:**

* Simplified the CSS classes for the failing case button by removing redundant class names, improving code clarity.