### PR TITLE
chore: copy typescript-go lib files to @rslint/tsgo platform packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,7 +195,7 @@ jobs:
   check:
     name: Test
     if: ${{ inputs.dry_run == false }}
-    needs: build
+    needs: [build]
     strategy:
       fail-fast: true
       matrix:
@@ -237,29 +237,7 @@ jobs:
           path: binaries
 
       - name: Move binaries
-        run: |
-          find ./binaries
-          # Move rslint binaries
-          for file in binaries/*/*-rslint; do
-            echo "Processing $file"
-            filename=$(basename "$file")
-            dirname="${filename%-rslint}"
-            target_dir="npm/rslint/$dirname"
-            mkdir -p "$target_dir"
-            echo "Copy $file to $target_dir/rslint"
-            cp "$file" "npm/rslint/$dirname/rslint"
-          done
-          # Move tsgo binaries
-          for file in binaries/*/*-tsgo; do
-            echo "Processing $file"
-            filename=$(basename "$file")
-            dirname="${filename%-tsgo}"
-            target_dir="npm/tsgo/$dirname"
-            mkdir -p "$target_dir"
-            echo "Copy $file to $target_dir/tsgo"
-            cp "$file" "npm/tsgo/$dirname/tsgo"
-          done
-          find ./npm
+        uses: ./.github/actions/move-artifacts
 
       - name: Format code
         run: pnpm format:check
@@ -334,6 +312,14 @@ jobs:
           go-version: 1.25.0
           cache-name: ${{ matrix.node_os }}-${{ matrix.node_arch }}
 
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
       - name: Install pnpm
         run: corepack enable
 
@@ -359,3 +345,17 @@ jobs:
         with:
           name: ${{ matrix.node_os }}-${{ matrix.node_arch }}-tsgo
           path: ${{ matrix.node_os }}-${{ matrix.node_arch }}-tsgo
+
+      - name: Build typescript-go
+        run: |
+          cd typescript-go
+          npm ci
+          npm run build
+          # Remove tsgo binary from typescript-go build, we use our own ./cmd/tsgo build
+          rm -f built/local/tsgo built/local/tsgo.exe
+
+      - name: Upload typescript-go built artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ matrix.node_os }}-${{ matrix.node_arch }}-tsgo-built
+          path: typescript-go/built

--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ vite.config.ts.timestamp-*
 /bin/rslint
 npm/*/rslint
 npm/*/rslint.exe
+npm/tsgo/*/local
 
 .idea
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,6 +3,7 @@
 **/.vscode
 **/.nyc_output
 **/.vs
+**/.rslib
 
 .yarn/plugins
 .yarn/releases
@@ -15,3 +16,5 @@ packages/rslint-test-tools/tests/typescript-eslint/rules
 packages/rslint/pkg/
 website/doc_build
 pnpm-lock.yaml
+npm/tsgo/**/lib/
+binaries/

--- a/npm/tsgo/darwin-arm64/package.json
+++ b/npm/tsgo/darwin-arm64/package.json
@@ -11,11 +11,11 @@
   "publishConfig": {
     "access": "public",
     "executableFiles": [
-      "./tsgo"
+      "./lib/tsgo"
     ]
   },
   "files": [
-    "tsgo"
+    "lib"
   ],
   "os": [
     "darwin"

--- a/npm/tsgo/darwin-x64/package.json
+++ b/npm/tsgo/darwin-x64/package.json
@@ -11,11 +11,11 @@
   "publishConfig": {
     "access": "public",
     "executableFiles": [
-      "./tsgo"
+      "./lib/tsgo"
     ]
   },
   "files": [
-    "tsgo"
+    "lib"
   ],
   "os": [
     "darwin"

--- a/npm/tsgo/linux-arm64/package.json
+++ b/npm/tsgo/linux-arm64/package.json
@@ -11,11 +11,11 @@
   "publishConfig": {
     "access": "public",
     "executableFiles": [
-      "./tsgo"
+      "./lib/tsgo"
     ]
   },
   "files": [
-    "tsgo"
+    "lib"
   ],
   "os": [
     "linux"

--- a/npm/tsgo/linux-x64/package.json
+++ b/npm/tsgo/linux-x64/package.json
@@ -11,11 +11,11 @@
   "publishConfig": {
     "access": "public",
     "executableFiles": [
-      "./tsgo"
+      "./lib/tsgo"
     ]
   },
   "files": [
-    "tsgo"
+    "lib"
   ],
   "os": [
     "linux"

--- a/npm/tsgo/win32-arm64/package.json
+++ b/npm/tsgo/win32-arm64/package.json
@@ -11,11 +11,11 @@
   "publishConfig": {
     "access": "public",
     "executableFiles": [
-      "./tsgo.exe"
+      "./lib/tsgo.exe"
     ]
   },
   "files": [
-    "tsgo.exe"
+    "lib"
   ],
   "os": [
     "win32"

--- a/npm/tsgo/win32-x64/package.json
+++ b/npm/tsgo/win32-x64/package.json
@@ -11,11 +11,11 @@
   "publishConfig": {
     "access": "public",
     "executableFiles": [
-      "./tsgo.exe"
+      "./lib/tsgo.exe"
     ]
   },
   "files": [
-    "tsgo.exe"
+    "lib"
   ],
   "os": [
     "win32"

--- a/packages/tsgo/bin/tsgo.cjs
+++ b/packages/tsgo/bin/tsgo.cjs
@@ -12,7 +12,7 @@ function getBinPath() {
   let platformKey = `${process.platform}-${os.arch()}`;
 
   return require.resolve(
-    `@rslint/tsgo-${platformKey}/tsgo${process.platform === 'win32' ? '.exe' : ''}`,
+    `@rslint/tsgo-${platformKey}/lib/tsgo${process.platform === 'win32' ? '.exe' : ''}`,
   );
 }
 function main() {

--- a/packages/tsgo/package.json
+++ b/packages/tsgo/package.json
@@ -10,16 +10,14 @@
   },
   "bugs": "https://github.com/web-infra-dev/rslint/issues",
   "files": [
-    "bin/tsgo.cjs",
-    "lib"
+    "bin/tsgo.cjs"
   ],
   "bin": {
     "tsgo": "./bin/tsgo.cjs"
   },
   "scripts": {
     "build:bin": "go build -o ./bin/tsgo ../../cmd/tsgo",
-    "build:tsgo": "cp -r ../../typescript-go/built/local ./lib",
-    "build": "pnpm run build:tsgo && pnpm run build:bin"
+    "build": "pnpm run build:bin"
   },
   "keywords": [
     "tsgo",


### PR DESCRIPTION
## Summary

Move typescript-go lib files from the main `@rslint/tsgo` package to platform-specific packages `@rslint/tsgo-{os}-{arch}`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
