### PR TITLE
feat: port @typescript-eslint/prefer-readonly rule

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/only_throw_error"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_as_const"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_promise_reject_errors"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly"
 	// "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly_parameter_types" // Temporarily disabled - incomplete implementation
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_reduce_type_parameter"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_return_this_type"
@@ -423,6 +424,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/only-throw-error", only_throw_error.OnlyThrowErrorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-as-const", prefer_as_const.PreferAsConstRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-promise-reject-errors", prefer_promise_reject_errors.PreferPromiseRejectErrorsRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-readonly", prefer_readonly.PreferReadonlyRule)
 	// TODO: prefer-readonly-parameter-types needs complete implementation for proper type checking
 	// Temporarily disabled until the isReadonlyType function is fully implemented with proper
 	// detection of readonly arrays, readonly objects, function types, and other edge cases

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -85,6 +85,20 @@ func RunLinterInProgram(program *compiler.Program, allowFiles []string, skipFile
 							Severity:   r.Severity,
 						})
 					},
+					ReportRangeWithFixes: func(textRange core.TextRange, msg rule.RuleMessage, fixes ...rule.RuleFix) {
+						// Check if rule is disabled at this position
+						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {
+							return
+						}
+						onDiagnostic(rule.RuleDiagnostic{
+							RuleName:   r.Name,
+							Range:      textRange,
+							Message:    msg,
+							FixesPtr:   &fixes,
+							SourceFile: file,
+							Severity:   r.Severity,
+						})
+					},
 					ReportRangeWithSuggestions: func(textRange core.TextRange, msg rule.RuleMessage, suggestions ...rule.RuleSuggestion) {
 						// Check if rule is disabled at this position
 						if disableManager.IsRuleDisabled(r.Name, textRange.Pos()) {

--- a/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.go
+++ b/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.go
@@ -1,0 +1,632 @@
+package prefer_readonly
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func messagePreferReadonly(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferReadonly",
+		Description: fmt.Sprintf("Member '%s' is never reassigned; mark it as `readonly`.", name),
+	}
+}
+
+type options struct {
+	onlyInlineLambdas bool
+}
+
+func parseOptions(rawOpts any) options {
+	opts := options{onlyInlineLambdas: false}
+	if rawOpts == nil {
+		return opts
+	}
+
+	var optsMap map[string]interface{}
+	if arr, ok := rawOpts.([]interface{}); ok && len(arr) > 0 {
+		optsMap, _ = arr[0].(map[string]interface{})
+	} else {
+		optsMap, _ = rawOpts.(map[string]interface{})
+	}
+
+	if optsMap != nil {
+		if v, ok := optsMap["onlyInlineLambdas"].(bool); ok {
+			opts.onlyInlineLambdas = v
+		}
+	}
+	return opts
+}
+
+const (
+	outsideConstructor       = -1
+	directlyInsideConstructor = 0
+)
+
+type typeToClassRelation int
+
+const (
+	relationNone             typeToClassRelation = iota
+	relationClass            typeToClassRelation = iota
+	relationInstance         typeToClassRelation = iota
+	relationClassAndInstance typeToClassRelation = iota
+)
+
+type classScope struct {
+	checker                                  *checker.Checker
+	classType                                *checker.Type
+	onlyInlineLambdas                        bool
+	constructorScopeDepth                    int
+	memberVariableModifications              *utils.Set[string]
+	memberVariableWithConstructorModifications *utils.Set[string]
+	staticVariableModifications              *utils.Set[string]
+	privateModifiableMembers                 map[string]*ast.Node
+	privateModifiableStatics                 map[string]*ast.Node
+}
+
+func newClassScope(ch *checker.Checker, classNode *ast.Node, onlyInlineLambdas bool) *classScope {
+	classType := ch.GetTypeAtLocation(classNode)
+	if classType != nil && utils.IsIntersectionType(classType) {
+		parts := utils.IntersectionTypeParts(classType)
+		if len(parts) > 0 {
+			classType = parts[0]
+		}
+	}
+
+	cs := &classScope{
+		checker:                                  ch,
+		classType:                                classType,
+		onlyInlineLambdas:                        onlyInlineLambdas,
+		constructorScopeDepth:                    outsideConstructor,
+		memberVariableModifications:              utils.NewSetWithSizeHint[string](4),
+		memberVariableWithConstructorModifications: utils.NewSetWithSizeHint[string](4),
+		staticVariableModifications:              utils.NewSetWithSizeHint[string](4),
+		privateModifiableMembers:                 make(map[string]*ast.Node),
+		privateModifiableStatics:                 make(map[string]*ast.Node),
+	}
+
+	// Scan class members for property declarations
+	members := classNode.Members()
+	for _, member := range members {
+		if ast.IsPropertyDeclaration(member) {
+			cs.addDeclaredVariable(member)
+		}
+	}
+
+	return cs
+}
+
+func (cs *classScope) addDeclaredVariable(node *ast.Node) {
+	flags := ast.GetCombinedModifierFlags(node)
+
+	// Must be private (either `private` keyword or `#` private field)
+	nameNode := getPropertyName(node)
+	isPrivateField := nameNode != nil && nameNode.Kind == ast.KindPrivateIdentifier
+	isPrivateKeyword := flags&ast.ModifierFlagsPrivate != 0
+
+	if !isPrivateKeyword && !isPrivateField {
+		return
+	}
+
+	// Skip if already readonly
+	if flags&ast.ModifierFlagsReadonly != 0 {
+		return
+	}
+
+	// Skip accessor properties
+	if flags&ast.ModifierFlagsAccessor != 0 {
+		return
+	}
+
+	// Skip computed property names (non-private identifiers)
+	if nameNode != nil && nameNode.Kind == ast.KindComputedPropertyName {
+		return
+	}
+
+	// Check onlyInlineLambdas option
+	if cs.onlyInlineLambdas {
+		initializer := getInitializer(node)
+		if initializer != nil && !ast.IsArrowFunction(initializer) {
+			return
+		}
+	}
+
+	name := getNameText(nameNode)
+	if name == "" {
+		return
+	}
+
+	if flags&ast.ModifierFlagsStatic != 0 {
+		cs.privateModifiableStatics[name] = node
+	} else {
+		cs.privateModifiableMembers[name] = node
+	}
+}
+
+func (cs *classScope) addVariableModification(node *ast.Node) {
+	// node is a PropertyAccessExpression
+	propAccess := node.AsPropertyAccessExpression()
+	modifierType := cs.checker.GetTypeAtLocation(propAccess.Expression)
+
+	relation := cs.getTypeToClassRelation(modifierType)
+
+	name := propAccess.Name().Text()
+
+	if relation == relationInstance && cs.constructorScopeDepth == directlyInsideConstructor {
+		cs.memberVariableWithConstructorModifications.Add(name)
+		return
+	}
+
+	if relation == relationInstance || relation == relationClassAndInstance {
+		cs.memberVariableModifications.Add(name)
+	}
+	if relation == relationClass || relation == relationClassAndInstance {
+		cs.staticVariableModifications.Add(name)
+	}
+}
+
+func (cs *classScope) enterConstructor(node *ast.Node) {
+	cs.constructorScopeDepth = directlyInsideConstructor
+
+	// Add parameter properties
+	funcData := node.FunctionLikeData()
+	if funcData != nil && funcData.Parameters != nil {
+		for _, param := range funcData.Parameters.Nodes {
+			flags := ast.GetCombinedModifierFlags(param)
+			if flags&ast.ModifierFlagsPrivate != 0 {
+				cs.addDeclaredVariable(param)
+			}
+		}
+	}
+}
+
+func (cs *classScope) enterNonConstructor() {
+	if cs.constructorScopeDepth != outsideConstructor {
+		cs.constructorScopeDepth++
+	}
+}
+
+func (cs *classScope) exitConstructor() {
+	cs.constructorScopeDepth = outsideConstructor
+}
+
+func (cs *classScope) exitNonConstructor() {
+	if cs.constructorScopeDepth != outsideConstructor {
+		cs.constructorScopeDepth--
+	}
+}
+
+func (cs *classScope) finalizeUnmodifiedPrivateNonReadonlys() []*ast.Node {
+	for name := range cs.memberVariableModifications.Keys() {
+		delete(cs.privateModifiableMembers, name)
+	}
+	for name := range cs.staticVariableModifications.Keys() {
+		delete(cs.privateModifiableStatics, name)
+	}
+
+	result := make([]*ast.Node, 0, len(cs.privateModifiableMembers)+len(cs.privateModifiableStatics))
+	for _, node := range cs.privateModifiableMembers {
+		result = append(result, node)
+	}
+	for _, node := range cs.privateModifiableStatics {
+		result = append(result, node)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Pos() < result[j].Pos() })
+	return result
+}
+
+func (cs *classScope) memberHasConstructorModifications(name string) bool {
+	return cs.memberVariableWithConstructorModifications.Has(name)
+}
+
+func (cs *classScope) getTypeToClassRelation(t *checker.Type) typeToClassRelation {
+	if t == nil {
+		return relationNone
+	}
+
+	// Handle TypeParameter (e.g., 'this' type in class methods)
+	if t.Flags()&checker.TypeFlagsTypeParameter != 0 {
+		constraint := checker.Checker_getBaseConstraintOfType(cs.checker, t)
+		if constraint != nil {
+			return cs.getTypeToClassRelation(constraint)
+		}
+		return relationNone
+	}
+
+	if utils.IsIntersectionType(t) {
+		result := relationNone
+		for _, subType := range utils.IntersectionTypeParts(t) {
+			subResult := cs.getTypeToClassRelation(subType)
+			switch subResult {
+			case relationClass:
+				if result == relationInstance {
+					return relationClassAndInstance
+				}
+				result = relationClass
+			case relationInstance:
+				if result == relationClass {
+					return relationClassAndInstance
+				}
+				result = relationInstance
+			}
+		}
+		return result
+	}
+
+	if utils.IsUnionType(t) {
+		parts := utils.UnionTypeParts(t)
+		if len(parts) > 0 {
+			return cs.getTypeToClassRelation(parts[0])
+		}
+		return relationNone
+	}
+
+	if t.Symbol() == nil || !typeIsOrHasBaseType(cs.checker, t, cs.classType) {
+		return relationNone
+	}
+
+	if utils.IsObjectType(t) && t.ObjectFlags()&checker.ObjectFlagsClassOrInterface != 0 && !isObjectFlagAnonymous(t) {
+		return relationInstance
+	}
+
+	return relationClass
+}
+
+func typeIsOrHasBaseType(ch *checker.Checker, t *checker.Type, baseType *checker.Type) bool {
+	if t == nil || baseType == nil {
+		return false
+	}
+	if t == baseType {
+		return true
+	}
+	// Compare by symbol identity - handles cases where 'this' type
+	// and class type are different objects representing the same class
+	tSym := t.Symbol()
+	baseSym := baseType.Symbol()
+	if tSym != nil && baseSym != nil && tSym == baseSym {
+		return true
+	}
+	// Only class/interface types have resolved base types
+	if !utils.IsObjectType(t) || t.ObjectFlags()&checker.ObjectFlagsClassOrInterface == 0 {
+		return false
+	}
+	baseTypes := ch.GetBaseTypes(t)
+	for _, bt := range baseTypes {
+		if typeIsOrHasBaseType(ch, bt, baseType) {
+			return true
+		}
+	}
+	return false
+}
+
+func isObjectFlagAnonymous(t *checker.Type) bool {
+	return t.ObjectFlags()&checker.ObjectFlagsAnonymous != 0
+}
+
+// Helper functions
+
+func getPropertyName(node *ast.Node) *ast.Node {
+	if ast.IsPropertyDeclaration(node) {
+		return node.AsPropertyDeclaration().Name()
+	}
+	if ast.IsParameter(node) {
+		return node.AsParameterDeclaration().Name()
+	}
+	return nil
+}
+
+func getInitializer(node *ast.Node) *ast.Node {
+	if ast.IsPropertyDeclaration(node) {
+		return node.AsPropertyDeclaration().Initializer
+	}
+	if ast.IsParameter(node) {
+		return node.AsParameterDeclaration().Initializer
+	}
+	return nil
+}
+
+func getTypeAnnotation(node *ast.Node) *ast.Node {
+	if ast.IsPropertyDeclaration(node) {
+		return node.AsPropertyDeclaration().Type
+	}
+	if ast.IsParameter(node) {
+		return node.AsParameterDeclaration().Type
+	}
+	return nil
+}
+
+func getNameText(nameNode *ast.Node) string {
+	if nameNode == nil {
+		return ""
+	}
+	if nameNode.Kind == ast.KindIdentifier {
+		return nameNode.AsIdentifier().Text
+	}
+	if nameNode.Kind == ast.KindPrivateIdentifier {
+		return nameNode.Text()
+	}
+	return ""
+}
+
+func getNameDisplayText(ctx rule.RuleContext, nameNode *ast.Node) string {
+	if nameNode == nil {
+		return ""
+	}
+	text := strings.TrimSpace(ctx.SourceFile.Text()[nameNode.Pos():nameNode.End()])
+	return text
+}
+
+func isConstructor(node *ast.Node) bool {
+	return ast.IsConstructorDeclaration(node)
+}
+
+func isFunctionScopeBoundary(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindArrowFunction, ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression, ast.KindMethodDeclaration,
+		ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+func isDestructuringAssignment(node *ast.Node) bool {
+	current := node.Parent
+	for current != nil {
+		parent := current.Parent
+		if parent == nil {
+			break
+		}
+
+		if ast.IsObjectLiteralExpression(parent) ||
+			ast.IsArrayLiteralExpression(parent) ||
+			ast.IsSpreadAssignment(parent) ||
+			(ast.IsSpreadElement(parent) && parent.Parent != nil && ast.IsArrayLiteralExpression(parent.Parent)) {
+			current = parent
+		} else if ast.IsBinaryExpression(parent) && !ast.IsPropertyAccessExpression(current) {
+			bin := parent.AsBinaryExpression()
+			return bin.Left == current && bin.OperatorToken.Kind == ast.KindEqualsToken
+		} else {
+			break
+		}
+	}
+	return false
+}
+
+var PreferReadonlyRule = rule.CreateRule(rule.Rule{
+	Name: "prefer-readonly",
+	Run: func(ctx rule.RuleContext, rawOpts any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+
+		opts := parseOptions(rawOpts)
+		var classScopeStack []*classScope
+
+		handlePropertyAccessExpression := func(node *ast.Node, parent *ast.Node, cs *classScope) {
+			if ast.IsBinaryExpression(parent) {
+				bin := parent.AsBinaryExpression()
+				if bin.Left == node && ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+					cs.addVariableModification(node)
+				}
+				return
+			}
+
+			if parent.Kind == ast.KindDeleteExpression || isDestructuringAssignment(node) {
+				cs.addVariableModification(node)
+				return
+			}
+
+			switch parent.Kind {
+			case ast.KindPostfixUnaryExpression:
+				unary := parent.AsPostfixUnaryExpression()
+				if unary != nil && (unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken) {
+					cs.addVariableModification(node)
+				}
+			case ast.KindPrefixUnaryExpression:
+				unary := parent.AsPrefixUnaryExpression()
+				if unary != nil && (unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken) {
+					cs.addVariableModification(node)
+				}
+			}
+		}
+
+		isFunctionScopeBoundaryInStack := func(node *ast.Node) bool {
+			if len(classScopeStack) == 0 {
+				return false
+			}
+			if isConstructor(node) {
+				return false
+			}
+			return isFunctionScopeBoundary(node)
+		}
+
+		listeners := rule.RuleListeners{
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				classScopeStack = append(classScopeStack, newClassScope(ctx.TypeChecker, node, opts.onlyInlineLambdas))
+			},
+			ast.KindClassExpression: func(node *ast.Node) {
+				classScopeStack = append(classScopeStack, newClassScope(ctx.TypeChecker, node, opts.onlyInlineLambdas))
+			},
+			rule.ListenerOnExit(ast.KindClassDeclaration): func(node *ast.Node) {
+				if len(classScopeStack) == 0 {
+					return
+				}
+				cs := classScopeStack[len(classScopeStack)-1]
+				classScopeStack = classScopeStack[:len(classScopeStack)-1]
+				reportViolations(ctx, cs, node)
+			},
+			rule.ListenerOnExit(ast.KindClassExpression): func(node *ast.Node) {
+				if len(classScopeStack) == 0 {
+					return
+				}
+				cs := classScopeStack[len(classScopeStack)-1]
+				classScopeStack = classScopeStack[:len(classScopeStack)-1]
+				reportViolations(ctx, cs, node)
+			},
+
+			// Enter/exit constructors and functions
+			ast.KindConstructor: func(node *ast.Node) {
+				if len(classScopeStack) > 0 {
+					classScopeStack[len(classScopeStack)-1].enterConstructor(node)
+				}
+			},
+			rule.ListenerOnExit(ast.KindConstructor): func(node *ast.Node) {
+				if len(classScopeStack) > 0 {
+					classScopeStack[len(classScopeStack)-1].exitConstructor()
+				}
+			},
+
+			ast.KindArrowFunction: func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].enterNonConstructor()
+				}
+			},
+			rule.ListenerOnExit(ast.KindArrowFunction): func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].exitNonConstructor()
+				}
+			},
+			ast.KindFunctionDeclaration: func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].enterNonConstructor()
+				}
+			},
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].exitNonConstructor()
+				}
+			},
+			ast.KindFunctionExpression: func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].enterNonConstructor()
+				}
+			},
+			rule.ListenerOnExit(ast.KindFunctionExpression): func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].exitNonConstructor()
+				}
+			},
+			ast.KindMethodDeclaration: func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].enterNonConstructor()
+				}
+			},
+			rule.ListenerOnExit(ast.KindMethodDeclaration): func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].exitNonConstructor()
+				}
+			},
+			ast.KindGetAccessor: func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].enterNonConstructor()
+				}
+			},
+			rule.ListenerOnExit(ast.KindGetAccessor): func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].exitNonConstructor()
+				}
+			},
+			ast.KindSetAccessor: func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].enterNonConstructor()
+				}
+			},
+			rule.ListenerOnExit(ast.KindSetAccessor): func(node *ast.Node) {
+				if isFunctionScopeBoundaryInStack(node) {
+					classScopeStack[len(classScopeStack)-1].exitNonConstructor()
+				}
+			},
+
+			// Track member access expressions
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				if len(classScopeStack) == 0 {
+					return
+				}
+				propAccess := node.AsPropertyAccessExpression()
+				if propAccess == nil {
+					return
+				}
+				handlePropertyAccessExpression(node, node.Parent, classScopeStack[len(classScopeStack)-1])
+			},
+		}
+
+		return listeners
+	},
+})
+
+func reportViolations(ctx rule.RuleContext, cs *classScope, classNode *ast.Node) {
+	violations := cs.finalizeUnmodifiedPrivateNonReadonlys()
+
+	for _, violatingNode := range violations {
+		nameNode := getPropertyName(violatingNode)
+		if nameNode == nil {
+			continue
+		}
+
+		nameText := getNameDisplayText(ctx, nameNode)
+
+		// Build the report range: from start of member to end of name
+		memberRange := getMemberHeadRange(ctx, violatingNode, nameNode)
+
+		// Build fixes
+		fixes := buildFixes(ctx, cs, violatingNode, nameNode)
+
+		ctx.ReportRangeWithFixes(memberRange, messagePreferReadonly(nameText), fixes...)
+	}
+}
+
+func getMemberHeadRange(ctx rule.RuleContext, node *ast.Node, nameNode *ast.Node) core.TextRange {
+	trimmed := utils.TrimNodeTextRange(ctx.SourceFile, node)
+	nameEnd := nameNode.End()
+	return trimmed.WithEnd(nameEnd)
+}
+
+func buildFixes(ctx rule.RuleContext, cs *classScope, node *ast.Node, nameNode *ast.Node) []rule.RuleFix {
+	var fixes []rule.RuleFix
+
+	// Insert 'readonly ' before the name
+	fixes = append(fixes, rule.RuleFixInsertBefore(ctx.SourceFile, nameNode, "readonly "))
+
+	// For property declarations without type annotation but with an initializer
+	// that has constructor modifications, we may need to add a type annotation
+	if ast.IsPropertyDeclaration(node) {
+		typeAnno := getTypeAnnotation(node)
+		initializer := getInitializer(node)
+
+		if typeAnno == nil && initializer != nil && nameNode.Kind == ast.KindIdentifier {
+			identName := nameNode.AsIdentifier().Text
+			if cs.memberHasConstructorModifications(identName) {
+				violatingType := ctx.TypeChecker.GetTypeAtLocation(node)
+				initializerType := ctx.TypeChecker.GetTypeAtLocation(initializer)
+
+				if violatingType != nil && initializerType != nil &&
+					isLiteralType(initializerType) && !isLiteralType(violatingType) {
+					annotation := ctx.TypeChecker.TypeToString(violatingType)
+					if annotation != "" {
+						fixes = append(fixes, rule.RuleFixInsertAfter(nameNode, ": "+annotation))
+					}
+				}
+			}
+		}
+	}
+
+	return fixes
+}
+
+func isLiteralType(t *checker.Type) bool {
+	if t == nil {
+		return false
+	}
+	flags := t.Flags()
+	return flags&checker.TypeFlagsStringLiteral != 0 ||
+		flags&checker.TypeFlagsNumberLiteral != 0 ||
+		flags&checker.TypeFlagsBooleanLiteral != 0 ||
+		flags&checker.TypeFlagsEnumLiteral != 0
+}

--- a/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.md
+++ b/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly.md
@@ -1,0 +1,63 @@
+# prefer-readonly
+
+## Rule Details
+
+Require private members to be marked as `readonly` if they're never modified outside of the constructor.
+
+Member variables with the `private` modifier or `#` private fields are only accessible within their declaring class. If that member is never reassigned after initialization (either at declaration or in the constructor), it should be marked as `readonly` to communicate intent and prevent accidental mutation.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+class Foo {
+  private neverModified = 'unchanged';
+}
+
+class Bar {
+  #neverModified = 'unchanged';
+}
+
+class Baz {
+  private neverModified = 'unchanged';
+
+  public constructor() {
+    this.neverModified = 'reassigned in constructor only';
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+class Foo {
+  private readonly neverModified = 'unchanged';
+}
+
+class Bar {
+  readonly #neverModified = 'unchanged';
+}
+
+class Baz {
+  private modifiedLater = 'unchanged';
+
+  public mutate() {
+    this.modifiedLater = 'changed outside constructor';
+  }
+}
+```
+
+## Options
+
+### `onlyInlineLambdas`
+
+When set to `true`, only checks members that are assigned an arrow function expression. This can be useful when a project wants to enforce `readonly` only for function-like members.
+
+```json
+{
+  "@typescript-eslint/prefer-readonly": ["warn", { "onlyInlineLambdas": true }]
+}
+```
+
+## Original Documentation
+
+- [typescript-eslint prefer-readonly](https://typescript-eslint.io/rules/prefer-readonly)

--- a/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly_test.go
+++ b/internal/plugins/typescript/rules/prefer_readonly/prefer_readonly_test.go
@@ -1,0 +1,2752 @@
+package prefer_readonly
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferReadonlyRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferReadonlyRule, []rule_tester.ValidTestCase{
+		// Non-class code
+		{Code: `function ignore() {}`},
+		{Code: `const ignore = function () {};`},
+		{Code: `const ignore = () => {};`},
+		{Code: `
+const container = { member: true };
+container.member;
+		`},
+		{Code: `
+const container = { member: 1 };
++container.member;
+		`},
+		{Code: `
+const container = { member: 1 };
+++container.member;
+		`},
+		{Code: `
+const container = { member: 1 };
+container.member++;
+		`},
+		{Code: `
+const container = { member: 1 };
+-container.member;
+		`},
+		{Code: `
+const container = { member: 1 };
+--container.member;
+		`},
+		{Code: `
+const container = { member: 1 };
+container.member--;
+		`},
+		// Empty class
+		{Code: `class TestEmpty {}`},
+		// Already readonly - private keyword
+		{Code: `
+class TestReadonlyStatic {
+  private static readonly correctlyReadonlyStatic = 7;
+}
+		`},
+		// Already readonly - private field
+		{Code: `
+class TestReadonlyStatic {
+  static readonly #correctlyReadonlyStatic = 7;
+}
+		`},
+		// Modified static in constructor - private keyword
+		{Code: `
+class TestModifiableStatic {
+  private static correctlyModifiableStatic = 7;
+
+  public constructor() {
+    TestModifiableStatic.correctlyModifiableStatic += 1;
+  }
+}
+		`},
+		// Modified static in constructor - private field
+		{Code: `
+class TestModifiableStatic {
+  static #correctlyModifiableStatic = 7;
+
+  public constructor() {
+    TestModifiableStatic.#correctlyModifiableStatic += 1;
+  }
+}
+		`},
+		// Already readonly inline - private keyword
+		{Code: `
+class TestReadonlyInline {
+  private readonly correctlyReadonlyInline = 7;
+}
+		`},
+		// Already readonly inline - private field
+		{Code: `
+class TestReadonlyInline {
+  readonly #correctlyReadonlyInline = 7;
+}
+		`},
+		// Readonly delayed (constructor assignment with readonly) - private keyword
+		{Code: `
+class TestReadonlyDelayed {
+  private readonly correctlyReadonlyDelayed = 7;
+
+  public constructor() {
+    this.correctlyReadonlyDelayed += 1;
+  }
+}
+		`},
+		// Readonly delayed - private field
+		{Code: `
+class TestReadonlyDelayed {
+  readonly #correctlyReadonlyDelayed = 7;
+
+  public constructor() {
+    this.#correctlyReadonlyDelayed += 1;
+  }
+}
+		`},
+		// Nested class expression: both modified - private keyword
+		{Code: `
+class TestModifiableInline {
+  private correctlyModifiableInline = 7;
+
+  public mutate() {
+    this.correctlyModifiableInline += 1;
+
+    return class {
+      private correctlyModifiableInline = 7;
+
+      mutate() {
+        this.correctlyModifiableInline += 1;
+      }
+    };
+  }
+}
+		`},
+		// Nested class expression: both modified - private field
+		{Code: `
+class TestModifiableInline {
+  #correctlyModifiableInline = 7;
+
+  public mutate() {
+    this.#correctlyModifiableInline += 1;
+
+    return class {
+      #correctlyModifiableInline = 7;
+
+      mutate() {
+        this.#correctlyModifiableInline += 1;
+      }
+    };
+  }
+}
+		`},
+		// Modified in method - private keyword
+		{Code: `
+class TestModifiableDelayed {
+  private correctlyModifiableDelayed = 7;
+
+  public mutate() {
+    this.correctlyModifiableDelayed += 1;
+  }
+}
+		`},
+		// Modified in method - private field
+		{Code: `
+class TestModifiableDelayed {
+  #correctlyModifiableDelayed = 7;
+
+  public mutate() {
+    this.#correctlyModifiableDelayed += 1;
+  }
+}
+		`},
+		// Deleted property
+		{Code: `
+class TestModifiableDeleted {
+  private correctlyModifiableDeleted = 7;
+
+  public mutate() {
+    delete this.correctlyModifiableDeleted;
+  }
+}
+		`},
+		// Modified in constructor arrow function - private keyword
+		{Code: `
+class TestModifiableWithinConstructor {
+  private correctlyModifiableWithinConstructor = 7;
+
+  public constructor() {
+    (() => {
+      this.correctlyModifiableWithinConstructor += 1;
+    })();
+  }
+}
+		`},
+		// Modified in constructor arrow function - private field
+		{Code: `
+class TestModifiableWithinConstructor {
+  #correctlyModifiableWithinConstructor = 7;
+
+  public constructor() {
+    (() => {
+      this.#correctlyModifiableWithinConstructor += 1;
+    })();
+  }
+}
+		`},
+		// Modified in constructor arrow function (variant naming) - private keyword
+		{Code: `
+class TestModifiableWithinConstructorArrowFunction {
+  private correctlyModifiableWithinConstructorArrowFunction = 7;
+
+  public constructor() {
+    (() => {
+      this.correctlyModifiableWithinConstructorArrowFunction += 1;
+    })();
+  }
+}
+		`},
+		// Modified in constructor arrow function (variant naming) - private field
+		{Code: `
+class TestModifiableWithinConstructorArrowFunction {
+  #correctlyModifiableWithinConstructorArrowFunction = 7;
+
+  public constructor() {
+    (() => {
+      this.#correctlyModifiableWithinConstructorArrowFunction += 1;
+    })();
+  }
+}
+		`},
+		// Modified via self in constructor function expression - private keyword
+		{Code: `
+class TestModifiableWithinConstructorInFunctionExpression {
+  private correctlyModifiableWithinConstructorInFunctionExpression = 7;
+
+  public constructor() {
+    const self = this;
+
+    (() => {
+      self.correctlyModifiableWithinConstructorInFunctionExpression += 1;
+    })();
+  }
+}
+		`},
+		// Modified via self in constructor function expression - private field
+		{Code: `
+class TestModifiableWithinConstructorInFunctionExpression {
+  #correctlyModifiableWithinConstructorInFunctionExpression = 7;
+
+  public constructor() {
+    const self = this;
+
+    (() => {
+      self.#correctlyModifiableWithinConstructorInFunctionExpression += 1;
+    })();
+  }
+}
+		`},
+		// Modified via self in constructor get accessor - private keyword
+		{Code: `
+class TestModifiableWithinConstructorInGetAccessor {
+  private correctlyModifiableWithinConstructorInGetAccessor = 7;
+
+  public constructor() {
+    const self = this;
+
+    const confusingObject = {
+      get accessor() {
+        return (self.correctlyModifiableWithinConstructorInGetAccessor += 1);
+      },
+    };
+  }
+}
+		`},
+		// Modified via self in constructor get accessor - private field
+		{Code: `
+class TestModifiableWithinConstructorInGetAccessor {
+  #correctlyModifiableWithinConstructorInGetAccessor = 7;
+
+  public constructor() {
+    const self = this;
+
+    const confusingObject = {
+      get accessor() {
+        return (self.#correctlyModifiableWithinConstructorInGetAccessor += 1);
+      },
+    };
+  }
+}
+		`},
+		// Modified via self in constructor method declaration - private keyword
+		{Code: `
+class TestModifiableWithinConstructorInMethodDeclaration {
+  private correctlyModifiableWithinConstructorInMethodDeclaration = 7;
+
+  public constructor() {
+    const self = this;
+
+    const confusingObject = {
+      methodDeclaration() {
+        self.correctlyModifiableWithinConstructorInMethodDeclaration = 7;
+      },
+    };
+  }
+}
+		`},
+		// Modified via self in constructor method declaration - private field
+		{Code: `
+class TestModifiableWithinConstructorInMethodDeclaration {
+  #correctlyModifiableWithinConstructorInMethodDeclaration = 7;
+
+  public constructor() {
+    const self = this;
+
+    const confusingObject = {
+      methodDeclaration() {
+        self.#correctlyModifiableWithinConstructorInMethodDeclaration = 7;
+      },
+    };
+  }
+}
+		`},
+		// Modified via self in constructor set accessor - private keyword
+		{Code: `
+class TestModifiableWithinConstructorInSetAccessor {
+  private correctlyModifiableWithinConstructorInSetAccessor = 7;
+
+  public constructor() {
+    const self = this;
+
+    const confusingObject = {
+      set accessor(value: number) {
+        self.correctlyModifiableWithinConstructorInSetAccessor += value;
+      },
+    };
+  }
+}
+		`},
+		// Modified via self in constructor set accessor - private field
+		{Code: `
+class TestModifiableWithinConstructorInSetAccessor {
+  #correctlyModifiableWithinConstructorInSetAccessor = 7;
+
+  public constructor() {
+    const self = this;
+
+    const confusingObject = {
+      set accessor(value: number) {
+        self.#correctlyModifiableWithinConstructorInSetAccessor += value;
+      },
+    };
+  }
+}
+		`},
+		// Post decremented via -= : private keyword
+		{Code: `
+class TestModifiablePostDecremented {
+  private correctlyModifiablePostDecremented = 7;
+
+  public mutate() {
+    this.correctlyModifiablePostDecremented -= 1;
+  }
+}
+		`},
+		// Post decremented via -= : private field
+		{Code: `
+class TestModifiablePostDecremented {
+  #correctlyModifiablePostDecremented = 7;
+
+  public mutate() {
+    this.#correctlyModifiablePostDecremented -= 1;
+  }
+}
+		`},
+		// Post incremented via += : private keyword
+		{Code: `
+class TestyModifiablePostIncremented {
+  private correctlyModifiablePostIncremented = 7;
+
+  public mutate() {
+    this.correctlyModifiablePostIncremented += 1;
+  }
+}
+		`},
+		// Post incremented via += : private field
+		{Code: `
+class TestyModifiablePostIncremented {
+  #correctlyModifiablePostIncremented = 7;
+
+  public mutate() {
+    this.#correctlyModifiablePostIncremented += 1;
+  }
+}
+		`},
+		// Pre decremented via -- : private keyword
+		{Code: `
+class TestModifiablePreDecremented {
+  private correctlyModifiablePreDecremented = 7;
+
+  public mutate() {
+    --this.correctlyModifiablePreDecremented;
+  }
+}
+		`},
+		// Pre decremented via -- : private field
+		{Code: `
+class TestModifiablePreDecremented {
+  #correctlyModifiablePreDecremented = 7;
+
+  public mutate() {
+    --this.#correctlyModifiablePreDecremented;
+  }
+}
+		`},
+		// Pre incremented via ++ : private keyword
+		{Code: `
+class TestModifiablePreIncremented {
+  private correctlyModifiablePreIncremented = 7;
+
+  public mutate() {
+    ++this.correctlyModifiablePreIncremented;
+  }
+}
+		`},
+		// Pre incremented via ++ : private field
+		{Code: `
+class TestModifiablePreIncremented {
+  #correctlyModifiablePreIncremented = 7;
+
+  public mutate() {
+    ++this.#correctlyModifiablePreIncremented;
+  }
+}
+		`},
+		// Protected and public are not reported
+		{Code: `
+class TestProtectedModifiable {
+  protected protectedModifiable = 7;
+}
+		`},
+		{Code: `
+class TestPublicModifiable {
+  public publicModifiable = 7;
+}
+		`},
+		// Readonly parameter
+		{Code: `
+class TestReadonlyParameter {
+  public constructor(private readonly correctlyReadonlyParameter = 7) {}
+}
+		`},
+		// Modified parameter
+		{Code: `
+class TestCorrectlyModifiableParameter {
+  public constructor(private correctlyModifiableParameter = 7) {}
+
+  public mutate() {
+    this.correctlyModifiableParameter += 1;
+  }
+}
+		`},
+		// onlyInlineLambdas: non-lambda is skipped - private keyword
+		{
+			Code: `
+class TestCorrectlyNonInlineLambdas {
+  private correctlyNonInlineLambda = 7;
+}
+			`,
+			Options: []interface{}{map[string]interface{}{"onlyInlineLambdas": true}},
+		},
+		// onlyInlineLambdas: non-lambda is skipped - private field
+		{
+			Code: `
+class TestCorrectlyNonInlineLambdas {
+  #correctlyNonInlineLambda = 7;
+}
+			`,
+			Options: []interface{}{map[string]interface{}{"onlyInlineLambdas": true}},
+		},
+		// Computed property
+		{Code: `
+class TestComputedParameter {
+  public mutate() {
+    this['computed'] = 1;
+  }
+}
+		`},
+		{Code: `
+class TestComputedParameter {
+  private ['computed-ignored-by-rule'] = 1;
+}
+		`},
+		// Destructuring assignment - private keyword
+		{Code: `
+class Foo {
+  private value: number = 0;
+
+  bar(newValue: { value: number }) {
+    ({ value: this.value } = newValue);
+    return this.value;
+  }
+}
+		`},
+		// Destructuring assignment - private field
+		{Code: `
+class Foo {
+  #value: number = 0;
+
+  bar(newValue: { value: number }) {
+    ({ value: this.#value } = newValue);
+    return this.#value;
+  }
+}
+		`},
+		// Spread destructuring - private keyword
+		{Code: `
+class Foo {
+  private value: Record<string, number> = {};
+
+  bar(newValue: Record<string, number>) {
+    ({ ...this.value } = newValue);
+    return this.value;
+  }
+}
+		`},
+		// Spread destructuring - private field
+		{Code: `
+class Foo {
+  #value: Record<string, number> = {};
+
+  bar(newValue: Record<string, number>) {
+    ({ ...this.#value } = newValue);
+    return this.#value;
+  }
+}
+		`},
+		// Array spread destructuring - private keyword
+		{Code: `
+class Foo {
+  private value: number[] = [];
+
+  bar(newValue: number[]) {
+    [...this.value] = newValue;
+    return this.value;
+  }
+}
+		`},
+		// Array spread destructuring - private field
+		{Code: `
+class Foo {
+  #value: number[] = [];
+
+  bar(newValue: number[]) {
+    [...this.#value] = newValue;
+    return this.#value;
+  }
+}
+		`},
+		// Array element destructuring - private keyword
+		{Code: `
+class Foo {
+  private value: number = 0;
+
+  bar(newValue: number[]) {
+    [this.value] = newValue;
+    return this.value;
+  }
+}
+		`},
+		// Array element destructuring - private field
+		{Code: `
+class Foo {
+  #value: number = 0;
+
+  bar(newValue: number[]) {
+    [this.#value] = newValue;
+    return this.#value;
+  }
+}
+		`},
+		// Object that is reassigned - private keyword
+		{Code: `
+class Test {
+  private testObj = {
+    prop: '',
+  };
+
+  public test(): void {
+    this.testObj = '';
+  }
+}
+		`},
+		// Object that is reassigned - private field
+		{Code: `
+class Test {
+  #testObj = {
+    prop: '',
+  };
+
+  public test(): void {
+    this.#testObj = '';
+  }
+}
+		`},
+		// TestObject reassigned - private keyword
+		{Code: `
+class TestObject {
+  public prop: number;
+}
+
+class Test {
+  private testObj = new TestObject();
+
+  public test(): void {
+    this.testObj = new TestObject();
+  }
+}
+		`},
+		// TestObject reassigned - private field
+		{Code: `
+class TestObject {
+  public prop: number;
+}
+
+class Test {
+  #testObj = new TestObject();
+
+  public test(): void {
+    this.#testObj = new TestObject();
+  }
+}
+		`},
+		// Intersection type
+		{Code: `
+class TestIntersection {
+  private prop: number = 3;
+
+  test() {
+    const that = {} as this & { _foo: 'bar' };
+    that.prop = 1;
+  }
+}
+		`},
+		// Union type
+		{Code: `
+class TestUnion {
+  private prop: number = 3;
+
+  test() {
+    const that = {} as this | (this & { _foo: 'bar' });
+    that.prop = 1;
+  }
+}
+		`},
+		// Static intersection
+		{Code: `
+class TestStaticIntersection {
+  private static prop: number;
+
+  test() {
+    const that = {} as typeof TestStaticIntersection & { _foo: 'bar' };
+    that.prop = 1;
+  }
+}
+		`},
+		// Static union
+		{Code: `
+class TestStaticUnion {
+  private static prop: number = 1;
+
+  test() {
+    const that = {} as
+      | typeof TestStaticUnion
+      | (typeof TestStaticUnion & { _foo: 'bar' });
+    that.prop = 1;
+  }
+}
+		`},
+		// Both intersection - order 1
+		{Code: `
+class TestBothIntersection {
+  private prop1: number = 1;
+  private static prop2: number;
+
+  test() {
+    const that = {} as typeof TestBothIntersection & this;
+    that.prop1 = 1;
+    that.prop2 = 1;
+  }
+}
+		`},
+		// Both intersection - order 2
+		{Code: `
+class TestBothIntersection {
+  private prop1: number = 1;
+  private static prop2: number;
+
+  test() {
+    const that = {} as this & typeof TestBothIntersection;
+    that.prop1 = 1;
+    that.prop2 = 1;
+  }
+}
+		`},
+		// Accessor properties
+		{Code: `
+class TestStaticPrivateAccessor {
+  private static accessor staticAcc = 1;
+}
+		`},
+		{Code: `
+class TestStaticPrivateFieldAccessor {
+  static accessor #staticAcc = 1;
+}
+		`},
+		{Code: `
+class TestPrivateAccessor {
+  private accessor acc = 3;
+}
+		`},
+		{Code: `
+class TestPrivateFieldAccessor {
+  accessor #acc = 3;
+}
+		`},
+		// Function returning class with method modification - private keyword
+		{Code: `
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    private _name: string;
+
+    public test(value: string) {
+      this._name = value;
+    }
+  };
+}
+		`},
+		// Function returning class with method modification - private field
+		{Code: `
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    #name: string;
+
+    public test(value: string) {
+      this.#name = value;
+    }
+  };
+}
+		`},
+	}, []rule_tester.InvalidTestCase{
+		// Basic private static
+		{
+			Code: `
+class TestIncorrectlyModifiableStatic {
+  private static incorrectlyModifiableStatic = 7;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableStatic {
+  private static readonly incorrectlyModifiableStatic = 7;
+}
+			`},
+		},
+		// Private field static
+		{
+			Code: `
+class TestIncorrectlyModifiableStatic {
+  static #incorrectlyModifiableStatic = 7;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableStatic {
+  static readonly #incorrectlyModifiableStatic = 7;
+}
+			`},
+		},
+		// Static arrow - private keyword
+		{
+			Code: `
+class TestIncorrectlyModifiableStaticArrow {
+  private static incorrectlyModifiableStaticArrow = () => 7;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableStaticArrow {
+  private static readonly incorrectlyModifiableStaticArrow = () => 7;
+}
+			`},
+		},
+		// Static arrow - private field
+		{
+			Code: `
+class TestIncorrectlyModifiableStaticArrow {
+  static #incorrectlyModifiableStaticArrow = () => 7;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableStaticArrow {
+  static readonly #incorrectlyModifiableStaticArrow = () => 7;
+}
+			`},
+		},
+		// Nested class expressions - both reported (private keyword)
+		{
+			Code: `
+class TestIncorrectlyModifiableInline {
+  private incorrectlyModifiableInline = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      private incorrectlyModifiableInline = 7;
+    };
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 7},
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableInline {
+  private readonly incorrectlyModifiableInline = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      private readonly incorrectlyModifiableInline = 7;
+    };
+  }
+}
+			`},
+		},
+		// Nested class expressions - both reported (private field)
+		{
+			Code: `
+class TestIncorrectlyModifiableInline {
+  #incorrectlyModifiableInline = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      #incorrectlyModifiableInline = 7;
+    };
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 7},
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableInline {
+  readonly #incorrectlyModifiableInline = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      readonly #incorrectlyModifiableInline = 7;
+    };
+  }
+}
+			`},
+		},
+		// Constructor assignment with literal type widening - private keyword
+		{
+			Code: `
+class TestIncorrectlyModifiableDelayed {
+  private incorrectlyModifiableDelayed = 7;
+
+  public constructor() {
+    this.incorrectlyModifiableDelayed = 7;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableDelayed {
+  private readonly incorrectlyModifiableDelayed: number = 7;
+
+  public constructor() {
+    this.incorrectlyModifiableDelayed = 7;
+  }
+}
+			`},
+		},
+		// Constructor assignment - private field
+		{
+			Code: `
+class TestIncorrectlyModifiableDelayed {
+  #incorrectlyModifiableDelayed = 7;
+
+  public constructor() {
+    this.#incorrectlyModifiableDelayed = 7;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableDelayed {
+  readonly #incorrectlyModifiableDelayed = 7;
+
+  public constructor() {
+    this.#incorrectlyModifiableDelayed = 7;
+  }
+}
+			`},
+		},
+		// Child class expression modifiable - only outer reported (private keyword)
+		{
+			Code: `
+class TestChildClassExpressionModifiable {
+  private childClassExpressionModifiable = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      private childClassExpressionModifiable = 7;
+
+      mutate() {
+        this.childClassExpressionModifiable += 1;
+      }
+    };
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestChildClassExpressionModifiable {
+  private readonly childClassExpressionModifiable = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      private childClassExpressionModifiable = 7;
+
+      mutate() {
+        this.childClassExpressionModifiable += 1;
+      }
+    };
+  }
+}
+			`},
+		},
+		// Child class expression modifiable - only outer reported (private field)
+		{
+			Code: `
+class TestChildClassExpressionModifiable {
+  #childClassExpressionModifiable = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      #childClassExpressionModifiable = 7;
+
+      mutate() {
+        this.#childClassExpressionModifiable += 1;
+      }
+    };
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestChildClassExpressionModifiable {
+  readonly #childClassExpressionModifiable = 7;
+
+  public createConfusingChildClass() {
+    return class {
+      #childClassExpressionModifiable = 7;
+
+      mutate() {
+        this.#childClassExpressionModifiable += 1;
+      }
+    };
+  }
+}
+			`},
+		},
+		// Binary expr minus (not assignment) - private keyword
+		{
+			Code: `
+class TestIncorrectlyModifiablePostMinus {
+  private incorrectlyModifiablePostMinus = 7;
+
+  public mutate() {
+    this.incorrectlyModifiablePostMinus - 1;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePostMinus {
+  private readonly incorrectlyModifiablePostMinus = 7;
+
+  public mutate() {
+    this.incorrectlyModifiablePostMinus - 1;
+  }
+}
+			`},
+		},
+		// Binary expr plus (not assignment) - private keyword
+		{
+			Code: `
+class TestIncorrectlyModifiablePostPlus {
+  private incorrectlyModifiablePostPlus = 7;
+
+  public mutate() {
+    this.incorrectlyModifiablePostPlus + 1;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePostPlus {
+  private readonly incorrectlyModifiablePostPlus = 7;
+
+  public mutate() {
+    this.incorrectlyModifiablePostPlus + 1;
+  }
+}
+			`},
+		},
+		// Unary minus (not --) - private keyword
+		{
+			Code: `
+class TestIncorrectlyModifiablePreMinus {
+  private incorrectlyModifiablePreMinus = 7;
+
+  public mutate() {
+    -this.incorrectlyModifiablePreMinus;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePreMinus {
+  private readonly incorrectlyModifiablePreMinus = 7;
+
+  public mutate() {
+    -this.incorrectlyModifiablePreMinus;
+  }
+}
+			`},
+		},
+		// Unary plus (not ++) - private keyword
+		{
+			Code: `
+class TestIncorrectlyModifiablePrePlus {
+  private incorrectlyModifiablePrePlus = 7;
+
+  public mutate() {
+    +this.incorrectlyModifiablePrePlus;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePrePlus {
+  private readonly incorrectlyModifiablePrePlus = 7;
+
+  public mutate() {
+    +this.incorrectlyModifiablePrePlus;
+  }
+}
+			`},
+		},
+		// Overlapping class variable
+		{
+			Code: `
+class TestOverlappingClassVariable {
+  private overlappingClassVariable = 7;
+
+  public workWithSimilarClass(other: SimilarClass) {
+    other.overlappingClassVariable = 7;
+  }
+}
+
+class SimilarClass {
+  public overlappingClassVariable = 7;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestOverlappingClassVariable {
+  private readonly overlappingClassVariable = 7;
+
+  public workWithSimilarClass(other: SimilarClass) {
+    other.overlappingClassVariable = 7;
+  }
+}
+
+class SimilarClass {
+  public overlappingClassVariable = 7;
+}
+			`},
+		},
+		// Constructor parameter property
+		{
+			Code: `
+class TestIncorrectlyModifiableParameter {
+  public constructor(private incorrectlyModifiableParameter = 7) {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableParameter {
+  public constructor(private readonly incorrectlyModifiableParameter = 7) {}
+}
+			`},
+		},
+		// onlyInlineLambdas: inline lambda should be reported
+		{
+			Code: `
+class TestCorrectlyNonInlineLambdas {
+  private incorrectlyInlineLambda = () => 7;
+}
+			`,
+			Options: []interface{}{map[string]interface{}{"onlyInlineLambdas": true}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestCorrectlyNonInlineLambdas {
+  private readonly incorrectlyInlineLambda = () => 7;
+}
+			`},
+		},
+		// Object sub-property write - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {
+    prop: '',
+  };
+
+  public test(): void {
+    this.testObj.prop = '';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {
+    prop: '',
+  };
+
+  public test(): void {
+    this.testObj.prop = '';
+  }
+}
+			`},
+		},
+		// TestObject sub-property write - private keyword
+		{
+			Code: `
+class TestObject {
+  public prop: number;
+}
+
+class Test {
+  private testObj = new TestObject();
+
+  public test(): void {
+    this.testObj.prop = 10;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 7},
+			},
+			Output: []string{`
+class TestObject {
+  public prop: number;
+}
+
+class Test {
+  private readonly testObj = new TestObject();
+
+  public test(): void {
+    this.testObj.prop = 10;
+  }
+}
+			`},
+		},
+		// Optional chaining - still report
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj?.prop;
+  }
+}
+			`},
+		},
+		// Non-null assertion - still report
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj!.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj!.prop;
+  }
+}
+			`},
+		},
+		// Nested property access (not direct assignment)
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj.prop.prop = '';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj.prop.prop = '';
+  }
+}
+			`},
+		},
+		// Intersection: unrelated prop write, class prop should be readonly
+		{
+			Code: `
+class Test {
+  private prop: number = 3;
+
+  test() {
+    const that = {} as this & { _foo: 'bar' };
+    that._foo = 1;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: number = 3;
+
+  test() {
+    const that = {} as this & { _foo: 'bar' };
+    that._foo = 1;
+  }
+}
+			`},
+		},
+		// Union: prop only read, should be readonly
+		{
+			Code: `
+class Test {
+  private prop: number = 3;
+
+  test() {
+    const that = {} as this | (this & { _foo: 'bar' });
+    that.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: number = 3;
+
+  test() {
+    const that = {} as this | (this & { _foo: 'bar' });
+    that.prop;
+  }
+}
+			`},
+		},
+		// String literal with constructor modification - type annotation added
+		{
+			Code: `
+class Test {
+  private prop = 'hello';
+
+  constructor() {
+    this.prop = 'world';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: string = 'hello';
+
+  constructor() {
+    this.prop = 'world';
+  }
+}
+			`},
+		},
+		// Number literal with constructor modification
+		{
+			Code: `
+class Test {
+  private prop = 10;
+
+  constructor() {
+    this.prop = 11;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: number = 10;
+
+  constructor() {
+    this.prop = 11;
+  }
+}
+			`},
+		},
+		// Boolean literal with constructor modification
+		{
+			Code: `
+class Test {
+  private prop = true;
+
+  constructor() {
+    this.prop = false;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: boolean = true;
+
+  constructor() {
+    this.prop = false;
+  }
+}
+			`},
+		},
+		// With existing type annotation - no additional annotation
+		{
+			Code: `
+class Test {
+  private prop: string = 'hello';
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: string = 'hello';
+}
+			`},
+		},
+		// Constructor assignment without literal modification - no type widening
+		{
+			Code: `
+class Test {
+  private prop: string;
+
+  constructor() {
+    this.prop = 'hello';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: string;
+
+  constructor() {
+    this.prop = 'hello';
+  }
+}
+			`},
+		},
+		// Binary expr minus - private field
+		{
+			Code: `
+class TestIncorrectlyModifiablePostMinus {
+  #incorrectlyModifiablePostMinus = 7;
+
+  public mutate() {
+    this.#incorrectlyModifiablePostMinus - 1;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePostMinus {
+  readonly #incorrectlyModifiablePostMinus = 7;
+
+  public mutate() {
+    this.#incorrectlyModifiablePostMinus - 1;
+  }
+}
+			`},
+		},
+		// Binary expr plus - private field
+		{
+			Code: `
+class TestIncorrectlyModifiablePostPlus {
+  #incorrectlyModifiablePostPlus = 7;
+
+  public mutate() {
+    this.#incorrectlyModifiablePostPlus + 1;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePostPlus {
+  readonly #incorrectlyModifiablePostPlus = 7;
+
+  public mutate() {
+    this.#incorrectlyModifiablePostPlus + 1;
+  }
+}
+			`},
+		},
+		// Unary minus - private field
+		{
+			Code: `
+class TestIncorrectlyModifiablePreMinus {
+  #incorrectlyModifiablePreMinus = 7;
+
+  public mutate() {
+    -this.#incorrectlyModifiablePreMinus;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePreMinus {
+  readonly #incorrectlyModifiablePreMinus = 7;
+
+  public mutate() {
+    -this.#incorrectlyModifiablePreMinus;
+  }
+}
+			`},
+		},
+		// Unary plus - private field
+		{
+			Code: `
+class TestIncorrectlyModifiablePrePlus {
+  #incorrectlyModifiablePrePlus = 7;
+
+  public mutate() {
+    +this.#incorrectlyModifiablePrePlus;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiablePrePlus {
+  readonly #incorrectlyModifiablePrePlus = 7;
+
+  public mutate() {
+    +this.#incorrectlyModifiablePrePlus;
+  }
+}
+			`},
+		},
+		// Multi-parameter constructor property
+		{
+			Code: `
+class TestIncorrectlyModifiableParameter {
+  public constructor(
+    public ignore: boolean,
+    private incorrectlyModifiableParameter = 7,
+  ) {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 5},
+			},
+			Output: []string{`
+class TestIncorrectlyModifiableParameter {
+  public constructor(
+    public ignore: boolean,
+    private readonly incorrectlyModifiableParameter = 7,
+  ) {}
+}
+			`},
+		},
+		// ClassWithName - unused private (private keyword)
+		{
+			Code: `
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    private _name: string;
+  };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 4},
+			},
+			Output: []string{`
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    private readonly _name: string;
+  };
+}
+			`},
+		},
+		// ClassWithName - unused private (private field)
+		{
+			Code: `
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    #name: string;
+  };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 4},
+			},
+			Output: []string{`
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    readonly #name: string;
+  };
+}
+			`},
+		},
+		// testObj sub-property write - private field
+		{
+			Code: `
+class Test {
+  #testObj = {
+    prop: '',
+  };
+
+  public test(): void {
+    this.#testObj.prop = '';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {
+    prop: '',
+  };
+
+  public test(): void {
+    this.#testObj.prop = '';
+  }
+}
+			`},
+		},
+		// TestObject sub-property write - private field
+		{
+			Code: `
+class TestObject {
+  public prop: number;
+}
+
+class Test {
+  #testObj = new TestObject();
+
+  public test(): void {
+    this.#testObj.prop = 10;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 7},
+			},
+			Output: []string{`
+class TestObject {
+  public prop: number;
+}
+
+class Test {
+  readonly #testObj = new TestObject();
+
+  public test(): void {
+    this.#testObj.prop = 10;
+  }
+}
+			`},
+		},
+		// Object property read - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {
+    prop: '',
+  };
+  public test(): void {
+    this.testObj.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {
+    prop: '',
+  };
+  public test(): void {
+    this.testObj.prop;
+  }
+}
+			`},
+		},
+		// Object property read - private field
+		{
+			Code: `
+class Test {
+  #testObj = {
+    prop: '',
+  };
+  public test(): void {
+    this.#testObj.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {
+    prop: '',
+  };
+  public test(): void {
+    this.#testObj.prop;
+  }
+}
+			`},
+		},
+		// Optional chaining - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj?.prop;
+  }
+}
+			`},
+		},
+		// Non-null assertion - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj!.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj!.prop;
+  }
+}
+			`},
+		},
+		// Nested prop.prop write - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj.prop.prop = '';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj.prop.prop = '';
+  }
+}
+			`},
+		},
+		// Method call on nested prop - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj.prop.doesSomething();
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj.prop.doesSomething();
+  }
+}
+			`},
+		},
+		// Method call on nested prop - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj.prop.doesSomething();
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj.prop.doesSomething();
+  }
+}
+			`},
+		},
+		// Optional chaining ?.prop.prop - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj?.prop.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj?.prop.prop;
+  }
+}
+			`},
+		},
+		// Optional chaining ?.prop.prop - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj?.prop.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj?.prop.prop;
+  }
+}
+			`},
+		},
+		// Optional chaining ?.prop?.prop - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj?.prop?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj?.prop?.prop;
+  }
+}
+			`},
+		},
+		// Optional chaining ?.prop?.prop - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj?.prop?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj?.prop?.prop;
+  }
+}
+			`},
+		},
+		// Optional chaining .prop?.prop - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj.prop?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj.prop?.prop;
+  }
+}
+			`},
+		},
+		// Optional chaining .prop?.prop - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj.prop?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj.prop?.prop;
+  }
+}
+			`},
+		},
+		// Non-null + optional !.prop?.prop - private keyword
+		{
+			Code: `
+class Test {
+  private testObj = {};
+  public test(): void {
+    this.testObj!.prop?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly testObj = {};
+  public test(): void {
+    this.testObj!.prop?.prop;
+  }
+}
+			`},
+		},
+		// Non-null + optional !.prop?.prop - private field
+		{
+			Code: `
+class Test {
+  #testObj = {};
+  public test(): void {
+    this.#testObj!.prop?.prop;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  readonly #testObj = {};
+  public test(): void {
+    this.#testObj!.prop?.prop;
+  }
+}
+			`},
+		},
+		// Intersection type in constructor
+		{
+			Code: `
+class Test {
+  private prop: number;
+
+  constructor() {
+    const that = {} as this & { _foo: 'bar' };
+    that.prop = 1;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: number;
+
+  constructor() {
+    const that = {} as this & { _foo: 'bar' };
+    that.prop = 1;
+  }
+}
+			`},
+		},
+		// String literal no constructor
+		{
+			Code: `
+class Test {
+  private prop = 'hello';
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = 'hello';
+}
+			`},
+		},
+		// Declared const 'hello' with constructor
+		{
+			Code: `
+declare const hello: 'hello';
+
+class Test {
+  private prop = hello;
+
+  constructor() {
+    this.prop = 'world';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 5},
+			},
+			Output: []string{`
+declare const hello: 'hello';
+
+class Test {
+  private readonly prop = hello;
+
+  constructor() {
+    this.prop = 'world';
+  }
+}
+			`},
+		},
+		// Declared const 'hello' without constructor
+		{
+			Code: `
+declare const hello: 'hello';
+
+class Test {
+  private prop = hello;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 5},
+			},
+			Output: []string{`
+declare const hello: 'hello';
+
+class Test {
+  private readonly prop = hello;
+}
+			`},
+		},
+		// Number literal without constructor
+		{
+			Code: `
+class Test {
+  private prop = 10;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = 10;
+}
+			`},
+		},
+		// Declared const 10 with constructor
+		{
+			Code: `
+declare const hello: 10;
+
+class Test {
+  private prop = hello;
+
+  constructor() {
+    this.prop = 11;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 5},
+			},
+			Output: []string{`
+declare const hello: 10;
+
+class Test {
+  private readonly prop = hello;
+
+  constructor() {
+    this.prop = 11;
+  }
+}
+			`},
+		},
+		// Boolean literal without constructor
+		{
+			Code: `
+class Test {
+  private prop = true;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = true;
+}
+			`},
+		},
+		// Declared const true with constructor
+		{
+			Code: `
+declare const hello: true;
+
+class Test {
+  private prop = hello;
+
+  constructor() {
+    this.prop = false;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 5},
+			},
+			Output: []string{`
+declare const hello: true;
+
+class Test {
+  private readonly prop = hello;
+
+  constructor() {
+    this.prop = false;
+  }
+}
+			`},
+		},
+		// Enum with constructor
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+class Test {
+  private prop = Foo.Bar;
+
+  constructor() {
+    this.prop = Foo.Bazz;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 8},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+class Test {
+  private readonly prop = Foo.Bar;
+
+  constructor() {
+    this.prop = Foo.Bazz;
+  }
+}
+			`},
+		},
+		// Enum without constructor
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+class Test {
+  private prop = Foo.Bar;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 8},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+class Test {
+  private readonly prop = Foo.Bar;
+}
+			`},
+		},
+		// Enum const foo with constructor
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const foo = Foo.Bar;
+
+class Test {
+  private prop = foo;
+
+  constructor() {
+    this.prop = foo;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 10},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const foo = Foo.Bar;
+
+class Test {
+  private readonly prop = foo;
+
+  constructor() {
+    this.prop = foo;
+  }
+}
+			`},
+		},
+		// Enum const foo without constructor
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const foo = Foo.Bar;
+
+class Test {
+  private prop = foo;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 10},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const foo = Foo.Bar;
+
+class Test {
+  private readonly prop = foo;
+}
+			`},
+		},
+		// Declare const foo: Foo
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+declare const foo: Foo;
+
+class Test {
+  private prop = foo;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 10},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+declare const foo: Foo;
+
+class Test {
+  private readonly prop = foo;
+}
+			`},
+		},
+		// Enum with const shadowing by value
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const bar = Foo.Bar;
+
+function wrapper() {
+  const Foo = 10;
+
+  class Test {
+    private prop = bar;
+
+    constructor() {
+      this.prop = bar;
+    }
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 13},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const bar = Foo.Bar;
+
+function wrapper() {
+  const Foo = 10;
+
+  class Test {
+    private readonly prop = bar;
+
+    constructor() {
+      this.prop = bar;
+    }
+  }
+}
+			`},
+		},
+		// Enum with type shadowing
+		{
+			Code: `
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const bar = Foo.Bar;
+
+function wrapper() {
+  type Foo = 10;
+
+  class Test {
+    private prop = bar;
+
+    constructor() {
+      this.prop = bar;
+    }
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 13},
+			},
+			Output: []string{`
+enum Foo {
+  Bar,
+  Bazz,
+}
+
+const bar = Foo.Bar;
+
+function wrapper() {
+  type Foo = 10;
+
+  class Test {
+    private readonly prop = bar;
+
+    constructor() {
+      this.prop = bar;
+    }
+  }
+}
+			`},
+		},
+		// IIFE enum const
+		{
+			Code: `
+const Bar = (function () {
+  enum Foo {
+    Bar,
+    Bazz,
+  }
+
+  return Foo;
+})();
+
+const bar = Bar.Bar;
+
+class Test {
+  private prop = bar;
+
+  constructor() {
+    this.prop = bar;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 14},
+			},
+			Output: []string{`
+const Bar = (function () {
+  enum Foo {
+    Bar,
+    Bazz,
+  }
+
+  return Foo;
+})();
+
+const bar = Bar.Bar;
+
+class Test {
+  private readonly prop = bar;
+
+  constructor() {
+    this.prop = bar;
+  }
+}
+			`},
+		},
+		// Object literal without constructor
+		{
+			Code: `
+class Test {
+  private prop = { foo: 'bar' };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = { foo: 'bar' };
+}
+			`},
+		},
+		// Object literal with constructor
+		{
+			Code: `
+class Test {
+  private prop = { foo: 'bar' };
+
+  constructor() {
+    this.prop = { foo: 'bazz' };
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = { foo: 'bar' };
+
+  constructor() {
+    this.prop = { foo: 'bazz' };
+  }
+}
+			`},
+		},
+		// Array literal without constructor
+		{
+			Code: `
+class Test {
+  private prop = [1, 2, 'three'];
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = [1, 2, 'three'];
+}
+			`},
+		},
+		// Array literal with constructor
+		{
+			Code: `
+class Test {
+  private prop = [1, 2, 'three'];
+
+  constructor() {
+    this.prop = [1, 2, 'four'];
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = [1, 2, 'three'];
+
+  constructor() {
+    this.prop = [1, 2, 'four'];
+  }
+}
+			`},
+		},
+		// Boolean conditional constructor assignment with type widening
+		{
+			Code: `
+class X {
+  private _isValid = true;
+
+  getIsValid = () => this._isValid;
+
+  constructor(data?: {}) {
+    if (!data) {
+      this._isValid = false;
+    }
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class X {
+  private readonly _isValid: boolean = true;
+
+  getIsValid = () => this._isValid;
+
+  constructor(data?: {}) {
+    if (!data) {
+      this._isValid = false;
+    }
+  }
+}
+			`},
+		},
+		// String | number type annotation
+		{
+			Code: `
+class Test {
+  private prop: string | number = 'hello';
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop: string | number = 'hello';
+}
+			`},
+		},
+		// Prop no type annotation, no initializer, constructor only
+		{
+			Code: `
+class Test {
+  private prop;
+
+  constructor() {
+    this.prop = 'hello';
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop;
+
+  constructor() {
+    this.prop = 'hello';
+  }
+}
+			`},
+		},
+		// Conditional constructor if/else
+		{
+			Code: `
+class Test {
+  private prop;
+
+  constructor(x: boolean) {
+    if (x) {
+      this.prop = 'hello';
+    } else {
+      this.prop = 10;
+    }
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop;
+
+  constructor(x: boolean) {
+    if (x) {
+      this.prop = 'hello';
+    } else {
+      this.prop = 10;
+    }
+  }
+}
+			`},
+		},
+		// Union type declared const
+		{
+			Code: `
+declare const hello: 'hello' | 10;
+
+class Test {
+  private prop = hello;
+
+  constructor() {
+    this.prop = 10;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 5},
+			},
+			Output: []string{`
+declare const hello: 'hello' | 10;
+
+class Test {
+  private readonly prop = hello;
+
+  constructor() {
+    this.prop = 10;
+  }
+}
+			`},
+		},
+		// Null without constructor
+		{
+			Code: `
+class Test {
+  private prop = null;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = null;
+}
+			`},
+		},
+		// Null with constructor
+		{
+			Code: `
+class Test {
+  private prop = null;
+
+  constructor() {
+    this.prop = null;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = null;
+
+  constructor() {
+    this.prop = null;
+  }
+}
+			`},
+		},
+		// As expression
+		{
+			Code: `
+class Test {
+  private prop = 'hello' as string;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = 'hello' as string;
+}
+			`},
+		},
+		// Promise.resolve
+		{
+			Code: `
+class Test {
+  private prop = Promise.resolve('hello');
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferReadonly", Line: 3},
+			},
+			Output: []string{`
+class Test {
+  private readonly prop = Promise.resolve('hello');
+}
+			`},
+		},
+	})
+}

--- a/internal/rule/rule.go
+++ b/internal/rule/rule.go
@@ -167,6 +167,7 @@ type RuleContext struct {
 	TypeChecker                *checker.Checker
 	DisableManager             *DisableManager
 	ReportRange                func(textRange core.TextRange, msg RuleMessage)
+	ReportRangeWithFixes       func(textRange core.TextRange, msg RuleMessage, fixes ...RuleFix)
 	ReportRangeWithSuggestions func(textRange core.TextRange, msg RuleMessage, suggestions ...RuleSuggestion)
 	ReportNode                 func(node *ast.Node, msg RuleMessage)
 	ReportNodeWithFixes        func(node *ast.Node, msg RuleMessage, fixes ...RuleFix)

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -153,7 +153,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/prefer-optional-chain/prefer-optional-chain.test.ts',
     // './tests/typescript-eslint/rules/prefer-promise-reject-errors.test.ts',
     // './tests/typescript-eslint/rules/prefer-readonly-parameter-types.test.ts',
-    // './tests/typescript-eslint/rules/prefer-readonly.test.ts',
+    './tests/typescript-eslint/rules/prefer-readonly.test.ts',
     // './tests/typescript-eslint/rules/prefer-reduce-type-parameter.test.ts',
     // './tests/typescript-eslint/rules/prefer-regexp-exec.test.ts',
     // './tests/typescript-eslint/rules/prefer-return-this-type.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-readonly.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-readonly.test.ts.snap
@@ -1,0 +1,3593 @@
+// Rstest Snapshot v1
+
+exports[`prefer-readonly > invalid 1`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableStatic {
+          private static incorrectlyModifiableStatic = 7;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiableStatic' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableStatic {
+          private static readonly incorrectlyModifiableStatic = 7;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 2`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableStatic {
+          static #incorrectlyModifiableStatic = 7;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiableStatic' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableStatic {
+          static readonly #incorrectlyModifiableStatic = 7;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 3`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableStaticArrow {
+          private static incorrectlyModifiableStaticArrow = () => 7;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiableStaticArrow' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableStaticArrow {
+          private static readonly incorrectlyModifiableStaticArrow = () => 7;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 4`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableStaticArrow {
+          static #incorrectlyModifiableStaticArrow = () => 7;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiableStaticArrow' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableStaticArrow {
+          static readonly #incorrectlyModifiableStaticArrow = () => 7;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 5`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableInline {
+          private incorrectlyModifiableInline = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              private incorrectlyModifiableInline = 7;
+            };
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiableInline' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+    {
+      "message": "Member 'incorrectlyModifiableInline' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 7,
+        },
+        "start": {
+          "column": 15,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableInline {
+          private readonly incorrectlyModifiableInline = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              private readonly incorrectlyModifiableInline = 7;
+            };
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 6`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableInline {
+          #incorrectlyModifiableInline = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              #incorrectlyModifiableInline = 7;
+            };
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiableInline' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+    {
+      "message": "Member '#incorrectlyModifiableInline' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 7,
+        },
+        "start": {
+          "column": 15,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableInline {
+          readonly #incorrectlyModifiableInline = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              readonly #incorrectlyModifiableInline = 7;
+            };
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 7`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableDelayed {
+          private incorrectlyModifiableDelayed = 7;
+
+          public constructor() {
+            this.incorrectlyModifiableDelayed = 7;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiableDelayed' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableDelayed {
+          private readonly incorrectlyModifiableDelayed: number = 7;
+
+          public constructor() {
+            this.incorrectlyModifiableDelayed = 7;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 8`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableDelayed {
+          #incorrectlyModifiableDelayed = 7;
+
+          public constructor() {
+            this.#incorrectlyModifiableDelayed = 7;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiableDelayed' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableDelayed {
+          readonly #incorrectlyModifiableDelayed = 7;
+
+          public constructor() {
+            this.#incorrectlyModifiableDelayed = 7;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 9`] = `
+{
+  "code": "
+        class TestChildClassExpressionModifiable {
+          private childClassExpressionModifiable = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              private childClassExpressionModifiable = 7;
+
+              mutate() {
+                this.childClassExpressionModifiable += 1;
+              }
+            };
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'childClassExpressionModifiable' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestChildClassExpressionModifiable {
+          private readonly childClassExpressionModifiable = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              private childClassExpressionModifiable = 7;
+
+              mutate() {
+                this.childClassExpressionModifiable += 1;
+              }
+            };
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 10`] = `
+{
+  "code": "
+        class TestChildClassExpressionModifiable {
+          #childClassExpressionModifiable = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              #childClassExpressionModifiable = 7;
+
+              mutate() {
+                this.#childClassExpressionModifiable += 1;
+              }
+            };
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#childClassExpressionModifiable' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestChildClassExpressionModifiable {
+          readonly #childClassExpressionModifiable = 7;
+
+          public createConfusingChildClass() {
+            return class {
+              #childClassExpressionModifiable = 7;
+
+              mutate() {
+                this.#childClassExpressionModifiable += 1;
+              }
+            };
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 11`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePostMinus {
+          private incorrectlyModifiablePostMinus = 7;
+
+          public mutate() {
+            this.incorrectlyModifiablePostMinus - 1;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiablePostMinus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePostMinus {
+          private readonly incorrectlyModifiablePostMinus = 7;
+
+          public mutate() {
+            this.incorrectlyModifiablePostMinus - 1;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 12`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePostMinus {
+          #incorrectlyModifiablePostMinus = 7;
+
+          public mutate() {
+            this.#incorrectlyModifiablePostMinus - 1;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiablePostMinus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePostMinus {
+          readonly #incorrectlyModifiablePostMinus = 7;
+
+          public mutate() {
+            this.#incorrectlyModifiablePostMinus - 1;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 13`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePostPlus {
+          private incorrectlyModifiablePostPlus = 7;
+
+          public mutate() {
+            this.incorrectlyModifiablePostPlus + 1;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiablePostPlus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePostPlus {
+          private readonly incorrectlyModifiablePostPlus = 7;
+
+          public mutate() {
+            this.incorrectlyModifiablePostPlus + 1;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 14`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePostPlus {
+          #incorrectlyModifiablePostPlus = 7;
+
+          public mutate() {
+            this.#incorrectlyModifiablePostPlus + 1;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiablePostPlus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePostPlus {
+          readonly #incorrectlyModifiablePostPlus = 7;
+
+          public mutate() {
+            this.#incorrectlyModifiablePostPlus + 1;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 15`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePreMinus {
+          private incorrectlyModifiablePreMinus = 7;
+
+          public mutate() {
+            -this.incorrectlyModifiablePreMinus;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiablePreMinus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePreMinus {
+          private readonly incorrectlyModifiablePreMinus = 7;
+
+          public mutate() {
+            -this.incorrectlyModifiablePreMinus;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 16`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePreMinus {
+          #incorrectlyModifiablePreMinus = 7;
+
+          public mutate() {
+            -this.#incorrectlyModifiablePreMinus;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiablePreMinus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePreMinus {
+          readonly #incorrectlyModifiablePreMinus = 7;
+
+          public mutate() {
+            -this.#incorrectlyModifiablePreMinus;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 17`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePrePlus {
+          private incorrectlyModifiablePrePlus = 7;
+
+          public mutate() {
+            +this.incorrectlyModifiablePrePlus;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiablePrePlus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePrePlus {
+          private readonly incorrectlyModifiablePrePlus = 7;
+
+          public mutate() {
+            +this.incorrectlyModifiablePrePlus;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 18`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiablePrePlus {
+          #incorrectlyModifiablePrePlus = 7;
+
+          public mutate() {
+            +this.#incorrectlyModifiablePrePlus;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#incorrectlyModifiablePrePlus' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiablePrePlus {
+          readonly #incorrectlyModifiablePrePlus = 7;
+
+          public mutate() {
+            +this.#incorrectlyModifiablePrePlus;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 19`] = `
+{
+  "code": "
+        class TestOverlappingClassVariable {
+          private overlappingClassVariable = 7;
+
+          public workWithSimilarClass(other: SimilarClass) {
+            other.overlappingClassVariable = 7;
+          }
+        }
+
+        class SimilarClass {
+          public overlappingClassVariable = 7;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'overlappingClassVariable' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestOverlappingClassVariable {
+          private readonly overlappingClassVariable = 7;
+
+          public workWithSimilarClass(other: SimilarClass) {
+            other.overlappingClassVariable = 7;
+          }
+        }
+
+        class SimilarClass {
+          public overlappingClassVariable = 7;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 20`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableParameter {
+          public constructor(private incorrectlyModifiableParameter = 7) {}
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiableParameter' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableParameter {
+          public constructor(private readonly incorrectlyModifiableParameter = 7) {}
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 21`] = `
+{
+  "code": "
+        class TestIncorrectlyModifiableParameter {
+          public constructor(
+            public ignore: boolean,
+            private incorrectlyModifiableParameter = 7,
+          ) {}
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyModifiableParameter' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestIncorrectlyModifiableParameter {
+          public constructor(
+            public ignore: boolean,
+            private readonly incorrectlyModifiableParameter = 7,
+          ) {}
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 22`] = `
+{
+  "code": "
+        class TestCorrectlyNonInlineLambdas {
+          private incorrectlyInlineLambda = () => 7;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'incorrectlyInlineLambda' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestCorrectlyNonInlineLambdas {
+          private readonly incorrectlyInlineLambda = () => 7;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 23`] = `
+{
+  "code": "
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    private _name: string;
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '_name' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    private readonly _name: string;
+  };
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 24`] = `
+{
+  "code": "
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    #name: string;
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#name' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+function ClassWithName<TBase extends new (...args: any[]) => {}>(Base: TBase) {
+  return class extends Base {
+    readonly #name: string;
+  };
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 25`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {
+            prop: '',
+          };
+
+          public test(): void {
+            this.testObj.prop = '';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {
+            prop: '',
+          };
+
+          public test(): void {
+            this.testObj.prop = '';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 26`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {
+            prop: '',
+          };
+
+          public test(): void {
+            this.#testObj.prop = '';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {
+            prop: '',
+          };
+
+          public test(): void {
+            this.#testObj.prop = '';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 27`] = `
+{
+  "code": "
+        class TestObject {
+          public prop: number;
+        }
+
+        class Test {
+          private testObj = new TestObject();
+
+          public test(): void {
+            this.testObj.prop = 10;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 7,
+        },
+        "start": {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestObject {
+          public prop: number;
+        }
+
+        class Test {
+          private readonly testObj = new TestObject();
+
+          public test(): void {
+            this.testObj.prop = 10;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 28`] = `
+{
+  "code": "
+        class TestObject {
+          public prop: number;
+        }
+
+        class Test {
+          #testObj = new TestObject();
+
+          public test(): void {
+            this.#testObj.prop = 10;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 7,
+        },
+        "start": {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class TestObject {
+          public prop: number;
+        }
+
+        class Test {
+          readonly #testObj = new TestObject();
+
+          public test(): void {
+            this.#testObj.prop = 10;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 29`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {
+            prop: '',
+          };
+          public test(): void {
+            this.testObj.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {
+            prop: '',
+          };
+          public test(): void {
+            this.testObj.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 30`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {
+            prop: '',
+          };
+          public test(): void {
+            this.#testObj.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {
+            prop: '',
+          };
+          public test(): void {
+            this.#testObj.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 31`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 32`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 33`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj!.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj!.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 34`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj!.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj!.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 35`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj.prop.prop = '';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj.prop.prop = '';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 36`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj.prop.prop = '';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj.prop.prop = '';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 37`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj.prop.doesSomething();
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj.prop.doesSomething();
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 38`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj.prop.doesSomething();
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj.prop.doesSomething();
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 39`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj?.prop.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj?.prop.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 40`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj?.prop.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj?.prop.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 41`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj?.prop?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj?.prop?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 42`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj?.prop?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj?.prop?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 43`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj.prop?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj.prop?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 44`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj.prop?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj.prop?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 45`] = `
+{
+  "code": "
+        class Test {
+          private testObj = {};
+          public test(): void {
+            this.testObj!.prop?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly testObj = {};
+          public test(): void {
+            this.testObj!.prop?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 46`] = `
+{
+  "code": "
+        class Test {
+          #testObj = {};
+          public test(): void {
+            this.#testObj!.prop?.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '#testObj' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          readonly #testObj = {};
+          public test(): void {
+            this.#testObj!.prop?.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 47`] = `
+{
+  "code": "
+        class Test {
+          private prop: number = 3;
+
+          test() {
+            const that = {} as this & { _foo: 'bar' };
+            that._foo = 1;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: number = 3;
+
+          test() {
+            const that = {} as this & { _foo: 'bar' };
+            that._foo = 1;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 48`] = `
+{
+  "code": "
+        class Test {
+          private prop: number = 3;
+
+          test() {
+            const that = {} as this | (this & { _foo: 'bar' });
+            that.prop;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: number = 3;
+
+          test() {
+            const that = {} as this | (this & { _foo: 'bar' });
+            that.prop;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 49`] = `
+{
+  "code": "
+        class Test {
+          private prop: number;
+
+          constructor() {
+            const that = {} as this & { _foo: 'bar' };
+            that.prop = 1;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: number;
+
+          constructor() {
+            const that = {} as this & { _foo: 'bar' };
+            that.prop = 1;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 50`] = `
+{
+  "code": "
+        class Test {
+          private prop = 'hello';
+
+          constructor() {
+            this.prop = 'world';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: string = 'hello';
+
+          constructor() {
+            this.prop = 'world';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 51`] = `
+{
+  "code": "
+        class Test {
+          private prop = 'hello';
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = 'hello';
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 52`] = `
+{
+  "code": "
+        declare const hello: 'hello';
+
+        class Test {
+          private prop = hello;
+
+          constructor() {
+            this.prop = 'world';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        declare const hello: 'hello';
+
+        class Test {
+          private readonly prop = hello;
+
+          constructor() {
+            this.prop = 'world';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 53`] = `
+{
+  "code": "
+        declare const hello: 'hello';
+
+        class Test {
+          private prop = hello;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        declare const hello: 'hello';
+
+        class Test {
+          private readonly prop = hello;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 54`] = `
+{
+  "code": "
+        class Test {
+          private prop = 10;
+
+          constructor() {
+            this.prop = 11;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: number = 10;
+
+          constructor() {
+            this.prop = 11;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 55`] = `
+{
+  "code": "
+        class Test {
+          private prop = 10;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = 10;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 56`] = `
+{
+  "code": "
+        declare const hello: 10;
+
+        class Test {
+          private prop = hello;
+
+          constructor() {
+            this.prop = 11;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        declare const hello: 10;
+
+        class Test {
+          private readonly prop = hello;
+
+          constructor() {
+            this.prop = 11;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 57`] = `
+{
+  "code": "
+        class Test {
+          private prop = true;
+
+          constructor() {
+            this.prop = false;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: boolean = true;
+
+          constructor() {
+            this.prop = false;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 58`] = `
+{
+  "code": "
+        class Test {
+          private prop = true;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = true;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 59`] = `
+{
+  "code": "
+        declare const hello: true;
+
+        class Test {
+          private prop = hello;
+
+          constructor() {
+            this.prop = false;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        declare const hello: true;
+
+        class Test {
+          private readonly prop = hello;
+
+          constructor() {
+            this.prop = false;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 60`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        class Test {
+          private prop = Foo.Bar;
+
+          constructor() {
+            this.prop = Foo.Bazz;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 8,
+        },
+        "start": {
+          "column": 11,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        class Test {
+          private readonly prop: Foo = Foo.Bar;
+
+          constructor() {
+            this.prop = Foo.Bazz;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 61`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        class Test {
+          private prop = Foo.Bar;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 8,
+        },
+        "start": {
+          "column": 11,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        class Test {
+          private readonly prop = Foo.Bar;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 62`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const foo = Foo.Bar;
+
+        class Test {
+          private prop = foo;
+
+          constructor() {
+            this.prop = foo;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 10,
+        },
+        "start": {
+          "column": 11,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const foo = Foo.Bar;
+
+        class Test {
+          private readonly prop: Foo = foo;
+
+          constructor() {
+            this.prop = foo;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 63`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const foo = Foo.Bar;
+
+        class Test {
+          private prop = foo;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 10,
+        },
+        "start": {
+          "column": 11,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const foo = Foo.Bar;
+
+        class Test {
+          private readonly prop = foo;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 64`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        declare const foo: Foo;
+
+        class Test {
+          private prop = foo;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 10,
+        },
+        "start": {
+          "column": 11,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        declare const foo: Foo;
+
+        class Test {
+          private readonly prop = foo;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 65`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const bar = Foo.Bar;
+
+        function wrapper() {
+          const Foo = 10;
+
+          class Test {
+            private prop = bar;
+
+            constructor() {
+              this.prop = bar;
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 13,
+        },
+        "start": {
+          "column": 13,
+          "line": 13,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const bar = Foo.Bar;
+
+        function wrapper() {
+          const Foo = 10;
+
+          class Test {
+            private readonly prop = bar;
+
+            constructor() {
+              this.prop = bar;
+            }
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 66`] = `
+{
+  "code": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const bar = Foo.Bar;
+
+        function wrapper() {
+          type Foo = 10;
+
+          class Test {
+            private prop = bar;
+
+            constructor() {
+              this.prop = bar;
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 13,
+        },
+        "start": {
+          "column": 13,
+          "line": 13,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        enum Foo {
+          Bar,
+          Bazz,
+        }
+
+        const bar = Foo.Bar;
+
+        function wrapper() {
+          type Foo = 10;
+
+          class Test {
+            private readonly prop = bar;
+
+            constructor() {
+              this.prop = bar;
+            }
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 67`] = `
+{
+  "code": "
+        const Bar = (function () {
+          enum Foo {
+            Bar,
+            Bazz,
+          }
+
+          return Foo;
+        })();
+
+        const bar = Bar.Bar;
+
+        class Test {
+          private prop = bar;
+
+          constructor() {
+            this.prop = bar;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 14,
+        },
+        "start": {
+          "column": 11,
+          "line": 14,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        const Bar = (function () {
+          enum Foo {
+            Bar,
+            Bazz,
+          }
+
+          return Foo;
+        })();
+
+        const bar = Bar.Bar;
+
+        class Test {
+          private readonly prop = bar;
+
+          constructor() {
+            this.prop = bar;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 68`] = `
+{
+  "code": "
+        class Test {
+          private prop = { foo: 'bar' };
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = { foo: 'bar' };
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 69`] = `
+{
+  "code": "
+        class Test {
+          private prop = { foo: 'bar' };
+
+          constructor() {
+            this.prop = { foo: 'bazz' };
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = { foo: 'bar' };
+
+          constructor() {
+            this.prop = { foo: 'bazz' };
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 70`] = `
+{
+  "code": "
+        class Test {
+          private prop = [1, 2, 'three'];
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = [1, 2, 'three'];
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 71`] = `
+{
+  "code": "
+        class Test {
+          private prop = [1, 2, 'three'];
+
+          constructor() {
+            this.prop = [1, 2, 'four'];
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = [1, 2, 'three'];
+
+          constructor() {
+            this.prop = [1, 2, 'four'];
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 72`] = `
+{
+  "code": "
+        class X {
+          private _isValid = true;
+
+          getIsValid = () => this._isValid;
+
+          constructor(data?: {}) {
+            if (!data) {
+              this._isValid = false;
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member '_isValid' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class X {
+          private readonly _isValid: boolean = true;
+
+          getIsValid = () => this._isValid;
+
+          constructor(data?: {}) {
+            if (!data) {
+              this._isValid = false;
+            }
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 73`] = `
+{
+  "code": "
+        class Test {
+          private prop: string = 'hello';
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: string = 'hello';
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 74`] = `
+{
+  "code": "
+        class Test {
+          private prop: string | number = 'hello';
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: string | number = 'hello';
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 75`] = `
+{
+  "code": "
+        class Test {
+          private prop: string;
+
+          constructor() {
+            this.prop = 'hello';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop: string;
+
+          constructor() {
+            this.prop = 'hello';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 76`] = `
+{
+  "code": "
+        class Test {
+          private prop;
+
+          constructor() {
+            this.prop = 'hello';
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop;
+
+          constructor() {
+            this.prop = 'hello';
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 77`] = `
+{
+  "code": "
+        class Test {
+          private prop;
+
+          constructor(x: boolean) {
+            if (x) {
+              this.prop = 'hello';
+            } else {
+              this.prop = 10;
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop;
+
+          constructor(x: boolean) {
+            if (x) {
+              this.prop = 'hello';
+            } else {
+              this.prop = 10;
+            }
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 78`] = `
+{
+  "code": "
+        declare const hello: 'hello' | 10;
+
+        class Test {
+          private prop = hello;
+
+          constructor() {
+            this.prop = 10;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        declare const hello: 'hello' | 10;
+
+        class Test {
+          private readonly prop = hello;
+
+          constructor() {
+            this.prop = 10;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 79`] = `
+{
+  "code": "
+        class Test {
+          private prop = null;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = null;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 80`] = `
+{
+  "code": "
+        class Test {
+          private prop = null;
+
+          constructor() {
+            this.prop = null;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = null;
+
+          constructor() {
+            this.prop = null;
+          }
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 81`] = `
+{
+  "code": "
+        class Test {
+          private prop = 'hello' as string;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = 'hello' as string;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-readonly > invalid 82`] = `
+{
+  "code": "
+        class Test {
+          private prop = Promise.resolve('hello');
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Member 'prop' is never reassigned; mark it as \`readonly\`.",
+      "messageId": "preferReadonly",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-readonly",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        class Test {
+          private readonly prop = Promise.resolve('hello');
+        }
+      ",
+  "ruleCount": 1,
+}
+`;

--- a/rslint.json
+++ b/rslint.json
@@ -53,7 +53,8 @@
       "@typescript-eslint/no-explicit-any": "warn",
       "@typescript-eslint/no-misused-promises": "warn",
       "@typescript-eslint/no-unused-vars": "warn",
-      "@typescript-eslint/require-await": "warn"
+      "@typescript-eslint/require-await": "warn",
+      "@typescript-eslint/prefer-readonly": "warn"
     },
     "plugins": ["@typescript-eslint"]
   }

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -158,3 +158,4 @@ nodesep
 ranksep
 marginx
 marginy
+Readonlys


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/prefer-readonly` rule from typescript-eslint to rslint.

This rule enforces that private class members never reassigned outside the constructor should be marked as `readonly`.

- Detects private/`#` members that are only read (not written) outside constructor
- Supports `onlyInlineLambdas` option to only check arrow function members
- Provides autofix to insert `readonly` modifier
- Handles type annotation widening for literal types when constructor assigns
- Supports nested class declarations/expressions with proper scope tracking
- Handles intersection/union types and TypeParameter (`this` keyword) resolution
- Adds `ReportRangeWithFixes` to `RuleContext` for range-based fix reporting

## Related Links

- https://typescript-eslint.io/rules/prefer-readonly/
- Related Issue: https://github.com/web-infra-dev/rslint/issues/37

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).