### PR TITLE
[WIP] feat: add TypeChecker API and Playground type info panel

### DIFF
--- a/internal/api/typechecker.go
+++ b/internal/api/typechecker.go
@@ -1,0 +1,903 @@
+// Package ipc provides IPC communication between JS and Go using stdio
+package ipc
+
+import (
+	"context"
+	"sync"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/compiler"
+)
+
+// TypeChecker holds the state for type checking
+type TypeChecker struct {
+	programs    []*compiler.Program
+	checkers    map[string]*checker.Checker // filePath -> Checker
+	sourceFiles map[string]*ast.SourceFile  // filePath -> SourceFile
+	mu          sync.RWMutex
+}
+
+// NewTypeChecker creates a new TypeChecker from programs and source files
+// Note: sourceFiles keys should be the same paths used for checker lookups
+func NewTypeChecker(
+	programs []*compiler.Program,
+	sourceFiles map[string]*ast.SourceFile,
+) *TypeChecker {
+	checkers := make(map[string]*checker.Checker)
+
+	// Build a reverse map from absolute path to relative path
+	absToRelPath := make(map[string]string)
+	for relPath, sf := range sourceFiles {
+		absToRelPath[sf.FileName()] = relPath
+	}
+
+	// Get type checkers from programs, using the same keys as sourceFiles
+	for _, program := range programs {
+		c, _ := program.GetTypeChecker(context.Background())
+		for _, sf := range program.GetSourceFiles() {
+			// Use the relative path as key (matching sourceFiles)
+			if relPath, ok := absToRelPath[sf.FileName()]; ok {
+				checkers[relPath] = c
+			} else {
+				// Fallback to absolute path if not in our sourceFiles map
+				checkers[sf.FileName()] = c
+			}
+		}
+	}
+
+	return &TypeChecker{
+		programs:    programs,
+		checkers:    checkers,
+		sourceFiles: sourceFiles,
+	}
+}
+
+// Helper functions
+
+// findTokenAtPosition finds the token at the given position in a source file
+func findTokenAtPosition(sourceFile *ast.SourceFile, position int) *ast.Node {
+	var result *ast.Node
+
+	var visit func(node *ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Pos() <= position && position < node.End() {
+			result = node
+			node.ForEachChild(visit)
+		}
+		return false
+	}
+
+	sourceFile.AsNode().ForEachChild(visit)
+	return result
+}
+
+// getSymbolFlagNames converts symbol flags to a slice of flag names
+func getSymbolFlagNames(flags ast.SymbolFlags) []string {
+	var names []string
+
+	flagMap := map[ast.SymbolFlags]string{
+		ast.SymbolFlagsFunctionScopedVariable: "FunctionScopedVariable",
+		ast.SymbolFlagsBlockScopedVariable:    "BlockScopedVariable",
+		ast.SymbolFlagsProperty:               "Property",
+		ast.SymbolFlagsEnumMember:             "EnumMember",
+		ast.SymbolFlagsFunction:               "Function",
+		ast.SymbolFlagsClass:                  "Class",
+		ast.SymbolFlagsInterface:              "Interface",
+		ast.SymbolFlagsConstEnum:              "ConstEnum",
+		ast.SymbolFlagsRegularEnum:            "RegularEnum",
+		ast.SymbolFlagsValueModule:            "ValueModule",
+		ast.SymbolFlagsNamespaceModule:        "NamespaceModule",
+		ast.SymbolFlagsTypeLiteral:            "TypeLiteral",
+		ast.SymbolFlagsObjectLiteral:          "ObjectLiteral",
+		ast.SymbolFlagsMethod:                 "Method",
+		ast.SymbolFlagsConstructor:            "Constructor",
+		ast.SymbolFlagsGetAccessor:            "GetAccessor",
+		ast.SymbolFlagsSetAccessor:            "SetAccessor",
+		ast.SymbolFlagsSignature:              "Signature",
+		ast.SymbolFlagsTypeParameter:          "TypeParameter",
+		ast.SymbolFlagsTypeAlias:              "TypeAlias",
+		ast.SymbolFlagsExportValue:            "ExportValue",
+		ast.SymbolFlagsAlias:                  "Alias",
+		ast.SymbolFlagsPrototype:              "Prototype",
+		ast.SymbolFlagsExportStar:             "ExportStar",
+		ast.SymbolFlagsOptional:               "Optional",
+		ast.SymbolFlagsTransient:              "Transient",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}
+
+// getTypeFlagNames converts type flags to a slice of flag names
+func getTypeFlagNames(flags checker.TypeFlags) []string {
+	var names []string
+
+	flagMap := map[checker.TypeFlags]string{
+		checker.TypeFlagsAny:             "Any",
+		checker.TypeFlagsUnknown:         "Unknown",
+		checker.TypeFlagsString:          "String",
+		checker.TypeFlagsNumber:          "Number",
+		checker.TypeFlagsBoolean:         "Boolean",
+		checker.TypeFlagsEnum:            "Enum",
+		checker.TypeFlagsBigInt:          "BigInt",
+		checker.TypeFlagsStringLiteral:   "StringLiteral",
+		checker.TypeFlagsNumberLiteral:   "NumberLiteral",
+		checker.TypeFlagsBooleanLiteral:  "BooleanLiteral",
+		checker.TypeFlagsEnumLiteral:     "EnumLiteral",
+		checker.TypeFlagsBigIntLiteral:   "BigIntLiteral",
+		checker.TypeFlagsESSymbol:        "ESSymbol",
+		checker.TypeFlagsUniqueESSymbol:  "UniqueESSymbol",
+		checker.TypeFlagsVoid:            "Void",
+		checker.TypeFlagsUndefined:       "Undefined",
+		checker.TypeFlagsNull:            "Null",
+		checker.TypeFlagsNever:           "Never",
+		checker.TypeFlagsTypeParameter:   "TypeParameter",
+		checker.TypeFlagsObject:          "Object",
+		checker.TypeFlagsUnion:           "Union",
+		checker.TypeFlagsIntersection:    "Intersection",
+		checker.TypeFlagsIndex:           "Index",
+		checker.TypeFlagsIndexedAccess:   "IndexedAccess",
+		checker.TypeFlagsConditional:     "Conditional",
+		checker.TypeFlagsSubstitution:    "Substitution",
+		checker.TypeFlagsNonPrimitive:    "NonPrimitive",
+		checker.TypeFlagsTemplateLiteral: "TemplateLiteral",
+		checker.TypeFlagsStringMapping:   "StringMapping",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}
+
+// getObjectFlagNames converts object flags to a slice of flag names
+func getObjectFlagNames(flags checker.ObjectFlags) []string {
+	var names []string
+
+	flagMap := map[checker.ObjectFlags]string{
+		checker.ObjectFlagsClass:        "Class",
+		checker.ObjectFlagsInterface:    "Interface",
+		checker.ObjectFlagsReference:    "Reference",
+		checker.ObjectFlagsTuple:        "Tuple",
+		checker.ObjectFlagsAnonymous:    "Anonymous",
+		checker.ObjectFlagsMapped:       "Mapped",
+		checker.ObjectFlagsInstantiated: "Instantiated",
+		checker.ObjectFlagsObjectLiteral: "ObjectLiteral",
+		checker.ObjectFlagsEvolvingArray: "EvolvingArray",
+		checker.ObjectFlagsReverseMapped: "ReverseMapped",
+		checker.ObjectFlagsJsxAttributes: "JsxAttributes",
+		checker.ObjectFlagsJSLiteral:     "JSLiteral",
+		checker.ObjectFlagsFreshLiteral:  "FreshLiteral",
+		checker.ObjectFlagsArrayLiteral:  "ArrayLiteral",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}
+
+// getCheckFlagNames converts check flags to a slice of flag names
+func getCheckFlagNames(flags ast.CheckFlags) []string {
+	var names []string
+
+	flagMap := map[ast.CheckFlags]string{
+		ast.CheckFlagsInstantiated:       "Instantiated",
+		ast.CheckFlagsSyntheticProperty:  "SyntheticProperty",
+		ast.CheckFlagsSyntheticMethod:    "SyntheticMethod",
+		ast.CheckFlagsReadonly:           "Readonly",
+		ast.CheckFlagsReadPartial:        "ReadPartial",
+		ast.CheckFlagsWritePartial:       "WritePartial",
+		ast.CheckFlagsHasNonUniformType:  "HasNonUniformType",
+		ast.CheckFlagsHasLiteralType:     "HasLiteralType",
+		ast.CheckFlagsContainsPublic:     "ContainsPublic",
+		ast.CheckFlagsContainsProtected:  "ContainsProtected",
+		ast.CheckFlagsContainsPrivate:    "ContainsPrivate",
+		ast.CheckFlagsContainsStatic:     "ContainsStatic",
+		ast.CheckFlagsLate:               "Late",
+		ast.CheckFlagsReverseMapped:      "ReverseMapped",
+		ast.CheckFlagsOptionalParameter:  "OptionalParameter",
+		ast.CheckFlagsRestParameter:      "RestParameter",
+		ast.CheckFlagsDeferredType:       "DeferredType",
+		ast.CheckFlagsHasNeverType:       "HasNeverType",
+		ast.CheckFlagsMapped:             "Mapped",
+		ast.CheckFlagsStripOptional:      "StripOptional",
+		ast.CheckFlagsUnresolved:         "Unresolved",
+		ast.CheckFlagsSynthetic:          "Synthetic",
+		ast.CheckFlagsIsDiscriminantComputed: "IsDiscriminantComputed",
+		ast.CheckFlagsIsDiscriminant:     "IsDiscriminant",
+		ast.CheckFlagsPartial:            "Partial",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}
+
+// getFlowFlagNames converts flow flags to a slice of flag names
+func getFlowFlagNames(flags ast.FlowFlags) []string {
+	var names []string
+
+	flagMap := map[ast.FlowFlags]string{
+		ast.FlowFlagsUnreachable:    "Unreachable",
+		ast.FlowFlagsStart:          "Start",
+		ast.FlowFlagsBranchLabel:    "BranchLabel",
+		ast.FlowFlagsLoopLabel:      "LoopLabel",
+		ast.FlowFlagsAssignment:     "Assignment",
+		ast.FlowFlagsTrueCondition:  "TrueCondition",
+		ast.FlowFlagsFalseCondition: "FalseCondition",
+		ast.FlowFlagsSwitchClause:   "SwitchClause",
+		ast.FlowFlagsArrayMutation:  "ArrayMutation",
+		ast.FlowFlagsCall:           "Call",
+		ast.FlowFlagsReduceLabel:    "ReduceLabel",
+		ast.FlowFlagsReferenced:     "Referenced",
+		ast.FlowFlagsShared:         "Shared",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}
+
+// formatNodeLocation creates a NodeLocation from file path and node
+func formatNodeLocation(filePath string, node *ast.Node) NodeLocation {
+	return NodeLocation{
+		FilePath: filePath,
+		Pos:      node.Pos(),
+		Kind:     int(node.Kind),
+	}
+}
+
+// TypeInfoCollector recursively collects type information while tracking visited objects
+type TypeInfoCollector struct {
+	checker        *checker.Checker
+	filePath       string
+	types          map[uint32]TypeDetails
+	symbols        map[uint64]SymbolDetails
+	visitedTypes   map[uint32]bool
+	visitedSymbols map[uint64]bool
+	// Use pointer-based maps for cycle detection (no IDs exposed)
+	visitedFlowNodes map[*ast.FlowNode]*FlowNodeDetails
+}
+
+// newTypeInfoCollector creates a new TypeInfoCollector
+func newTypeInfoCollector(c *checker.Checker, filePath string) *TypeInfoCollector {
+	return &TypeInfoCollector{
+		checker:          c,
+		filePath:         filePath,
+		types:            make(map[uint32]TypeDetails),
+		symbols:          make(map[uint64]SymbolDetails),
+		visitedTypes:     make(map[uint32]bool),
+		visitedSymbols:   make(map[uint64]bool),
+		visitedFlowNodes: make(map[*ast.FlowNode]*FlowNodeDetails),
+	}
+}
+
+// collectType recursively collects Type information
+func (c *TypeInfoCollector) collectType(t *checker.Type) uint32 {
+	if t == nil {
+		return 0
+	}
+
+	typeId := uint32(t.Id())
+
+	// Check if already visited to prevent cycles
+	if c.visitedTypes[typeId] {
+		return typeId
+	}
+	c.visitedTypes[typeId] = true
+
+	flags := t.Flags()
+	objectFlags := t.ObjectFlags()
+
+	details := TypeDetails{
+		Id:              typeId,
+		Flags:           uint32(flags),
+		FlagNames:       getTypeFlagNames(flags),
+		ObjectFlags:     uint32(objectFlags),
+		ObjectFlagNames: getObjectFlagNames(objectFlags),
+		TypeString:      c.checker.TypeToString(t),
+	}
+
+	// Collect Symbol
+	symbol := t.Symbol()
+	if symbol != nil {
+		symbolId := c.collectSymbol(symbol)
+		details.Symbol = &symbolId
+	}
+
+	// Collect Target (for TypeReference types)
+	if objectFlags&checker.ObjectFlagsReference != 0 {
+		objType := t.AsObjectType()
+		if objType != nil && objType.Target() != nil {
+			targetId := c.collectType(objType.Target())
+			details.Target = &targetId
+		}
+	}
+
+	// Collect Types (for Union/Intersection)
+	if flags&checker.TypeFlagsUnionOrIntersection != 0 {
+		types := t.Types()
+		if types != nil {
+			typeIds := make([]uint32, 0, len(types))
+			for _, subType := range types {
+				typeIds = append(typeIds, c.collectType(subType))
+			}
+			details.Types = typeIds
+		}
+	}
+
+	// Collect IntrinsicName (for IntrinsicType)
+	if flags&checker.TypeFlagsIntrinsic != 0 {
+		// Check for intrinsic types (any, unknown, string, number, boolean, void, undefined, null, never, etc.)
+		intrinsicType := t.AsIntrinsicType()
+		if intrinsicType != nil {
+			details.IntrinsicName = intrinsicType.IntrinsicName()
+		}
+	}
+
+	// Collect Value (for LiteralType)
+	if flags&checker.TypeFlagsLiteral != 0 {
+		literalType := t.AsLiteralType()
+		if literalType != nil {
+			details.Value = literalType.Value()
+		}
+	}
+
+	// Collect TypeParameters (for InterfaceType)
+	if objectFlags&checker.ObjectFlagsClassOrInterface != 0 {
+		interfaceType := t.AsInterfaceType()
+		if interfaceType != nil {
+			typeParams := interfaceType.TypeParameters()
+			if len(typeParams) > 0 {
+				paramIds := make([]uint32, 0, len(typeParams))
+				for _, tp := range typeParams {
+					paramIds = append(paramIds, c.collectType(tp))
+				}
+				details.TypeParameters = paramIds
+			}
+		}
+	}
+
+	// Collect FixedLength and ElementInfos (for TupleType)
+	if checker.IsTupleType(t) {
+		tupleType := t.AsTupleType()
+		if tupleType != nil {
+			fixedLen := tupleType.FixedLength()
+			details.FixedLength = &fixedLen
+			elementInfos := tupleType.ElementInfos()
+			if len(elementInfos) > 0 {
+				elemDetails := make([]ElementInfoDetail, 0, len(elementInfos))
+				for _, ei := range elementInfos {
+					elemDetails = append(elemDetails, ElementInfoDetail{
+						Flags: uint32(ei.TupleElementFlags()),
+					})
+				}
+				details.ElementInfos = elemDetails
+			}
+		}
+	}
+
+	// Collect Properties, CallSignatures, ConstructSignatures (for StructuredType)
+	if flags&checker.TypeFlagsStructuredType != 0 {
+		structuredType := t.AsStructuredType()
+		if structuredType != nil {
+			// Properties
+			props := structuredType.Properties()
+			if len(props) > 0 {
+				propIds := make([]uint64, 0, len(props))
+				for _, prop := range props {
+					propIds = append(propIds, c.collectSymbol(prop))
+				}
+				details.Properties = propIds
+			}
+
+			// CallSignatures - store SignatureString directly (no IDs for Signature)
+			callSigs := structuredType.CallSignatures()
+			if len(callSigs) > 0 {
+				sigStrings := make([]string, 0, len(callSigs))
+				for _, sig := range callSigs {
+					sigStrings = append(sigStrings, c.checker.SignatureToStringEx(sig, nil, 0))
+				}
+				details.CallSignatures = sigStrings
+			}
+
+			// ConstructSignatures - store SignatureString directly (no IDs for Signature)
+			constructSigs := structuredType.ConstructSignatures()
+			if len(constructSigs) > 0 {
+				sigStrings := make([]string, 0, len(constructSigs))
+				for _, sig := range constructSigs {
+					sigStrings = append(sigStrings, c.checker.SignatureToStringEx(sig, nil, 0))
+				}
+				details.ConstructSignatures = sigStrings
+			}
+		}
+	}
+
+	c.types[typeId] = details
+	return typeId
+}
+
+// collectSymbol collects Symbol information
+func (c *TypeInfoCollector) collectSymbol(symbol *ast.Symbol) uint64 {
+	if symbol == nil {
+		return 0
+	}
+
+	symbolId := uint64(ast.GetSymbolId(symbol))
+
+	// Check if already visited to prevent cycles
+	if c.visitedSymbols[symbolId] {
+		return symbolId
+	}
+	c.visitedSymbols[symbolId] = true
+
+	details := SymbolDetails{
+		Id:             symbolId,
+		Flags:          uint32(symbol.Flags),
+		FlagNames:      getSymbolFlagNames(symbol.Flags),
+		CheckFlags:     uint32(symbol.CheckFlags),
+		CheckFlagNames: getCheckFlagNames(symbol.CheckFlags),
+		Name:           symbol.Name,
+		SymbolString:   c.checker.SymbolToString(symbol),
+	}
+
+	// Collect Declarations
+	if len(symbol.Declarations) > 0 {
+		decls := make([]NodeLocation, 0, len(symbol.Declarations))
+		for _, decl := range symbol.Declarations {
+			decls = append(decls, formatNodeLocation(c.filePath, decl))
+		}
+		details.Declarations = decls
+	}
+
+	// ValueDeclaration
+	if symbol.ValueDeclaration != nil {
+		loc := formatNodeLocation(c.filePath, symbol.ValueDeclaration)
+		details.ValueDeclaration = &loc
+	}
+
+	// Members (recursively collect)
+	if len(symbol.Members) > 0 {
+		members := make(map[string]uint64)
+		for name, member := range symbol.Members {
+			members[name] = c.collectSymbol(member)
+		}
+		details.Members = members
+	}
+
+	// Exports (recursively collect)
+	if len(symbol.Exports) > 0 {
+		exports := make(map[string]uint64)
+		for name, export := range symbol.Exports {
+			exports[name] = c.collectSymbol(export)
+		}
+		details.Exports = exports
+	}
+
+	// Parent (ID only, don't recursively collect to avoid large trees)
+	if symbol.Parent != nil {
+		parentId := uint64(ast.GetSymbolId(symbol.Parent))
+		details.Parent = &parentId
+	}
+
+	c.symbols[symbolId] = details
+	return symbolId
+}
+
+// collectSignature collects Signature information
+// Note: Signature has no internal ID in typescript-go, returns details directly
+func (c *TypeInfoCollector) collectSignature(sig *checker.Signature) *SignatureDetails {
+	if sig == nil {
+		return nil
+	}
+
+	details := &SignatureDetails{
+		SignatureString:  c.checker.SignatureToStringEx(sig, nil, 0),
+		HasRestParameter: sig.HasRestParameter(),
+	}
+
+	// TypeParameters
+	typeParams := sig.TypeParameters()
+	if len(typeParams) > 0 {
+		paramIds := make([]uint32, 0, len(typeParams))
+		for _, tp := range typeParams {
+			paramIds = append(paramIds, c.collectType(tp))
+		}
+		details.TypeParameters = paramIds
+	}
+
+	// Parameters
+	params := checker.Signature_parameters(sig)
+	if len(params) > 0 {
+		paramDetails := make([]ParameterDetail, 0, len(params))
+		for _, param := range params {
+			paramDetails = append(paramDetails, ParameterDetail{
+				Name:     param.Name,
+				SymbolId: c.collectSymbol(param),
+			})
+		}
+		details.Parameters = paramDetails
+	}
+
+	// ThisParameter
+	thisParam := sig.ThisParameter()
+	if thisParam != nil {
+		details.ThisParameter = &ParameterDetail{
+			Name:     thisParam.Name,
+			SymbolId: c.collectSymbol(thisParam),
+		}
+	}
+
+	// ReturnType
+	returnType := c.checker.GetReturnTypeOfSignature(sig)
+	if returnType != nil {
+		returnTypeId := c.collectType(returnType)
+		details.ReturnType = &returnTypeId
+	}
+
+	// Declaration
+	decl := checker.Signature_declaration(sig)
+	if decl != nil {
+		loc := formatNodeLocation(c.filePath, decl)
+		details.Declaration = &loc
+	}
+
+	return details
+}
+
+// collectFlowNode collects FlowNode information
+// Note: FlowNode has no internal ID in typescript-go, returns details directly
+// Uses pointer-based map for cycle detection
+func (c *TypeInfoCollector) collectFlowNode(flow *ast.FlowNode) *FlowNodeDetails {
+	if flow == nil {
+		return nil
+	}
+
+	// Check if already visited to prevent cycles
+	if existing, exists := c.visitedFlowNodes[flow]; exists {
+		return existing
+	}
+
+	// Create details and register immediately for cycle detection
+	details := &FlowNodeDetails{
+		Flags:     uint32(flow.Flags),
+		FlagNames: getFlowFlagNames(flow.Flags),
+	}
+	c.visitedFlowNodes[flow] = details
+
+	// Node
+	if flow.Node != nil {
+		loc := formatNodeLocation(c.filePath, flow.Node)
+		details.Node = &loc
+	}
+
+	// Antecedent (single)
+	if flow.Antecedent != nil {
+		details.Antecedent = c.collectFlowNode(flow.Antecedent)
+	}
+
+	// Antecedents (list)
+	if flow.Antecedents != nil {
+		var antecedents []*FlowNodeDetails
+		for list := flow.Antecedents; list != nil; list = list.Next {
+			if list.Flow != nil {
+				antecedents = append(antecedents, c.collectFlowNode(list.Flow))
+			}
+		}
+		if len(antecedents) > 0 {
+			details.Antecedents = antecedents
+		}
+	}
+
+	return details
+}
+
+// findNodeAtPosition finds the node at position with matching kind
+func findNodeAtPosition(sourceFile *ast.SourceFile, position int, kind int) *ast.Node {
+	var result *ast.Node
+
+	var visit func(node *ast.Node) bool
+	visit = func(node *ast.Node) bool {
+		if node.Pos() <= position && position < node.End() {
+			// If kind matches and position matches, this is our target
+			if node.Pos() == position && int(node.Kind) == kind {
+				result = node
+				return true // Stop searching
+			}
+			// Otherwise continue searching children
+			node.ForEachChild(visit)
+		}
+		return false
+	}
+
+	sourceFile.AsNode().ForEachChild(visit)
+	return result
+}
+
+// getNodeAndChecker is a helper that finds the node and checker for a given NodeLocation
+func (tc *TypeChecker) getNodeAndChecker(loc NodeLocation) (*ast.Node, *checker.Checker, string) {
+	tc.mu.RLock()
+	defer tc.mu.RUnlock()
+
+	sourceFile, ok := tc.sourceFiles[loc.FilePath]
+	if !ok {
+		return nil, nil, loc.FilePath
+	}
+
+	c, ok := tc.checkers[loc.FilePath]
+	if !ok {
+		return nil, nil, loc.FilePath
+	}
+
+	// Find node at position matching the kind
+	node := findNodeAtPosition(sourceFile, loc.Pos, loc.Kind)
+	if node == nil {
+		// Fallback to token at position
+		node = findTokenAtPosition(sourceFile, loc.Pos)
+	}
+
+	return node, c, loc.FilePath
+}
+
+// GetNodeType returns type information for a node (lazy loading)
+func (tc *TypeChecker) GetNodeType(loc NodeLocation) *NodeTypeResponse {
+	node, c, filePath := tc.getNodeAndChecker(loc)
+	if node == nil || c == nil {
+		return nil
+	}
+
+	response := &NodeTypeResponse{}
+	collector := newTypeInfoCollector(c, filePath)
+
+	// Get Type
+	t := c.GetTypeAtLocation(node)
+	if t != nil {
+		collector.collectType(t)
+		if details, ok := collector.types[uint32(t.Id())]; ok {
+			response.Type = &details
+		}
+	}
+
+	// Get ContextualType (only for expressions)
+	if ast.IsExpression(node) {
+		contextualType := checker.Checker_getContextualType(c, node, 0)
+		if contextualType != nil {
+			collector.collectType(contextualType)
+			if details, ok := collector.types[uint32(contextualType.Id())]; ok {
+				response.ContextualType = &details
+			}
+		}
+	}
+
+	// Include all collected related types and symbols for reference lookup
+	if len(collector.types) > 0 {
+		response.RelatedTypes = collector.types
+	}
+	if len(collector.symbols) > 0 {
+		response.RelatedSymbols = collector.symbols
+	}
+
+	return response
+}
+
+// GetNodeSymbol returns symbol information for a node (lazy loading)
+func (tc *TypeChecker) GetNodeSymbol(loc NodeLocation) *NodeSymbolResponse {
+	node, c, filePath := tc.getNodeAndChecker(loc)
+	if node == nil || c == nil {
+		return nil
+	}
+
+	response := &NodeSymbolResponse{}
+	collector := newTypeInfoCollector(c, filePath)
+
+	// Get Symbol
+	symbol := c.GetSymbolAtLocation(node)
+	if symbol != nil {
+		symbolId := collector.collectSymbol(symbol)
+		if details, ok := collector.symbols[symbolId]; ok {
+			response.Symbol = &details
+		}
+	}
+
+	// Include all collected related types and symbols for reference lookup
+	if len(collector.types) > 0 {
+		response.RelatedTypes = collector.types
+	}
+	if len(collector.symbols) > 0 {
+		response.RelatedSymbols = collector.symbols
+	}
+
+	return response
+}
+
+// GetNodeSignature returns signature information for a node (lazy loading)
+func (tc *TypeChecker) GetNodeSignature(loc NodeLocation) *NodeSignatureResponse {
+	node, c, filePath := tc.getNodeAndChecker(loc)
+	if node == nil || c == nil {
+		return nil
+	}
+
+	response := &NodeSignatureResponse{}
+	collector := newTypeInfoCollector(c, filePath)
+
+	// Get Signature (only for call-like expressions)
+	if ast.IsCallLikeExpression(node) {
+		sig := c.GetResolvedSignature(node)
+		if sig != nil {
+			response.Signature = collector.collectSignature(sig)
+		}
+	}
+
+	// Include all collected related types and symbols for reference lookup
+	if len(collector.types) > 0 {
+		response.RelatedTypes = collector.types
+	}
+	if len(collector.symbols) > 0 {
+		response.RelatedSymbols = collector.symbols
+	}
+
+	return response
+}
+
+// GetNodeFlowNode returns flow node information for a node (lazy loading)
+func (tc *TypeChecker) GetNodeFlowNode(loc NodeLocation) *NodeFlowNodeResponse {
+	node, c, filePath := tc.getNodeAndChecker(loc)
+	if node == nil || c == nil {
+		return nil
+	}
+
+	response := &NodeFlowNodeResponse{}
+
+	// Get FlowNode
+	flowNodeData := node.FlowNodeData()
+	if flowNodeData != nil && flowNodeData.FlowNode != nil {
+		collector := newTypeInfoCollector(c, filePath)
+		response.FlowNode = collector.collectFlowNode(flowNodeData.FlowNode)
+	}
+
+	return response
+}
+
+// GetNodeInfo returns basic node information (Kind, Flags, ModifierFlags, Pos, End)
+func (tc *TypeChecker) GetNodeInfo(loc NodeLocation) *NodeInfoResponse {
+	node, _, _ := tc.getNodeAndChecker(loc)
+	if node == nil {
+		return nil
+	}
+
+	return &NodeInfoResponse{
+		Kind:              int(node.Kind),
+		KindName:          node.Kind.String(),
+		Flags:             uint32(node.Flags),
+		FlagNames:         getNodeFlagNames(node.Flags),
+		ModifierFlags:     uint32(node.ModifierFlags()),
+		ModifierFlagNames: getModifierFlagNames(node.ModifierFlags()),
+		Pos:               node.Pos(),
+		End:               node.End(),
+	}
+}
+
+// getNodeFlagNames converts node flags to a slice of flag names
+func getNodeFlagNames(flags ast.NodeFlags) []string {
+	var names []string
+
+	flagMap := map[ast.NodeFlags]string{
+		ast.NodeFlagsLet:                             "Let",
+		ast.NodeFlagsConst:                           "Const",
+		ast.NodeFlagsUsing:                           "Using",
+		ast.NodeFlagsReparsed:                        "Reparsed",
+		ast.NodeFlagsSynthesized:                     "Synthesized",
+		ast.NodeFlagsOptionalChain:                   "OptionalChain",
+		ast.NodeFlagsExportContext:                   "ExportContext",
+		ast.NodeFlagsContainsThis:                    "ContainsThis",
+		ast.NodeFlagsHasImplicitReturn:               "HasImplicitReturn",
+		ast.NodeFlagsHasExplicitReturn:               "HasExplicitReturn",
+		ast.NodeFlagsDisallowInContext:               "DisallowInContext",
+		ast.NodeFlagsYieldContext:                    "YieldContext",
+		ast.NodeFlagsDecoratorContext:                "DecoratorContext",
+		ast.NodeFlagsAwaitContext:                    "AwaitContext",
+		ast.NodeFlagsDisallowConditionalTypesContext: "DisallowConditionalTypesContext",
+		ast.NodeFlagsThisNodeHasError:                "ThisNodeHasError",
+		ast.NodeFlagsJavaScriptFile:                  "JavaScriptFile",
+		ast.NodeFlagsThisNodeOrAnySubNodesHasError:   "ThisNodeOrAnySubNodesHasError",
+		ast.NodeFlagsHasAggregatedChildData:          "HasAggregatedChildData",
+		ast.NodeFlagsPossiblyContainsDynamicImport:   "PossiblyContainsDynamicImport",
+		ast.NodeFlagsPossiblyContainsImportMeta:      "PossiblyContainsImportMeta",
+		ast.NodeFlagsHasJSDoc:                        "HasJSDoc",
+		ast.NodeFlagsJSDoc:                           "JSDoc",
+		ast.NodeFlagsAmbient:                         "Ambient",
+		ast.NodeFlagsInWithStatement:                 "InWithStatement",
+		ast.NodeFlagsJsonFile:                        "JsonFile",
+		ast.NodeFlagsDeprecated:                      "Deprecated",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}
+
+// getModifierFlagNames converts modifier flags to a slice of flag names
+func getModifierFlagNames(flags ast.ModifierFlags) []string {
+	var names []string
+
+	flagMap := map[ast.ModifierFlags]string{
+		ast.ModifierFlagsPublic:     "Public",
+		ast.ModifierFlagsPrivate:    "Private",
+		ast.ModifierFlagsProtected:  "Protected",
+		ast.ModifierFlagsReadonly:   "Readonly",
+		ast.ModifierFlagsOverride:   "Override",
+		ast.ModifierFlagsExport:     "Export",
+		ast.ModifierFlagsAbstract:   "Abstract",
+		ast.ModifierFlagsAmbient:    "Ambient",
+		ast.ModifierFlagsStatic:     "Static",
+		ast.ModifierFlagsAccessor:   "Accessor",
+		ast.ModifierFlagsAsync:      "Async",
+		ast.ModifierFlagsDefault:    "Default",
+		ast.ModifierFlagsConst:      "Const",
+		ast.ModifierFlagsIn:         "In",
+		ast.ModifierFlagsOut:        "Out",
+		ast.ModifierFlagsDecorator:  "Decorator",
+		ast.ModifierFlagsDeprecated: "Deprecated",
+	}
+
+	for flag, name := range flagMap {
+		if flags&flag != 0 {
+			names = append(names, name)
+		}
+	}
+
+	if len(names) == 0 {
+		names = append(names, "None")
+	}
+
+	return names
+}

--- a/packages/rslint-wasm/src/index.ts
+++ b/packages/rslint-wasm/src/index.ts
@@ -1,5 +1,20 @@
 import { BrowserRslintService } from '@rslint/core/browser';
-import { RSLintService, Diagnostic } from '@rslint/core/service';
+import {
+  RSLintService,
+  Diagnostic,
+  RemoteTypeChecker,
+  LintResult,
+  NodeLocation,
+  TypeDetails,
+  SymbolDetails,
+  SignatureDetails,
+  FlowNodeDetails,
+  NodeTypeResponse,
+  NodeSymbolResponse,
+  NodeSignatureResponse,
+  NodeFlowNodeResponse,
+  NodeInfoResponse,
+} from '@rslint/core/service';
 declare const WEB_WORKER_SOURCE_CODE: string;
 async function initialize(options: { wasmURL: string }) {
   let blob = new Blob([WEB_WORKER_SOURCE_CODE], { type: 'text/javascript' });
@@ -13,4 +28,20 @@ async function initialize(options: { wasmURL: string }) {
   return service;
 }
 
-export { initialize, type RSLintService, type Diagnostic };
+export {
+  initialize,
+  type RSLintService,
+  type Diagnostic,
+  type RemoteTypeChecker,
+  type LintResult,
+  type NodeLocation,
+  type TypeDetails,
+  type SymbolDetails,
+  type SignatureDetails,
+  type FlowNodeDetails,
+  type NodeTypeResponse,
+  type NodeSymbolResponse,
+  type NodeSignatureResponse,
+  type NodeFlowNodeResponse,
+  type NodeInfoResponse,
+};

--- a/packages/rslint/src/checker-types.ts
+++ b/packages/rslint/src/checker-types.ts
@@ -1,0 +1,153 @@
+/**
+ * Type definitions for RemoteTypeChecker
+ * These types mirror the Go-side types in internal/api/checker_session.go
+ */
+
+/**
+ * NodeLocation identifies a node in a source file using structured parameters.
+ * This replaces the magic string format "filePath.pos.kind".
+ */
+export interface NodeLocation {
+  /** Relative file path (e.g., "index.ts") */
+  filePath: string;
+  /** Start position of the node */
+  pos: number;
+  /** SyntaxKind of the node */
+  kind: number;
+}
+
+/**
+ * Detailed type information for NodeTypeInfo response.
+ *
+ * Note: Field names use PascalCase to match Go-side JSON output directly,
+ * enabling frontend display of field names as-is. This differs from the
+ * lightweight *Info types above which use camelCase.
+ */
+
+/**
+ * Type information with full details
+ */
+export interface TypeDetails {
+  Id: number;
+  Flags: number;
+  FlagNames: string[];
+  ObjectFlags: number;
+  ObjectFlagNames: string[];
+  Symbol?: number;
+  Target?: number;
+  Types?: number[];
+  TypeString: string;
+  IntrinsicName?: string;
+  Value?: string | number | boolean;
+  TypeParameters?: number[];
+  FixedLength?: number;
+  ElementInfos?: Array<{ Flags: number }>;
+  Properties?: number[];
+  CallSignatures?: string[];
+  ConstructSignatures?: string[];
+}
+
+/**
+ * Symbol information with full details
+ */
+export interface SymbolDetails {
+  Id: number;
+  Flags: number;
+  FlagNames: string[];
+  CheckFlags: number;
+  CheckFlagNames: string[];
+  Name: string;
+  SymbolString: string;
+  Declarations?: NodeLocation[];
+  ValueDeclaration?: NodeLocation;
+  Members?: Record<string, number>;
+  Exports?: Record<string, number>;
+  Parent?: number;
+}
+
+/**
+ * Signature information with full details
+ * Note: Signature has no internal ID in typescript-go
+ */
+export interface SignatureDetails {
+  SignatureString: string;
+  TypeParameters?: number[];
+  Parameters: Array<{
+    Name: string;
+    SymbolId: number;
+  }>;
+  ThisParameter?: {
+    Name: string;
+    SymbolId: number;
+  };
+  HasRestParameter: boolean;
+  ReturnType?: number;
+  Declaration?: NodeLocation;
+}
+
+/**
+ * FlowNode information with full details
+ * Note: FlowNode has no internal ID in typescript-go
+ */
+export interface FlowNodeDetails {
+  Flags: number;
+  FlagNames: string[];
+  Node?: NodeLocation;
+  Antecedent?: FlowNodeDetails;
+  Antecedents?: FlowNodeDetails[];
+}
+
+/**
+ * Response from getNodeType (lazy loading)
+ */
+export interface NodeTypeResponse {
+  Type?: TypeDetails;
+  ContextualType?: TypeDetails;
+  /** Related types collected during traversal (for reference lookup by ID) */
+  RelatedTypes?: Record<number, TypeDetails>;
+  /** Related symbols collected during traversal (for reference lookup by ID) */
+  RelatedSymbols?: Record<number, SymbolDetails>;
+}
+
+/**
+ * Response from getNodeSymbol (lazy loading)
+ */
+export interface NodeSymbolResponse {
+  Symbol?: SymbolDetails;
+  /** Related types collected during traversal (for reference lookup by ID) */
+  RelatedTypes?: Record<number, TypeDetails>;
+  /** Related symbols collected during traversal (for reference lookup by ID) */
+  RelatedSymbols?: Record<number, SymbolDetails>;
+}
+
+/**
+ * Response from getNodeSignature (lazy loading)
+ */
+export interface NodeSignatureResponse {
+  Signature?: SignatureDetails;
+  /** Related types collected during traversal (for reference lookup by ID) */
+  RelatedTypes?: Record<number, TypeDetails>;
+  /** Related symbols collected during traversal (for reference lookup by ID) */
+  RelatedSymbols?: Record<number, SymbolDetails>;
+}
+
+/**
+ * Response from getNodeFlowNode (lazy loading)
+ */
+export interface NodeFlowNodeResponse {
+  FlowNode?: FlowNodeDetails;
+}
+
+/**
+ * Response from getNodeInfo (lazy loading)
+ */
+export interface NodeInfoResponse {
+  Kind: number;
+  KindName: string;
+  Flags: number;
+  FlagNames: string[];
+  ModifierFlags: number;
+  ModifierFlagNames: string[];
+  Pos: number;
+  End: number;
+}

--- a/packages/rslint/src/remote-typechecker.ts
+++ b/packages/rslint/src/remote-typechecker.ts
@@ -1,0 +1,81 @@
+/**
+ * RemoteTypeChecker provides a JS-side proxy to the Go-side TypeChecker
+ * All method calls are forwarded via IPC to the Go backend
+ */
+
+import type { RslintServiceInterface } from './types.js';
+import type {
+  NodeLocation,
+  NodeTypeResponse,
+  NodeSymbolResponse,
+  NodeSignatureResponse,
+  NodeFlowNodeResponse,
+  NodeInfoResponse,
+} from './checker-types.js';
+
+/**
+ * RemoteTypeChecker provides access to TypeScript type information
+ * through the rslint IPC interface
+ */
+export class RemoteTypeChecker {
+  private service: RslintServiceInterface;
+
+  constructor(service: RslintServiceInterface) {
+    this.service = service;
+  }
+
+  /**
+   * Get type information for a node (lazy loading)
+   * @param node - NodeLocation identifying the node
+   */
+  async getNodeType(node: NodeLocation): Promise<NodeTypeResponse | null> {
+    return this.sendRequest('checker.getNodeType', { node });
+  }
+
+  /**
+   * Get symbol information for a node (lazy loading)
+   * @param node - NodeLocation identifying the node
+   */
+  async getNodeSymbol(node: NodeLocation): Promise<NodeSymbolResponse | null> {
+    return this.sendRequest('checker.getNodeSymbol', { node });
+  }
+
+  /**
+   * Get signature information for a node (lazy loading)
+   * @param node - NodeLocation identifying the node
+   */
+  async getNodeSignature(node: NodeLocation): Promise<NodeSignatureResponse | null> {
+    return this.sendRequest('checker.getNodeSignature', { node });
+  }
+
+  /**
+   * Get flow node information for a node (lazy loading)
+   * @param node - NodeLocation identifying the node
+   */
+  async getNodeFlowNode(node: NodeLocation): Promise<NodeFlowNodeResponse | null> {
+    return this.sendRequest('checker.getNodeFlowNode', { node });
+  }
+
+  /**
+   * Get basic node information (Kind, Flags, ModifierFlags, Pos, End)
+   * @param node - NodeLocation identifying the node
+   */
+  async getNodeInfo(node: NodeLocation): Promise<NodeInfoResponse | null> {
+    return this.sendRequest('checker.getNodeInfo', { node });
+  }
+
+  /**
+   * Send a request to the checker backend
+   */
+  private async sendRequest<T>(
+    kind: string,
+    data: { node: NodeLocation },
+  ): Promise<T | null> {
+    try {
+      const response = await this.service.sendMessage(kind, data);
+      return response as T;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/packages/rslint/src/types.ts
+++ b/packages/rslint/src/types.ts
@@ -28,6 +28,7 @@ export interface LintResponse {
   ruleCount: number;
   duration: string;
   encodedSourceFiles?: Record<string, string>; // Binary encoded source files as base64-encoded strings
+  hasTypeChecker?: boolean; // Whether type checker is available
 }
 
 export interface LintOptions {
@@ -38,6 +39,7 @@ export interface LintOptions {
   fileContents?: Record<string, string>; // Map of file paths to their contents for VFS
   languageOptions?: LanguageOptions; // Override languageOptions from config file
   includeEncodedSourceFiles?: boolean; // Whether to include encoded source files in response
+  includeTypeChecker?: boolean; // Whether to create a type checker session
 }
 
 export interface LanguageOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,6 +290,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.13
+        version: 1.1.13(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-toggle':
         specifier: ^1.1.10
         version: 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -308,9 +311,15 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       lucide-react:
         specifier: ^0.555.0
         version: 0.555.0(react@19.1.1)
+      react-resizable-panels:
+        specifier: ^4.4.1
+        version: 4.4.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       swr:
         specifier: ^2.3.6
         version: 2.3.6(react@19.1.1)
@@ -1224,6 +1233,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
@@ -1270,6 +1292,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.13':
+    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-toggle-group@1.1.11':
@@ -4130,6 +4165,12 @@ packages:
       '@types/react':
         optional: true
 
+  react-resizable-panels@4.4.1:
+    resolution: {integrity: sha512-dpM9oI6rGlAq7VYDeafSRA1JmkJv8aNuKySR+tZLQQLfaeqTnQLSM52EcoI/QdowzsjVUCk6jViKS0xHWITVRQ==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
   react-router-dom@6.30.1:
     resolution: {integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==}
     engines: {node: '>=14.0.0'}
@@ -4704,6 +4745,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   terminal-link@4.0.0:
     resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
@@ -5865,6 +5907,16 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
@@ -5926,6 +5978,22 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
+
+  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
   '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -9250,6 +9318,11 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.1.10)(react@19.1.1)
     optionalDependencies:
       '@types/react': 19.1.10
+
+  react-resizable-panels@4.4.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   react-router-dom@6.30.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:

--- a/website/package.json
+++ b/website/package.json
@@ -11,21 +11,24 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@rspress/core": "2.0.0-rc.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "input-otp": "^1.4.2",
+    "jsonc-parser": "^3.3.1",
     "lucide-react": "^0.555.0",
+    "react-resizable-panels": "^4.4.1",
     "swr": "^2.3.6",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
-    "@rslint/wasm": "workspace:*",
-    "@rslint/api": "workspace:*",
     "@rsbuild/plugin-sass": "^1.4.0",
+    "@rslint/api": "workspace:*",
+    "@rslint/wasm": "workspace:*",
     "@rspress/core": "2.0.0-rc.0",
     "@rspress/plugin-llms": "2.0.0-rc.0",
     "@rstack-dev/doc-ui": "1.12.0",
@@ -33,6 +36,7 @@
     "@types/node": "^22.19.0",
     "@types/react": "19.1.10",
     "@types/react-dom": "^19.1.7",
+    "monaco-editor": "0.55.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "rsbuild-plugin-google-analytics": "^1.0.4",
@@ -40,7 +44,6 @@
     "rspress-plugin-font-open-sans": "^1.0.3",
     "rspress-plugin-sitemap": "^1.2.0",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5.9.2",
-    "monaco-editor": "0.55.1"
+    "typescript": "^5.9.2"
   }
 }

--- a/website/theme/components/Playground/Editor.tsx
+++ b/website/theme/components/Playground/Editor.tsx
@@ -4,7 +4,15 @@ import { type Diagnostic } from '@rslint/wasm';
 import './Editor.css';
 
 window.MonacoEnvironment = {
-  getWorker: function (moduleId, label) {
+  getWorker: function (_moduleId, label) {
+    if (label === 'json' || label === 'jsonc') {
+      return new Worker(
+        new URL(
+          'monaco-editor/esm/vs/language/json/json.worker',
+          import.meta.url,
+        ),
+      );
+    }
     if (label === 'typescript' || label === 'javascript') {
       return new Worker(
         new URL(

--- a/website/theme/components/Playground/EditorTabs.tsx
+++ b/website/theme/components/Playground/EditorTabs.tsx
@@ -1,0 +1,119 @@
+import React, { useRef, useState, Ref } from 'react';
+import { parse, ParseError } from 'jsonc-parser';
+import { Editor, EditorRef } from './Editor';
+import { JsonEditor, JsonEditorRef } from './JsonEditor';
+import { Button } from '@components/ui/button';
+
+function isValidJsonc(text: string): boolean {
+  const errors: ParseError[] = [];
+  parse(text, errors);
+  return errors.length === 0;
+}
+
+export type EditorTabType = 'code' | 'rslint.json' | 'tsconfig';
+
+export interface EditorTabsRef {
+  getCodeValue: () => string | undefined;
+  getRslintConfig: () => string;
+  getTsconfigContent: () => string;
+  getEditorRef: () => EditorRef | null;
+}
+
+interface EditorTabsProps {
+  defaultRslintConfig: string;
+  defaultTsconfig: string;
+  onCodeChange?: (value: string) => void;
+  onSelectionChange?: (start: number, end: number) => void;
+  onRslintConfigChange?: (value: string) => void;
+  onTsconfigChange?: (value: string) => void;
+}
+
+export const EditorTabs = ({
+  ref,
+  defaultRslintConfig,
+  defaultTsconfig,
+  onCodeChange,
+  onSelectionChange,
+  onRslintConfigChange,
+  onTsconfigChange,
+}: EditorTabsProps & { ref: Ref<EditorTabsRef> }) => {
+  const editorRef = useRef<EditorRef | null>(null);
+  const rslintEditorRef = useRef<JsonEditorRef | null>(null);
+  const tsconfigEditorRef = useRef<JsonEditorRef | null>(null);
+
+  const [activeTab, setActiveTab] = useState<EditorTabType>('code');
+  const [rslintConfig, setRslintConfig] = useState(defaultRslintConfig);
+  const [tsconfigContent, setTsconfigContent] = useState(defaultTsconfig);
+
+  React.useImperativeHandle(ref, () => ({
+    getCodeValue: () => editorRef.current?.getValue(),
+    getRslintConfig: () => rslintConfig,
+    getTsconfigContent: () => tsconfigContent,
+    getEditorRef: () => editorRef.current,
+  }));
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex items-center gap-2 p-2">
+        <Button
+          type="button"
+          variant={activeTab === 'code' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setActiveTab('code')}
+          aria-pressed={activeTab === 'code'}
+        >
+          code
+        </Button>
+        <Button
+          type="button"
+          variant={activeTab === 'rslint.json' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setActiveTab('rslint.json')}
+          aria-pressed={activeTab === 'rslint.json'}
+        >
+          rslint.json
+        </Button>
+        <Button
+          type="button"
+          variant={activeTab === 'tsconfig' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setActiveTab('tsconfig')}
+          aria-pressed={activeTab === 'tsconfig'}
+        >
+          tsconfig
+        </Button>
+      </div>
+      <div className={`flex-1 ${activeTab !== 'code' ? 'hidden' : ''}`}>
+        <Editor
+          ref={editorRef}
+          onChange={v => onCodeChange?.(v)}
+          onSelectionChange={onSelectionChange}
+        />
+      </div>
+      <div className={`flex-1 ${activeTab !== 'rslint.json' ? 'hidden' : ''}`}>
+        <JsonEditor
+          ref={rslintEditorRef}
+          defaultValue={defaultRslintConfig}
+          onChange={v => {
+            if (isValidJsonc(v)) {
+              setRslintConfig(v);
+              onRslintConfigChange?.(v);
+            }
+          }}
+        />
+      </div>
+      <div className={`flex-1 ${activeTab !== 'tsconfig' ? 'hidden' : ''}`}>
+        <JsonEditor
+          ref={tsconfigEditorRef}
+          defaultValue={defaultTsconfig}
+          onChange={v => {
+            if (isValidJsonc(v)) {
+              setTsconfigContent(v);
+              onTsconfigChange?.(v);
+            }
+          }}
+        />
+      </div>
+    </div>
+  );
+};

--- a/website/theme/components/Playground/JsonEditor.tsx
+++ b/website/theme/components/Playground/JsonEditor.tsx
@@ -1,0 +1,61 @@
+import React, { useRef, useEffect, Ref } from 'react';
+import * as monaco from 'monaco-editor';
+
+// Configure JSON defaults to allow comments and trailing commas
+monaco.json.jsonDefaults.setDiagnosticsOptions({
+  validate: true,
+  allowComments: true,
+  trailingCommas: 'ignore',
+});
+
+export interface JsonEditorRef {
+  getValue: () => string | undefined;
+}
+
+export const JsonEditor = ({
+  ref,
+  defaultValue,
+  onChange,
+}: {
+  ref: Ref<JsonEditorRef>;
+  defaultValue: string;
+  onChange?: (value: string) => void;
+}) => {
+  const divEl = useRef<HTMLDivElement>(null);
+  const editorRef =
+    useRef<import('monaco-editor').editor.IStandaloneCodeEditor>(null);
+
+  React.useImperativeHandle(ref, () => ({
+    getValue: () => editorRef.current?.getValue(),
+  }));
+
+  useEffect(() => {
+    if (!divEl.current) {
+      return;
+    }
+
+    const editor = monaco.editor.create(divEl.current, {
+      value: defaultValue,
+      language: 'json',
+      automaticLayout: true,
+      scrollBeyondLastLine: false,
+      minimap: { enabled: false },
+    });
+
+    editorRef.current = editor;
+
+    editor.onDidChangeModelContent(() => {
+      const val = editor.getValue() || '';
+      onChange?.(val);
+    });
+
+    // Trigger initial onChange
+    onChange?.(editor.getValue() || '');
+
+    return () => {
+      editor.dispose();
+    };
+  }, []);
+
+  return <div className="h-full w-full" ref={divEl}></div>;
+};

--- a/website/theme/components/Playground/NodeDetailPanel.tsx
+++ b/website/theme/components/Playground/NodeDetailPanel.tsx
@@ -1,0 +1,305 @@
+import React from 'react';
+import { ObjectTree, EnumValueMap } from './ObjectTree';
+import type {
+  TypeDetails,
+  SymbolDetails,
+  SignatureDetails,
+  FlowNodeDetails,
+  NodeLocation,
+} from '@rslint/wasm';
+import { SyntaxKind } from '@rslint/api';
+
+// Node detail info passed from parent
+export interface NodeDetailInfo {
+  kind?: number;
+  kindName?: string;
+  flags?: number;
+  flagNames?: string[];
+  modifierFlags?: number;
+  modifierFlagNames?: string[];
+  pos: number;
+  end: number;
+  text?: string;
+  // Type info (when available) - full TypeDetails from Go
+  type?: TypeDetails;
+  contextualType?: TypeDetails;
+  // Symbol info (when available) - full SymbolDetails from Go
+  symbol?: SymbolDetails;
+  // Signature info (when available) - full SignatureDetails from Go
+  signature?: SignatureDetails;
+  // FlowNode info (when available) - full FlowNodeDetails from Go
+  flowNode?: FlowNodeDetails;
+  // Related objects for reference lookup (Type ID -> TypeDetails, Symbol ID -> SymbolDetails)
+  relatedTypes?: Record<number, TypeDetails>;
+  relatedSymbols?: Record<number, SymbolDetails>;
+}
+
+interface NodeDetailPanelProps {
+  detail?: NodeDetailInfo;
+}
+
+export const NodeDetailPanel: React.FC<NodeDetailPanelProps> = ({ detail }) => {
+  if (!detail) {
+    return (
+      <div className="h-full flex flex-col border border-gray-200 rounded-md bg-white overflow-hidden">
+        <div className="flex-1 flex items-center justify-center p-4 text-gray-500 text-sm">
+          Select a node to view details
+        </div>
+      </div>
+    );
+  }
+
+  // Helper to resolve Type ID to TypeString
+  const resolveTypeId = (typeId: number): string => {
+    const type = detail.relatedTypes?.[typeId];
+    return type ? type.TypeString : `Type#${typeId}`;
+  };
+
+  // Helper to resolve Symbol ID to SymbolString
+  const resolveSymbolId = (symbolId: number): string => {
+    const symbol = detail.relatedSymbols?.[symbolId];
+    return symbol ? symbol.SymbolString : `Symbol#${symbolId}`;
+  };
+
+  // Helper to convert Types array (of IDs) to resolved TypeStrings
+  const resolveTypesArray = (typeIds?: number[]): Array<{ id: number; typeString: string }> | undefined => {
+    if (!typeIds) return undefined;
+    return typeIds.map(id => ({ id, typeString: resolveTypeId(id) }));
+  };
+
+  // Helper to convert Properties array (of Symbol IDs) to resolved info
+  const resolvePropertiesArray = (symbolIds?: number[]): Array<{ id: number; symbolString: string }> | undefined => {
+    if (!symbolIds) return undefined;
+    return symbolIds.map(id => ({ id, symbolString: resolveSymbolId(id) }));
+  };
+
+  // Helper to format NodeLocation to a readable string
+  const formatNodeLocation = (loc: NodeLocation): string => {
+    const kindName = SyntaxKind[loc.kind] || `Kind(${loc.kind})`;
+    return `${kindName} @ ${loc.filePath}:${loc.pos}`;
+  };
+
+  // Helper to format Declarations array (of NodeLocation) to readable strings
+  const formatDeclarations = (locs?: NodeLocation[]): string[] | undefined => {
+    if (!locs || locs.length === 0) return undefined;
+    return locs.map(formatNodeLocation);
+  };
+
+  // Build node object for tree display
+  const nodeData: Record<string, unknown> = {
+    kind: detail.kind,
+    pos: detail.pos,
+    end: detail.end,
+  };
+  if (detail.text) {
+    nodeData.text = detail.text;
+  }
+  // Always show flags
+  if (detail.flags !== undefined) {
+    nodeData.flags = detail.flags;
+  }
+  if (detail.modifierFlags !== undefined) {
+    nodeData.modifierFlags = detail.modifierFlags;
+  }
+
+  // Build enum values map for tooltips
+  const nodeEnumValues: EnumValueMap = {
+    kind: detail.kindName || `Unknown(${detail.kind})`,
+    flags: detail.flagNames?.length ? detail.flagNames.join('\n') : 'None',
+    modifierFlags: detail.modifierFlagNames?.length ? detail.modifierFlagNames.join('\n') : 'None',
+  };
+
+  return (
+    <div className="h-full flex flex-col border border-gray-200 rounded-md bg-white overflow-hidden">
+      <div className="flex-1 overflow-auto p-3">
+        {/* Node */}
+        <div className="pb-3">
+          <div className="text-xs font-semibold text-gray-800 mb-2">Node</div>
+          <ObjectTree
+            data={nodeData}
+            name={detail.kindName}
+            defaultExpanded
+            enumValues={nodeEnumValues}
+          />
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 my-3" />
+
+        {/* Type */}
+        <div className="pb-3">
+          <div className="text-xs font-semibold text-gray-800 mb-2">Type</div>
+          {detail.type ? (
+            <>
+              {/* TypeToString() result */}
+              <div className="mb-2">
+                <span className="text-xs text-gray-600">TypeToString(): </span>
+                <span className="text-xs font-mono text-blue-700">{detail.type.TypeString}</span>
+              </div>
+              {/* Full Type object */}
+              <ObjectTree
+                data={{
+                  Id: detail.type.Id,
+                  Flags: detail.type.Flags,
+                  ObjectFlags: detail.type.ObjectFlags,
+                  ...(detail.type.Symbol !== undefined && { Symbol: `${resolveSymbolId(detail.type.Symbol)} (id: ${detail.type.Symbol})` }),
+                  ...(detail.type.IntrinsicName && { IntrinsicName: detail.type.IntrinsicName }),
+                  ...(detail.type.Value !== undefined && { Value: detail.type.Value }),
+                  ...(detail.type.Types && { Types: resolveTypesArray(detail.type.Types) }),
+                  ...(detail.type.Properties && { Properties: resolvePropertiesArray(detail.type.Properties) }),
+                  ...(detail.type.CallSignatures && { CallSignatures: detail.type.CallSignatures }),
+                  ...(detail.type.Target !== undefined && { Target: `${resolveTypeId(detail.type.Target)} (id: ${detail.type.Target})` }),
+                }}
+                name="Type"
+                defaultExpanded
+                enumValues={{
+                  Flags: detail.type.FlagNames?.join('\n') || 'None',
+                  ObjectFlags: detail.type.ObjectFlagNames?.join('\n') || 'None',
+                }}
+              />
+            </>
+          ) : (
+            <div className="text-xs text-gray-400 italic font-mono">Not available</div>
+          )}
+        </div>
+
+        {/* ContextualType */}
+        {detail.contextualType && (
+          <>
+            <div className="border-t border-gray-200 my-3" />
+            <div className="pb-3">
+              <div className="text-xs font-semibold text-gray-800 mb-2">ContextualType</div>
+              {/* TypeToString() result */}
+              <div className="mb-2">
+                <span className="text-xs text-gray-600">TypeToString(): </span>
+                <span className="text-xs font-mono text-blue-700">{detail.contextualType.TypeString}</span>
+              </div>
+              {/* Full ContextualType object */}
+              <ObjectTree
+                data={{
+                  Id: detail.contextualType.Id,
+                  Flags: detail.contextualType.Flags,
+                  ObjectFlags: detail.contextualType.ObjectFlags,
+                  ...(detail.contextualType.Symbol !== undefined && { Symbol: `${resolveSymbolId(detail.contextualType.Symbol)} (id: ${detail.contextualType.Symbol})` }),
+                  ...(detail.contextualType.IntrinsicName && { IntrinsicName: detail.contextualType.IntrinsicName }),
+                  ...(detail.contextualType.Types && { Types: resolveTypesArray(detail.contextualType.Types) }),
+                  ...(detail.contextualType.Target !== undefined && { Target: `${resolveTypeId(detail.contextualType.Target)} (id: ${detail.contextualType.Target})` }),
+                }}
+                name="ContextualType"
+                defaultExpanded
+                enumValues={{
+                  Flags: detail.contextualType.FlagNames?.join('\n') || 'None',
+                  ObjectFlags: detail.contextualType.ObjectFlagNames?.join('\n') || 'None',
+                }}
+              />
+            </div>
+          </>
+        )}
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 my-3" />
+
+        {/* Symbol */}
+        <div className="pb-3">
+          <div className="text-xs font-semibold text-gray-800 mb-2">Symbol</div>
+          {detail.symbol ? (
+            <>
+              {/* symbolToString() result */}
+              <div className="mb-2">
+                <span className="text-xs text-gray-600">SymbolToString(): </span>
+                <span className="text-xs font-mono text-blue-700">{detail.symbol.SymbolString}</span>
+              </div>
+              {/* Full Symbol object */}
+              <ObjectTree
+                data={{
+                  Id: detail.symbol.Id,
+                  Name: detail.symbol.Name,
+                  Flags: detail.symbol.Flags,
+                  CheckFlags: detail.symbol.CheckFlags,
+                  ...(detail.symbol.Declarations && { Declarations: formatDeclarations(detail.symbol.Declarations) }),
+                  ...(detail.symbol.ValueDeclaration && { ValueDeclaration: formatNodeLocation(detail.symbol.ValueDeclaration) }),
+                  ...(detail.symbol.Members && Object.keys(detail.symbol.Members).length > 0 && {
+                    Members: Object.fromEntries(
+                      Object.entries(detail.symbol.Members).map(([name, id]) => [name, `${resolveSymbolId(id)} (id: ${id})`])
+                    )
+                  }),
+                  ...(detail.symbol.Exports && Object.keys(detail.symbol.Exports).length > 0 && {
+                    Exports: Object.fromEntries(
+                      Object.entries(detail.symbol.Exports).map(([name, id]) => [name, `${resolveSymbolId(id)} (id: ${id})`])
+                    )
+                  }),
+                  ...(detail.symbol.Parent !== undefined && { Parent: `${resolveSymbolId(detail.symbol.Parent)} (id: ${detail.symbol.Parent})` }),
+                }}
+                name="Symbol"
+                defaultExpanded
+                enumValues={{
+                  Flags: detail.symbol.FlagNames?.join('\n') || 'None',
+                  CheckFlags: detail.symbol.CheckFlagNames?.join('\n') || 'None',
+                }}
+              />
+            </>
+          ) : (
+            <div className="text-xs text-gray-400 italic font-mono">Not available</div>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 my-3" />
+
+        {/* Signature */}
+        <div className="pb-3">
+          <div className="text-xs font-semibold text-gray-800 mb-2">Signature</div>
+          {detail.signature ? (
+            <>
+              {/* signatureToString() result */}
+              <div className="mb-2">
+                <span className="text-xs text-gray-600">signatureToString(): </span>
+                <span className="text-xs font-mono text-blue-700">{detail.signature.SignatureString}</span>
+              </div>
+              {/* Full Signature object */}
+              <ObjectTree
+                data={{
+                  HasRestParameter: detail.signature.HasRestParameter,
+                  ...(detail.signature.TypeParameters && { TypeParameters: resolveTypesArray(detail.signature.TypeParameters) }),
+                  ...(detail.signature.Parameters && { Parameters: detail.signature.Parameters }),
+                  ...(detail.signature.ThisParameter && { ThisParameter: detail.signature.ThisParameter }),
+                  ...(detail.signature.ReturnType !== undefined && { ReturnType: `${resolveTypeId(detail.signature.ReturnType)} (id: ${detail.signature.ReturnType})` }),
+                  ...(detail.signature.Declaration && { Declaration: formatNodeLocation(detail.signature.Declaration) }),
+                }}
+                name="Signature"
+                defaultExpanded
+              />
+            </>
+          ) : (
+            <div className="text-xs text-gray-400 italic font-mono">Not available</div>
+          )}
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-gray-200 my-3" />
+
+        {/* FlowNode */}
+        <div>
+          <div className="text-xs font-semibold text-gray-800 mb-2">FlowNode</div>
+          {detail.flowNode ? (
+            <ObjectTree
+              data={{
+                Flags: detail.flowNode.Flags,
+                ...(detail.flowNode.Node && { Node: formatNodeLocation(detail.flowNode.Node) }),
+                ...(detail.flowNode.Antecedent && { Antecedent: detail.flowNode.Antecedent }),
+                ...(detail.flowNode.Antecedents && { Antecedents: detail.flowNode.Antecedents }),
+              }}
+              name="FlowNode"
+              defaultExpanded
+              enumValues={{
+                Flags: detail.flowNode.FlagNames?.join('\n') || 'None',
+              }}
+            />
+          ) : (
+            <div className="text-xs text-gray-400 italic font-mono">Not available</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/website/theme/components/Playground/ObjectTree.tsx
+++ b/website/theme/components/Playground/ObjectTree.tsx
@@ -1,0 +1,269 @@
+import React, { useState } from 'react';
+
+// Simple tooltip component using CSS
+const Tooltip: React.FC<{ text: string; children: React.ReactNode }> = ({ text, children }) => (
+  <span className="relative group">
+    {children}
+    <span className="absolute left-0 bottom-full mb-1 px-2 py-1 text-xs text-white bg-gray-800 rounded whitespace-pre-line opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-50">
+      {text}
+    </span>
+  </span>
+);
+
+// Enum field configuration - maps field name to enum name
+// Note: We support both camelCase and PascalCase field names for flexibility
+export const ENUM_FIELDS: Record<string, string> = {
+  // camelCase variants (used by Node info)
+  kind: 'SyntaxKind',
+  flags: 'NodeFlags',
+  modifierFlags: 'ModifierFlags',
+  symbolFlags: 'SymbolFlags',
+  typeFlags: 'TypeFlags',
+  // PascalCase variants (used by Type/Symbol/FlowNode info from Go)
+  Flags: 'Flags',
+  ObjectFlags: 'ObjectFlags',
+  CheckFlags: 'CheckFlags',
+};
+
+// Value to enum key mapping (passed from parent with actual resolved names)
+export interface EnumValueMap {
+  [fieldName: string]: string; // fieldName -> resolved enum key string
+}
+
+interface ObjectTreeProps {
+  data: unknown;
+  name?: string;
+  defaultExpanded?: boolean;
+  enumValues?: EnumValueMap;
+}
+
+interface TreeNodeProps {
+  name: string;
+  value: unknown;
+  defaultExpanded?: boolean;
+  depth?: number;
+  enumValues?: EnumValueMap;
+}
+
+function getValueType(value: unknown): string {
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+  if (Array.isArray(value)) return 'array';
+  return typeof value;
+}
+
+function formatString(str: string): string {
+  return str
+    .replace(/\\/g, '\\\\')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+}
+
+function getValuePreview(value: unknown, maxLen = 50): string {
+  const type = getValueType(value);
+  switch (type) {
+    case 'null':
+      return 'null';
+    case 'undefined':
+      return 'undefined';
+    case 'string': {
+      const formatted = formatString(value as string);
+      return `"${formatted.length > maxLen ? formatted.slice(0, maxLen) + '...' : formatted}"`;
+    }
+    case 'number':
+    case 'boolean':
+      return String(value);
+    case 'array':
+      return `Array(${(value as unknown[]).length})`;
+    case 'object':
+      return `{${Object.keys(value as object).length} keys}`;
+    case 'function':
+      return 'ƒ()';
+    default:
+      return String(value);
+  }
+}
+
+function isExpandable(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  const type = typeof value;
+  return type === 'object' || Array.isArray(value);
+}
+
+const TreeNode: React.FC<TreeNodeProps> = ({
+  name,
+  value,
+  defaultExpanded = false,
+  depth = 0,
+  enumValues,
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const type = getValueType(value);
+  const expandable = isExpandable(value);
+
+  // Check if this field is an enum field
+  const enumName = ENUM_FIELDS[name];
+  const enumKey = enumValues?.[name];
+  // Don't show tooltip for flags with value 0
+  const flagFields = ['flags', 'modifierFlags', 'symbolFlags', 'typeFlags', 'Flags', 'ObjectFlags', 'CheckFlags'];
+  const isZeroFlag = flagFields.includes(name) && value === 0;
+  const hasEnumInfo = !!(enumName && enumKey) && !isZeroFlag;
+  // For flags, show the resolved flag names directly; for kind/other, show enum prefix
+  const tooltipText = hasEnumInfo
+    ? (flagFields.includes(name) ? enumKey : `${enumName}.${enumKey}`)
+    : undefined;
+
+  const toggleExpand = () => {
+    if (expandable) {
+      setExpanded(!expanded);
+    }
+  };
+
+  const renderValue = () => {
+    if (!expandable) {
+      const preview = getValuePreview(value);
+      const valueSpan = (
+        <span
+          className={`whitespace-pre-wrap break-all ${
+            type === 'string' ? 'text-blue-700' :
+            type === 'number' || type === 'boolean' ? 'text-blue-600' :
+            type === 'null' || type === 'undefined' ? 'text-gray-400 italic' :
+            'text-gray-600'
+          } ${hasEnumInfo ? 'underline decoration-dotted cursor-help' : ''}`}
+        >
+          {preview}
+        </span>
+      );
+
+      if (hasEnumInfo && tooltipText) {
+        return <Tooltip text={tooltipText}>{valueSpan}</Tooltip>;
+      }
+      return valueSpan;
+    }
+
+    if (!expanded) {
+      return (
+        <span className="ml-1 text-gray-400">
+          {getValuePreview(value)}
+        </span>
+      );
+    }
+
+    const entries = Array.isArray(value)
+      ? (value as unknown[]).map((v, i) => [String(i), v] as [string, unknown])
+      : Object.entries(value as object);
+
+    return (
+      <div className="ml-3.5 border-l border-gray-200 pl-2">
+        {entries.map(([key, val]) => (
+          <TreeNode
+            key={key}
+            name={key}
+            value={val}
+            defaultExpanded={false}
+            depth={depth + 1}
+            enumValues={enumValues}
+          />
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div>
+      <div
+        className={`flex items-start py-0.5 ${expandable ? 'cursor-pointer hover:bg-gray-100 rounded' : ''}`}
+        onClick={toggleExpand}
+      >
+        {expandable ? (
+          <span className={`inline-flex items-center justify-center w-3.5 h-[18px] text-[8px] text-gray-500 transition-transform duration-100 flex-shrink-0 ${expanded ? 'rotate-90' : ''}`}>
+            ▶
+          </span>
+        ) : (
+          <span className="w-3.5 flex-shrink-0" />
+        )}
+        <span className="text-amber-700">{name}</span>
+        <span className="text-gray-800 mr-1">:</span>
+        {!expanded && renderValue()}
+      </div>
+      {expanded && expandable && renderValue()}
+    </div>
+  );
+};
+
+export const ObjectTree: React.FC<ObjectTreeProps> = ({
+  data,
+  name,
+  defaultExpanded = true,
+  enumValues,
+}) => {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const expandable = isExpandable(data);
+  const type = getValueType(data);
+
+  if (!expandable) {
+    return (
+      <div className="font-mono text-xs leading-relaxed">
+        <div className="flex items-start py-0.5">
+          {name && (
+            <>
+              <span className="w-3.5 flex-shrink-0" />
+              <span className="text-amber-700">{name}</span>
+              <span className="text-gray-800 mr-1">:</span>
+            </>
+          )}
+          <span
+            className={`whitespace-pre-wrap break-all ${
+              type === 'string' ? 'text-blue-700' :
+              type === 'number' || type === 'boolean' ? 'text-blue-600' :
+              'text-gray-400 italic'
+            }`}
+          >
+            {getValuePreview(data)}
+          </span>
+        </div>
+      </div>
+    );
+  }
+
+  const entries = Array.isArray(data)
+    ? (data as unknown[]).map((v, i) => [String(i), v] as [string, unknown])
+    : Object.entries(data as object);
+
+  return (
+    <div className="font-mono text-xs leading-relaxed">
+      <div
+        className="flex items-start py-0.5 cursor-pointer hover:bg-gray-100 rounded"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <span className={`inline-flex items-center justify-center w-3.5 h-[18px] text-[8px] text-gray-500 transition-transform duration-100 flex-shrink-0 ${expanded ? 'rotate-90' : ''}`}>
+          ▶
+        </span>
+        {name && (
+          <>
+            <span className="text-amber-700">{name}</span>
+            <span className="text-gray-800 mr-1">:</span>
+          </>
+        )}
+        {!expanded && (
+          <span className="ml-1 text-gray-400">{getValuePreview(data)}</span>
+        )}
+      </div>
+      {expanded && (
+        <div className="ml-3.5 border-l border-gray-200 pl-2">
+          {entries.map(([key, val]) => (
+            <TreeNode
+              key={key}
+              name={key}
+              value={val}
+              defaultExpanded={false}
+              depth={1}
+              enumValues={enumValues}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/website/theme/components/Playground/ResultPanel.css
+++ b/website/theme/components/Playground/ResultPanel.css
@@ -1,3 +1,9 @@
+.result-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
 .result-header {
   background: #f6f8fa;
   display: flex;
@@ -32,7 +38,8 @@
 
 .result-content {
   padding: 8px;
-  height: calc(100% - 46px);
+  flex: 1;
+  overflow: hidden;
 }
 
 .loading-state {
@@ -45,7 +52,8 @@
 }
 
 .lint-results {
-  height: calc(100% - 8px);
+  height: 100%;
+  overflow: auto;
 }
 
 /* Shadcn Alert used for messages */
@@ -131,6 +139,11 @@
   height: 100%;
 }
 
+.ast-tree-container {
+  height: 100%;
+  overflow: hidden;
+}
+
 .ast-tree {
   height: 100%;
   overflow: auto;
@@ -138,6 +151,13 @@
   border-radius: 6px;
   background: #fff;
   padding: 6px 6px 10px 6px;
+}
+
+/* AST Detail Panel */
+.ast-detail-container {
+  height: 100%;
+  overflow: hidden;
+  padding-left: 8px;
 }
 
 .ast-node-row {

--- a/website/theme/components/Playground/index.css
+++ b/website/theme/components/Playground/index.css
@@ -6,11 +6,11 @@
 }
 
 .editor-panel {
-  flex: 5;
+  height: 100%;
   background: #ffffff;
 }
 
 .result-panel {
-  flex: 3;
+  height: 100%;
   background: #ffffff;
 }

--- a/website/theme/components/Playground/index.tsx
+++ b/website/theme/components/Playground/index.tsx
@@ -1,9 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as Rslint from '@rslint/wasm';
-import { Editor, EditorRef } from './Editor';
-import { ResultPanel, Diagnostic } from './ResultPanel';
+import type { RemoteTypeChecker } from '@rslint/wasm';
+import { parse as parseJsonc } from 'jsonc-parser';
+import { EditorTabs, EditorTabsRef } from './EditorTabs';
+import { ResultPanel, Diagnostic, NodeDetailInfo } from './ResultPanel';
+import {
+  ResizablePanelGroup,
+  ResizablePanel,
+  ResizableHandle,
+} from '@components/ui/resizable';
 import './index.css';
-import { RemoteSourceFile, type Node, SyntaxKind } from '@rslint/api';
+import { RemoteSourceFile, type Node, SyntaxKind, RemoteNode } from '@rslint/api';
 
 const wasmURL = new URL('@rslint/wasm/rslint.wasm', import.meta.url).href;
 let rslintService: Rslint.RSLintService | null = null;
@@ -17,8 +24,35 @@ async function ensureService() {
   return rslintService;
 }
 
+const DEFAULT_RSLINT_CONFIG = JSON.stringify(
+  [
+    {
+      languageOptions: {
+        parserOptions: {
+          project: ['./tsconfig.json'],
+        },
+      },
+      rules: {
+        '@typescript-eslint/no-unsafe-member-access': 'error',
+      },
+      plugins: ['@typescript-eslint'],
+    },
+  ],
+  null,
+  2,
+);
+
+const DEFAULT_TSCONFIG = JSON.stringify({
+  compilerOptions: {},
+}, null, 2);
+
 const Playground: React.FC = () => {
-  const editorRef = useRef<EditorRef | null>(null);
+  const editorTabsRef = useRef<EditorTabsRef | null>(null);
+
+  const [code, setCode] = useState('');
+  const [rslintConfig, setRslintConfig] = useState(DEFAULT_RSLINT_CONFIG);
+  const [tsconfigContent, setTsconfigContent] = useState(DEFAULT_TSCONFIG);
+
   const [diagnostics, setDiagnostics] = useState<Diagnostic[]>([]);
   const [initialized, setInitialized] = useState(false);
   const [error, setError] = useState<string | undefined>();
@@ -33,25 +67,54 @@ const Playground: React.FC = () => {
   const [selectedAstRange, setSelectedAstRange] = useState<
     { start: number; end: number } | undefined
   >();
+  const [selectedNodeDetail, setSelectedNodeDetail] = useState<NodeDetailInfo | undefined>();
+  // Store the RemoteSourceFile for node lookup
+  const remoteSourceFileRef = useRef<RemoteSourceFile | null>(null);
+  // Store the RemoteTypeChecker for type queries
+  const typeCheckerRef = useRef<RemoteTypeChecker | null>(null);
 
   async function runLint() {
     try {
       setError(undefined);
       if (!initialized) setLoading(true);
       const service = await ensureService();
-      const code = editorRef.current?.getValue() ?? '';
+      // Parse JSONC to extract rules and convert to standard JSON
+      const rslintConfigParsed = parseJsonc(rslintConfig);
+      const rslintConfigJson = JSON.stringify(rslintConfigParsed);
+      const tsconfigParsed = parseJsonc(tsconfigContent);
+      const tsconfigJson = JSON.stringify(tsconfigParsed);
+
+      // Extract rules from rslint config (support both array and object format)
+      let ruleOptions: Record<string, unknown> = {};
+      if (Array.isArray(rslintConfigParsed)) {
+        // Flat config format: array of config objects
+        for (const config of rslintConfigParsed) {
+          if (config?.rules) {
+            ruleOptions = { ...ruleOptions, ...config.rules };
+          }
+        }
+      } else if (rslintConfigParsed?.rules) {
+        // Legacy config format: single object with rules
+        ruleOptions = rslintConfigParsed.rules;
+      }
 
       const result = await service.lint({
         includeEncodedSourceFiles: true,
+        includeTypeChecker: true, // Request a type checker session
         fileContents: {
           '/index.ts': code,
+          '/tsconfig.json': tsconfigJson,
+          '/rslint.json': rslintConfigJson,
         },
         config: 'rslint.json',
-        ruleOptions: {
-          '@typescript-eslint/no-unsafe-member-access': 'error',
-        },
+        ruleOptions: ruleOptions as Record<string, string>,
       });
       setInitialized(true);
+
+      // Store the type checker for later use
+      if (result.typeChecker) {
+        typeCheckerRef.current = result.typeChecker;
+      }
 
       // Convert diagnostics to the expected format
       const convertedDiagnostics: Diagnostic[] = result.diagnostics.map(
@@ -69,7 +132,7 @@ const Playground: React.FC = () => {
       );
 
       setDiagnostics(convertedDiagnostics);
-      editorRef.current?.attachDiag(result.diagnostics);
+      editorTabsRef.current?.getEditorRef()?.attachDiag(result.diagnostics);
       interface ASTNode {
         type: string;
         start: number;
@@ -85,21 +148,24 @@ const Playground: React.FC = () => {
         const astBuffer = result.encodedSourceFiles!['index.ts'];
         const buffer = Uint8Array.from(atob(astBuffer), c => c.charCodeAt(0));
         const source = new RemoteSourceFile(buffer, new TextDecoder());
+        // Store for later node lookup
+        remoteSourceFileRef.current = source;
         // capture the exact source text from encoded source file
         try {
           sourceTextForTs = (source as any).text as string | undefined;
         } catch {}
         // Convert a RemoteNode (from tsgo/rslint-api) to a minimal ESTree node
 
-        function RemoteNodeToEstree(node: Node): ASTNode {
+        function RemoteNodeToEstree(node: RemoteNode): ASTNode {
           const current: ASTNode = {
             type: SyntaxKind[node.kind],
             start: node.pos,
             end: node.end,
             text: (node as any).text,
           };
+          // console.log('node: ', current.type, node.pos, node.end, node.kind, node.flags);
           const children: ASTNode[] = [];
-          node.forEachChild((child: Node) => {
+          node.forEachChild((child: RemoteNode) => {
             children.push(RemoteNodeToEstree(child));
           });
           if (children.length) current.children = children;
@@ -115,6 +181,7 @@ const Playground: React.FC = () => {
         console.warn('AST generation failed:', astError);
         setAst(undefined);
         setAstTree(undefined);
+        remoteSourceFileRef.current = null;
         lastSourceTextRef.current = code;
       }
       // If TS AST tab has been opened and TS module loaded, refresh TS AST too
@@ -140,6 +207,140 @@ const Playground: React.FC = () => {
     }, 250);
   }
 
+  // Find RemoteNode by position and return both the node and its details
+  function findNodeAtPosition(start: number, end: number): { node: RemoteNode; detail: NodeDetailInfo } | undefined {
+    const source = remoteSourceFileRef.current;
+    if (!source) return undefined;
+
+    let bestNode: RemoteNode | null = null;
+    let bestDepth = -1;
+
+    function visit(node: RemoteNode, depth: number) {
+      if (node.pos <= start && node.end >= end) {
+        if (depth > bestDepth) {
+          bestNode = node;
+          bestDepth = depth;
+        }
+        node.forEachChild((child: RemoteNode) => visit(child, depth + 1));
+      }
+    }
+
+    visit(source, 0);
+
+    if (!bestNode) return undefined;
+
+    const node = bestNode as RemoteNode;
+    const kindName = SyntaxKind[node.kind] || `Unknown(${node.kind})`;
+
+    // Extract flags (basic parsing)
+    const flags = node.flags;
+    const flagNames: string[] = [];
+    // Common NodeFlags values (from TypeScript)
+    if (flags & 1) flagNames.push('Let');
+    if (flags & 2) flagNames.push('Const');
+    if (flags & 4) flagNames.push('NestedNamespace');
+    if (flags & 8) flagNames.push('Synthesized');
+    if (flags & 16) flagNames.push('Namespace');
+    if (flags & 32) flagNames.push('ExportContext');
+    if (flags & 64) flagNames.push('ContainsThis');
+    if (flags & 128) flagNames.push('HasImplicitReturn');
+    if (flags & 256) flagNames.push('HasExplicitReturn');
+    if (flags & 512) flagNames.push('GlobalAugmentation');
+    if (flags & 1024) flagNames.push('HasAsyncFunctions');
+    if (flags & 2048) flagNames.push('DisallowInContext');
+    if (flags & 4096) flagNames.push('YieldContext');
+    if (flags & 8192) flagNames.push('DecoratorContext');
+    if (flags & 16384) flagNames.push('AwaitContext');
+    if (flags & 32768) flagNames.push('ThisNodeHasError');
+    if (flags & 65536) flagNames.push('JavaScriptFile');
+    if (flags & 131072) flagNames.push('ThisNodeOrAnySubNodesHasError');
+    if (flags & 262144) flagNames.push('HasAggregatedChildData');
+
+    const detail: NodeDetailInfo = {
+      kind: node.kind,
+      kindName,
+      flags,
+      flagNames: flagNames.length > 0 ? flagNames : undefined,
+      pos: node.pos,
+      end: node.end,
+      text: (node as any).text,
+      // Type/Symbol info will be fetched asynchronously
+      type: undefined,
+      contextualType: undefined,
+      symbol: undefined,
+      signature: undefined,
+      flowNode: undefined,
+    };
+
+    return { node, detail };
+  }
+
+  // The file path used for type checker queries (must match the key in encodedSourceFiles/sourceFiles)
+  // Note: Go side uses relative paths, so this should be 'index.ts' not '/index.ts'
+  const MAIN_FILE_PATH = 'index.ts';
+
+  // Update node detail when selection changes
+  async function handleAstNodeSelect(start: number, end: number) {
+    setSelectedAstRange({ start, end });
+    const result = findNodeAtPosition(start, end);
+
+    if (!result) {
+      setSelectedNodeDetail(undefined);
+      return;
+    }
+
+    const { node, detail } = result;
+
+    // Use the lazy-loading APIs for type info
+    if (typeCheckerRef.current) {
+      try {
+        const nodeLocation = {
+          filePath: MAIN_FILE_PATH,
+          pos: node.pos,
+          kind: node.kind,
+        };
+
+        // Fetch type, symbol, signature, and flow node info in parallel
+        const [typeResp, symbolResp, signatureResp, flowNodeResp] = await Promise.all([
+          typeCheckerRef.current.getNodeType(nodeLocation),
+          typeCheckerRef.current.getNodeSymbol(nodeLocation),
+          typeCheckerRef.current.getNodeSignature(nodeLocation),
+          typeCheckerRef.current.getNodeFlowNode(nodeLocation),
+        ]);
+
+        // Merge all related types and symbols from different responses
+        const mergedRelatedTypes: Record<number, any> = {
+          ...typeResp?.RelatedTypes,
+          ...symbolResp?.RelatedTypes,
+          ...signatureResp?.RelatedTypes,
+        };
+        const mergedRelatedSymbols: Record<number, any> = {
+          ...typeResp?.RelatedSymbols,
+          ...symbolResp?.RelatedSymbols,
+          ...signatureResp?.RelatedSymbols,
+        };
+
+        // Update detail with full type/symbol/signature/flowNode info
+        const updatedDetail: NodeDetailInfo = {
+          ...detail,
+          type: typeResp?.Type,
+          contextualType: typeResp?.ContextualType,
+          symbol: symbolResp?.Symbol,
+          signature: signatureResp?.Signature,
+          flowNode: flowNodeResp?.FlowNode,
+          relatedTypes: Object.keys(mergedRelatedTypes).length > 0 ? mergedRelatedTypes : undefined,
+          relatedSymbols: Object.keys(mergedRelatedSymbols).length > 0 ? mergedRelatedSymbols : undefined,
+        };
+        setSelectedNodeDetail(updatedDetail);
+        return;
+      } catch (e) {
+        console.warn('Failed to get node type info:', e);
+      }
+    }
+
+    setSelectedNodeDetail(detail);
+  }
+
   // Cleanup any pending timers on unmount
   useEffect(() => {
     return () => {
@@ -149,7 +350,13 @@ const Playground: React.FC = () => {
       }
     };
   }, []);
-  // Initial lint is triggered by Editor's initial onChange
+
+  // Re-run lint when code or config changes
+  useEffect(() => {
+    if (code) {
+      scheduleRunLint();
+    }
+  }, [code, rslintConfig, tsconfigContent]);
 
   async function buildTypeScriptAst(text: string) {
     const ts = tsModuleRef.current!;
@@ -192,45 +399,83 @@ const Playground: React.FC = () => {
     }
   }
 
+  // Get saved layout from localStorage
+  const getDefaultLayout = () => {
+    if (typeof window === 'undefined') return undefined;
+    try {
+      const saved = localStorage.getItem('playground-layout');
+      if (saved) {
+        return JSON.parse(saved);
+      }
+    } catch {
+      // ignore
+    }
+    return undefined;
+  };
+
+  const handleLayoutChanged = (layout: Record<string, number>) => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('playground-layout', JSON.stringify(layout));
+    }
+  };
+
+  const savedLayout = getDefaultLayout();
+
   return (
     <div className="playground-container">
-      <div className="editor-panel">
-        <Editor
-          ref={editorRef}
-          onChange={() => scheduleRunLint()}
-          onSelectionChange={(start, end) =>
-            setSelectedAstRange({ start, end })
-          }
-        />
-      </div>
-      <ResultPanel
-        initialized={initialized}
-        diagnostics={diagnostics}
-        ast={ast}
-        astTree={astTree}
-        tsAstTree={tsAstTree}
-        error={error}
-        loading={loading}
-        onAstNodeSelect={(start, end) =>
-          editorRef.current?.revealRangeByOffset(start, end)
-        }
-        selectedAstNodeRange={selectedAstRange}
-        onRequestTsAst={async () => {
-          tsAstActiveRef.current = true;
-          if (!tsModuleRef.current) {
-            try {
-              const mod = await import('typescript');
-              tsModuleRef.current = mod as any;
-            } catch (e) {
-              console.warn('Failed to load TypeScript module:', e);
-              return;
-            }
-          }
-          await buildTypeScriptAst(
-            lastSourceTextRef.current || editorRef.current?.getValue() || '',
-          );
-        }}
-      />
+      <ResizablePanelGroup
+        orientation="horizontal"
+        id="playground-layout"
+        defaultLayout={savedLayout}
+        onLayoutChanged={handleLayoutChanged}
+      >
+        <ResizablePanel id="editor" defaultSize={savedLayout?.editor ?? 60} minSize={30}>
+          <div className="editor-panel h-full">
+            <EditorTabs
+              ref={editorTabsRef}
+              defaultRslintConfig={DEFAULT_RSLINT_CONFIG}
+              defaultTsconfig={DEFAULT_TSCONFIG}
+              onCodeChange={setCode}
+              onSelectionChange={(start, end) => handleAstNodeSelect(start, end)}
+              onRslintConfigChange={setRslintConfig}
+              onTsconfigChange={setTsconfigContent}
+            />
+          </div>
+        </ResizablePanel>
+        <ResizableHandle withHandle />
+        <ResizablePanel id="result" defaultSize={savedLayout?.result ?? 40} minSize={20}>
+          <ResultPanel
+            initialized={initialized}
+            diagnostics={diagnostics}
+            ast={ast}
+            astTree={astTree}
+            tsAstTree={tsAstTree}
+            error={error}
+            loading={loading}
+            onAstNodeSelect={(start, end) => {
+              editorTabsRef.current?.getEditorRef()?.revealRangeByOffset(start, end);
+              handleAstNodeSelect(start, end);
+            }}
+            selectedAstNodeRange={selectedAstRange}
+            selectedNodeDetail={selectedNodeDetail}
+            onRequestTsAst={async () => {
+              tsAstActiveRef.current = true;
+              if (!tsModuleRef.current) {
+                try {
+                  const mod = await import('typescript');
+                  tsModuleRef.current = mod as any;
+                } catch (e) {
+                  console.warn('Failed to load TypeScript module:', e);
+                  return;
+                }
+              }
+              await buildTypeScriptAst(
+                lastSourceTextRef.current || editorTabsRef.current?.getCodeValue() || '',
+              );
+            }}
+          />
+        </ResizablePanel>
+      </ResizablePanelGroup>
     </div>
   );
 };

--- a/website/theme/components/ui/resizable.tsx
+++ b/website/theme/components/ui/resizable.tsx
@@ -1,0 +1,44 @@
+import * as React from 'react';
+import { GripVertical } from 'lucide-react';
+import { Group, Panel, Separator } from 'react-resizable-panels';
+
+import { cn } from '@/theme/lib/utils';
+
+const ResizablePanelGroup = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof Group>) => (
+  <Group
+    className={cn(
+      'flex h-full w-full data-[panel-group-direction=vertical]:flex-col',
+      className,
+    )}
+    {...props}
+  />
+);
+
+const ResizablePanel = Panel;
+
+const ResizableHandle = ({
+  withHandle,
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator> & {
+  withHandle?: boolean;
+}) => (
+  <Separator
+    className={cn(
+      'relative flex w-px items-center justify-center bg-border after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90',
+      className,
+    )}
+    {...props}
+  >
+    {withHandle && (
+      <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border bg-border">
+        <GripVertical className="h-2.5 w-2.5" />
+      </div>
+    )}
+  </Separator>
+);
+
+export { ResizablePanelGroup, ResizablePanel, ResizableHandle };


### PR DESCRIPTION
## Summary

This PR introduces a TypeChecker lazy loading API for rslint and integrates real-time type information display in the Playground.

Changes:
  - Go Backend (`internal/api/`)
    - Add typechecker.go: Implements TypeChecker struct with on-demand querying for node Type, Symbol, Signature, and FlowNode information
    - Extend IPC protocol with 5 new checker-related message kinds (`checker.getNodeType`, `checker.getNodeSymbol`, `checker.getNodeSignature`, `checker.getNodeFlowNode`, `checker.getNodeInfo`)
    - Support recursive collection of related types and symbols with cycle detection
  - JS/TS SDK (packages/rslint/)
    - Add `checker-types.ts`: Define TypeScript interfaces for TypeDetails, SymbolDetails, SignatureDetails, FlowNodeDetails, etc.
    - Add `remote-typechecker.ts`: Implement RemoteTypeChecker class that proxies calls to Go backend via IPC
  - Website Playground (`website/`)
    - Add NodeDetailPanel: Display detailed type information for selected AST nodes
    - Add ObjectTree: Tree view component for visualizing complex object structures
    - Add EditorTabs and JsonEditor: Support multi-tab editor with config editing
    - Add resizable component: Draggable panel resizing
    - Integrate TypeChecker: Fetch and display type information when clicking AST nodes

Snapshot:
<img width="2402" height="1368" alt="image" src="https://github.com/user-attachments/assets/90c250e2-4b3f-4833-b846-d94865429847" />

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [ ] Tests updated (or not required).
- [ ] Documentation updated (or not required).
