### PR TITLE
chore: update test command in release workflow to use npm instead of pnpm -r test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,7 +280,7 @@ jobs:
           sudo apt-get install -y xvfb libxss1 libgtk-3-0 libgconf-2-4 libnss3 libxrandr2 libasound2 libpangocairo-1.0-0 libatk1.0-0 libcairo-gobject2 libgtk-3-0 libgdk-pixbuf2.0-0
 
       - name: Test on Linux
-        run: xvfb-run -a pnpm -r test
+        run: xvfb-run -a npm run test
 
   build:
     env:


### PR DESCRIPTION
## Summary

use `npm run test` instead of `pnpm -r test` in release ci

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
