### PR TITLE
fix(config): enable bundle option in rslib.config

### DIFF
--- a/packages/rslint-api/rslib.config.ts
+++ b/packages/rslint-api/rslib.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     {
       format: 'esm',
       dts: {
-        bundle: false,
+        bundle: true,
       },
     },
   ],


### PR DESCRIPTION
## Summary

turn on `dts.bundle` in `rslib.config.ts` for `@rslint/api` to avoid website build error

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
