### PR TITLE
feat(website): show WASM loading status in playground

### DIFF
--- a/website/theme/components/Playground/ResultPanel.css
+++ b/website/theme/components/Playground/ResultPanel.css
@@ -56,6 +56,15 @@
   height: calc(100% - 46px);
 }
 
+.loading-state {
+  display: flex;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  color: #656d76;
+}
+
 .lint-results {
   height: calc(100% - 8px);
 }

--- a/website/theme/components/Playground/ResultPanel.tsx
+++ b/website/theme/components/Playground/ResultPanel.tsx
@@ -17,12 +17,14 @@ interface ResultPanelProps {
   error?: string;
   fixedCode?: string;
   typeInfo?: string;
+  loading?: boolean;
 }
 
 type TabType = 'lint' | 'fixed' | 'ast' | 'type';
 
 export const ResultPanel: React.FC<ResultPanelProps> = props => {
-  const { diagnostics, ast, error, initialized, fixedCode, typeInfo } = props;
+  const { diagnostics, ast, error, initialized, fixedCode, typeInfo, loading } =
+    props;
   const [activeTab, setActiveTab] = useState<TabType>('lint');
 
   return (
@@ -100,7 +102,23 @@ export const ResultPanel: React.FC<ResultPanelProps> = props => {
             </div>
           )}
         </div>
-      ) : null}
+      ) : (
+        <div className="result-content">
+          {loading ? (
+            <div className="loading-state">
+              <div className="spinner"></div>
+              <div>Loading WASM...</div>
+            </div>
+          ) : error ? (
+            <div className="error-message">
+              <div className="error-icon">⚠️</div>
+              <div className="error-text">
+                <strong>Error:</strong> {error}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/website/theme/components/Playground/index.tsx
+++ b/website/theme/components/Playground/index.tsx
@@ -23,10 +23,12 @@ const Playground: React.FC = () => {
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState<string | undefined>();
   const [ast, setAst] = useState<string | undefined>();
+  const [loading, setLoading] = useState(true);
 
   async function runLint() {
     try {
       setError(undefined);
+      if (!initialized) setLoading(true);
       const service = await ensureService();
       const code = editorRef.current?.getValue() ?? '';
 
@@ -93,6 +95,8 @@ const Playground: React.FC = () => {
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       setError(`Linting failed: ${errorMessage}`);
+    } finally {
+      setLoading(false);
     }
   }
 
@@ -110,6 +114,7 @@ const Playground: React.FC = () => {
         diagnostics={diagnostics}
         ast={ast}
         error={error}
+        loading={loading}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- show loading state while the playground initializes WebAssembly
- display spinner and error message when WASM fails to load

## Testing
- `pnpm run format`
- `pnpm build` *(fails: rslib not found)*
- `pnpm run test` *(fails: rstest not found)*
- `pnpm run test:go` *(fails: missing module typescript-go)*
- `pnpm run check-spell` *(fails: Forbidden - 403)*
- `pnpm run lint:go` *(fails: Go version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bf8de38430832dbf792184f2be51d8