### PR TITLE
feat: show full ast info in playground

### DIFF
--- a/website/theme/components/Playground/index.tsx
+++ b/website/theme/components/Playground/index.tsx
@@ -65,6 +65,8 @@ const Playground: React.FC = () => {
         kind: string;
         pos: number;
         end: number;
+        text: string;
+        identifier?: string;
         [key: string]: any;
       }
 
@@ -73,6 +75,7 @@ const Playground: React.FC = () => {
         const astBuffer = result.encodedSourceFiles!['index.ts'];
         const buffer = Uint8Array.from(atob(astBuffer), c => c.charCodeAt(0));
         const source = new RemoteSourceFile(buffer, new TextDecoder());
+        const sourceText = source.text ?? '';
 
         function serializeNode(
           node: Node,
@@ -83,6 +86,7 @@ const Playground: React.FC = () => {
               kind: SyntaxKind[node.kind],
               pos: node.pos,
               end: node.end,
+              text: sourceText.slice(node.pos, node.end),
             };
           seen.add(node);
 
@@ -90,7 +94,12 @@ const Playground: React.FC = () => {
             kind: SyntaxKind[node.kind],
             pos: node.pos,
             end: node.end,
+            text: sourceText.slice(node.pos, node.end),
           };
+          const identifier = (node as any).escapedText ?? (node as any).text;
+          if (identifier !== undefined) {
+            base.identifier = String(identifier);
+          }
 
           for (const key in node as any) {
             if (key === 'parent') continue;


### PR DESCRIPTION
## Summary
- display complete AST node data in playground AST panel

## Testing
- `pnpm run format website/theme/components/Playground/index.tsx`
- `pnpm run lint website/theme/components/Playground/index.tsx` *(fails: rslint not found)*
- `pnpm run test` *(fails: rstest not found)*
- `pnpm run test:go` *(fails: cannot load module typescript-go)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa9c3820c832d9e0f9997656e0ad3