### PR TITLE
feat: port rule @typescript-eslint/no-inferrable-types

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_floating_promises"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_for_in_array"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_implied_eval"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_inferrable_types"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_invalid_void_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_meaningless_void_operator"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_misused_new"
@@ -395,6 +396,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-floating-promises", no_floating_promises.NoFloatingPromisesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-for-in-array", no_for_in_array.NoForInArrayRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-implied-eval", no_implied_eval.NoImpliedEvalRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-inferrable-types", no_inferrable_types.NoInferrableTypesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-meaningless-void-operator", no_meaningless_void_operator.NoMeaninglessVoidOperatorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-misused-new", no_misused_new.NoMisusedNewRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-misused-promises", no_misused_promises.NoMisusedPromisesRule)

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -85,6 +85,20 @@ func RunLinterInProgram(program *compiler.Program, allowFiles []string, skipFile
 							Severity:   r.Severity,
 						})
 					},
+					ReportRangeWithFixes: func(textRange core.TextRange, msg rule.RuleMessage, fixes ...rule.RuleFix) {
+						// Check if rule is disabled at this position
+						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+							return
+						}
+						onDiagnostic(rule.RuleDiagnostic{
+							RuleName:   r.Name,
+							Range:      textRange,
+							Message:    msg,
+							FixesPtr:   &fixes,
+							SourceFile: file,
+							Severity:   r.Severity,
+						})
+					},
 					ReportRangeWithSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
 						// Check if rule is disabled at this position
 						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.go
@@ -1,0 +1,343 @@
+package no_inferrable_types
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+type Options struct {
+	IgnoreParameters bool
+	IgnoreProperties bool
+}
+
+func parseOptions(options any) Options {
+	// Default values match typescript-eslint defaults
+	opts := Options{
+		IgnoreParameters: false,
+		IgnoreProperties: false,
+	}
+	if options == nil {
+		return opts
+	}
+
+	var optsMap map[string]interface{}
+	// Handle array format: [{ option: value }]
+	if arr, ok := options.([]interface{}); ok {
+		if len(arr) > 0 {
+			optsMap, _ = arr[0].(map[string]interface{})
+		}
+	} else {
+		// Handle direct object format
+		optsMap, _ = options.(map[string]interface{})
+	}
+
+	if optsMap != nil {
+		if v, ok := optsMap["ignoreParameters"].(bool); ok {
+			opts.IgnoreParameters = v
+		}
+		if v, ok := optsMap["ignoreProperties"].(bool); ok {
+			opts.IgnoreProperties = v
+		}
+	}
+	return opts
+}
+
+func buildNoInferrableTypesMessage(typeName string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noInferrableType",
+		Description: "Type " + typeName + " trivially inferred from a " + typeName + " literal, remove type annotation.",
+	}
+}
+
+// getInferrableType checks if the initializer is an inferrable type
+// Returns the type name if inferrable, empty string otherwise
+func getInferrableType(init *ast.Node) string {
+	if init == nil {
+		return ""
+	}
+
+	switch init.Kind {
+	case ast.KindBigIntLiteral:
+		return "bigint"
+
+	case ast.KindTrueKeyword, ast.KindFalseKeyword:
+		return "boolean"
+
+	case ast.KindNumericLiteral:
+		return "number"
+
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
+		return "string"
+
+	case ast.KindNullKeyword:
+		return "null"
+
+	case ast.KindRegularExpressionLiteral:
+		return "RegExp"
+
+	case ast.KindIdentifier:
+		id := init.AsIdentifier()
+		if id != nil {
+			switch id.Text {
+			case "undefined":
+				return "undefined"
+			case "Infinity", "NaN":
+				return "number"
+			}
+		}
+
+	case ast.KindPrefixUnaryExpression:
+		unary := init.AsPrefixUnaryExpression()
+		if unary != nil {
+			switch unary.Operator {
+			case ast.KindExclamationToken:
+				// !x is boolean
+				return "boolean"
+			case ast.KindPlusToken, ast.KindMinusToken:
+				// +x, -x with number/bigint literals or function calls
+				if unary.Operand != nil {
+					if unary.Operand.Kind == ast.KindNumericLiteral {
+						return "number"
+					}
+					if unary.Operand.Kind == ast.KindBigIntLiteral {
+						return "bigint"
+					}
+					// Check for Infinity, NaN identifiers
+					if unary.Operand.Kind == ast.KindIdentifier {
+						id := unary.Operand.AsIdentifier()
+						if id != nil && (id.Text == "Infinity" || id.Text == "NaN") {
+							return "number"
+						}
+					}
+					// Check for function calls like -BigInt(10), -Number('1')
+					if unary.Operand.Kind == ast.KindCallExpression {
+						call := unary.Operand.AsCallExpression()
+						if call != nil && call.Expression != nil && call.Expression.Kind == ast.KindIdentifier {
+							funcName := call.Expression.AsIdentifier()
+							if funcName != nil {
+								switch funcName.Text {
+								case "BigInt":
+									return "bigint"
+								case "Number":
+									return "number"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+	case ast.KindVoidExpression:
+		return "undefined"
+
+	case ast.KindCallExpression:
+		call := init.AsCallExpression()
+		if call != nil && call.Expression != nil && call.Expression.Kind == ast.KindIdentifier {
+			funcName := call.Expression.AsIdentifier()
+			if funcName != nil {
+				switch funcName.Text {
+				case "BigInt":
+					return "bigint"
+				case "Boolean":
+					return "boolean"
+				case "Number":
+					return "number"
+				case "String":
+					return "string"
+				case "Symbol":
+					return "symbol"
+				case "RegExp":
+					return "RegExp"
+				}
+			}
+		}
+
+	case ast.KindNewExpression:
+		newExpr := init.AsNewExpression()
+		if newExpr != nil && newExpr.Expression != nil && newExpr.Expression.Kind == ast.KindIdentifier {
+			className := newExpr.Expression.AsIdentifier()
+			if className != nil && className.Text == "RegExp" {
+				return "RegExp"
+			}
+		}
+	}
+
+	return ""
+}
+
+// matchesTypeAnnotation checks if the type annotation matches the expected type
+func matchesTypeAnnotation(typeNode *ast.Node, expectedType string) bool {
+	if typeNode == nil {
+		return false
+	}
+
+	switch expectedType {
+	case "bigint":
+		return typeNode.Kind == ast.KindBigIntKeyword
+	case "boolean":
+		return typeNode.Kind == ast.KindBooleanKeyword
+	case "number":
+		return typeNode.Kind == ast.KindNumberKeyword
+	case "string":
+		return typeNode.Kind == ast.KindStringKeyword
+	case "null":
+		// null type can be KindNullKeyword directly or wrapped in LiteralType
+		if typeNode.Kind == ast.KindNullKeyword {
+			return true
+		}
+		if typeNode.Kind == ast.KindLiteralType {
+			litType := typeNode.AsLiteralTypeNode()
+			if litType != nil && litType.Literal != nil {
+				return litType.Literal.Kind == ast.KindNullKeyword
+			}
+		}
+		return false
+	case "undefined":
+		return typeNode.Kind == ast.KindUndefinedKeyword
+	case "symbol":
+		return typeNode.Kind == ast.KindSymbolKeyword
+	case "RegExp":
+		if typeNode.Kind == ast.KindTypeReference {
+			typeRef := typeNode.AsTypeReference()
+			if typeRef != nil && typeRef.TypeName != nil && typeRef.TypeName.Kind == ast.KindIdentifier {
+				return typeRef.TypeName.AsIdentifier().Text == "RegExp"
+			}
+		}
+	}
+	return false
+}
+
+var NoInferrableTypesRule = rule.CreateRule(rule.Rule{
+	Name: "no-inferrable-types",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		checkDeclaration := func(reportNode *ast.Node, typeAnnotation *ast.Node, initializer *ast.Node, hasQuestionToken bool, hasExclamationToken bool) {
+			if typeAnnotation == nil || initializer == nil {
+				return
+			}
+
+			inferrableType := getInferrableType(initializer)
+			if inferrableType == "" {
+				return
+			}
+
+			if matchesTypeAnnotation(typeAnnotation, inferrableType) {
+				// Report with fix to remove type annotation
+				// Find the colon position by scanning backwards from typeAnnotation
+				colonPos := typeAnnotation.Pos()
+				sourceText := ctx.SourceFile.Text()
+				for i := colonPos - 1; i >= 0; i-- {
+					if sourceText[i] == ':' {
+						colonPos = i
+						break
+					}
+				}
+
+				// If there's a question token (optional) or exclamation token (definite assignment),
+				// we need to remove it too and adjust the position
+				if hasQuestionToken || hasExclamationToken {
+					for i := colonPos - 1; i >= 0; i-- {
+						ch := sourceText[i]
+						if ch == '?' || ch == '!' {
+							colonPos = i
+							break
+						} else if ch != ' ' && ch != '\t' {
+							break
+						}
+					}
+				}
+
+				fixRange := core.NewTextRange(colonPos, typeAnnotation.End())
+				// Report range spans from the name node (trimmed) to the end of the initializer
+				// This matches typescript-eslint's behavior of reporting on the full declaration
+				trimmedStartPos := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, reportNode.Pos()).Pos()
+				reportRange := core.NewTextRange(trimmedStartPos, initializer.End())
+				ctx.ReportRangeWithFixes(
+					reportRange,
+					buildNoInferrableTypesMessage(inferrableType),
+					rule.RuleFixRemoveRange(fixRange),
+				)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				varDecl := node.AsVariableDeclaration()
+				if varDecl == nil {
+					return
+				}
+				// Report on the name node for correct column position
+				reportNode := varDecl.Name()
+				if reportNode == nil {
+					reportNode = node
+				}
+				checkDeclaration(reportNode, varDecl.Type, varDecl.Initializer, false, false)
+			},
+
+			ast.KindParameter: func(node *ast.Node) {
+				if opts.IgnoreParameters {
+					return
+				}
+				param := node.AsParameterDeclaration()
+				if param == nil {
+					return
+				}
+				// Check for optional parameter with question token
+				hasQuestionToken := param.QuestionToken != nil
+				// Report on the name node for correct column position
+				reportNode := param.Name()
+				if reportNode == nil {
+					reportNode = node
+				}
+				checkDeclaration(reportNode, param.Type, param.Initializer, hasQuestionToken, false)
+			},
+
+			ast.KindPropertyDeclaration: func(node *ast.Node) {
+				if opts.IgnoreProperties {
+					return
+				}
+				prop := node.AsPropertyDeclaration()
+				if prop == nil {
+					return
+				}
+				// Check if this is an auto-accessor property
+				isAutoAccessor := false
+				if prop.Modifiers() != nil {
+					for _, mod := range prop.Modifiers().Nodes {
+						// Skip readonly properties
+						if mod.Kind == ast.KindReadonlyKeyword {
+							return
+						}
+						// Check for accessor modifier
+						if mod.Kind == ast.KindAccessorKeyword {
+							isAutoAccessor = true
+						}
+					}
+				}
+				// Check for optional property with question token - skip these
+				if prop.PostfixToken != nil && prop.PostfixToken.Kind == ast.KindQuestionToken {
+					return
+				}
+				// Check for definite assignment assertion (!) - these should be reported with fix
+				hasExclamationToken := prop.PostfixToken != nil && prop.PostfixToken.Kind == ast.KindExclamationToken
+				// For auto-accessor properties, report from the accessor keyword (full node)
+				// For regular properties, report from the name node
+				var reportNode *ast.Node
+				if isAutoAccessor {
+					// Use the full property declaration node for auto-accessors
+					reportNode = node
+				} else {
+					reportNode = prop.Name()
+					if reportNode == nil {
+						reportNode = node
+					}
+				}
+				checkDeclaration(reportNode, prop.Type, prop.Initializer, false, hasExclamationToken)
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.md
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types.md
@@ -1,0 +1,98 @@
+# no-inferrable-types
+
+## Rule Details
+
+Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.
+
+TypeScript is able to infer the types of parameters, properties, and variables from their default or initial values. There is no need to use an explicit type annotation for trivially inferred types (boolean, bigint, number, null, RegExp, string, symbol, undefined).
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+const a: bigint = 10n;
+const a: bigint = -10n;
+const a: bigint = BigInt(10);
+const a: boolean = true;
+const a: boolean = false;
+const a: boolean = Boolean(null);
+const a: boolean = !0;
+const a: number = 10;
+const a: number = +10;
+const a: number = -10;
+const a: number = Number('1');
+const a: number = Infinity;
+const a: number = NaN;
+const a: null = null;
+const a: RegExp = /a/;
+const a: RegExp = RegExp('a');
+const a: RegExp = new RegExp('a');
+const a: string = 'str';
+const a: string = `str`;
+const a: string = String(1);
+const a: symbol = Symbol('a');
+const a: undefined = undefined;
+const a: undefined = void 0;
+
+function fn(a: number = 5) {}
+const fn = (a: boolean = true) => {};
+
+class Foo {
+  prop: number = 5;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+const a = 10n;
+const a = true;
+const a = 'str';
+const a = null;
+const a = /a/;
+const a = undefined;
+const a = Symbol('a');
+
+function fn(a = 5) {}
+const fn = (a = true) => {};
+
+class Foo {
+  prop = 5;
+}
+
+// Readonly properties are allowed
+class Bar {
+  readonly prop: number = 5;
+}
+```
+
+## Options
+
+### `ignoreParameters`
+
+When set to `true`, ignores explicit type annotations on function parameters with default values.
+
+```json
+{
+  "@typescript-eslint/no-inferrable-types": [
+    "warn",
+    { "ignoreParameters": true }
+  ]
+}
+```
+
+### `ignoreProperties`
+
+When set to `true`, ignores explicit type annotations on class properties with initializers.
+
+```json
+{
+  "@typescript-eslint/no-inferrable-types": [
+    "warn",
+    { "ignoreProperties": true }
+  ]
+}
+```
+
+## Original Documentation
+
+https://typescript-eslint.io/rules/no-inferrable-types

--- a/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
+++ b/internal/plugins/typescript/rules/no_inferrable_types/no_inferrable_types_test.go
@@ -1,0 +1,388 @@
+package no_inferrable_types
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoInferrableTypesRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoInferrableTypesRule, []rule_tester.ValidTestCase{
+		// No type annotation - valid
+		{Code: `const a = 10;`},
+		{Code: `const a = true;`},
+		{Code: `const a = 'str';`},
+		{Code: `const a = null;`},
+		{Code: `const a = undefined;`},
+		{Code: `const a = /a/;`},
+		{Code: `const a = 10n;`},
+		{Code: `const a = Symbol('a');`},
+
+		// Type annotation with different type - valid
+		{Code: `const a: unknown = 10;`},
+		{Code: `const a: any = true;`},
+
+		// Function parameters with ignoreParameters: true
+		{
+			Code:    `function fn(a: number = 5) {}`,
+			Options: []interface{}{map[string]interface{}{"ignoreParameters": true}},
+		},
+
+		// Class properties with ignoreProperties: true
+		{
+			Code:    `class Foo { prop: number = 5; }`,
+			Options: []interface{}{map[string]interface{}{"ignoreProperties": true}},
+		},
+
+		// Readonly class properties should be ignored even without option
+		{Code: `class Foo { readonly prop: number = 5; }`},
+
+		// Optional properties with initializers are not flagged by this rule.
+		{
+			Code: `class Foo {
+  a?: number = 5;
+}`,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// bigint
+		{
+			Code:   `const a: bigint = 10n;`,
+			Output: []string{`const a = 10n;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: bigint = -10n;`,
+			Output: []string{`const a = -10n;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: bigint = BigInt(10);`,
+			Output: []string{`const a = BigInt(10);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// boolean
+		{
+			Code:   `const a: boolean = true;`,
+			Output: []string{`const a = true;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: boolean = false;`,
+			Output: []string{`const a = false;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: boolean = Boolean(null);`,
+			Output: []string{`const a = Boolean(null);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: boolean = !0;`,
+			Output: []string{`const a = !0;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// number
+		{
+			Code:   `const a: number = 10;`,
+			Output: []string{`const a = 10;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: number = +10;`,
+			Output: []string{`const a = +10;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: number = -10;`,
+			Output: []string{`const a = -10;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: number = Number('1');`,
+			Output: []string{`const a = Number('1');`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: number = Infinity;`,
+			Output: []string{`const a = Infinity;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: number = NaN;`,
+			Output: []string{`const a = NaN;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// null
+		{
+			Code:   `const a: null = null;`,
+			Output: []string{`const a = null;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// RegExp
+		{
+			Code:   `const a: RegExp = /a/;`,
+			Output: []string{`const a = /a/;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: RegExp = RegExp('a');`,
+			Output: []string{`const a = RegExp('a');`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: RegExp = new RegExp('a');`,
+			Output: []string{`const a = new RegExp('a');`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// string
+		{
+			Code:   `const a: string = 'str';`,
+			Output: []string{`const a = 'str';`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   "const a: string = `str`;",
+			Output: []string{"const a = `str`;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: string = String(1);`,
+			Output: []string{`const a = String(1);`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// symbol
+		{
+			Code:   `const a: symbol = Symbol('a');`,
+			Output: []string{`const a = Symbol('a');`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// undefined
+		{
+			Code:   `const a: undefined = undefined;`,
+			Output: []string{`const a = undefined;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+		{
+			Code:   `const a: undefined = void 0;`,
+			Output: []string{`const a = void 0;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    7,
+				},
+			},
+		},
+
+		// Function parameters (without ignoreParameters option)
+		{
+			Code:   `function fn(a: number = 5) {}`,
+			Output: []string{`function fn(a = 5) {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    13,
+				},
+			},
+		},
+		{
+			Code:   `const fn = (a: boolean = true) => {};`,
+			Output: []string{`const fn = (a = true) => {};`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    13,
+				},
+			},
+		},
+
+		// Class properties (without ignoreProperties option)
+		{
+			Code:   `class Foo { prop: number = 5; }`,
+			Output: []string{`class Foo { prop = 5; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      1,
+					Column:    13,
+				},
+			},
+		},
+
+		// Class properties with definite assignment assertion (!)
+		{
+			Code: `class A {
+  a!: number = 1;
+}`,
+			Output: []string{`class A {
+  a = 1;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      2,
+					Column:    3,
+				},
+			},
+		},
+
+		// Auto-accessor properties
+		{
+			Code: `class Foo {
+  accessor a: number = 5;
+}`,
+			Output: []string{`class Foo {
+  accessor a = 5;
+}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noInferrableType",
+					Line:      2,
+					Column:    3,
+				},
+			},
+		},
+	})
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -167,6 +167,7 @@ type RuleContext struct {
 	TypeChecker                *checker.Checker
 	DisableManager             *DisableManager
 	ReportRange                func(textRange core.TextRange, msg RuleMessage)
+	ReportRangeWithFixes       func(textRange core.TextRange, msg RuleMessage, fixes ...RuleFix)
 	ReportRangeWithSuggestions func(textRange core.TextRange, msg RuleMessage, suggestions ...RuleSuggestion)
 	ReportNode                 func(node *ast.Node, msg RuleMessage)
 	ReportNodeWithFixes        func(node *ast.Node, msg RuleMessage, fixes ...RuleFix)

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -86,7 +86,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-extraneous-class.test.ts',
     // './tests/typescript-eslint/rules/no-for-in-array.test.ts',
     // './tests/typescript-eslint/rules/no-import-type-side-effects.test.ts',
-    // './tests/typescript-eslint/rules/no-inferrable-types.test.ts',
+    './tests/typescript-eslint/rules/no-inferrable-types.test.ts',
     // './tests/typescript-eslint/rules/no-invalid-this.test.ts',
     // './tests/typescript-eslint/rules/no-invalid-void-type.test.ts',
     // './tests/typescript-eslint/rules/no-loop-func.test.ts',

--- a/packages/rslint-test-tools/tests/cli/basic.test.ts
+++ b/packages/rslint-test-tools/tests/cli/basic.test.ts
@@ -458,7 +458,7 @@ describe('CLI Configuration Tests', () => {
         include: ['**/*.ts'],
       }),
       'test.ts': `
-        const a: string = "hello";
+        const a = "hello";
         console.log(a.length); // This is safe
       `,
     });

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-inferrable-types.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-inferrable-types.test.ts.snap
@@ -1,0 +1,1312 @@
+// Rstest Snapshot v1
+
+exports[`no-inferrable-types > invalid 1`] = `
+{
+  "code": "const a: bigint = 10n;",
+  "diagnostics": [
+    {
+      "message": "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = 10n;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 2`] = `
+{
+  "code": "const a: bigint = -10n;",
+  "diagnostics": [
+    {
+      "message": "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -10n;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 3`] = `
+{
+  "code": "const a: bigint = BigInt(10);",
+  "diagnostics": [
+    {
+      "message": "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = BigInt(10);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 4`] = `
+{
+  "code": "const a: bigint = -BigInt(10);",
+  "diagnostics": [
+    {
+      "message": "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -BigInt(10);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 5`] = `
+{
+  "code": "const a: bigint = BigInt?.(10);",
+  "diagnostics": [
+    {
+      "message": "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = BigInt?.(10);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 6`] = `
+{
+  "code": "const a: bigint = -BigInt?.(10);",
+  "diagnostics": [
+    {
+      "message": "Type bigint trivially inferred from a bigint literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -BigInt?.(10);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 7`] = `
+{
+  "code": "const a: boolean = false;",
+  "diagnostics": [
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = false;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 8`] = `
+{
+  "code": "const a: boolean = true;",
+  "diagnostics": [
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = true;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 9`] = `
+{
+  "code": "const a: boolean = Boolean(null);",
+  "diagnostics": [
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Boolean(null);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 10`] = `
+{
+  "code": "const a: boolean = Boolean?.(null);",
+  "diagnostics": [
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Boolean?.(null);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 11`] = `
+{
+  "code": "const a: boolean = !0;",
+  "diagnostics": [
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = !0;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 12`] = `
+{
+  "code": "const a: number = 10;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = 10;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 13`] = `
+{
+  "code": "const a: number = +10;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = +10;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 14`] = `
+{
+  "code": "const a: number = -10;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -10;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 15`] = `
+{
+  "code": "const a: number = Number('1');",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Number('1');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 16`] = `
+{
+  "code": "const a: number = +Number('1');",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = +Number('1');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 17`] = `
+{
+  "code": "const a: number = -Number('1');",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -Number('1');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 18`] = `
+{
+  "code": "const a: number = Number?.('1');",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Number?.('1');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 19`] = `
+{
+  "code": "const a: number = +Number?.('1');",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = +Number?.('1');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 20`] = `
+{
+  "code": "const a: number = -Number?.('1');",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -Number?.('1');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 21`] = `
+{
+  "code": "const a: number = Infinity;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Infinity;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 22`] = `
+{
+  "code": "const a: number = +Infinity;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = +Infinity;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 23`] = `
+{
+  "code": "const a: number = -Infinity;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -Infinity;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 24`] = `
+{
+  "code": "const a: number = NaN;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = NaN;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 25`] = `
+{
+  "code": "const a: number = +NaN;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = +NaN;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 26`] = `
+{
+  "code": "const a: number = -NaN;",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = -NaN;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 27`] = `
+{
+  "code": "const a: null = null;",
+  "diagnostics": [
+    {
+      "message": "Type null trivially inferred from a null literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 28`] = `
+{
+  "code": "const a: RegExp = /a/;",
+  "diagnostics": [
+    {
+      "message": "Type RegExp trivially inferred from a RegExp literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = /a/;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 29`] = `
+{
+  "code": "const a: RegExp = RegExp('a');",
+  "diagnostics": [
+    {
+      "message": "Type RegExp trivially inferred from a RegExp literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = RegExp('a');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 30`] = `
+{
+  "code": "const a: RegExp = RegExp?.('a');",
+  "diagnostics": [
+    {
+      "message": "Type RegExp trivially inferred from a RegExp literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = RegExp?.('a');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 31`] = `
+{
+  "code": "const a: RegExp = new RegExp('a');",
+  "diagnostics": [
+    {
+      "message": "Type RegExp trivially inferred from a RegExp literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = new RegExp('a');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 32`] = `
+{
+  "code": "const a: string = 'str';",
+  "diagnostics": [
+    {
+      "message": "Type string trivially inferred from a string literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = 'str';",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 33`] = `
+{
+  "code": "const a: string = \`str\`;",
+  "diagnostics": [
+    {
+      "message": "Type string trivially inferred from a string literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = \`str\`;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 34`] = `
+{
+  "code": "const a: string = String(1);",
+  "diagnostics": [
+    {
+      "message": "Type string trivially inferred from a string literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = String(1);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 35`] = `
+{
+  "code": "const a: string = String?.(1);",
+  "diagnostics": [
+    {
+      "message": "Type string trivially inferred from a string literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = String?.(1);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 36`] = `
+{
+  "code": "const a: symbol = Symbol('a');",
+  "diagnostics": [
+    {
+      "message": "Type symbol trivially inferred from a symbol literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Symbol('a');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 37`] = `
+{
+  "code": "const a: symbol = Symbol?.('a');",
+  "diagnostics": [
+    {
+      "message": "Type symbol trivially inferred from a symbol literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = Symbol?.('a');",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 38`] = `
+{
+  "code": "const a: undefined = undefined;",
+  "diagnostics": [
+    {
+      "message": "Type undefined trivially inferred from a undefined literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 39`] = `
+{
+  "code": "const a: undefined = void someValue;",
+  "diagnostics": [
+    {
+      "message": "Type undefined trivially inferred from a undefined literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const a = void someValue;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 40`] = `
+{
+  "code": "const fn = (a?: number = 5) => {};",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const fn = (a = 5) => {};",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 41`] = `
+{
+  "code": "
+class A {
+  a!: number = 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class A {
+  a = 1;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 42`] = `
+{
+  "code": "const fn = (a: number = 5, b: boolean = true, c: string = 'foo') => {};",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+    {
+      "message": "Type string trivially inferred from a string literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "const fn = (a = 5, b = true, c = 'foo') => {};",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 43`] = `
+{
+  "code": "
+class Foo {
+  a: number = 5;
+  b: boolean = true;
+  c: string = 'foo';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+    {
+      "message": "Type string trivially inferred from a string literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+class Foo {
+  a = 5;
+  b = true;
+  c = 'foo';
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 44`] = `
+{
+  "code": "
+class Foo {
+  constructor(public a: boolean = true) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type boolean trivially inferred from a boolean literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 22,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class Foo {
+  constructor(public a = true) {}
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-inferrable-types > invalid 45`] = `
+{
+  "code": "
+class Foo {
+  accessor a: number = 5;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Type number trivially inferred from a number literal, remove type annotation.",
+      "messageId": "noInferrableType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-inferrable-types",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class Foo {
+  accessor a = 5;
+}
+      ",
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-inferrable-types` rule to rslint.

This rule disallows explicit type declarations for variables or parameters initialized to a number, string, boolean, or other primitives that TypeScript can automatically infer.

### Features
- Supports all inferrable types: bigint, boolean, number, null, RegExp, string, symbol, undefined
- Handles function calls (BigInt, Boolean, Number, String, Symbol, RegExp)
- Handles unary expressions (!, +, -)
- Handles void expressions
- Options: `ignoreParameters`, `ignoreProperties`
- Properly handles readonly properties (skipped)
- Properly handles optional properties with `?` (skipped)
- Properly handles definite assignment assertion (`!`)
- Properly handles auto-accessor properties with `accessor` keyword
- Includes auto-fix to remove redundant type annotations

### Infrastructure Changes
- Added `ReportRangeWithFixes` to rule context for custom range reporting with fixes

## Related Links

- https://typescript-eslint.io/rules/no-inferrable-types
- Related Issue: https://github.com/web-infra-dev/rslint/issues/37

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).