### PR TITLE
ci: add renovate configuration for dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -24,6 +24,6 @@
     {
       matchDepTypes: ['peerDependencies'],
       enabled: false,
-    }
-  ]
+    },
+  ],
 }


### PR DESCRIPTION
Configure renovate to automatically update dependencies on a weekly schedule. Includes rules for handling patch updates, peer dependencies, and specific package exceptions.
