### PR TITLE
feat: port rule no-loss-of-precision

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_constant_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_constructor_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_debugger"
+	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
 )
@@ -465,6 +466,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-constant-condition", no_constant_condition.NoConstantConditionRule)
 	GlobalRuleRegistry.Register("no-constructor-return", no_constructor_return.NoConstructorReturnRule)
 	GlobalRuleRegistry.Register("no-debugger", no_debugger.NoDebuggerRule)
+	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)
 }

--- a/internal/rules/no_loss_of_precision/no_loss_of_precision.go
+++ b/internal/rules/no_loss_of_precision/no_loss_of_precision.go
@@ -1,0 +1,243 @@
+package no_loss_of_precision
+
+import (
+	"math"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+var ruleMessage = rule.RuleMessage{
+	Id:          "no-loss-of-precision",
+	Description: "This number literal will lose precision at runtime.",
+}
+
+// Regex patterns for parsing numbers
+var (
+	binaryPattern      = regexp.MustCompile(`(?i)^0b[01]+$`)
+	octalPattern       = regexp.MustCompile(`(?i)^0o[0-7]+$`)
+	hexPattern         = regexp.MustCompile(`(?i)^0x[0-9a-f]+$`)
+	legacyOctalPattern = regexp.MustCompile(`^0[0-7]+$`)
+)
+
+// NoLossOfPrecisionRule disallows literal numbers that lose precision
+// https://eslint.org/docs/latest/rules/no-loss-of-precision
+var NoLossOfPrecisionRule = rule.Rule{
+	Name: "no-loss-of-precision",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindNumericLiteral: func(node *ast.Node) {
+				// Get the raw text directly from source
+				// We can't use numLiteral.Text because the parser normalizes numbers
+				start := node.Pos()
+				end := node.End()
+				text := ctx.SourceFile.Text()
+
+				if end <= start || end > len(text) {
+					return
+				}
+
+				raw := strings.TrimSpace(text[start:end])
+				if raw == "" {
+					return
+				}
+
+				if losesPrecision(raw) {
+					ctx.ReportNode(node, ruleMessage)
+				}
+			},
+		}
+	},
+}
+
+// removeNumericSeparators removes underscore separators from numeric literals
+func removeNumericSeparators(s string) string {
+	return strings.ReplaceAll(s, "_", "")
+}
+
+// losesPrecision checks if the given numeric literal loses precision
+func losesPrecision(raw string) bool {
+	normalized := removeNumericSeparators(raw)
+
+	if binaryPattern.MatchString(normalized) {
+		return notBaseTenLosesPrecision(normalized[2:], 2)
+	}
+	if octalPattern.MatchString(normalized) {
+		return notBaseTenLosesPrecision(normalized[2:], 8)
+	}
+	if hexPattern.MatchString(normalized) {
+		return notBaseTenLosesPrecision(normalized[2:], 16)
+	}
+	if legacyOctalPattern.MatchString(normalized) {
+		return notBaseTenLosesPrecision(normalized[1:], 8)
+	}
+
+	return baseTenLosesPrecision(normalized)
+}
+
+// notBaseTenLosesPrecision checks if a non-base-10 number loses precision
+func notBaseTenLosesPrecision(digits string, base int) bool {
+	// Parse as big.Int for arbitrary precision
+	original := new(big.Int)
+	_, ok := original.SetString(strings.ToLower(digits), base)
+	if !ok {
+		return false
+	}
+
+	// Convert to float64 (JavaScript Number)
+	f, _ := new(big.Float).SetInt(original).Float64()
+
+	// Check for infinity
+	if math.IsInf(f, 0) {
+		return true
+	}
+
+	// Convert float64 back to big.Int
+	reconstructed := new(big.Int)
+	bf := new(big.Float).SetFloat64(f)
+	bf.Int(reconstructed)
+
+	// Compare: if they differ, precision was lost
+	return original.Cmp(reconstructed) != 0
+}
+
+// baseTenLosesPrecision checks if a base-10 number loses precision
+func baseTenLosesPrecision(raw string) bool {
+	// Parse using big.Float for arbitrary precision
+	rawBigFloat, _, err := new(big.Float).SetPrec(256).Parse(raw, 10)
+	if err != nil {
+		return false
+	}
+
+	// Convert to float64 (this is what JavaScript does)
+	jsValue, _ := rawBigFloat.Float64()
+
+	// Check for infinity
+	if math.IsInf(jsValue, 0) {
+		return true
+	}
+
+	// Get significant info from raw
+	rawSigDigits, rawExp, rawPrecision := getSignificantInfo(raw)
+
+	// If raw precision exceeds JavaScript's ~17 significant digits, it's precision loss
+	if rawPrecision > 17 {
+		return true
+	}
+
+	// Get JS representation
+	precision := rawPrecision
+	if precision < 1 {
+		precision = 1
+	}
+	jsStr := strconv.FormatFloat(jsValue, 'e', precision-1, 64)
+	jsSigDigits, jsExp, _ := getSignificantInfo(jsStr)
+
+	rawAbs := strings.TrimPrefix(rawSigDigits, "-")
+	jsAbs := strings.TrimPrefix(jsSigDigits, "-")
+
+	// Check sign
+	if strings.HasPrefix(rawSigDigits, "-") != strings.HasPrefix(jsSigDigits, "-") {
+		return true
+	}
+
+	// Handle zero
+	if rawAbs == "0" {
+		return jsAbs != "0"
+	}
+
+	// Check exponent
+	if rawExp != jsExp {
+		return true
+	}
+
+	// Compare significant digits (trimmed)
+	if len(rawAbs) <= len(jsAbs) {
+		return !strings.HasPrefix(jsAbs, rawAbs)
+	}
+
+	// rawAbs is longer than jsAbs
+	if !strings.HasPrefix(rawAbs, jsAbs) {
+		return true
+	}
+	extra := rawAbs[len(jsAbs):]
+	return strings.Trim(extra, "0") != ""
+}
+
+// getSignificantInfo extracts significant digits, exponent, and precision from a number string
+func getSignificantInfo(raw string) (sigDigits string, exp int, rawPrecision int) {
+	negative := false
+	if strings.HasPrefix(raw, "-") {
+		negative = true
+		raw = raw[1:]
+	} else if strings.HasPrefix(raw, "+") {
+		raw = raw[1:]
+	}
+
+	// Handle scientific notation
+	var mantissa string
+	expOffset := 0
+	if idx := strings.IndexAny(raw, "eE"); idx >= 0 {
+		mantissa = raw[:idx]
+		expOffset, _ = strconv.Atoi(raw[idx+1:])
+	} else {
+		mantissa = raw
+	}
+
+	// Split by decimal point
+	var intPart, fracPart string
+	if dotIdx := strings.Index(mantissa, "."); dotIdx >= 0 {
+		intPart = mantissa[:dotIdx]
+		fracPart = mantissa[dotIdx+1:]
+	} else {
+		intPart = mantissa
+		fracPart = ""
+	}
+
+	// Combine all digits
+	allDigits := intPart + fracPart
+
+	// Find first non-zero digit
+	firstNonZero := 0
+	for firstNonZero < len(allDigits) && allDigits[firstNonZero] == '0' {
+		firstNonZero++
+	}
+
+	if firstNonZero == len(allDigits) {
+		return "0", 0, 1
+	}
+
+	// Calculate exponent
+	exp = len(intPart) - firstNonZero - 1 + expOffset
+
+	// Get significant digits
+	sigDigitsWithZeros := allDigits[firstNonZero:]
+	sigDigits = strings.TrimRight(sigDigitsWithZeros, "0")
+	if sigDigits == "" {
+		sigDigits = "0"
+	}
+
+	// Check if trailing zeros in fractional part represent precision
+	// This happens when there's a non-zero digit in the fractional part
+	// followed by trailing zeros (e.g., ".1230000...")
+	fracPartTrimmed := strings.TrimRight(fracPart, "0")
+	fracHasNonZero := len(strings.TrimLeft(fracPart, "0")) > 0
+
+	if fracHasNonZero && len(fracPart) > len(fracPartTrimmed) {
+		// Trailing zeros after non-zero digit in fractional part = precision intent
+		rawPrecision = len(sigDigitsWithZeros)
+	} else {
+		// No precision intent from trailing zeros
+		rawPrecision = len(sigDigits)
+	}
+
+	if negative {
+		sigDigits = "-" + sigDigits
+	}
+
+	return sigDigits, exp, rawPrecision
+}

--- a/internal/rules/no_loss_of_precision/no_loss_of_precision.md
+++ b/internal/rules/no_loss_of_precision/no_loss_of_precision.md
@@ -1,0 +1,68 @@
+# no-loss-of-precision
+
+Disallow literal numbers that lose precision.
+
+## Rule Details
+
+This rule prevents the use of number literals that lose precision when converted to a JavaScript `Number` due to 64-bit floating-point rounding.
+
+JavaScript Numbers are represented as 64-bit floating-point values according to the IEEE 754 standard. This means they can only accurately represent integers up to `Number.MAX_SAFE_INTEGER` (2^53 - 1 = 9007199254740991). Numbers exceeding this limit, or decimal numbers with too many significant digits, will lose precision at runtime.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+// Integers exceeding MAX_SAFE_INTEGER
+var x = 9007199254740993;
+
+// Very large integers with precision loss
+var x = 5123000000000000000000000000001;
+
+// Decimals with too many significant digits
+var x = 1.0000000000000000000000123;
+
+// Scientific notation causing precision loss
+var x = 9.007199254740993e15;
+
+// Binary, octal, hex exceeding safe limits
+var x = 0x20000000000001;
+var x = 0o400000000000000001;
+var x = 0b100000000000000000000000000000000000000000000000000001;
+
+// Numbers that become Infinity
+var x = 2e999;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// Safe integers
+var x = 12345;
+var x = 9007199254740991; // MAX_SAFE_INTEGER
+
+// Safe decimals
+var x = 123.456;
+var x = 0.00000000000000000000000123;
+
+// Safe scientific notation
+var x = 123e34;
+
+// Safe binary, octal, hex
+var x = 0x1fffffffffffff;
+var x = 0o377777777777777777;
+var x = 0b11111111111111111111111111111111111111111111111111111;
+
+// Using numeric separators (ES2021)
+var x = 9007_1992547409_91;
+```
+
+## Options
+
+This rule has no options.
+
+## When Not To Use It
+
+If you don't mind the precision loss in certain numeric literals, you can disable this rule.
+
+## Original Documentation
+
+[ESLint no-loss-of-precision](https://eslint.org/docs/latest/rules/no-loss-of-precision)

--- a/internal/rules/no_loss_of_precision/no_loss_of_precision_test.go
+++ b/internal/rules/no_loss_of_precision/no_loss_of_precision_test.go
@@ -1,0 +1,171 @@
+package no_loss_of_precision
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLossOfPrecisionRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLossOfPrecisionRule,
+		// Valid cases - numbers that don't lose precision
+		[]rule_tester.ValidTestCase{
+			// Basic integers and decimals
+			{Code: `var x = 12345`},
+			{Code: `var x = 123.456`},
+			{Code: `var x = -123.456`},
+			{Code: `var x = 0`},
+			{Code: `var x = 0.0`},
+			{Code: `var x = -0`},
+
+			// Scientific notation
+			{Code: `var x = 123e34`},
+			{Code: `var x = 123e-34`},
+			{Code: `var x = 12.3e34`},
+			{Code: `var x = -12.3e34`},
+
+			// Edge cases within safe precision
+			{Code: `var x = 9007199254740991`},  // MAX_SAFE_INTEGER
+			{Code: `var x = -9007199254740991`}, // MIN_SAFE_INTEGER
+			{Code: `var x = 12300000000000000000000000`},
+			{Code: `var x = 0.00000000000000000000000123`},
+
+			// With numeric separators (ES2021)
+			{Code: `var x = 12_34_56`},
+			{Code: `var x = 12_3.4_56`},
+			{Code: `var x = 1_230000000_00000000_00000_000`},
+			{Code: `var x = 9007_1992547409_91`},
+
+			// Binary format (safe precision)
+			{Code: `var x = 0b11111111111111111111111111111111111111111111111111111`},
+
+			// Octal format (safe precision)
+			{Code: `var x = 0o377777777777777777`},
+
+			// Hex format (safe precision)
+			{Code: `var x = 0x1FFFFFFFFFFFFF`},
+			{Code: `var x = 0X1FFFFFFFFFFFFF`},
+		},
+		// Invalid cases - numbers that lose precision
+		[]rule_tester.InvalidTestCase{
+			// Integers exceeding safe integer limit
+			{
+				Code: `var x = 9007199254740993`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = -9007199254740993`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 10},
+				},
+			},
+
+			// Very large integers
+			{
+				Code: `var x = 5123000000000000000000000000001`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// Scientific notation causing precision loss
+			{
+				Code: `var x = 9007199254740.993e3`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = 9.007199254740993e15`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// Decimal precision beyond JavaScript limits
+			{
+				Code: `var x = 900719.9254740994`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = 1.0000000000000000000000123`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = .1230000000000000000000000`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// Exponent causes Infinity
+			{
+				Code: `var x = 2e999`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// Binary exceeds safe integer
+			{
+				Code: `var x = 0b100000000000000000000000000000000000000000000000000001`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// Octal exceeds safe integer
+			{
+				Code: `var x = 0o400000000000000001`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// Hex exceeds safe integer
+			{
+				Code: `var x = 0x20000000000001`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = 0X20000000000001`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+
+			// With numeric separators
+			{
+				Code: `var x = 900719925474099_3`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = 9.0_0719925_474099_3e15`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = 0X2_000000000_0001`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "no-loss-of-precision", Line: 1, Column: 9},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -7,6 +7,9 @@ export default defineConfig({
     // cli
     './tests/cli/basic.test.ts',
 
+    // eslint
+    './tests/eslint/rules/no-loss-of-precision.test.ts',
+
     // eslint-plugin-import
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rslint.json
+++ b/packages/rslint-test-tools/tests/eslint/rslint.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.virtual.json"]
+      }
+    },
+    "rules": {},
+    "plugins": []
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint/rule-tester.ts
@@ -1,0 +1,143 @@
+import path from 'node:path';
+import { test, describe, expect } from '@rstest/core';
+import { lint, type LintResponse } from '@rslint/core';
+import assert from 'node:assert';
+
+interface TsDiagnostic {
+  line?: number;
+  column?: number;
+  endLine?: number;
+  endColumn?: number;
+  messageId?: string;
+}
+
+function toCamelCase(name: string): string {
+  return name.replace(/-([a-z])/g, g => g[1].toUpperCase());
+}
+
+function checkDiagnosticEqual(
+  rslintDiagnostic: {
+    messageId: string;
+    range: {
+      start: { line: number; column: number };
+      end: { line: number; column: number };
+    };
+  }[],
+  tsDiagnostic: TsDiagnostic[],
+) {
+  assert(
+    rslintDiagnostic.length === tsDiagnostic.length,
+    `Length mismatch: ${rslintDiagnostic.length} !== ${tsDiagnostic.length}`,
+  );
+  for (let i = 0; i < rslintDiagnostic.length; i++) {
+    const rslintDiag = rslintDiagnostic[i];
+    const tsDiag = tsDiagnostic[i];
+    assert(
+      toCamelCase(rslintDiag.messageId) === tsDiag.messageId,
+      `Message mismatch: ${rslintDiag.messageId} !== ${tsDiag.messageId}`,
+    );
+    if (tsDiag.line) {
+      assert(
+        rslintDiag.range.start.line === tsDiag.line,
+        `Start line mismatch: ${rslintDiag.range.start.line} !== ${tsDiag.line}`,
+      );
+    }
+    if (tsDiag.column) {
+      assert(
+        rslintDiag.range.start.column === tsDiag.column,
+        `Start column mismatch: ${rslintDiag.range.start.column} !== ${tsDiag.column}`,
+      );
+    }
+  }
+}
+
+export type ValidTestCase =
+  | string
+  | {
+      code: string;
+      only?: boolean;
+      skip?: boolean;
+    };
+
+export interface InvalidTestCase {
+  code: string;
+  errors: TsDiagnostic[];
+  only?: boolean;
+  skip?: boolean;
+}
+
+function filterSnapshot(diags: LintResponse & { code?: string }): LintResponse {
+  for (const diag of diags.diagnostics ?? []) {
+    const d = diag as unknown as Record<string, unknown>;
+    delete d.filePath;
+    delete d.fixes;
+  }
+  return diags;
+}
+
+export class RuleTester {
+  public run(
+    ruleName: string,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    describe(ruleName, () => {
+      const cwd = path.resolve(import.meta.dirname);
+      const config = path.resolve(cwd, './rslint.json');
+
+      let hasOnly =
+        cases.valid.some(x => typeof x === 'object' && x.only) ||
+        cases.invalid.some(x => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (typeof validCase === 'object' && validCase.skip) continue;
+          if (hasOnly && (typeof validCase === 'string' || !validCase.only))
+            continue;
+
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+          const virtual_entry = path.resolve(cwd, 'src/virtual.ts');
+
+          const diags = await lint({
+            config,
+            workingDirectory: cwd,
+            fileContents: { [virtual_entry]: code },
+            ruleOptions: { [ruleName]: [] } as any,
+          });
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case, but got: ${JSON.stringify(diags)} \nwith code:\n${code}`,
+          );
+        }
+      });
+
+      test('invalid', async () => {
+        for (const item of cases.invalid) {
+          if (item.skip) continue;
+          if (hasOnly && !item.only) continue;
+
+          const { code, errors } = item;
+          const virtual_entry = path.resolve(cwd, 'src/virtual.ts');
+
+          const diags = await lint({
+            config,
+            workingDirectory: cwd,
+            fileContents: { [virtual_entry]: code },
+            ruleOptions: { [ruleName]: [] } as any,
+          });
+
+          assert(
+            diags.diagnostics?.length > 0,
+            `Expected diagnostics for invalid case: ${code}`,
+          );
+          checkDiagnosticEqual(diags.diagnostics, errors);
+          expect(filterSnapshot({ ...diags, code })).toMatchSnapshot();
+        }
+      });
+    });
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-loss-of-precision.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-loss-of-precision.test.ts.snap
@@ -1,0 +1,183 @@
+// Rstest Snapshot v1
+
+exports[`no-loss-of-precision > invalid 1`] = `
+{
+  "code": "const x = 9007199254740993;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loss-of-precision > invalid 2`] = `
+{
+  "code": "const x = 9_007_199_254_740_993;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loss-of-precision > invalid 3`] = `
+{
+  "code": "const x = 9_007_199_254_740.993e3;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loss-of-precision > invalid 4`] = `
+{
+  "code": "const x = 0x20000000000001;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loss-of-precision > invalid 5`] = `
+{
+  "code": "const x = 0o400000000000000001;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loss-of-precision > invalid 6`] = `
+{
+  "code": "const x = 0b100_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loss-of-precision > invalid 7`] = `
+{
+  "code": "const x = 2e999;",
+  "diagnostics": [
+    {
+      "message": "This number literal will lose precision at runtime.",
+      "messageId": "no-loss-of-precision",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loss-of-precision",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-loss-of-precision.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-loss-of-precision.test.ts
@@ -1,0 +1,49 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-loss-of-precision', {
+  valid: [
+    'const x = 12345;',
+    'const x = 123.456;',
+    'const x = -123.456;',
+    'const x = 123e34;',
+    'const x = 0x1FFFFFFFFFFFFF;',
+    'const x = 0o377777777777777777;',
+    'const x = 0b11111111111111111111111111111111111111111111111111111;',
+    'const x = 9007199254740991;',
+    'const x = 123_456;',
+    'const x = 123_00_000_000_000_000_000_000_000;',
+    'const x = 123.000_000_000_000_000_000_000_0;',
+  ],
+  invalid: [
+    {
+      code: 'const x = 9007199254740993;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+    {
+      code: 'const x = 9_007_199_254_740_993;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+    {
+      code: 'const x = 9_007_199_254_740.993e3;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+    {
+      code: 'const x = 0x20000000000001;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+    {
+      code: 'const x = 0o400000000000000001;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+    {
+      code: 'const x = 0b100_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+    {
+      code: 'const x = 2e999;',
+      errors: [{ messageId: 'noLossOfPrecision' }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint/tsconfig.virtual.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "experimentalDecorators": true
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}


### PR DESCRIPTION
## Summary

Port the ESLint `no-loss-of-precision` rule to rslint.

This rule disallows literal numbers that lose precision when converted to JavaScript Number (IEEE 754 64-bit floating-point). Supports base-10 integers/decimals, scientific notation, binary (0b), octal (0o), hexadecimal (0x), and ES2021 numeric separators.

Also adds the core ESLint rule JS test infrastructure under `packages/rslint-test-tools/tests/eslint/`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-loss-of-precision
- Related Issue: https://github.com/web-infra-dev/rslint/issues/223

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).