### PR TITLE
ci: add PR labeler configuration and workflow

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,12 @@
+'release: feature':
+  - '/^(feat|types|style)/'
+'release: bug fix':
+  - '/^fix/'
+'release: performance':
+  - '/^perf/'
+'release: breaking change':
+  - '/^breaking change/'
+'release: document':
+  - '/^docs/'
+'release: refactor':
+  - '/^refactor/'

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -1,0 +1,26 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+
+permissions:
+  # Permits `github/issue-labeler` to add a label to a pull request
+  pull-requests: write
+  contents: read
+
+jobs:
+  change-labeling:
+    name: Labeling for changes
+    runs-on: ubuntu-latest
+    if: github.repository == 'web-infra-dev/rslint'
+    steps:
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          configuration-path: .github/pr-labeler.yml
+          enable-versioned-regex: 0
+          include-title: 1
+          sync-labels: 1


### PR DESCRIPTION
## Summary

Add GitHub Actions workflow and labeler configuration to automatically label pull requests based on their title patterns.

This helps categorize our release note:

<img width="1600" height="1588" alt="image" src="https://github.com/user-attachments/assets/ee6bc78c-51e7-4cdb-b5b0-2fa3abc2758c" />

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
