### PR TITLE
fix: switch binPath default value to built-in

### DIFF
--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -49,7 +49,7 @@
             "built-in",
             "custom"
           ],
-          "default": "local",
+          "default": "built-in",
           "markdownEnumDescriptions": [
             "Use workspace node_modules Rslint binary (may have version incompatibility with extension)",
             "Use extension's built-in Rslint binary (may differ from local @rslint/core diagnostics)",


### PR DESCRIPTION
make it easy for users to fix lsp crash without need to upgrade local @rslint/core, we can switch back when lsp is much more stable