### PR TITLE
ci: enable cloneSubmodules in renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
     'helpers:pinGitHubActionDigests',
   ],
   ignorePaths: ['**/tests/**', '**/node_modules/**', '**/typescript-go/**'],
+  cloneSubmodules: true,
   packageRules: [
     // Use chore as semantic commit type for commit messages
     {


### PR DESCRIPTION
## Summary

Enable submodule cloning to ensure all dependencies are properly updated during renovate runs.

Fix the renovate error: https://github.com/web-infra-dev/rslint/pull/331#issuecomment-3252198857

Doc: https://docs.renovatebot.com/configuration-options/#clonesubmodules