### PR TITLE
chore: protected token in environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     name: ${{ inputs.dry_run == true && 'Dry Run - NPM Packages' || 'Publish NPM Packages' }}
     needs: [build]
     runs-on: ubuntu-22.04
-    environment: npm
+    environment: release
     permissions:
       # For push git tags
       contents: write
@@ -111,6 +111,7 @@ jobs:
     name: ${{ inputs.dry_run == true && 'Dry Run - VSCode Extensions' || 'Publish VSCode Extensions' }}
     needs: [build]
     runs-on: rspack-ubuntu-22.04-large
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -155,6 +156,7 @@ jobs:
     name: ${{ inputs.dry_run == true && 'Dry Run - Open VSX Extensions' || 'Publish Open VSX Extensions' }}
     needs: [build]
     runs-on: ubuntu-22.04
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
use environment token instead so we can review publish pipeline