### PR TITLE
chore: add port rule skill for ai agent

### DIFF
--- a/agents/AST_PATTERNS.md
+++ b/agents/AST_PATTERNS.md
@@ -1,0 +1,373 @@
+# Rslint AST Patterns Guide
+
+This document provides patterns and examples for working with the AST (Abstract Syntax Tree) when implementing lint rules.
+
+> **Note**: This is a reference document for [PORT_RULE.md](./PORT_RULE.md). See that document for the complete rule porting workflow.
+
+---
+
+## Message Builder Pattern
+
+Define message builders as functions for reusability and clarity:
+
+```go
+// Define all messages at package level
+func messageNoDebugger() rule.RuleMessage {
+    return rule.RuleMessage{
+        Id:          "no-debugger",
+        Description: "Unexpected 'debugger' statement.",
+    }
+}
+
+func messageWithData(name string) rule.RuleMessage {
+    return rule.RuleMessage{
+        Id:          "unexpected",
+        Description: fmt.Sprintf("Unexpected use of '%s'.", name),
+    }
+}
+
+// Use in listener
+ctx.ReportNode(node, messageNoDebugger())
+```
+
+---
+
+## Listener Types
+
+Besides basic `ast.Kind*` listeners, there are special listener types defined in `internal/rule/rule.go`:
+
+### Basic Listener
+
+Triggers when **entering** a node:
+
+```go
+rule.RuleListeners{
+    ast.KindFunctionDeclaration: func(node *ast.Node) {
+        // Executes when entering a function declaration node
+    },
+}
+```
+
+### Exit Listener
+
+Triggers when **exiting** a node (after all children have been processed):
+
+```go
+rule.RuleListeners{
+    rule.ListenerOnExit(ast.KindFunctionDeclaration): func(node *ast.Node) {
+        // Executes when exiting a function declaration node
+        // Useful when you need to collect child node info before reporting
+    },
+}
+```
+
+**Use Case**: When you need to traverse all child nodes first, then make a decision based on collected information.
+
+### Pattern Listeners
+
+For allow/deny pattern matching. **Note**: These require a `kind` argument:
+
+```go
+rule.RuleListeners{
+    // Triggers when allow pattern matches for the specified node kind
+    rule.ListenerOnAllowPattern(ast.KindCallExpression): func(node *ast.Node) {
+        // Handle allowed pattern
+    },
+
+    // Triggers when allow pattern does NOT match for the specified node kind
+    rule.ListenerOnNotAllowPattern(ast.KindCallExpression): func(node *ast.Node) {
+        // Handle non-allowed pattern
+    },
+}
+```
+
+**Use Case**: When the rule involves allow/deny list matching.
+
+---
+
+## AST Traversal Patterns
+
+### 1. ForEachChild - Iterate Direct Children
+
+```go
+node.ForEachChild(func(child *ast.Node) bool {
+    if child.Kind == ast.KindIdentifier {
+        id := child.AsIdentifier()
+        fmt.Println(id.Text())
+    }
+    return false // false = continue, true = stop
+})
+```
+
+### 2. Parent Chain - Find Specific Parent
+
+```go
+func findParentOfKind(node *ast.Node, kind ast.Kind) *ast.Node {
+    current := node.Parent
+    for current != nil {
+        if current.Kind == kind {
+            return current
+        }
+        current = current.Parent
+    }
+    return nil
+}
+
+// Example: Find the containing function
+func findContainingFunction(node *ast.Node) *ast.Node {
+    current := node.Parent
+    for current != nil {
+        switch current.Kind {
+        case ast.KindFunctionDeclaration,
+             ast.KindFunctionExpression,
+             ast.KindArrowFunction,
+             ast.KindMethodDeclaration:
+            return current
+        }
+        current = current.Parent
+    }
+    return nil
+}
+```
+
+### 3. NodeList Iteration
+
+```go
+// Iterate over function arguments
+callExpr := node.AsCallExpression()
+if args := callExpr.Arguments; args != nil {
+    for _, arg := range args.Nodes {
+        // Process each argument
+        processArgument(arg)
+    }
+}
+
+// Iterate over statement block
+block := node.AsBlock()
+for _, stmt := range block.Statements {
+    // Process each statement
+}
+```
+
+### 4. Type Casting and Checking
+
+```go
+// Safe type casting pattern
+if node.Kind == ast.KindCallExpression {
+    callExpr := node.AsCallExpression()
+    if callExpr != nil {
+        // Check if it's a specific function call
+        if callExpr.Expression.Kind == ast.KindIdentifier {
+            id := callExpr.Expression.AsIdentifier()
+            if id.Text() == "eval" {
+                // Handle eval call
+            }
+        }
+    }
+}
+
+// Handle PropertyAccessExpression (e.g., console.log)
+if node.Kind == ast.KindPropertyAccessExpression {
+    propAccess := node.AsPropertyAccessExpression()
+    objectName := ""
+    propertyName := propAccess.Name.Text()
+
+    if propAccess.Expression.Kind == ast.KindIdentifier {
+        objectName = propAccess.Expression.AsIdentifier().Text()
+    }
+    // objectName = "console", propertyName = "log"
+}
+```
+
+---
+
+## Using TypeChecker
+
+For rules that need type information, access `TypeChecker` via `RuleContext`:
+
+```go
+Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+    return rule.RuleListeners{
+        ast.KindCallExpression: func(node *ast.Node) {
+            if ctx.TypeChecker == nil {
+                return // TypeChecker may not be available
+            }
+
+            // Get the type of an expression
+            callExpr := node.AsCallExpression()
+            exprType := ctx.TypeChecker.GetTypeAtLocation(callExpr.Expression)
+
+            // Check if it's a Promise type
+            if exprType != nil {
+                typeStr := ctx.TypeChecker.TypeToString(exprType)
+                // Use type information for analysis
+            }
+        },
+    }
+}
+```
+
+### Common TypeChecker Methods
+
+See `typescript-go/_packages/api/src/api.ts` for full API:
+
+| Method                            | Description              |
+| --------------------------------- | ------------------------ |
+| `GetTypeAtLocation(node)`         | Get the type of a node   |
+| `GetSymbolAtLocation(node)`       | Get the symbol of a node |
+| `TypeToString(type)`              | Convert type to string   |
+| `GetSignaturesOfType(type, kind)` | Get function signatures  |
+
+---
+
+## Complex Rule Patterns
+
+### Control Flow Analysis
+
+Reference: `internal/rules/constructor_super/constructor_super.go`
+
+For rules that need to track state across multiple code paths (if/else, switch, try/catch):
+
+```go
+// Track super() calls across code paths
+type CodePath struct {
+    hasSuper    bool
+    isReachable bool
+}
+
+func analyzeCodePaths(node *ast.Node) []CodePath {
+    // Analyze if/else, switch, try/catch branches
+    // Ensure all paths call super()
+}
+```
+
+### Function Return Value Analysis
+
+Reference: `internal/rules/array_callback_return/array_callback_return.go`
+
+For rules that check if functions return values:
+
+```go
+// Check if a callback function has a return value
+func checkCallbackReturn(funcNode *ast.Node) bool {
+    hasReturn := false
+    funcNode.ForEachChild(func(child *ast.Node) bool {
+        if child.Kind == ast.KindReturnStatement {
+            ret := child.AsReturnStatement()
+            if ret.Expression != nil {
+                hasReturn = true
+                return true // Stop traversal
+            }
+        }
+        return false // Continue traversal
+    })
+    return hasReturn
+}
+```
+
+### Type Annotation Checking
+
+Reference: `internal/plugins/typescript/rules/no_explicit_any/no_explicit_any.go`
+
+For rules that check type annotations:
+
+```go
+// Check if a type annotation is any
+func isAnyType(node *ast.Node) bool {
+    if node.Kind == ast.KindAnyKeyword {
+        return true
+    }
+    // Handle type references: type Foo = any
+    if node.Kind == ast.KindTypeReference {
+        typeRef := node.AsTypeReferenceNode()
+        if typeRef.TypeName.Kind == ast.KindIdentifier {
+            return typeRef.TypeName.AsIdentifier().Text() == "any"
+        }
+    }
+    return false
+}
+```
+
+---
+
+## Reporting Functions
+
+`RuleContext` provides multiple reporting methods (defined in `internal/rule/rule.go`):
+
+### Basic Report
+
+```go
+ctx.ReportNode(node, rule.RuleMessage{
+    Id:          "messageId",
+    Description: "Error description",
+})
+```
+
+### Report with Text Range
+
+```go
+ctx.ReportRange(core.TextRange{Pos: start, End: end}, rule.RuleMessage{...})
+```
+
+### Report with Autofix
+
+```go
+ctx.ReportNodeWithFixes(node, rule.RuleMessage{...},
+    rule.RuleFix{
+        Range: core.TextRange{Pos: start, End: end},
+        Text:  "replacement text",  // Note: field is "Text", not "NewText"
+    },
+)
+```
+
+### Report with Suggestions
+
+Suggestions are optional fixes that users can choose to apply:
+
+```go
+ctx.ReportNodeWithSuggestions(node, rule.RuleMessage{...},
+    rule.RuleSuggestion{
+        Message: rule.RuleMessage{
+            Id:          "suggestRemove",
+            Description: "Remove this statement",
+        },
+        FixesArr: []rule.RuleFix{  // Note: field is "FixesArr", not "Fixes"
+            {Range: core.TextRange{...}, Text: ""},
+        },
+    },
+)
+```
+
+---
+
+## Fix Helper Functions
+
+Defined in `internal/rule/rule.go`:
+
+```go
+// Insert text before node (requires SourceFile)
+rule.RuleFixInsertBefore(ctx.SourceFile, node, "text to insert")
+
+// Insert text after node
+rule.RuleFixInsertAfter(node, "text to insert")
+
+// Replace node text (requires SourceFile)
+rule.RuleFixReplace(ctx.SourceFile, node, "replacement text")
+
+// Replace a specific range
+rule.RuleFixReplaceRange(textRange, "replacement text")
+
+// Remove node (requires SourceFile)
+rule.RuleFixRemove(ctx.SourceFile, node)
+
+// Remove a specific range
+rule.RuleFixRemoveRange(textRange)
+```
+
+---
+
+## See Also
+
+- [PORT_RULE.md](./PORT_RULE.md) - Main rule porting workflow
+- [UTILS_REFERENCE.md](./UTILS_REFERENCE.md) - Utility functions reference
+- [QUICK_REFERENCE.md](./QUICK_REFERENCE.md) - Commands and checklist

--- a/agents/QUICK_REFERENCE.md
+++ b/agents/QUICK_REFERENCE.md
@@ -1,0 +1,109 @@
+# Rslint Quick Reference Card
+
+A quick reference for common commands, file locations, and checklists when porting ESLint rules.
+
+> **Note**: This is a reference document for [PORT_RULE.md](./PORT_RULE.md). See that document for the complete rule porting workflow.
+
+---
+
+## Commands Cheatsheet
+
+| Task          | Command                                                                           |
+| ------------- | --------------------------------------------------------------------------------- |
+| Create branch | `git checkout -b feat/port-rule-<name>-$(date +%Y%m%d)`                           |
+| Go unit test  | `go test -count=1 ./internal/rules/<rule_name>`                                   |
+| Go full test  | `go test -count=1 ./internal/rules/...`                                           |
+| Build binary  | `cd packages/rslint && pnpm run build:bin`                                        |
+| JS unit test  | `cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>` |
+| Type check    | `pnpm typecheck`                                                                  |
+| Lint check    | `pnpm lint`                                                                       |
+
+---
+
+## File Locations
+
+| File Type         | Core Rules                                                     | Plugin Rules                                                     |
+| ----------------- | -------------------------------------------------------------- | ---------------------------------------------------------------- |
+| Go implementation | `internal/rules/<name>/`                                       | `internal/plugins/<plugin>/rules/<name>/`                        |
+| Go tests          | `internal/rules/<name>/<name>_test.go`                         | `internal/plugins/<plugin>/rules/<name>/<name>_test.go`          |
+| Documentation     | `internal/rules/<name>/<name>.md`                              | `internal/plugins/<plugin>/rules/<name>/<name>.md`               |
+| JS tests          | `packages/rslint-test-tools/tests/eslint/rules/<name>.test.ts` | `packages/rslint-test-tools/tests/<plugin>/rules/<name>.test.ts` |
+
+---
+
+## Rule Registration
+
+Location: `internal/config/config.go`
+
+| Rule Type            | Registration Function                      | Name Format                            |
+| -------------------- | ------------------------------------------ | -------------------------------------- |
+| ESLint Core          | `registerAllCoreEslintRules()`             | `"no-debugger"`                        |
+| @typescript-eslint   | `registerAllTypeScriptEslintPluginRules()` | `"@typescript-eslint/no-explicit-any"` |
+| eslint-plugin-import | `registerAllEslintImportPluginRules()`     | `"import/no-self-import"`              |
+
+**Registration Format**:
+
+```go
+GlobalRuleRegistry.Register("rule-name", package.RuleNameRule)
+```
+
+---
+
+## Naming Conventions
+
+| Item                          | Convention                     | Example                                                      |
+| ----------------------------- | ------------------------------ | ------------------------------------------------------------ |
+| Go directory name             | snake_case                     | `no_empty_interface/`                                        |
+| Go file name                  | snake_case                     | `no_empty_interface.go`                                      |
+| Go variable name (Rule)       | PascalCase + Rule suffix       | `NoEmptyInterfaceRule`                                       |
+| Rule name (ESLint Core)       | kebab-case                     | `"no-debugger"`                                              |
+| Rule name (typescript-eslint) | kebab-case (auto-prefixed)     | `"no-explicit-any"` → `"@typescript-eslint/no-explicit-any"` |
+| Rule name (import)            | kebab-case (manually prefixed) | `"import/no-self-import"`                                    |
+| JS test file name             | kebab-case                     | `no-empty-interface.test.ts`                                 |
+| MessageId                     | camelCase                      | `"unexpectedAny"`, `"missingSuper"`                          |
+
+---
+
+## Go Module Imports
+
+```go
+import (
+    // Core rule interface
+    "github.com/web-infra-dev/rslint/internal/rule"
+
+    // AST and type system (from typescript-go submodule)
+    "github.com/microsoft/typescript-go/shim/ast"
+    "github.com/microsoft/typescript-go/shim/checker"
+    "github.com/microsoft/typescript-go/shim/core"
+
+    // Utility functions
+    "github.com/web-infra-dev/rslint/internal/utils"
+
+    // Test framework
+    "github.com/web-infra-dev/rslint/internal/rule_tester"
+
+    // Fixtures (test files only)
+    "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+)
+```
+
+---
+
+## Checklist Before Submission
+
+- [ ] Go tests pass (`go test -count=1 ./internal/rules/<name>`)
+- [ ] Build binary (`cd packages/rslint && pnpm run build:bin`)
+- [ ] JS tests pass (`cd packages/rslint-test-tools && npx rstest run <name>`)
+- [ ] Type check passes (`pnpm typecheck`)
+- [ ] Lint check passes (`pnpm lint`)
+- [ ] Rule registered (`internal/config/config.go`)
+- [ ] Test file registered (`packages/rslint-test-tools/rstest.config.mts`)
+- [ ] Documentation created (`<rule_name>.md`)
+
+---
+
+## See Also
+
+- [PORT_RULE.md](./PORT_RULE.md) - Main rule porting workflow
+- [UTILS_REFERENCE.md](./UTILS_REFERENCE.md) - Utility functions reference
+- [AST_PATTERNS.md](./AST_PATTERNS.md) - AST traversal patterns and examples

--- a/agents/UTILS_REFERENCE.md
+++ b/agents/UTILS_REFERENCE.md
@@ -1,0 +1,362 @@
+# Rslint Utility Functions Reference
+
+This document provides a comprehensive reference for utility functions available in `internal/utils/`. These utilities are commonly used when implementing lint rules.
+
+> **Note**: This is a reference document for [PORT_RULE.md](./PORT_RULE.md). See that document for the complete rule porting workflow.
+
+---
+
+## Overview
+
+| File                        | Description                                          |
+| --------------------------- | ---------------------------------------------------- |
+| `utils.go`                  | Basic utilities (text range, comments, collections)  |
+| `ts_api_utils.go`           | TypeScript API utilities (type checking, signatures) |
+| `ts_eslint.go`              | TypeScript-ESLint compatibility utilities            |
+| `builtin_symbol_likes.go`   | Builtin symbol checking (Promise, Error, etc.)       |
+| `type_matches_specifier.go` | Type specifier matching for rule options             |
+| `set.go`                    | Generic Set data structure                           |
+
+---
+
+## `internal/utils/utils.go` - Basic Utilities
+
+```go
+import "github.com/web-infra-dev/rslint/internal/utils"
+```
+
+### Text Range & Comments
+
+```go
+// Get trimmed text range of a node (removes leading/trailing whitespace)
+trimmedRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+
+// Get all comments in a range (returns iterator)
+for comment := range utils.GetCommentsInRange(ctx.SourceFile, textRange) {
+    // comment is ast.CommentRange
+}
+
+// Check if there are comments in a range
+hasComments := utils.HasCommentsInRange(ctx.SourceFile, textRange)
+```
+
+### Type Recursion
+
+```go
+// Recursively check each part of union/intersection types
+utils.TypeRecurser(t, func(subType *checker.Type) bool {
+    // Return true to stop recursion, false to continue
+    return false
+})
+```
+
+### AST Helpers
+
+```go
+// Get heritage clauses of a class/interface
+heritageClauses := utils.GetHeritageClauses(classNode) // *ast.NodeList
+
+// Check if a node has a specific modifier (e.g., async, static, public)
+isAsync := utils.IncludesModifier(funcNode, ast.KindAsyncKeyword)
+```
+
+### Collection Operations (Generic)
+
+```go
+// Filter, Map, Some, Every, Flatten - Similar to JS array methods
+filtered := utils.Filter(items, func(item T) bool { return condition })
+mapped := utils.Map(items, func(item T) U { return transform(item) })
+hasAny := utils.Some(items, func(item T) bool { return condition })
+allMatch := utils.Every(items, func(item T) bool { return condition })
+```
+
+### Other Utilities
+
+```go
+// Create a pointer (useful for optional fields)
+ptr := utils.Ref(value) // *T
+
+// Check if a character is a JS whitespace character
+isWhite := utils.IsStrWhiteSpace(r)
+```
+
+---
+
+## `internal/utils/ts_api_utils.go` - TypeScript API Utilities
+
+### Type Flag Checking
+
+```go
+// Check type flags
+utils.IsTypeFlagSet(t, checker.TypeFlagsString)  // Check any TypeFlags
+utils.IsUnionType(t)           // Is union type
+utils.IsIntersectionType(t)    // Is intersection type
+utils.IsTypeAnyType(t)         // Is any type
+utils.IsTypeUnknownType(t)     // Is unknown type
+utils.IsObjectType(t)          // Is object type
+utils.IsTypeParameter(t)       // Is type parameter
+utils.IsIntrinsicType(t)       // Is intrinsic type
+utils.IsIntrinsicErrorType(t)  // Is error type
+utils.IsIntrinsicVoidType(t)   // Is void type
+
+// Boolean literal types
+utils.IsBooleanLiteralType(t)
+utils.IsTrueLiteralType(t)
+utils.IsFalseLiteralType(t)
+```
+
+### Union/Intersection Type Splitting
+
+```go
+// Get all parts of a union type
+parts := utils.UnionTypeParts(t)       // []*checker.Type
+parts := utils.IntersectionTypeParts(t)
+```
+
+### Function Signatures
+
+```go
+// Get call signatures
+sigs := utils.GetCallSignatures(typeChecker, t)
+sigs := utils.GetConstructSignatures(typeChecker, t)
+sigs := utils.CollectAllCallSignatures(typeChecker, t) // Including union types
+```
+
+### Symbol Checking
+
+```go
+utils.IsSymbolFlagSet(symbol, ast.SymbolFlagsFunction)
+```
+
+### Promise/Callback Checking
+
+```go
+// Check if a parameter is a callback function
+isCallback := utils.IsCallback(typeChecker, paramSymbol, node)
+
+// Check if a type is thenable (has .then method)
+isThen := utils.IsThenableType(typeChecker, node, t)
+```
+
+### Token and Comment Iteration
+
+```go
+// Iterate over all tokens of a node
+utils.ForEachToken(node, func(token *ast.Node) {
+    // Process each token
+}, ctx.SourceFile)
+
+// Iterate over all comments of a node
+utils.ForEachComment(node, func(comment *ast.CommentRange) {
+    // Process each comment
+}, ctx.SourceFile)
+
+// Get all children of a node (including tokens)
+children := utils.GetChildren(node, ctx.SourceFile)
+```
+
+### Compiler Options
+
+```go
+// Check strict mode options
+isEnabled := utils.IsStrictCompilerOptionEnabled(options, options.NoImplicitAny)
+```
+
+---
+
+## `internal/utils/ts_eslint.go` - TypeScript-ESLint Compatibility
+
+### Constraint Types
+
+```go
+// Get constraint info (handles generics)
+constraintType, isTypeParameter := utils.GetConstraintInfo(typeChecker, t)
+
+// Get constrained type at location
+constrainedType := utils.GetConstrainedTypeAtLocation(typeChecker, node)
+```
+
+### Await Checking
+
+```go
+// Check if a type needs to be awaited
+awaitable := utils.NeedsToBeAwaited(typeChecker, node, t)
+// Returns: TypeAwaitableAlways | TypeAwaitableNever | TypeAwaitableMay
+```
+
+### Type Names
+
+```go
+// Get string name of a type
+typeName := utils.GetTypeName(typeChecker, t)
+```
+
+### Array Method Checking
+
+```go
+// Check if it's an array method call with predicate (every, filter, find, etc.)
+isArrayMethod := utils.IsArrayMethodCallWithPredicate(typeChecker, callExpr)
+```
+
+### Declaration Retrieval
+
+```go
+// Get the declaration of a variable
+decl := utils.GetDeclaration(typeChecker, node)
+
+// Check if it's a rest parameter declaration
+isRest := utils.IsRestParameterDeclaration(decl)
+```
+
+### Any Type Checking
+
+```go
+// Check if type is any[]
+isAnyArray := utils.IsTypeAnyArrayType(t, typeChecker)
+
+// Check if type is unknown[]
+isUnknownArray := utils.IsTypeUnknownArrayType(t, typeChecker)
+
+// Discriminate any type
+anyType := utils.DiscriminateAnyType(t, typeChecker, program, node)
+// Returns: DiscriminatedAnyTypeAny | DiscriminatedAnyTypePromiseAny |
+//          DiscriminatedAnyTypeAnyArray | DiscriminatedAnyTypeSafe
+```
+
+### Unsafe Assignment Checking
+
+```go
+// Check for unsafe any-to-non-any assignment
+receiver, sender, unsafe := utils.IsUnsafeAssignment(t, receiverT, typeChecker, senderNode)
+```
+
+### Contextual Types
+
+```go
+// Get contextual type of a node
+contextualType := utils.GetContextualType(typeChecker, node)
+```
+
+### Other Helpers
+
+```go
+// Get this expression
+thisExpr := utils.GetThisExpression(node)
+
+// Get parent function node
+parentFunc := utils.GetParentFunctionNode(node)
+
+// Get for statement head location (for reporting)
+headLoc := utils.GetForStatementHeadLoc(ctx.SourceFile, forNode)
+
+// Check if expression precedence is higher than await
+isHigher := utils.IsHigherPrecedenceThanAwait(node)
+
+// Check if it's a strong precedence node (no parentheses needed)
+isStrong := utils.IsStrongPrecedenceNode(innerNode)
+
+// Check if it's a parenthesis-less arrow function
+isParenless := utils.IsParenlessArrowFunction(node)
+
+// Get member name
+name, nameType := utils.GetNameFromMember(ctx.SourceFile, member)
+// nameType: MemberNameTypePrivate | MemberNameTypeQuoted | MemberNameTypeNormal | MemberNameTypeExpression
+```
+
+### Enum Types
+
+```go
+// Get enum literals
+enumLiterals := utils.GetEnumLiterals(t)
+
+// Get enum types
+enumTypes := utils.GetEnumTypes(typeChecker, t)
+```
+
+---
+
+## `internal/utils/builtin_symbol_likes.go` - Builtin Symbol Checking
+
+### Builtin Type Checking
+
+```go
+// Check if it's a Promise type (including derived classes)
+isPromise := utils.IsPromiseLike(program, typeChecker, t)
+
+// Check if it's a PromiseConstructor type
+isPromiseCtor := utils.IsPromiseConstructorLike(program, typeChecker, t)
+
+// Check if it's an Error type (including derived classes)
+isError := utils.IsErrorLike(program, typeChecker, t)
+
+// Check if it's a Readonly<Error> type
+isReadonlyError := utils.IsReadonlyErrorLike(program, typeChecker, t)
+
+// Check if it's a Readonly<T> type
+isReadonly := utils.IsReadonlyTypeLike(program, typeChecker, t, predicate)
+```
+
+### Generic Builtin Symbol Checking
+
+```go
+// Check if it's a builtin symbol with specified names
+isBuiltin := utils.IsBuiltinSymbolLike(program, typeChecker, t, "Promise", "Error")
+
+// Check if it's any builtin symbol
+isAnyBuiltin := utils.IsAnyBuiltinSymbolLike(program, typeChecker, t)
+
+// Check if a symbol is from the default library
+isFromLib := utils.IsSymbolFromDefaultLibrary(program, symbol)
+
+// Check if a source file is the default library
+isLibFile := utils.IsSourceFileDefaultLibrary(program, sourceFile)
+```
+
+---
+
+## `internal/utils/type_matches_specifier.go` - Type Specifier Matching
+
+Used for specifying type sources in rule options (e.g., allowing certain types from specific packages).
+
+```go
+// Define type specifier
+specifier := utils.TypeOrValueSpecifier{
+    From:    utils.TypeOrValueSpecifierFromPackage, // FromFile | FromLib | FromPackage
+    Name:    utils.NameList{"SomeType"},
+    Package: "some-package", // Used when From == FromPackage
+    Path:    "./some-file",  // Used when From == FromFile
+}
+
+// Check if a type matches a specifier
+matches := utils.TypeMatchesSomeSpecifier(t, specifiers, inlineSpecifiers, program)
+
+// With callee names (for export aliases like `export { test as it }`)
+matches := utils.TypeMatchesSomeSpecifierWithCalleeNames(t, specifiers, inlineSpecifiers, program, calleeNames)
+```
+
+---
+
+## `internal/utils/set.go` - Set Data Structure
+
+Generic Set implementation for efficient membership checking.
+
+```go
+// Create a Set
+set := utils.NewSetFromItems("a", "b", "c")
+set := utils.NewSetWithSizeHint[string](100)
+
+// Set operations
+set.Add("d")
+set.Delete("a")
+exists := set.Has("b")
+length := set.Len()
+set.Clear()
+```
+
+---
+
+## See Also
+
+- [PORT_RULE.md](./PORT_RULE.md) - Main rule porting workflow
+- [AST_PATTERNS.md](./AST_PATTERNS.md) - AST traversal patterns and examples
+- [QUICK_REFERENCE.md](./QUICK_REFERENCE.md) - Commands and checklist

--- a/agents/port-rule/SKILL.md
+++ b/agents/port-rule/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: port-rule
+description: Port ESLint rules to rslint (a Go-based linter). Use when users want to port/migrate/implement an ESLint rule, add a new lint rule, or mention "port rule" or specific ESLint rule names like "no-unused-vars", "no-console", etc. This skill guides through the complete workflow from setup to PR submission.
+---
+
+# Port Rule
+
+Port ESLint rules to rslint with 1:1 behavior parity.
+
+## Prerequisites
+
+### Step 1: Get Rule Name
+
+If user didn't provide the rule name, ask for it. Accept formats:
+
+- ESLint core: `no-console`, `no-unused-vars`
+- TypeScript-ESLint: `@typescript-eslint/no-explicit-any`
+- Other plugins: `import/no-duplicates`, `react/jsx-uses-react`
+
+### Step 2: Get Rule Documentation URL
+
+If user already provided a documentation URL, skip this step.
+
+Otherwise, ask user to choose:
+
+1. **Auto search** (Recommended) - Run the search script to find documentation
+2. **Provide URL manually** - User provides the URL directly
+
+**For auto search**, run:
+
+```bash
+node agents/port-rule/scripts/search_rule.mjs <rule-name>
+```
+
+The script searches:
+
+- ESLint core rules → https://eslint.org/docs/latest/rules/
+- TypeScript-ESLint rules → https://typescript-eslint.io/rules/
+- Other plugins → GitHub repositories
+
+**After search**:
+
+- If found: Show results and ask user to confirm the URLs are correct
+- If not found: Ask user to provide the documentation URL manually
+
+## Workflow
+
+After prerequisites are complete, follow the phases in [PORT_RULE.md](references/PORT_RULE.md):
+
+1. **Phase 0: Branch Setup** - Create feature branch from main
+2. **Phase 1: Preparation** - Collect test cases and identify edge cases
+3. **Phase 2: Implementation** - Write Go rule, tests, and documentation
+4. **Phase 3: Integration** - Add JS tests and register rule
+5. **Phase 4: Verification** - Build binary and run all tests
+6. **Phase 5: Submission** - Commit and create PR
+
+## Quick Reference
+
+**Directory Structure**:
+
+- Core rules: `internal/rules/<rule_name_snake_case>/`
+- Plugin rules: `internal/plugins/<plugin_name>/rules/<rule_name_snake_case>/`
+
+**Key Commands**:
+
+```bash
+# Build binary (REQUIRED before JS tests)
+cd packages/rslint && pnpm run build:bin
+
+# Run Go tests
+go test -count=1 ./internal/rules/<rule_name>
+
+# Run JS tests
+cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>
+```
+
+## References
+
+- [PORT_RULE.md](references/PORT_RULE.md) - Complete porting guide with code templates
+- [AST_PATTERNS.md](../AST_PATTERNS.md) - AST traversal patterns
+- [UTILS_REFERENCE.md](../UTILS_REFERENCE.md) - Utility functions
+- [QUICK_REFERENCE.md](../QUICK_REFERENCE.md) - Commands cheatsheet

--- a/agents/port-rule/references/PORT_RULE.md
+++ b/agents/port-rule/references/PORT_RULE.md
@@ -1,0 +1,400 @@
+# Rslint Rule Porting Guide for AI Agents
+
+## Role & Objective
+
+You are an expert Software Engineer tasked with porting ESLint rules to `rslint`, a high-performance linter written in Go. Your goal is to implement the rule logic in Go, ensuring 1:1 parity with the original ESLint behavior, including all edge cases and error messages.
+
+---
+
+## Related Documents
+
+| Document                                       | Description                                                         |
+| ---------------------------------------------- | ------------------------------------------------------------------- |
+| [AST_PATTERNS.md](../../AST_PATTERNS.md)       | AST traversal patterns, listeners, TypeChecker, reporting functions |
+| [UTILS_REFERENCE.md](../../UTILS_REFERENCE.md) | Utility functions in `internal/utils/`                              |
+| [QUICK_REFERENCE.md](../../QUICK_REFERENCE.md) | Commands cheatsheet, file locations, naming conventions, checklist  |
+
+---
+
+## Source Code Reference
+
+Before starting, familiarize yourself with these key source locations:
+
+### Core Infrastructure
+
+| File/Directory                        | Description                                                                                                              |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `internal/rule/rule.go`               | **Core rule interface** - `Rule`, `RuleContext`, `RuleListeners`, `RuleMessage`, `RuleFix`, `RuleSuggestion` definitions |
+| `internal/rule/disable_manager.go`    | Logic for handling `// eslint-disable` comments                                                                          |
+| `internal/config/config.go`           | Rule registration and config loading                                                                                     |
+| `internal/rule_tester/rule_tester.go` | Go test framework - `RunRuleTester`, `ValidTestCase`, `InvalidTestCase`                                                  |
+
+### AST & Type System
+
+| File/Directory                                        | Description                                                          |
+| ----------------------------------------------------- | -------------------------------------------------------------------- |
+| `typescript-go/_packages/ast/src/nodes.ts`            | **AST node type definitions** - All JS/TS syntax nodes               |
+| `typescript-go/_packages/ast/src/syntaxKind.enum.ts`  | **SyntaxKind enum** - Node type constants (maps to Go's `ast.Kind*`) |
+| `typescript-go/_packages/api/src/typeFlags.enum.ts`   | **TypeFlags enum** - Type checking flags                             |
+| `typescript-go/_packages/api/src/symbolFlags.enum.ts` | **SymbolFlags enum** - Symbol flags                                  |
+| `shim/ast/shim.go`                                    | Go-side AST shim implementation (auto-generated)                     |
+
+### Example Rules (Recommended Reading)
+
+| Rule                    | Path                                                 | Highlights                              |
+| ----------------------- | ---------------------------------------------------- | --------------------------------------- |
+| `no-debugger`           | `internal/rules/no_debugger/`                        | Simplest rule example                   |
+| `constructor-super`     | `internal/rules/constructor_super/`                  | Complex control flow analysis           |
+| `array-callback-return` | `internal/rules/array_callback_return/`              | Options parsing, function body analysis |
+| `no-explicit-any`       | `internal/plugins/typescript/rules/no_explicit_any/` | TypeScript rule, Fix suggestions        |
+
+---
+
+## Workflow Overview
+
+1. **Setup**: Create and switch to a new branch from main.
+2. **Preparation**: Gather requirements and test cases.
+3. **Implementation**: Write Go code and unit tests.
+4. **Integration**: Add JS tests and register the rule.
+5. **Verification**: Build and verify everything works.
+
+---
+
+## Phase 0: Branch Setup
+
+**Goal**: Start from a clean state.
+
+1. **Checkout Main**: Ensure your workspace is on the latest `main` branch code.
+
+   ```bash
+   git checkout main && git pull origin main
+   ```
+
+2. **Create Branch**: Create a new feature branch for the rule.
+   - **Naming Convention**: `feat/port-rule-<rule_name_snake_case>-<YYYYMMDD>`
+   ```bash
+   git checkout -b feat/port-rule-<rule_name_snake_case>-$(date +%Y%m%d)
+   ```
+
+---
+
+## Phase 1: Preparation (CRITICAL)
+
+**Goal**: Understand _exactly_ what the rule does before writing code.
+
+1. **Locate Official Source**:
+   - **Priority**: If the user provides an official link, **FIRST** read and analyze that link's content.
+   - **Fallback**: If no link is provided, search for the rule documentation (ESLint website or Plugin repo) and source code (GitHub).
+   - Find the rule test file (usually `tests/lib/rules/<rule>.js`).
+
+2. **Collect Test Cases**:
+   - Extract **ALL** `valid` and `invalid` cases from the official documentation.
+   - Extract representative cases from the official unit tests, covering all branches of logic.
+   - **Add Boundary Cases**: Add sufficient boundary cases (e.g., empty files, nested structures, edge cases in syntax).
+   - **Ensure Coverage**: Ensure Line and Column numbers are tested in invalid cases.
+
+3. **Identify Edge Cases**:
+   - Does the rule handle comments?
+   - Does it handle Optional Chaining (`?.`)?
+   - Does it handle TypeScript-specific syntax (if applicable)?
+   - Does it handle empty bodies or malformed code?
+
+---
+
+## Phase 2: Implementation (Go)
+
+### Step 1: Directory Setup
+
+- **Core Rules**: `internal/rules/<rule_name_snake_case>/`
+- **Plugin Rules**: `internal/plugins/<plugin_name>/rules/<rule_name_snake_case>/`
+
+**Action**: Create the directory and three files:
+
+1. `<rule_name>.go` (Implementation)
+2. `<rule_name>_test.go` (Tests)
+3. `<rule_name>.md` (Documentation)
+
+### Step 2: Write Rule Logic
+
+**File**: `<rule_name>.go`
+
+**Prerequisites**:
+
+- Read `internal/rule/rule.go` to understand core definitions
+- Reference existing rules for the standard implementation pattern
+- Review AST node types in `shim/ast/shim.go`
+- See [AST_PATTERNS.md](../../AST_PATTERNS.md) for traversal patterns and examples
+
+**Rule Interface**:
+
+```go
+// For typescript-eslint rules (auto-prefixes with @typescript-eslint/):
+var MyRuleRule = rule.CreateRule(rule.Rule{
+    Name: "my-rule",
+    Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+        return rule.RuleListeners{
+            ast.KindSomeNode: func(node *ast.Node) {
+                // Check conditions and report
+            },
+        }
+    },
+})
+
+// For ESLint Core rules:
+var MyCoreRule = rule.Rule{
+    Name: "my-core-rule",
+    Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+        // ...
+    },
+}
+```
+
+**Key Points**:
+
+- `RuleListeners` is a map from `ast.Kind` to a callback function
+- Each callback receives a `*ast.Node` and reports diagnostics via `ctx.ReportNode()`
+- Options parsing happens inside the `Run` function before returning listeners
+- Use `rule.CreateRule` **ONLY** for `@typescript-eslint` rules (it adds the prefix)
+
+**AST Shim API Warning**: In `github.com/microsoft/typescript-go/shim/ast`:
+
+- **General Nodes** (`*ast.Node`): Use methods (e.g., `node.Kind()`, `node.Text()`)
+- **Concrete Nodes** (e.g., `*ast.Identifier`): Use fields (e.g., `id.Text`)
+- Do not assume; check the shim source code to confirm.
+
+### Handling Options
+
+ESLint options are weakly typed (JSON). You **MUST** handle both Go and JS test formats:
+
+```go
+func parseOptions(options any) Options {
+    opts := Options{/* defaults */}
+    if options == nil {
+        return opts
+    }
+
+    var optsMap map[string]interface{}
+    // Handle array format (JS tests pass []interface{})
+    if arr, ok := options.([]interface{}); ok && len(arr) > 0 {
+        optsMap, _ = arr[0].(map[string]interface{})
+    } else {
+        // Handle object format (Go tests pass map[string]interface{})
+        optsMap, _ = options.(map[string]interface{})
+    }
+
+    if optsMap != nil {
+        // Parse options from optsMap...
+    }
+    return opts
+}
+```
+
+### Step 3: Write Documentation
+
+**File**: `<rule_name>.md`
+
+**Template**:
+
+````markdown
+# <rule-name>
+
+## Rule Details
+
+[Description of the rule]
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+// Example
+var x = { a: 1, a: 2 };
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// Example
+var x = { a: 1, b: 2 };
+```
+
+## Original Documentation
+
+[Link to ESLint documentation]
+````
+
+### Step 4: Write Go Tests
+
+**File**: `<rule_name>_test.go`
+
+- Use `rule_tester.RunRuleTester`
+- Invalid cases **MUST** include `Line` and `Column` assertions
+- Use `map[string]interface{}` to pass options in Go tests
+- Ensure `tsconfig.json` path uses `fixtures.GetRootDir()`
+
+**Debug Flags**:
+
+```go
+rule_tester.ValidTestCase{
+    Code: `some code`,
+    Only: true,  // Run only this test
+}
+
+rule_tester.InvalidTestCase{
+    Code: `some code`,
+    Skip: true,  // Skip this test
+    Errors: []rule_tester.InvalidTestCaseError{...},
+}
+```
+
+**Test Case Structs**: See `internal/rule_tester/rule_tester.go` for `ValidTestCase`, `InvalidTestCase`, and `InvalidTestCaseError` definitions.
+
+---
+
+## Phase 3: Integration (JS)
+
+### Step 5: Check & Setup Test Environment
+
+**Goal**: Ensure the test directory and necessary configuration files exist.
+
+1. **Check Directory**: Verify if `packages/rslint-test-tools/tests/<plugin-name>` exists.
+
+2. **Check Configuration**:
+   - **Reference**: Use `packages/rslint-test-tools/tests/eslint-plugin-import` as the template.
+   - **Required Files**:
+     - `rslint.json` (Configuration for the linter)
+     - `tsconfig.files.json` (TS Config for file-based tests)
+     - `tsconfig.virtual.json` (TS Config for virtual/code-based tests)
+   - **Plugin Configuration**: In `rslint.json`, set `plugins` field:
+     - **Core Rules**: `"plugins": []`
+     - **Plugin Rules**: `"plugins": ["eslint-plugin-import"]`
+   - **Warning**: When copying `rule-tester.ts`, remove any hardcoded rule prefixes (e.g., `ruleName = 'import/' + ruleName;`).
+
+### Step 6: Add JS Tests
+
+**File Locations**:
+
+- **Core Rules**: `packages/rslint-test-tools/tests/eslint/rules/<rule-name>.test.ts`
+- **Plugin Rules**: `packages/rslint-test-tools/tests/<plugin-name>/rules/<rule-name>.test.ts`
+
+**Setup RuleTester**:
+
+- **typescript-eslint Rules**: Import `RuleTester` from `@typescript-eslint/rule-tester`
+- **Other Rules**: Refer to `packages/rslint-test-tools/tests/eslint-plugin-import/rule-tester.ts`
+
+**Options Format**: JS tests use array format: `options: [{ allow: ['warn'] }]`
+
+### Step 7: Register Test File
+
+**File**: `packages/rslint-test-tools/rstest.config.mts`
+
+Add the new test file path to the `include` array.
+
+### Step 8: Register Rule in Config
+
+**File**: `internal/config/config.go`
+
+1. Import your new package
+2. Register in the appropriate function:
+   - Core rules: `registerAllCoreEslintRules()`
+   - TypeScript rules: `registerAllTypeScriptEslintPluginRules()`
+   - Import rules: `registerAllEslintImportPluginRules()`
+3. Format: `GlobalRuleRegistry.Register("rule-name", package.RuleNameRule)`
+
+---
+
+## Phase 4: Verification & Build
+
+**Goal**: Ensure the compiled binary runs the rule correctly.
+
+1. **Build Binary (REQUIRED)**:
+
+   ```bash
+   cd packages/rslint && pnpm run build:bin
+   ```
+
+2. **Run Tests**:
+
+   ```bash
+   # Go tests
+   go test -count=1 ./internal/rules/<rule_name>
+
+   # JS tests
+   cd packages/rslint-test-tools && npx rstest run --testTimeout=10000 <rule-name>
+   ```
+
+3. **Project-wide Checks**:
+   ```bash
+   pnpm typecheck && pnpm lint
+   ```
+
+---
+
+## Phase 5: Submission & PR
+
+**Goal**: Submit the new rule.
+
+1. **Configure Project Settings (Conditional)**:
+   - If the rule's plugin is already in `rslint.json` `plugins`, add the rule with `"warn"` severity
+   - Otherwise, do NOT modify `rslint.json`
+
+2. **Commit Changes**:
+
+   ```bash
+   git add <specific_files_related_to_port>
+   git commit -m "feat: port rule <rule-name>"
+   ```
+
+   - Use specific file paths with `git add` (NOT `git add .`)
+   - Ensure all tests pass before committing
+
+3. **Push & Create PR**:
+
+   ```bash
+   git push origin feat/port-rule-<rule_name_snake_case>-$(date +%Y%m%d)
+
+   gh pr create --base main --title "feat: port rule <rule-name>" --body "## Description
+   Ported the \`<rule-name>\` rule from ESLint to rslint.
+
+   ## References
+   - **Original Rule**: <link_to_eslint_doc>
+
+   ## Agent Info
+   - **Model**: <ai_model_name>"
+   ```
+
+---
+
+## Troubleshooting
+
+### "Expected diagnostics... but received false"
+
+If JS tests fail with 0 diagnostics found:
+
+1. **Did you rebuild the binary?** Run `cd packages/rslint && pnpm run build:bin`
+2. **Is the rule registered?** Check `internal/config/config.go`
+3. **Are test files included?** Check `rstest.config.mts`
+4. **Is rslint.json configured?** Ensure the rule is enabled
+5. **Debug Mode**: Use `fmt.Fprintf(os.Stderr, "DEBUG: ...")` in Go code
+
+### Line/Column Mismatch
+
+1. Check 0-based vs 1-based column expectations
+2. Multi-byte characters may affect column calculation
+3. Debug with:
+   ```go
+   pos := ctx.SourceFile.LineMap().LineAndColumn(node.Pos())
+   fmt.Fprintf(os.Stderr, "DEBUG: Line=%d, Column=%d\n", pos.Line, pos.Column)
+   ```
+
+### TypeChecker is nil
+
+1. Ensure test fixtures have correct `tsconfig.json`
+2. Use `fixtures.GetRootDir()` for correct path
+3. Check `parserOptions.project` is configured correctly
+
+---
+
+## See Also
+
+- [AST_PATTERNS.md](../../AST_PATTERNS.md) - AST traversal, listeners, reporting functions, fix helpers
+- [UTILS_REFERENCE.md](../../UTILS_REFERENCE.md) - Utility functions in `internal/utils/`
+- [QUICK_REFERENCE.md](../../QUICK_REFERENCE.md) - Commands, file locations, naming conventions, checklist

--- a/agents/port-rule/scripts/search_rule.mjs
+++ b/agents/port-rule/scripts/search_rule.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * Search for ESLint rule documentation.
+ *
+ * Usage:
+ *   node search_rule.mjs <rule-name>
+ *
+ * Examples:
+ *   node search_rule.mjs no-console
+ *   node search_rule.mjs @typescript-eslint/no-explicit-any
+ *   node search_rule.mjs import/no-duplicates
+ */
+
+/**
+ * Parse rule name to determine plugin and rule.
+ * @param {string} ruleName
+ * @returns {{plugin: string, rule: string}}
+ */
+function parseRuleName(ruleName) {
+  ruleName = ruleName.trim();
+
+  // @typescript-eslint/rule-name
+  if (ruleName.startsWith('@typescript-eslint/')) {
+    return {
+      plugin: 'typescript-eslint',
+      rule: ruleName.replace('@typescript-eslint/', ''),
+    };
+  }
+
+  // plugin/rule-name format (e.g., import/no-duplicates)
+  if (ruleName.includes('/')) {
+    const [plugin, rule] = ruleName.split('/', 2);
+    return { plugin, rule };
+  }
+
+  // Core ESLint rule
+  return { plugin: 'eslint', rule: ruleName };
+}
+
+/**
+ * Fetch URL content.
+ * @param {string} url
+ * @returns {Promise<string|null>}
+ */
+async function fetchUrl(url) {
+  try {
+    const response = await fetch(url, {
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; ESLintRuleSearch/1.0)',
+      },
+      redirect: 'follow',
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    return await response.text();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Search ESLint core rules.
+ * @param {string} ruleName
+ * @returns {Promise<object|null>}
+ */
+async function searchEslintCore(ruleName) {
+  const docUrl = `https://eslint.org/docs/latest/rules/${ruleName}`;
+  const content = await fetchUrl(docUrl);
+
+  if (!content) {
+    return null;
+  }
+
+  // Check if page contains the rule name in title
+  const titleMatch = content.match(/<title[^>]*>([^<]+)<\/title>/);
+  if (!titleMatch) {
+    return null;
+  }
+
+  const title = titleMatch[1];
+  if (
+    !title.toLowerCase().includes(ruleName) &&
+    title.includes('Page Not Found')
+  ) {
+    return null;
+  }
+
+  return {
+    found: true,
+    plugin: 'eslint',
+    rule: ruleName,
+    docUrl,
+    sourceUrl: `https://github.com/eslint/eslint/blob/main/lib/rules/${ruleName}.js`,
+    testUrl: `https://github.com/eslint/eslint/blob/main/tests/lib/rules/${ruleName}.js`,
+    title: title.replace(' - ESLint - Pluggable JavaScript Linter', '').trim(),
+  };
+}
+
+/**
+ * Search typescript-eslint rules.
+ * @param {string} ruleName
+ * @returns {Promise<object|null>}
+ */
+async function searchTypescriptEslint(ruleName) {
+  const docUrl = `https://typescript-eslint.io/rules/${ruleName}`;
+  const content = await fetchUrl(docUrl);
+
+  if (!content) {
+    return null;
+  }
+
+  // Check for valid rule page - handle <title data-rh="true"> format
+  const titleMatch = content.match(/<title[^>]*>([^<]+)<\/title>/);
+  if (!titleMatch) {
+    return null;
+  }
+
+  const title = titleMatch[1];
+  if (title.includes('Page Not Found') || title.includes('404')) {
+    return null;
+  }
+
+  return {
+    found: true,
+    plugin: 'typescript-eslint',
+    rule: ruleName,
+    docUrl,
+    sourceUrl: `https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/${ruleName}.ts`,
+    testUrl: `https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/${ruleName}.test.ts`,
+    title: title.replace(' | typescript-eslint', '').trim(),
+  };
+}
+
+/**
+ * Build result for plugin rule.
+ * @param {string} owner
+ * @param {string} repoName
+ * @param {string} pluginName
+ * @param {string} ruleName
+ * @returns {object}
+ */
+function buildPluginResult(owner, repoName, pluginName, ruleName) {
+  const baseUrl = `https://github.com/${owner}/${repoName}`;
+
+  return {
+    found: true,
+    plugin: pluginName,
+    rule: ruleName,
+    docUrl: `${baseUrl}#rules`,
+    sourceUrl: `${baseUrl}/tree/main/src/rules`,
+    repoUrl: baseUrl,
+    title: `${pluginName}/${ruleName}`,
+  };
+}
+
+/**
+ * Search for ESLint plugin on GitHub.
+ * @param {string} pluginName
+ * @param {string} ruleName
+ * @returns {Promise<object|null>}
+ */
+async function searchGithubPlugin(pluginName, ruleName) {
+  const repoPatterns = [
+    `eslint-plugin-${pluginName}`,
+    `eslint-plugin-${pluginName.replace(/-/g, '')}`,
+  ];
+
+  const commonOwners = [
+    'import-js',
+    'jsx-eslint',
+    'eslint-community',
+    'mysticatea',
+  ];
+
+  for (const repoName of repoPatterns) {
+    // Try common organizations/users
+    for (const owner of commonOwners) {
+      const apiUrl = `https://api.github.com/repos/${owner}/${repoName}`;
+      const content = await fetchUrl(apiUrl);
+
+      if (content) {
+        try {
+          const repoData = JSON.parse(content);
+          if (repoData.id) {
+            return buildPluginResult(owner, repoName, pluginName, ruleName);
+          }
+        } catch {
+          continue;
+        }
+      }
+    }
+
+    // Search GitHub
+    const searchUrl = `https://api.github.com/search/repositories?q=${encodeURIComponent(repoName)}+eslint+plugin&sort=stars&per_page=5`;
+    const content = await fetchUrl(searchUrl);
+
+    if (content) {
+      try {
+        const searchData = JSON.parse(content);
+        if (searchData.items?.length) {
+          for (const item of searchData.items) {
+            if (
+              item.name.toLowerCase().includes(repoName.toLowerCase()) ||
+              item.name.toLowerCase().includes(pluginName.toLowerCase())
+            ) {
+              return buildPluginResult(
+                item.owner.login,
+                item.name,
+                pluginName,
+                ruleName,
+              );
+            }
+          }
+        }
+      } catch {
+        continue;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Search for ESLint rule documentation.
+ * @param {string} ruleName
+ * @returns {Promise<object>}
+ */
+async function searchRule(ruleName) {
+  const { plugin, rule } = parseRuleName(ruleName);
+
+  let result = null;
+
+  if (plugin === 'eslint') {
+    result = await searchEslintCore(rule);
+  } else if (plugin === 'typescript-eslint') {
+    result = await searchTypescriptEslint(rule);
+  } else {
+    result = await searchGithubPlugin(plugin, rule);
+  }
+
+  if (result) {
+    return result;
+  }
+
+  return {
+    found: false,
+    plugin,
+    rule,
+    error: `Could not find rule '${ruleName}'. Please provide the documentation URL manually.`,
+  };
+}
+
+/**
+ * Main function.
+ */
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 1) {
+    console.log('Usage: node search_rule.mjs <rule-name>');
+    console.log('\nExamples:');
+    console.log('  node search_rule.mjs no-console');
+    console.log('  node search_rule.mjs @typescript-eslint/no-explicit-any');
+    console.log('  node search_rule.mjs import/no-duplicates');
+    process.exit(1);
+  }
+
+  const ruleName = args[0];
+  const result = await searchRule(ruleName);
+
+  console.log(JSON.stringify(result, null, 2));
+
+  if (result.found) {
+    console.log('\n' + '='.repeat(60));
+    console.log(`Rule: ${result.title || result.rule}`);
+    console.log(`Plugin: ${result.plugin}`);
+    console.log(`Documentation: ${result.docUrl}`);
+    if (result.sourceUrl) {
+      console.log(`Source Code: ${result.sourceUrl}`);
+    }
+    if (result.testUrl) {
+      console.log(`Test File: ${result.testUrl}`);
+    }
+    console.log('='.repeat(60));
+    process.exit(0);
+  } else {
+    console.error(`\nError: ${result.error}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/cspell.config.cjs
+++ b/cspell.config.cjs
@@ -16,6 +16,7 @@ module.exports = {
     'packages/rslint-test-tools/tests',
     'packages/rslint/pkg/mod',
     'cmd/tsgo',
+    './agents',
   ],
   dictionaries: ['dictionary'],
   dictionaryDefinitions: [


### PR DESCRIPTION
## Summary

1. Skill Definition (`SKILL.md`): Defines a skill that triggers when users want to port ESLint rules. Includes prerequisites (getting rule name and documentation URL) and workflow phases.
2. Main Porting Guide (`PORT_RULE.md`): A comprehensive 5-phase workflow:
    - Phase 0: Branch setup
    - Phase 1: Preparation (test case collection)
    - Phase 2: Go implementation
    - Phase 3: JS integration
    - Phase 4: Verification & build
    - Phase 5: Submission & PR
3. Reference Documents: Three supporting documents covering AST patterns, utility functions, and quick
commands.
4. Search Script: A Node.js script that searches ESLint, typescript-eslint, and GitHub for rule
documentation URLs.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
