### PR TITLE
chore: declare tsgo dependency in packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "prettier": "3.5.0",
     "typescript": "5.8.3",
     "zx": "8.7.1",
-    "@typescript/native-preview": "latest"
+    "@typescript/native-preview": "7.0.0-dev.20250904.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/packages/rslint-api/package.json
+++ b/packages/rslint-api/package.json
@@ -19,7 +19,8 @@
   "devDependencies": {
     "@typescript/api": "workspace:*",
     "@rslib/core": "0.12.4",
-    "@types/node": "24.3.0"
+    "@types/node": "24.3.0",
+    "@typescript/native-preview": "7.0.0-dev.20250904.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/rslint-wasm/package.json
+++ b/packages/rslint-wasm/package.json
@@ -31,7 +31,8 @@
     "cross-env": "^10.0.0",
     "esbuild-plugin-polyfill-node": "0.3.0",
     "memfs": "^4.38.2",
-    "prebundle": "1.4.1"
+    "prebundle": "1.4.1",
+    "@typescript/native-preview": "7.0.0-dev.20250904.1"
   },
   "dependencies": {
     "@rslint/core": "workspace:*"

--- a/packages/rslint/package.json
+++ b/packages/rslint/package.json
@@ -55,7 +55,8 @@
   "devDependencies": {
     "@types/node": "24.0.14",
     "typescript": "5.8.3",
-    "@rslint/api": "workspace:*"
+    "@rslint/api": "workspace:*",
+    "@typescript/native-preview": "7.0.0-dev.20250904.1"
   },
   "optionalDependencies": {
     "@rslint/darwin-arm64": "workspace:*",

--- a/packages/rule-tester/package.json
+++ b/packages/rule-tester/package.json
@@ -33,7 +33,8 @@
   "description": "Rule testing utilities for rslint",
   "devDependencies": {
     "@types/node": "24.0.14",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "@typescript/native-preview": "7.0.0-dev.20250904.1"
   },
   "dependencies": {
     "@rslint/core": "workspace:*"

--- a/packages/vscode-extension/package.json
+++ b/packages/vscode-extension/package.json
@@ -96,6 +96,7 @@
     "ovsx": "^0.10.5",
     "rimraf": "6.0.1",
     "typescript": "^5.0.0",
+    "@typescript/native-preview": "7.0.0-dev.20250904.1",
     "vscode-languageclient": "^9.0.1",
     "vscode-languageserver": "^9.0.1",
     "vscode-languageserver-textdocument": "^1.0.12"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         specifier: ^0.3.2
         version: 0.3.2
       '@typescript/native-preview':
-        specifier: latest
+        specifier: 7.0.0-dev.20250904.1
         version: 7.0.0-dev.20250904.1
       husky:
         specifier: ^9.1.7
@@ -63,6 +63,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20250904.1
+        version: 7.0.0-dev.20250904.1
     optionalDependencies:
       '@rslint/darwin-arm64':
         specifier: workspace:*
@@ -94,6 +97,9 @@ importers:
       '@typescript/api':
         specifier: workspace:*
         version: link:../../typescript-go/_packages/api
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20250904.1
+        version: 7.0.0-dev.20250904.1
 
   packages/rslint-test-tools:
     devDependencies:
@@ -146,6 +152,9 @@ importers:
       prebundle:
         specifier: 1.4.1
         version: 1.4.1(typescript@5.9.2)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20250904.1
+        version: 7.0.0-dev.20250904.1
 
   packages/rule-tester:
     dependencies:
@@ -159,6 +168,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20250904.1
+        version: 7.0.0-dev.20250904.1
 
   packages/utils: {}
 
@@ -203,6 +215,9 @@ importers:
       typescript:
         specifier: ^5.0.0
         version: 5.8.3
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20250904.1
+        version: 7.0.0-dev.20250904.1
       vscode-languageclient:
         specifier: ^9.0.1
         version: 9.0.1


### PR DESCRIPTION
## Summary
- add `@typescript/native-preview` dev dependency to packages using tsgo
- pin `@typescript/native-preview` at `7.0.0-dev.20250904.1` across the monorepo

## Testing
- `pnpm install` *(fails: "@typescript/api@workspace:*" package missing)*
- `pnpm --filter @rslint/core test` *(fails: `rstest` not found)*
- `pnpm --filter @typescript-eslint/rule-tester test` *(fails: `rstest` not found)*
- `pnpm --filter rslint test` *(fails: `tsgo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be55ab368c832da6a6217ccea573a7