### PR TITLE
fix: fix crash when open non-ts files

### DIFF
--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -215,17 +215,20 @@ func (s *Server) handleDocumentDiagnostic(ctx context.Context, params *lsproto.D
 	uriString := string(params.TextDocument.Uri)
 	uri := params.TextDocument.Uri
 	content := s.documents[uri]
+	// Collect diagnostics
+	var lsp_diagnostics []*lsproto.Diagnostic
 
 	// Only process TypeScript/JavaScript files
 	if !isTypeScriptFile(uriString) {
-		return lsproto.DocumentDiagnosticResponse{}, nil
+		return lsproto.RelatedFullDocumentDiagnosticReportOrUnchangedDocumentDiagnosticReport{
+			FullDocumentDiagnosticReport: &lsproto.RelatedFullDocumentDiagnosticReport{
+				Items: lsp_diagnostics,
+			},
+		}, nil
 	}
 
 	// Initialize rule registry with all available rules (ensure it's done once)
 	config.RegisterAllRules()
-
-	// Collect diagnostics
-	var lsp_diagnostics []*lsproto.Diagnostic
 
 	rule_diags, err := runLintWithProjectService(uri, s.projectService, ctx, s.rslintConfig)
 


### PR DESCRIPTION
typescirpt-go has a check for returned diagnostics to ensure at least return non-nil for diagnosticReport https://github.com/microsoft/typescript-go/blob/bca9518930e5bc91885a9c959283bab4b4de015c/internal/lsp/lsproto/lsp_generated.go#L24559
return empty FullDocumentDiagnosticReport to avoid crash