### PR TITLE
feat: no-explicit-any rule

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_duplicate_type_constituents"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_empty_function"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_empty_interface"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_explicit_any"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_floating_promises"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_for_in_array"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_implied_eval"
@@ -109,7 +110,6 @@ type ParserOptions struct {
 	ProjectService bool         `json:"projectService"`
 	Project        ProjectPaths `json:"project,omitempty"`
 }
-
 
 // Rules represents the rules configuration
 // This can be extended to include specific rule configurations
@@ -339,6 +339,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-base-to-string", no_base_to_string.NoBaseToStringRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-confusing-void-expression", no_confusing_void_expression.NoConfusingVoidExpressionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-duplicate-type-constituents", no_duplicate_type_constituents.NoDuplicateTypeConstituentsRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-explicit-any", no_explicit_any.NoExplicitAnyRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-empty-function", no_empty_function.NoEmptyFunctionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-empty-interface", no_empty_interface.NoEmptyInterfaceRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-floating-promises", no_floating_promises.NoFloatingPromisesRule)

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go
@@ -1,0 +1,129 @@
+package no_explicit_any
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type NoExplicitAnyOptions struct {
+	FixToUnknown   bool `json:"fixToUnknown"`
+	IgnoreRestArgs bool `json:"ignoreRestArgs"`
+}
+
+func buildUnexpectedAnyMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpectedAny",
+		Description: "Unexpected any. Specify a different type.",
+	}
+}
+
+func buildSuggestUnknownMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestUnknown",
+		Description: "Use `unknown` instead, this will force you to explicitly, and safely assert the type is correct.",
+	}
+}
+
+func buildSuggestNeverMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestNever",
+		Description: "Use `never` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+	}
+}
+
+func buildSuggestPropertyKeyMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestPropertyKey",
+		Description: "Use `PropertyKey` instead, this is more explicit than `keyof any`.",
+	}
+}
+
+func parseOptions(options any) NoExplicitAnyOptions {
+	opts := NoExplicitAnyOptions{}
+	if options == nil {
+		return opts
+	}
+	// Handle array format: [{ option: value }]
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) > 0 {
+			if m, ok := arr[0].(map[string]interface{}); ok {
+				if v, ok := m["fixToUnknown"].(bool); ok {
+					opts.FixToUnknown = v
+				}
+				if v, ok := m["ignoreRestArgs"].(bool); ok {
+					opts.IgnoreRestArgs = v
+				}
+			}
+		}
+		return opts
+	}
+	// Handle direct object format
+	if m, ok := options.(map[string]interface{}); ok {
+		if v, ok := m["fixToUnknown"].(bool); ok {
+			opts.FixToUnknown = v
+		}
+		if v, ok := m["ignoreRestArgs"].(bool); ok {
+			opts.IgnoreRestArgs = v
+		}
+	}
+	return opts
+}
+
+func isAnyInRestParameter(node *ast.Node) bool {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if p.Kind == ast.KindParameter {
+			param := p.AsParameterDeclaration()
+			return param.DotDotDotToken != nil
+		}
+	}
+	return false
+}
+
+func isWithinKeyofAny(node *ast.Node) bool {
+	if node.Parent == nil || node.Parent.Kind != ast.KindTypeOperator {
+		return false
+	}
+	typeOp := node.Parent.AsTypeOperatorNode()
+	return typeOp != nil && typeOp.Operator == ast.KindKeyOfKeyword
+}
+
+var NoExplicitAnyRule = rule.CreateRule(rule.Rule{
+	Name: "no-explicit-any",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		return rule.RuleListeners{
+			ast.KindAnyKeyword: func(node *ast.Node) {
+				if opts.IgnoreRestArgs && isAnyInRestParameter(node) {
+					return
+				}
+				if isWithinKeyofAny(node) {
+					if opts.FixToUnknown {
+						ctx.ReportNodeWithFixes(node, buildUnexpectedAnyMessage(), rule.RuleFixReplace(ctx.SourceFile, node.Parent, "PropertyKey"))
+					} else {
+						ctx.ReportNodeWithSuggestions(node, buildUnexpectedAnyMessage(), rule.RuleSuggestion{
+							Message:  buildSuggestPropertyKeyMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node.Parent, "PropertyKey")},
+						})
+					}
+					return
+				}
+
+				if opts.FixToUnknown {
+					ctx.ReportNodeWithFixes(node, buildUnexpectedAnyMessage(), rule.RuleFixReplace(ctx.SourceFile, node, "unknown"))
+				} else {
+					ctx.ReportNodeWithSuggestions(node, buildUnexpectedAnyMessage(),
+						rule.RuleSuggestion{
+							Message:  buildSuggestUnknownMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "unknown")},
+						},
+						rule.RuleSuggestion{
+							Message:  buildSuggestNeverMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, "never")},
+						},
+					)
+				}
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any_test.go
+++ b/internal/plugins/typescript/rules/no_explicit_any/no_explicit_any_test.go
@@ -1,0 +1,95 @@
+package no_explicit_any
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExplicitAnyRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoExplicitAnyRule, []rule_tester.ValidTestCase{
+		{Code: `const number: number = 1;`},
+		{
+			Code:    `function foo(...args: any[]) {}`,
+			Options: []interface{}{map[string]interface{}{"ignoreRestArgs": true}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `const number: any = 1;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedAny",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 18,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "suggestUnknown",
+							Output:    `const number: unknown = 1;`,
+						},
+						{
+							MessageId: "suggestNever",
+							Output:    `const number: never = 1;`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `type T = keyof any;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedAny",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 19,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "suggestPropertyKey",
+							Output:    `type T = PropertyKey;`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `function foo(...args: any[]) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedAny",
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "suggestUnknown",
+							Output:    `function foo(...args: unknown[]) {}`,
+						},
+						{
+							MessageId: "suggestNever",
+							Output:    `function foo(...args: never[]) {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code:    `const number: any = 1;`,
+			Options: []interface{}{map[string]interface{}{"fixToUnknown": true}},
+			Output:  []string{`const number: unknown = 1;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unexpectedAny",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 18,
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -18,6 +18,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-confusing-void-expression.test.ts',
     './tests/typescript-eslint/rules/no-empty-function.test.ts',
     './tests/typescript-eslint/rules/no-empty-interface.test.ts',
+    './tests/typescript-eslint/rules/no-explicit-any.test.ts',
     './tests/typescript-eslint/rules/no-require-imports.test.ts',
     // too many autofix errors
     './tests/typescript-eslint/rules/no-duplicate-type-constituents.test.ts',

--- a/packages/rslint-test-tools/rule-manifest.json
+++ b/packages/rslint-test-tools/rule-manifest.json
@@ -70,6 +70,12 @@
       "failing_case": []
     },
     {
+      "name": "no-explicit-any",
+      "group": "@typescript-eslint",
+      "status": "full",
+      "failing_case": []
+    },
+    {
       "name": "no-floating-promises",
       "group": "@typescript-eslint",
       "status": "partial-test",

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-explicit-any.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-explicit-any.test.ts.snap
@@ -1,0 +1,1791 @@
+// Rstest Snapshot v1
+
+exports[`no-explicit-any > invalid 1`] = `
+{
+  "code": "const number: any = 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 2`] = `
+{
+  "code": "function generic(): any {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 3`] = `
+{
+  "code": "function generic(): Array<any> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 4`] = `
+{
+  "code": "function generic(): any[] {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 5`] = `
+{
+  "code": "function generic(param: Array<any>): number {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 6`] = `
+{
+  "code": "function generic(param: any[]): number {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 7`] = `
+{
+  "code": "function generic(param: Array<any>): Array<any> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 8`] = `
+{
+  "code": "function generic(): Array<Array<any>> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 9`] = `
+{
+  "code": "function generic(): Array<any[]> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 10`] = `
+{
+  "code": "
+class Greeter {
+  constructor(param: Array<any>) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 28,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 11`] = `
+{
+  "code": "
+class Greeter {
+  message: any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 12`] = `
+{
+  "code": "
+class Greeter {
+  message: Array<any>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 13`] = `
+{
+  "code": "
+class Greeter {
+  message: any[];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 14`] = `
+{
+  "code": "
+class Greeter {
+  message: Array<Array<any>>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 15`] = `
+{
+  "code": "
+class Greeter {
+  message: Array<any[]>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 16`] = `
+{
+  "code": "
+interface Greeter {
+  message: any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 17`] = `
+{
+  "code": "
+interface Greeter {
+  message: Array<any>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 18`] = `
+{
+  "code": "
+interface Greeter {
+  message: any[];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 19`] = `
+{
+  "code": "
+interface Greeter {
+  message: Array<Array<any>>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 20`] = `
+{
+  "code": "
+interface Greeter {
+  message: Array<any[]>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 21`] = `
+{
+  "code": "
+type obj = {
+  message: any;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 22`] = `
+{
+  "code": "
+type obj = {
+  message: Array<any>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 23`] = `
+{
+  "code": "
+type obj = {
+  message: any[];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 24`] = `
+{
+  "code": "
+type obj = {
+  message: Array<Array<any>>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 25`] = `
+{
+  "code": "
+type obj = {
+  message: Array<any[]>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 26`] = `
+{
+  "code": "
+type obj = {
+  message: string | any;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 27`] = `
+{
+  "code": "
+type obj = {
+  message: string | Array<any>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 28`] = `
+{
+  "code": "
+type obj = {
+  message: string | any[];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 29`] = `
+{
+  "code": "
+type obj = {
+  message: string | Array<Array<any>>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 33,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 30`] = `
+{
+  "code": "
+type obj = {
+  message: string | Array<any[]>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 31`] = `
+{
+  "code": "
+type obj = {
+  message: string & any;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 32`] = `
+{
+  "code": "
+type obj = {
+  message: string & Array<any>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 33`] = `
+{
+  "code": "
+type obj = {
+  message: string & any[];
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 34`] = `
+{
+  "code": "
+type obj = {
+  message: string & Array<Array<any>>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 33,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 35`] = `
+{
+  "code": "
+type obj = {
+  message: string & Array<any[]>;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 36`] = `
+{
+  "code": "class Foo<t = any> extends Bar<any> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 37`] = `
+{
+  "code": "abstract class Foo<t = any> extends Bar<any> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 38`] = `
+{
+  "code": "abstract class Foo<t = any> implements Bar<any>, Baz<any> {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 39`] = `
+{
+  "code": "new Foo<any>();",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 40`] = `
+{
+  "code": "Foo<any>();",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 41`] = `
+{
+  "code": "
+function test<T extends Partial<any>>() {}
+const test = <T extends Partial<any>>() => {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 2,
+        },
+        "start": {
+          "column": 33,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 33,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 42`] = `
+{
+  "code": "
+        function foo(a: number, ...rest: any[]): void {
+          return;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 2,
+        },
+        "start": {
+          "column": 42,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 43`] = `
+{
+  "code": "type Any = any;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 44`] = `
+{
+  "code": "function foo5(...args: any) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 45`] = `
+{
+  "code": "const bar5 = function (...args: any) {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 46`] = `
+{
+  "code": "const baz5 = (...args: any) => {};",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 47`] = `
+{
+  "code": "
+interface Qux5 {
+  (...args: any): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 48`] = `
+{
+  "code": "function quux5(fn: (...args: any) => void): void {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 49`] = `
+{
+  "code": "function quuz5(): (...args: any) => void {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 50`] = `
+{
+  "code": "type Fred5 = (...args: any) => void;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 51`] = `
+{
+  "code": "type Corge5 = new (...args: any) => void;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 52`] = `
+{
+  "code": "
+interface Grault5 {
+  new (...args: any): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 53`] = `
+{
+  "code": "
+interface Garply5 {
+  f(...args: any): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 54`] = `
+{
+  "code": "declare function waldo5(...args: any): void;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 55`] = `
+{
+  "code": "type Keys = keyof any;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 56`] = `
+{
+  "code": "
+const integer = <
+  TKey extends keyof any,
+  TTarget extends { [K in TKey]: number },
+>(
+  target: TTarget,
+  key: TKey,
+) => {
+  /* ... */
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 57`] = `
+{
+  "code": "// fixToUnknown: true
+type Keys = keyof any;",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// fixToUnknown: true
+type Keys = PropertyKey;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 58`] = `
+{
+  "code": "
+// fixToUnknown: true
+const integer = <
+  TKey extends keyof any,
+  TTarget extends { [K in TKey]: number },
+>(
+  target: TTarget,
+  key: TKey,
+) => {
+  /* ... */
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 4,
+        },
+        "start": {
+          "column": 22,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+// fixToUnknown: true
+const integer = <
+  TKey extends PropertyKey,
+  TTarget extends { [K in TKey]: number },
+>(
+  target: TTarget,
+  key: TKey,
+) => {
+  /* ... */
+};
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-explicit-any > invalid 59`] = `
+{
+  "code": "
+// fixToUnknown: true
+const number: any = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unexpected any. Specify a different type.",
+      "messageId": "unexpectedAny",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-explicit-any",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+// fixToUnknown: true
+const number: unknown = 1;
+      ",
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
This pull request adds full support for the `@typescript-eslint/no-explicit-any` rule to the codebase, including its implementation, configuration, and tests. The rule is now available for use and is included in the manifest and test suite.

### TypeScript Rule Support

* Implemented the `no-explicit-any` rule in `internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go`, including configurable options, suggestion messages, and autofix logic.
* Added comprehensive tests for the new rule in `no_explicit_any_test.go`.

### Configuration and Registration

* Registered the new rule in the global rule registry and imported it in `internal/config/config.go`, making it available for configuration and use. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR23) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR342)

### Test Tooling and Manifest

* Added the rule to the test manifest (`rule-manifest.json`) and enabled its test file in the test runner configuration, ensuring it is tested with the rest of the suite. [[1]](diffhunk://#diff-97f49cbc1463bb26214e0d04af15995aa710b8c02a763b6b8b7e0bf67c20a0abR72-R77) [[2]](diffhunk://#diff-637e3b10d94c38ef075811da89c1207701046e16e45c6d0f60daedd0017d1ba1R21)