### PR TITLE
feat: port rule @typescript-eslint/prefer-optional-chain

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_namespace_keyword"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_optional_chain"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly"
 
@@ -471,6 +472,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-includes", prefer_includes.PreferIncludesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-namespace-keyword", prefer_namespace_keyword.PreferNamespaceKeywordRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-optional-chain", prefer_optional_chain.PreferOptionalChainRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-promise-reject-errors", prefer_promise_reject_errors.PreferPromiseRejectErrorsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-readonly", prefer_readonly.PreferReadonlyRule)
 	// TODO: prefer-readonly-parameter-types needs complete implementation for proper type checking

--- a/internal/plugins/typescript/rules/prefer_optional_chain/analyze_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/analyze_chain.go
@@ -1,0 +1,1161 @@
+package prefer_optional_chain
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type ChainAnalyzer struct {
+	ctx  rule.RuleContext
+	opts PreferOptionalChainOptions
+}
+
+func NewChainAnalyzer(ctx rule.RuleContext, opts PreferOptionalChainOptions) *ChainAnalyzer {
+	return &ChainAnalyzer{
+		ctx:  ctx,
+		opts: opts,
+	}
+}
+
+func (ca *ChainAnalyzer) AnalyzeChain(
+	operands []Operand,
+	operator ast.Kind,
+	parentNode *ast.Node,
+) {
+	if len(operands) < 2 {
+		return
+	}
+
+	// For && chains: each operand should be a valid guard, and consecutive operands
+	// should form subset relationships.
+	// For || chains: each operand (negated) should form subset relationships.
+
+	i := 0
+	for i < len(operands)-1 {
+		// Find the start of a potential chain
+		chainStart := i
+		if operands[i].Validity != OperandValid {
+			i++
+			continue
+		}
+
+		// Pre-compute which operands are "paired" strict checks.
+		// Paired means: two consecutive operands with Equal ComparedNodes and
+		// complementary strict checks (e.g., !== undefined + !== null).
+		// Paired operands together cover both nullish values.
+		pairedOperands := make(map[int]bool)
+		for j := range len(operands) - 1 {
+			a, b := operands[j], operands[j+1]
+			if a.ComparedNode != nil && b.ComparedNode != nil &&
+				compareNodesUncached(a.ComparedNode, b.ComparedNode) == NodeComparisonEqual &&
+				isComplementaryGuard(a, b) {
+				pairedOperands[j] = true
+				pairedOperands[j+1] = true
+			}
+		}
+
+		// Try to extend the chain
+		chainEnd := i + 1
+		for chainEnd < len(operands) {
+			curr := operands[chainEnd-1]
+			next := operands[chainEnd]
+
+			if next.Validity != OperandValid {
+				break
+			}
+
+			if curr.ComparedNode == nil || next.ComparedNode == nil {
+				break
+			}
+
+			// Check if the current guard is sufficient for optional chaining.
+			// Strict equality (!== null, !== undefined) only covers one nullish value.
+			// Skip the check if this operand is part of a complementary pair.
+			if !pairedOperands[chainEnd-1] && !ca.isGuardSufficientForChain(curr) {
+				break
+			}
+
+			cmp := compareNodesUncached(curr.ComparedNode, next.ComparedNode)
+			if cmp != NodeComparisonSubset && cmp != NodeComparisonEqual {
+				break
+			}
+
+			// When extending to a deeper property (Subset), verify the next guard
+			// is sufficient (or paired). Prevents extending through a lone strict
+			// check (e.g., !== undefined after != null).
+			if cmp == NodeComparisonSubset && !pairedOperands[chainEnd] && !ca.isGuardSufficientForChain(next) {
+				break
+			}
+
+			chainEnd++
+		}
+
+		if chainEnd-chainStart < 2 {
+			// Need at least 2 operands to form a chain
+			i++
+			continue
+		}
+
+		// Check the last operand - it should actually access a property
+		lastOperand := operands[chainEnd-1]
+		if lastOperand.ComparedNode == nil {
+			i++
+			continue
+		}
+
+		// The last operand must extend beyond the second-to-last operand (Subset, not Equal).
+		// If the last operand is Equal to the second-to-last, trim the chain back.
+		// E.g., `foo && foo.bar() && foo.bar()` → chain should be `foo && foo.bar()` only.
+		for chainEnd-chainStart >= 2 {
+			secondToLast := operands[chainEnd-2]
+			lastOp := operands[chainEnd-1]
+			if secondToLast.ComparedNode != nil && lastOp.ComparedNode != nil {
+				if compareNodesUncached(secondToLast.ComparedNode, lastOp.ComparedNode) == NodeComparisonEqual {
+					chainEnd--
+					continue
+				}
+			}
+			break
+		}
+		if chainEnd-chainStart < 2 {
+			i++
+			continue
+		}
+
+		// Skip if the first operand is a bare this/super keyword (not a property access)
+		// e.g., `this && this.foo` should not be flagged
+		firstCompared := operands[chainStart].ComparedNode
+		if firstCompared != nil {
+			fc := ast.SkipParentheses(firstCompared)
+			if fc.Kind == ast.KindThisKeyword || fc.Kind == ast.KindSuperKeyword {
+				i = chainEnd
+				continue
+			}
+		}
+
+		// typeof check on a bare identifier that's NOT nullable (e.g., `typeof globalThis`)
+		// is a "is defined?" check, not a null guard. Skip it from the chain.
+		// But typeof on a nullable parameter (e.g., `globalThis?: ...`) IS a valid guard.
+		if operands[chainStart].IsTypeof && firstCompared != nil {
+			fc := ast.SkipParentheses(firstCompared)
+			if fc.Kind == ast.KindIdentifier && !ca.nodeTypeHasFlags(fc, checker.TypeFlagsUndefined|checker.TypeFlagsVoid) {
+				chainStart++
+				if chainEnd-chainStart < 2 {
+					i = chainEnd
+					continue
+				}
+			}
+		}
+
+		// When the chain trails with a bare truthy/negation check on a call expression
+		// AND any guard uses strict UNDEFINED equality on a call expression result,
+		// truncate the chain for fix generation but keep the tail unchanged.
+		// Matches TS-ESLint: the rule is conservative for `!== undefined` chains with
+		// impure calls because the comparison result and call count both change.
+		originalChainEnd := chainEnd
+		if chainEnd-chainStart >= 2 {
+			last := operands[chainEnd-1]
+			if (last.ComparisonType == ComparisonBoolean || last.ComparisonType == ComparisonNotBoolean) &&
+				last.ComparedNode != nil &&
+				ast.IsCallExpression(ast.SkipParentheses(last.ComparedNode)) {
+				for gi := chainStart; gi < chainEnd-1; gi++ {
+					g := operands[gi]
+					if g.ComparedNode != nil &&
+						(g.ComparisonType == ComparisonNotStrictEqualUndefined ||
+							g.ComparisonType == ComparisonStrictEqualUndefined) &&
+						ast.IsCallExpression(ast.SkipParentheses(g.ComparedNode)) {
+						chainEnd = gi + 1
+						break
+					}
+				}
+			}
+		}
+		if chainEnd-chainStart < 2 {
+			i = originalChainEnd
+			continue
+		}
+
+		// For || chains, restore the last operand's original ComparisonType
+		// for comparison operators. These were inverted by isNegatedComparison()
+		// during DeMorgan classification, but output generation (wrapChainCode)
+		// and fix/suggest decision need the original source operator.
+		// Boolean types (ComparisonBoolean/ComparisonNotBoolean) are set directly
+		// and should NOT be de-inverted.
+		if operator == ast.KindBarBarToken {
+			ct := operands[chainEnd-1].ComparisonType
+			if ct != ComparisonBoolean && ct != ComparisonNotBoolean {
+				operands[chainEnd-1].ComparisonType = invertComparisonType(ct)
+			}
+		}
+
+		// Skip chains where the last operand's strict comparison would change
+		// truthiness when the optional chain returns undefined.
+		// e.g., `data && data.value !== null` → `data?.value !== null` changes
+		// from falsy to true when data is null/undefined.
+		if wouldChangeTruthiness(operands[chainStart:chainEnd], operator) {
+			i = originalChainEnd
+			continue
+		}
+
+		if chainEnd < originalChainEnd {
+			ca.reportChainWithTail(operands[chainStart:chainEnd], operands[chainEnd:originalChainEnd], operator, parentNode)
+		} else {
+			ca.reportChain(operands[chainStart:chainEnd], operator, parentNode)
+		}
+		i = originalChainEnd
+	}
+}
+
+func (ca *ChainAnalyzer) reportChain(
+	operands []Operand,
+	operator ast.Kind,
+	parentNode *ast.Node,
+) {
+	if len(operands) < 2 {
+		return
+	}
+
+	// Check requireNullish option
+	if ca.shouldSkipForRequireNullish(operands) {
+		return
+	}
+
+	// For chains with strict equality guards, ensure at least one guard is
+	// meaningful (its compared node's type actually includes the nullish value
+	// being checked). This prevents reporting chains where all guards are
+	// vacuous (e.g., `foo.bar !== undefined && foo.bar()` where foo.bar is
+	// always a function and never undefined).
+	if ca.hasOnlyVacuousStrictGuards(operands[:len(operands)-1]) {
+		return
+	}
+
+	// Build the optional chain expression
+	fixCode := ca.buildOptionalChainCode(operands, operator)
+	if fixCode == "" {
+		return
+	}
+
+	// Wrap the chain code based on the last operand's comparison type
+	lastOperand := operands[len(operands)-1]
+	fixCode = wrapChainCode(fixCode, lastOperand)
+
+	// Find the binary expression that encompasses all operands, covering any
+	// enclosing parentheses (e.g., `a && (a.b && a.b.c)` → the outer `&&`).
+	firstNode := operands[0].Node
+	reportNode := findBinaryExpressionCovering(parentNode, firstNode, operands[len(operands)-1].Node)
+	if reportNode == nil {
+		reportNode = parentNode
+	}
+
+	// Compute the fix range start by walking up from firstNode through any
+	// ParenthesizedExpressions to include opening parens in the range.
+	// E.g., `(a && a.b) && a.b.c` → startNode is the ParenthesizedExpression `(a && a.b)`.
+	// But for `foo?.a && bar && bar.a` → startNode stays as `bar` (no wrapping parens).
+	startNode := firstNode
+	n := firstNode.Parent
+	for n != nil && n != reportNode.Parent {
+		if ast.IsParenthesizedExpression(n) {
+			startNode = n
+		}
+		n = n.Parent
+	}
+	reportRange := utils.TrimNodeTextRange(ca.ctx.SourceFile, startNode).WithEnd(reportNode.End())
+
+	// Determine if we should use fix or suggestion
+	useFix := ca.shouldUseFix(operands)
+
+	msg := buildPreferOptionalChainMessage()
+	sugMsg := buildOptionalChainSuggestMessage()
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixReplaceRange(reportRange, fixCode),
+	}
+
+	rule.ReportNodeWithFixesOrSuggestions(ca.ctx, reportNode, useFix, msg, sugMsg, fixes...)
+}
+
+// reportChainWithTail reports a chain where the fix only covers the truncated
+// portion; the tail operands (which were not safe to fold, e.g., because they
+// depend on repeated impure call results) are preserved as-is in the source.
+// The fix range only covers operand[0] through the last truncated operand.
+func (ca *ChainAnalyzer) reportChainWithTail(
+	chainOps []Operand,
+	tailOps []Operand,
+	operator ast.Kind,
+	parentNode *ast.Node,
+) {
+	if len(chainOps) < 2 || len(tailOps) == 0 {
+		return
+	}
+
+	if ca.shouldSkipForRequireNullish(chainOps) {
+		return
+	}
+	// Check vacuousness across the FULL original chain (chain + tail), since the
+	// truncation was only for fix generation. Later guards in the tail may be the
+	// meaningful ones (tsgo narrows earlier guards' types away from nullish).
+	fullOps := make([]Operand, 0, len(chainOps)+len(tailOps))
+	fullOps = append(fullOps, chainOps...)
+	fullOps = append(fullOps, tailOps...)
+	if ca.hasOnlyVacuousStrictGuards(fullOps[:len(fullOps)-1]) {
+		return
+	}
+
+	fixCode := ca.buildOptionalChainCode(chainOps, operator)
+	if fixCode == "" {
+		return
+	}
+	fixCode = wrapChainCode(fixCode, chainOps[len(chainOps)-1])
+
+	// Report range covers the full expression (chain + tail) for display purposes,
+	// but fix range only covers the truncated chain — tail source text stays as-is.
+	firstNode := chainOps[0].Node
+	lastChainNode := chainOps[len(chainOps)-1].Node
+	lastTailNode := tailOps[len(tailOps)-1].Node
+	reportNode := findBinaryExpressionCovering(parentNode, firstNode, lastTailNode)
+	if reportNode == nil {
+		reportNode = parentNode
+	}
+
+	startNode := firstNode
+	n := firstNode.Parent
+	for n != nil && n != reportNode.Parent {
+		if ast.IsParenthesizedExpression(n) {
+			startNode = n
+		}
+		n = n.Parent
+	}
+	// Fix range: from start to the last chain operand's end (tail preserved as-is).
+	fixRange := utils.TrimNodeTextRange(ca.ctx.SourceFile, startNode).WithEnd(lastChainNode.End())
+
+	// For truncated chains, force suggestion for && chains (matches TS-ESLint).
+	useFix := ca.shouldUseFix(chainOps)
+	if operator == ast.KindAmpersandAmpersandToken {
+		useFix = false
+	}
+
+	msg := buildPreferOptionalChainMessage()
+	sugMsg := buildOptionalChainSuggestMessage()
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixReplaceRange(fixRange, fixCode),
+	}
+
+	rule.ReportNodeWithFixesOrSuggestions(ca.ctx, reportNode, useFix, msg, sugMsg, fixes...)
+}
+
+func (ca *ChainAnalyzer) shouldUseFix(operands []Operand) bool {
+	if derefBoolDefault(ca.opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing, false) {
+		return true
+	}
+
+	last := operands[len(operands)-1]
+
+	switch last.ComparisonType {
+	case ComparisonBoolean:
+		// For bare truthy checks, auto-fix is safe when the original expression
+		// can already return undefined (meaning the fix doesn't add a new undefined).
+		// This requires a guard that's a bare truthy/negation check (ComparisonBoolean/
+		// ComparisonNotBoolean) whose type includes undefined. Only bare truthy guards
+		// let the expression short-circuit to the guard's actual value (which may be
+		// undefined). Comparison guards (!= null, !== undefined, etc.) short-circuit
+		// to boolean (true/false), so even if the guard's type includes undefined,
+		// the expression can never return undefined.
+		if ca.ctx.TypeChecker != nil {
+			for _, guard := range operands[:len(operands)-1] {
+				if guard.ComparisonType != ComparisonBoolean && guard.ComparisonType != ComparisonNotBoolean {
+					continue
+				}
+				if guard.ComparedNode != nil {
+					t := ca.ctx.TypeChecker.GetTypeAtLocation(guard.ComparedNode)
+					if t != nil && utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsUndefined|checker.TypeFlagsVoid|checker.TypeFlagsAny) {
+						return true
+					}
+				}
+			}
+		}
+		// Fall through to type check on last operand
+
+	case ComparisonNotBoolean:
+		// !expr always returns boolean. !undefined = true, same as
+		// original || short-circuit. Always safe.
+		return true
+
+	case ComparisonEqualNullOrUndefined:
+		// == null/undefined: undefined == null is true. Matches original. Safe.
+		return true
+
+	case ComparisonNotEqualNullOrUndefined:
+		// != null/undefined: undefined != null is false. Matches original short-circuit. Safe.
+		return true
+
+	case ComparisonNotStrictEqualUndefined,
+		ComparisonStrictEqualUndefined:
+		// !== undefined / === undefined: the comparison result is the same
+		// whether applied to undefined or original short-circuit value. Safe.
+		return true
+
+	case ComparisonNotStrictEqualNull:
+		// !== null: undefined !== null is true, but original && chain
+		// short-circuits to false when guard fails. Semantics change! Not safe.
+		return false
+
+	case ComparisonStrictEqualNull:
+		// === null: undefined === null is false, but original || chain
+		// short-circuits to true. Semantics change! Not safe.
+		return false
+	}
+
+	// Fallback: check if the result type already includes undefined
+	if ca.ctx.TypeChecker != nil && last.ComparedNode != nil {
+		t := ca.ctx.TypeChecker.GetTypeAtLocation(last.ComparedNode)
+		if t != nil && utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsUndefined|checker.TypeFlagsVoid|checker.TypeFlagsAny) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (ca *ChainAnalyzer) shouldSkipForRequireNullish(operands []Operand) bool {
+	if !derefBoolDefault(ca.opts.RequireNullish, false) {
+		return false
+	}
+	if ca.ctx.TypeChecker == nil {
+		return false
+	}
+
+	// With requireNullish, at least one guard operand must have null/undefined in its type.
+	// Only check guard operands (all except the last), since the last operand is the
+	// chain target, not a guard. E.g., in `foo && foo.bar`, foo is the guard.
+	guards := operands
+	if len(guards) > 1 {
+		guards = operands[:len(operands)-1]
+	}
+	for _, op := range guards {
+		if op.ComparedNode == nil {
+			continue
+		}
+		t := ca.ctx.TypeChecker.GetTypeAtLocation(op.ComparedNode)
+		if t == nil {
+			continue
+		}
+		if utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) {
+			return false // has nullish -> don't skip
+		}
+	}
+	return true // no nullish found in any operand -> skip
+}
+
+// isGuardSufficientForChain checks whether a strict equality guard fully covers
+// the nullish types of the operand. Loose equality (!= / ==) catches both null
+// and undefined, so it's always sufficient. Strict equality (!== / ===) only
+// catches one, so we need to verify the type doesn't include the other.
+// isComplementaryGuard checks if two guards together cover both null and undefined.
+// E.g., (!== undefined, !== null) or (!== null, !== undefined) are complementary.
+func isComplementaryGuard(a, b Operand) bool {
+	coversNull := func(ct NullishComparisonType) bool {
+		return ct == ComparisonNotStrictEqualNull || ct == ComparisonStrictEqualNull
+	}
+	coversUndefined := func(ct NullishComparisonType) bool {
+		return ct == ComparisonNotStrictEqualUndefined || ct == ComparisonStrictEqualUndefined
+	}
+	return (coversNull(a.ComparisonType) && coversUndefined(b.ComparisonType)) ||
+		(coversUndefined(a.ComparisonType) && coversNull(b.ComparisonType))
+}
+
+func (ca *ChainAnalyzer) isGuardSufficientForChain(guard Operand) bool {
+	switch guard.ComparisonType {
+	case ComparisonBoolean, ComparisonNotBoolean:
+		return true
+	case ComparisonNotEqualNullOrUndefined, ComparisonEqualNullOrUndefined:
+		return true
+	case ComparisonNotStrictEqualNull, ComparisonStrictEqualNull:
+		if ca.ctx.TypeChecker == nil {
+			return false
+		}
+		return !ca.nodeTypeHasFlags(guard.ComparedNode, checker.TypeFlagsUndefined|checker.TypeFlagsVoid|checker.TypeFlagsAny|checker.TypeFlagsUnknown)
+	case ComparisonNotStrictEqualUndefined, ComparisonStrictEqualUndefined:
+		if ca.ctx.TypeChecker == nil {
+			return false
+		}
+		return !ca.nodeTypeHasFlags(guard.ComparedNode, checker.TypeFlagsNull|checker.TypeFlagsAny|checker.TypeFlagsUnknown)
+	}
+	return true
+}
+
+// hasOnlyVacuousStrictGuards returns true if all guards in the given operands
+// use strict equality checks and none of them have a type that actually includes
+// the nullish value being checked. A vacuous guard like `foo !== undefined` where
+// `foo` is always a non-nullable type should not trigger the rule.
+func (ca *ChainAnalyzer) hasOnlyVacuousStrictGuards(guards []Operand) bool {
+	if ca.ctx.TypeChecker == nil {
+		return false // can't determine without type info
+	}
+	for _, guard := range guards {
+		switch guard.ComparisonType {
+		case ComparisonBoolean, ComparisonNotBoolean,
+			ComparisonNotEqualNullOrUndefined, ComparisonEqualNullOrUndefined:
+			return false // non-strict guards are always meaningful
+		case ComparisonNotStrictEqualNull, ComparisonStrictEqualNull:
+			if ca.nodeTypeHasFlags(guard.ComparedNode, checker.TypeFlagsNull|checker.TypeFlagsAny|checker.TypeFlagsUnknown) {
+				return false
+			}
+		case ComparisonNotStrictEqualUndefined, ComparisonStrictEqualUndefined:
+			if ca.nodeTypeHasFlags(guard.ComparedNode, checker.TypeFlagsUndefined|checker.TypeFlagsVoid|checker.TypeFlagsAny|checker.TypeFlagsUnknown) {
+				return false
+			}
+		}
+	}
+	return true // all guards are vacuous
+}
+
+// nodeTypeHasFlags checks if a node's type includes any of the given flags,
+// iterating through union constituents. Returns false if type checker or node is nil.
+func (ca *ChainAnalyzer) nodeTypeHasFlags(node *ast.Node, flags checker.TypeFlags) bool {
+	if ca.ctx.TypeChecker == nil || node == nil {
+		return false
+	}
+	t := ca.ctx.TypeChecker.GetTypeAtLocation(node)
+	if t == nil {
+		return false
+	}
+	return utils.IsTypeFlagSetWithUnion(t, flags)
+}
+
+// wouldChangeTruthiness checks if the last operand's strict comparison wrapper
+// would evaluate to `true` when given `undefined` (which optional chain returns
+// for null/undefined), AND at least one guard is a truthy check (which means
+// the original short-circuits to a falsy value). This would change the
+// expression's truthiness, making the transformation unsafe.
+func wouldChangeTruthiness(operands []Operand, operator ast.Kind) bool {
+	last := operands[len(operands)-1]
+
+	// Only applicable when the last operand has a comparison wrapper
+	if last.ComparisonType == ComparisonBoolean || last.ComparisonType == ComparisonNotBoolean {
+		return false
+	}
+
+	// Check if any guard is a truthy check
+	hasTruthyGuard := false
+	for _, op := range operands[:len(operands)-1] {
+		if op.ComparisonType == ComparisonBoolean || op.ComparisonType == ComparisonNotBoolean {
+			hasTruthyGuard = true
+			break
+		}
+	}
+	if !hasTruthyGuard {
+		return false
+	}
+
+	// For && chains: check if `undefined <op> value` would be `true`
+	if operator == ast.KindAmpersandAmpersandToken {
+		switch last.ComparisonType {
+		case ComparisonNotStrictEqualNull:
+			// undefined !== null → true (BAD: changes from falsy to truthy)
+			return true
+		case ComparisonStrictEqualUndefined:
+			// undefined === undefined → true (BAD: changes from falsy to truthy)
+			return true
+		}
+	}
+
+	// For || chains (last operand has been de-inverted to its original source operator):
+	// check if `undefined <op> value` would be `false`
+	// (since || short-circuits on truthy, changing to falsy is problematic)
+	if operator == ast.KindBarBarToken {
+		switch last.ComparisonType {
+		case ComparisonStrictEqualNull:
+			// foo === null || ...: undefined === null → false (BAD: original is truthy)
+			return true
+		case ComparisonNotStrictEqualUndefined:
+			// foo !== undefined || ...: undefined !== undefined → false (BAD: original is truthy)
+			return true
+		}
+	}
+
+	return false
+}
+
+
+func (ca *ChainAnalyzer) buildOptionalChainCode(operands []Operand, operator ast.Kind) string {
+	if len(operands) < 2 {
+		return ""
+	}
+
+	// The last operand is the actual expression we want to convert to optional chain
+	lastOperand := operands[len(operands)-1]
+	if lastOperand.ComparedNode == nil {
+		return ""
+	}
+
+	// Flatten the last operand's node into a chain of accesses
+	parts := flattenChainExpression(lastOperand.ComparedNode)
+	if len(parts) == 0 {
+		return ca.getNodeText(lastOperand.ComparedNode)
+	}
+
+	// Determine which part indices need ?. insertion
+	// A guard matching at part[j] means: the access at part[j+1] should use ?.
+	optionalIndices := make(map[int]bool)
+
+	// Track the deepest guard match so we can use its parts for output
+	var deepestGuardParts []chainPart
+	deepestGuardPartIdx := -1
+
+	for i := range len(operands) - 1 {
+		guard := operands[i]
+		if guard.ComparedNode == nil {
+			continue
+		}
+
+		for j, part := range parts {
+			cmp := compareNodesUncached(guard.ComparedNode, part.node)
+			if cmp == NodeComparisonEqual {
+				// Guard matches this part exactly, so the NEXT access needs ?.
+				if j+1 < len(parts) {
+					optionalIndices[j+1] = true
+				}
+				// Track the deepest guard for output generation
+				if j > deepestGuardPartIdx {
+					deepestGuardPartIdx = j
+					deepestGuardParts = flattenChainExpression(guard.ComparedNode)
+				}
+				break
+			}
+		}
+	}
+
+	// If no optional indices were found, try a simpler approach:
+	// the first guard is a prefix of the last operand
+	if len(optionalIndices) == 0 {
+		firstGuard := operands[0]
+		if firstGuard.ComparedNode != nil {
+			for j, part := range parts {
+				cmp := compareNodesUncached(firstGuard.ComparedNode, part.node)
+				if cmp == NodeComparisonEqual && j+1 < len(parts) {
+					optionalIndices[j+1] = true
+					deepestGuardPartIdx = j
+					deepestGuardParts = flattenChainExpression(firstGuard.ComparedNode)
+					break
+				}
+			}
+		}
+	}
+
+	// Build the output with ?. inserted at appropriate positions
+	var sb strings.Builder
+
+	// Merge ?. and ! annotations from guards into the output.
+	// tsgo's AST QuestionDotToken flags may be on the wrong operand's nodes,
+	// so we scan the guard's source text (via GetSourceTextOfNodeFromSourceFile)
+	// to determine the correct ?. positions.
+	guardOptionals := make(map[int]bool)
+	guardNonNulls := make(map[int]bool)
+	if deepestGuardPartIdx >= 0 {
+		// Scan each guard's source text for ?. positions
+		for gi := range len(operands) - 1 {
+			guard := operands[gi]
+			if guard.ComparedNode == nil {
+				continue
+			}
+			guardText := ca.getNodeText(guard.ComparedNode)
+			depth := 0
+			for ci := 0; ci < len(guardText); ci++ {
+				if ci+1 < len(guardText) && guardText[ci] == '?' && guardText[ci+1] == '.' {
+					depth++
+					guardOptionals[depth] = true
+					ci++ // skip the '.'
+				} else if guardText[ci] == '.' {
+					depth++
+				}
+			}
+		}
+		guardNonNulls = collectNonNullPositions(operands[0 : len(operands)-1])
+		// Align base node NonNull with the guard:
+		// - If guard has NonNull base and target doesn't: use guard's base
+		// - If target has NonNull base but guard doesn't: strip it (use inner expression)
+		if len(deepestGuardParts) > 0 {
+			gp := deepestGuardParts[0]
+			if ast.IsNonNullExpression(gp.node) && !ast.IsNonNullExpression(parts[0].node) {
+				parts[0].node = gp.node
+			} else if !ast.IsNonNullExpression(gp.node) && ast.IsNonNullExpression(parts[0].node) {
+				// Guard has no NonNull but target does — strip it
+				parts[0].node = ast.SkipParentheses(parts[0].node.Expression())
+			}
+		}
+	}
+
+	// Write the base expression
+	if len(parts) > 0 {
+		baseNode := parts[0].node
+		baseText := ca.getNodeText(baseNode)
+
+		if needsParensAsBase(baseNode) {
+			sb.WriteString("(")
+			sb.WriteString(baseText)
+			sb.WriteString(")")
+		} else {
+			sb.WriteString(baseText)
+		}
+	}
+
+	// Write each accessor, inserting ?. where needed
+	for i := 1; i < len(parts); i++ {
+		// Use ?. from optionalIndices (new insertions) OR from guard source text
+		// (preserving existing ?. from the original code)
+		useOptional := optionalIndices[i] || (i <= deepestGuardPartIdx && guardOptionals[i])
+
+		// Check NonNull from guard (skip position 0 if base is already NonNull)
+		hasNonNull := false
+		if i-1 < deepestGuardPartIdx && (i-1 != 0 || !ast.IsNonNullExpression(parts[0].node)) {
+			hasNonNull = guardNonNulls[i-1]
+		}
+
+		ca.writeChainPart(&sb, parts[i], useOptional, hasNonNull)
+	}
+
+	return sb.String()
+}
+
+type accessKind int
+
+const (
+	accessKindProperty accessKind = iota
+	accessKindElement
+	accessKindCall
+)
+
+type chainPart struct {
+	node              *ast.Node
+	accessKind        accessKind
+	accessName        string
+	accessArgument    *ast.Node
+	callArgs          []*ast.Node
+	typeArgs          []*ast.Node
+	isAlreadyOptional bool
+	hasNonNullAfter   bool // the chain result up to this part is wrapped in NonNullExpression (!)
+}
+
+func flattenChainExpression(node *ast.Node) []chainPart {
+	n := ast.SkipParentheses(node)
+	var parts []chainPart
+	flattenChainExpressionRec(n, &parts)
+	return parts
+}
+
+func flattenChainExpressionRec(node *ast.Node, parts *[]chainPart) {
+	n := ast.SkipParentheses(node)
+
+	switch n.Kind {
+	case ast.KindNonNullExpression:
+		// For foo!, check if the inner expression is a chain access like (foo.bar)!
+		inner := ast.SkipParentheses(n.Expression())
+		if inner.Kind == ast.KindPropertyAccessExpression ||
+			inner.Kind == ast.KindElementAccessExpression ||
+			inner.Kind == ast.KindCallExpression {
+			// The NonNullExpression wraps a chain access - recurse into it
+			prevLen := len(*parts)
+			flattenChainExpressionRec(inner, parts)
+			// Mark the last added part as having NonNull after it (e.g., foo.bar! → .bar has NonNull)
+			if len(*parts) > prevLen {
+				(*parts)[len(*parts)-1].hasNonNullAfter = true
+			}
+		} else {
+			// Base-level NonNullExpression like foo! - preserve it as the base node
+			*parts = append(*parts, chainPart{node: n})
+		}
+		return
+
+	case ast.KindPropertyAccessExpression:
+		prop := n.AsPropertyAccessExpression()
+		flattenChainExpressionRec(prop.Expression, parts)
+		*parts = append(*parts, chainPart{
+			node:              n,
+			accessKind:        accessKindProperty,
+			accessName:        prop.Name().Text(),
+			isAlreadyOptional: prop.QuestionDotToken != nil,
+		})
+		return
+
+	case ast.KindElementAccessExpression:
+		elem := n.AsElementAccessExpression()
+		flattenChainExpressionRec(elem.Expression, parts)
+		*parts = append(*parts, chainPart{
+			node:              n,
+			accessKind:        accessKindElement,
+			accessArgument:    elem.ArgumentExpression,
+			isAlreadyOptional: elem.QuestionDotToken != nil,
+		})
+		return
+
+	case ast.KindCallExpression:
+		call := n.AsCallExpression()
+		flattenChainExpressionRec(call.Expression, parts)
+		var callArgs []*ast.Node
+		if call.Arguments != nil {
+			callArgs = call.Arguments.Nodes
+		}
+		var typeArgs []*ast.Node
+		if call.TypeArguments != nil {
+			typeArgs = call.TypeArguments.Nodes
+		}
+		*parts = append(*parts, chainPart{
+			node:              n,
+			accessKind:        accessKindCall,
+			callArgs:          callArgs,
+			typeArgs:          typeArgs,
+			isAlreadyOptional: call.QuestionDotToken != nil,
+		})
+		return
+	}
+
+	// Base case: identifier, this, etc.
+	*parts = append(*parts, chainPart{
+		node: n,
+	})
+}
+
+// writeChainPart writes a single accessor part to the string builder,
+// handling ?., !., and regular . delimiters.
+func (ca *ChainAnalyzer) writeChainPart(sb *strings.Builder, part chainPart, needsOptional bool, prevHasNonNull bool) {
+	switch part.accessKind {
+	case accessKindProperty:
+		if needsOptional {
+			sb.WriteString("?.")
+		} else if prevHasNonNull {
+			sb.WriteString("!.")
+		} else {
+			sb.WriteString(".")
+		}
+		sb.WriteString(part.accessName)
+
+	case accessKindElement:
+		if needsOptional {
+			sb.WriteString("?.")
+		} else if prevHasNonNull {
+			sb.WriteString("!")
+		}
+		sb.WriteString("[")
+		sb.WriteString(ca.getNodeText(part.accessArgument))
+		sb.WriteString("]")
+
+	case accessKindCall:
+		if needsOptional {
+			sb.WriteString("?.")
+		} else if prevHasNonNull {
+			sb.WriteString("!")
+		}
+		if len(part.typeArgs) > 0 {
+			sb.WriteString("<")
+			for j, ta := range part.typeArgs {
+				if j > 0 {
+					sb.WriteString(", ")
+				}
+				sb.WriteString(ca.getNodeText(ta))
+			}
+			sb.WriteString(">")
+		}
+		sb.WriteString("(")
+		for j, arg := range part.callArgs {
+			if j > 0 {
+				sb.WriteString(",")
+			}
+			// Use trivia-preserving text to keep comments (e.g., /* comment */a)
+			sb.WriteString(ca.getNodeTextWithTrivia(arg))
+		}
+		sb.WriteString(")")
+	}
+}
+
+// collectNonNullPositions walks the guard operands' ASTs to determine at which
+// chain depths a NonNullExpression (!) wraps the chain result.
+func collectNonNullPositions(guards []Operand) map[int]bool {
+	result := make(map[int]bool)
+	for _, guard := range guards {
+		if guard.ComparedNode == nil {
+			continue
+		}
+		collectNonNullRec(ast.SkipParentheses(guard.ComparedNode), result)
+	}
+	return result
+}
+
+func collectNonNullRec(node *ast.Node, result map[int]bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		prop := node.AsPropertyAccessExpression()
+		collectNonNullRec(ast.SkipParentheses(prop.Expression), result)
+	case ast.KindElementAccessExpression:
+		elem := node.AsElementAccessExpression()
+		collectNonNullRec(ast.SkipParentheses(elem.Expression), result)
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		collectNonNullRec(ast.SkipParentheses(call.Expression), result)
+	case ast.KindNonNullExpression:
+		inner := ast.SkipParentheses(node.Expression())
+		depth := chainDepth(inner)
+		result[depth] = true
+		collectNonNullRec(inner, result)
+	}
+}
+
+// chainDepth returns the number of access steps in a chain expression.
+// foo = 0, foo.bar = 1, foo.bar.baz = 2, etc.
+func chainDepth(node *ast.Node) int {
+	n := ast.SkipParentheses(node)
+	depth := 0
+	for {
+		switch n.Kind {
+		case ast.KindPropertyAccessExpression:
+			depth++
+			n = ast.SkipParentheses(n.AsPropertyAccessExpression().Expression)
+			continue
+		case ast.KindElementAccessExpression:
+			depth++
+			n = ast.SkipParentheses(n.AsElementAccessExpression().Expression)
+			continue
+		case ast.KindCallExpression:
+			depth++
+			n = ast.SkipParentheses(n.AsCallExpression().Expression)
+			continue
+		case ast.KindNonNullExpression:
+			n = ast.SkipParentheses(n.Expression())
+			continue
+		}
+		break
+	}
+	return depth
+}
+
+func needsParensAsBase(node *ast.Node) bool {
+	n := skipDownwards(node)
+	return ast.IsAwaitExpression(n)
+}
+
+// needsParensForOptionalBase checks if an expression needs parentheses when
+// used as the LHS of ?. in (expr || {}).bar → expr?.bar transforms.
+// E.g., `foo || undefined` needs parens: `(foo || undefined)?.bar`, not `foo || undefined?.bar`.
+func needsParensForOptionalBase(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindBinaryExpression,
+		ast.KindConditionalExpression,
+		ast.KindAwaitExpression,
+		ast.KindVoidExpression,
+		ast.KindTypeOfExpression,
+		ast.KindPrefixUnaryExpression,
+		ast.KindPostfixUnaryExpression,
+		ast.KindAsExpression,
+		ast.KindSatisfiesExpression:
+		return true
+	}
+	return false
+}
+
+func findBinaryExpressionCovering(root *ast.Node, first *ast.Node, last *ast.Node) *ast.Node {
+	firstPos, lastEnd := first.Pos(), last.End()
+	for node := first; node != nil; node = node.Parent {
+		if ast.IsBinaryExpression(node) {
+			op := node.AsBinaryExpression().OperatorToken.Kind
+			if (op == ast.KindAmpersandAmpersandToken || op == ast.KindBarBarToken) &&
+				node.Pos() <= firstPos && node.End() >= lastEnd {
+				return node
+			}
+		}
+		if node == root {
+			break
+		}
+	}
+	return nil
+}
+
+func (ca *ChainAnalyzer) getNodeText(node *ast.Node) string {
+	return scanner.GetSourceTextOfNodeFromSourceFile(ca.ctx.SourceFile, node, false)
+}
+
+// getNodeTextWithTrivia returns the source text for a node including leading
+// trivia (comments, whitespace). Used for call arguments where comments like
+// /* comment */ should be preserved in the output.
+func (ca *ChainAnalyzer) getNodeTextWithTrivia(node *ast.Node) string {
+	return scanner.GetSourceTextOfNodeFromSourceFile(ca.ctx.SourceFile, node, true)
+}
+
+func (ca *ChainAnalyzer) CheckNullishAndReport(node *ast.Node) bool {
+	if !derefBoolDefault(ca.opts.RequireNullish, false) {
+		return false
+	}
+
+	if ca.ctx.TypeChecker == nil {
+		return false
+	}
+
+	// With requireNullish, we need at least one part of the chain to include null/undefined in its type
+	t := ca.ctx.TypeChecker.GetTypeAtLocation(node)
+	if t == nil {
+		return false
+	}
+
+	if utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) {
+		return false // has nullish -> don't skip
+	}
+
+	return true // no nullish found -> skip the report
+}
+
+// AnalyzeOrEmptyObjectPattern checks for (foo || {}).bar / (foo ?? {}).bar patterns
+func (ca *ChainAnalyzer) AnalyzeOrEmptyObjectPattern(node *ast.Node) {
+	// node is a PropertyAccessExpression or ElementAccessExpression
+	var exprNode *ast.Node
+	var accessName string
+	var accessArgument *ast.Node
+	var isElementAccess bool
+
+	if ast.IsPropertyAccessExpression(node) {
+		prop := node.AsPropertyAccessExpression()
+		if prop.QuestionDotToken != nil {
+			return // already optional chain
+		}
+		exprNode = prop.Expression
+		accessName = prop.Name().Text()
+	} else if ast.IsElementAccessExpression(node) {
+		elem := node.AsElementAccessExpression()
+		if elem.QuestionDotToken != nil {
+			return // already optional chain
+		}
+		exprNode = elem.Expression
+		accessArgument = elem.ArgumentExpression
+		isElementAccess = true
+	} else {
+		return
+	}
+
+	// The expression should be a parenthesized || or ?? with {} on the right
+	inner := ast.SkipParentheses(exprNode)
+	if !ast.IsBinaryExpression(inner) {
+		return
+	}
+
+	bin := inner.AsBinaryExpression()
+	if bin.OperatorToken.Kind != ast.KindBarBarToken && bin.OperatorToken.Kind != ast.KindQuestionQuestionToken {
+		return
+	}
+
+	right := ast.SkipParentheses(bin.Right)
+	if !ast.IsEmptyObjectLiteral(right) {
+		return
+	}
+
+	// Check requireNullish option
+	if ca.CheckNullishAndReport(bin.Left) {
+		return
+	}
+
+	// Build the fix
+	leftText := ca.getNodeText(bin.Left)
+
+	// Check if left needs parens when used as the LHS of ?.
+	// Skip if the source already has parens around the left expression.
+	leftNode := ast.SkipParentheses(bin.Left)
+	if needsParensForOptionalBase(leftNode) && !ast.IsParenthesizedExpression(bin.Left) {
+		leftText = "(" + leftText + ")"
+	}
+
+	var fixCode string
+	if isElementAccess {
+		argText := ca.getNodeText(accessArgument)
+		fixCode = leftText + "?.[" + argText + "]"
+	} else {
+		fixCode = leftText + "?." + accessName
+	}
+
+	reportRange := utils.TrimNodeTextRange(ca.ctx.SourceFile, node).WithEnd(node.End())
+
+	msg := buildPreferOptionalChainMessage()
+	sugMsg := buildOptionalChainSuggestMessage()
+
+	fixes := []rule.RuleFix{
+		rule.RuleFixReplaceRange(reportRange, fixCode),
+	}
+
+	// (foo || {}).bar is always a suggestion, not a fix
+	rule.ReportNodeWithFixesOrSuggestions(ca.ctx, node, false, msg, sugMsg, fixes...)
+}
+
+// wrapChainCode wraps the generated optional chain code with the last operand's
+// comparison wrapper (e.g., `!= null`, `!`, `typeof ... !== 'undefined'`).
+func wrapChainCode(chainCode string, lastOperand Operand) string {
+	switch lastOperand.ComparisonType {
+	case ComparisonBoolean:
+		return chainCode
+
+	case ComparisonNotBoolean:
+		return "!" + chainCode
+
+	case ComparisonNotEqualNullOrUndefined:
+		if lastOperand.IsYoda {
+			if lastOperand.UsesNull {
+				return "null != " + chainCode
+			}
+			return "undefined != " + chainCode
+		}
+		if lastOperand.UsesNull {
+			return chainCode + " != null"
+		}
+		return chainCode + " != undefined"
+
+	case ComparisonNotStrictEqualNull:
+		if lastOperand.IsYoda {
+			return "null !== " + chainCode
+		}
+		return chainCode + " !== null"
+
+	case ComparisonNotStrictEqualUndefined:
+		if lastOperand.IsTypeof {
+			if lastOperand.IsYoda {
+				return "'undefined' !== typeof " + chainCode
+			}
+			return "typeof " + chainCode + " !== 'undefined'"
+		}
+		if lastOperand.IsYoda {
+			return "undefined !== " + chainCode
+		}
+		return chainCode + " !== undefined"
+
+	case ComparisonEqualNullOrUndefined:
+		if lastOperand.IsYoda {
+			if lastOperand.UsesNull {
+				return "null == " + chainCode
+			}
+			return "undefined == " + chainCode
+		}
+		if lastOperand.UsesNull {
+			return chainCode + " == null"
+		}
+		return chainCode + " == undefined"
+
+	case ComparisonStrictEqualNull:
+		if lastOperand.IsYoda {
+			return "null === " + chainCode
+		}
+		return chainCode + " === null"
+
+	case ComparisonStrictEqualUndefined:
+		if lastOperand.IsTypeof {
+			if lastOperand.IsYoda {
+				return "'undefined' === typeof " + chainCode
+			}
+			return "typeof " + chainCode + " === 'undefined'"
+		}
+		if lastOperand.IsYoda {
+			return "undefined === " + chainCode
+		}
+		return chainCode + " === undefined"
+	}
+
+	return chainCode
+}

--- a/internal/plugins/typescript/rules/prefer_optional_chain/base_cases_test.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/base_cases_test.go
@@ -1,0 +1,289 @@
+package prefer_optional_chain
+
+import (
+	"fmt"
+
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+type baseCase struct {
+	id          int
+	chain       string
+	declaration string
+	outputChain string
+}
+
+type baseCaseOptions struct {
+	operator           string // "&&" or "||"
+	mutateCode         func(string) string
+	mutateDeclaration  func(string) string
+	mutateOutput       func(string) string
+	skipIds            []int
+	useSuggestionFixer bool
+}
+
+func rawBaseCases(operator string) []baseCase {
+	return []baseCase{
+		// chained members
+		{
+			id:          1,
+			chain:       fmt.Sprintf("foo %s foo.bar;", operator),
+			declaration: "declare const foo: {bar: number} | null | undefined;",
+			outputChain: "foo?.bar;",
+		},
+		{
+			id:          2,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar.baz;", operator),
+			declaration: "declare const foo: {bar: {baz: number} | null | undefined};",
+			outputChain: "foo.bar?.baz;",
+		},
+		{
+			id:          3,
+			chain:       fmt.Sprintf("foo %s foo();", operator),
+			declaration: "declare const foo: (() => number) | null | undefined;",
+			outputChain: "foo?.();",
+		},
+		{
+			id:          4,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar();", operator),
+			declaration: "declare const foo: {bar: (() => number) | null | undefined};",
+			outputChain: "foo.bar?.();",
+		},
+		{
+			id:          5,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz %s foo.bar.baz.buzz;", operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.buzz;",
+		},
+		{
+			id:          6,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar.baz %s foo.bar.baz.buzz;", operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};",
+			outputChain: "foo.bar?.baz?.buzz;",
+		},
+		// case with a jump (i.e. a non-nullish prop)
+		{
+			id:          7,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz.buzz;", operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz.buzz;",
+		},
+		{
+			id:          8,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar.baz.buzz;", operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: number}} | null | undefined};",
+			outputChain: "foo.bar?.baz.buzz;",
+		},
+		// case where for some reason there is a doubled up expression
+		{
+			id:          9,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz %s foo.bar.baz %s foo.bar.baz.buzz;", operator, operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.buzz;",
+		},
+		{
+			id:          10,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar.baz %s foo.bar.baz %s foo.bar.baz.buzz;", operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo.bar?.baz?.buzz;",
+		},
+		// chained members with element access
+		{
+			id:          11,
+			chain:       fmt.Sprintf("foo %s foo[bar] %s foo[bar].baz %s foo[bar].baz.buzz;", operator, operator, operator),
+			declaration: "declare const bar: string;\ndeclare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.[bar]?.baz?.buzz;",
+		},
+		{
+			id:          12,
+			chain:       fmt.Sprintf("foo %s foo[bar].baz %s foo[bar].baz.buzz;", operator, operator),
+			declaration: "declare const bar: string;\ndeclare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.[bar].baz?.buzz;",
+		},
+		// case with a property access in computed property
+		{
+			id:          13,
+			chain:       fmt.Sprintf("foo %s foo[bar.baz] %s foo[bar.baz].buzz;", operator, operator),
+			declaration: "declare const bar: {baz: string};\ndeclare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;",
+			outputChain: "foo?.[bar.baz]?.buzz;",
+		},
+		// chained calls
+		{
+			id:          14,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz %s foo.bar.baz.buzz();", operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.buzz();",
+		},
+		{
+			id:          15,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz %s foo.bar.baz.buzz %s foo.bar.baz.buzz();", operator, operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.buzz?.();",
+		},
+		{
+			id:          16,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar.baz %s foo.bar.baz.buzz %s foo.bar.baz.buzz();", operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};",
+			outputChain: "foo.bar?.baz?.buzz?.();",
+		},
+		// case with a jump (i.e. a non-nullish prop)
+		{
+			id:          17,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz.buzz();", operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz.buzz();",
+		},
+		{
+			id:          18,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar.baz.buzz();", operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};",
+			outputChain: "foo.bar?.baz.buzz();",
+		},
+		{
+			id:          19,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz.buzz %s foo.bar.baz.buzz();", operator, operator, operator),
+			declaration: "declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz.buzz?.();",
+		},
+		{
+			id:          20,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar() %s foo.bar().baz %s foo.bar().baz.buzz %s foo.bar().baz.buzz();", operator, operator, operator, operator),
+			declaration: "declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};",
+			outputChain: "foo.bar?.()?.baz?.buzz?.();",
+		},
+		// chained calls with element access
+		{
+			id:          21,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz %s foo.bar.baz[buzz]();", operator, operator, operator),
+			declaration: "declare const buzz: string;\ndeclare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.[buzz]();",
+		},
+		{
+			id:          22,
+			chain:       fmt.Sprintf("foo %s foo.bar %s foo.bar.baz %s foo.bar.baz[buzz] %s foo.bar.baz[buzz]();", operator, operator, operator, operator),
+			declaration: "declare const buzz: string;\ndeclare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.[buzz]?.();",
+		},
+		// (partially) pre-optional chained
+		{
+			id:          23,
+			chain:       fmt.Sprintf("foo %s foo?.bar %s foo?.bar.baz %s foo?.bar.baz[buzz] %s foo?.bar.baz[buzz]();", operator, operator, operator, operator),
+			declaration: "declare const buzz: string;\ndeclare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;",
+			outputChain: "foo?.bar?.baz?.[buzz]?.();",
+		},
+		{
+			id:          24,
+			chain:       fmt.Sprintf("foo %s foo?.bar.baz %s foo?.bar.baz[buzz];", operator, operator),
+			declaration: "declare const buzz: string;\ndeclare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;",
+			outputChain: "foo?.bar.baz?.[buzz];",
+		},
+		{
+			id:          25,
+			chain:       fmt.Sprintf("foo %s foo?.() %s foo?.().bar;", operator, operator),
+			declaration: "declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;",
+			outputChain: "foo?.()?.bar;",
+		},
+		{
+			id:          26,
+			chain:       fmt.Sprintf("foo.bar %s foo.bar?.() %s foo.bar?.().baz;", operator, operator),
+			declaration: "declare const foo: {bar: () => ({baz: number} | null | undefined)};",
+			outputChain: "foo.bar?.()?.baz;",
+		},
+	}
+}
+
+func identity(s string) string {
+	return s
+}
+
+func generateInvalidBaseCases(opts baseCaseOptions) []rule_tester.InvalidTestCase {
+	mutateCode := opts.mutateCode
+	if mutateCode == nil {
+		mutateCode = identity
+	}
+	mutateDeclaration := opts.mutateDeclaration
+	if mutateDeclaration == nil {
+		mutateDeclaration = identity
+	}
+	mutateOutput := opts.mutateOutput
+	if mutateOutput == nil {
+		mutateOutput = mutateCode
+	}
+
+	skipIdsSet := make(map[int]bool)
+	for _, id := range opts.skipIds {
+		skipIdsSet[id] = true
+	}
+
+	cases := rawBaseCases(opts.operator)
+	var result []rule_tester.InvalidTestCase
+
+	for _, bc := range cases {
+		if skipIdsSet[bc.id] {
+			continue
+		}
+
+		declaration := mutateDeclaration(bc.declaration)
+		code := fmt.Sprintf("// %d\n%s\n%s", bc.id, declaration, mutateCode(bc.chain))
+		output := fmt.Sprintf("// %d\n%s\n%s", bc.id, declaration, mutateOutput(bc.outputChain))
+
+		if opts.useSuggestionFixer {
+			result = append(result, rule_tester.InvalidTestCase{
+				Code: code,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferOptionalChain",
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "optionalChainSuggest", Output: output},
+						},
+					},
+				},
+			})
+		} else {
+			result = append(result, rule_tester.InvalidTestCase{
+				Code:   code,
+				Output: []string{output},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferOptionalChain"},
+				},
+			})
+		}
+	}
+
+	return result
+}
+
+func generateValidBaseCases(opts baseCaseOptions) []rule_tester.ValidTestCase {
+	mutateCode := opts.mutateCode
+	if mutateCode == nil {
+		mutateCode = identity
+	}
+	mutateDeclaration := opts.mutateDeclaration
+	if mutateDeclaration == nil {
+		mutateDeclaration = identity
+	}
+
+	skipIdsSet := make(map[int]bool)
+	for _, id := range opts.skipIds {
+		skipIdsSet[id] = true
+	}
+
+	cases := rawBaseCases(opts.operator)
+	var result []rule_tester.ValidTestCase
+
+	for _, bc := range cases {
+		if skipIdsSet[bc.id] {
+			continue
+		}
+
+		declaration := mutateDeclaration(bc.declaration)
+		code := fmt.Sprintf("// %d\n%s\n%s", bc.id, declaration, mutateCode(bc.chain))
+
+		result = append(result, rule_tester.ValidTestCase{
+			Code: code,
+		})
+	}
+
+	return result
+}
+

--- a/internal/plugins/typescript/rules/prefer_optional_chain/compare_nodes.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/compare_nodes.go
@@ -1,0 +1,332 @@
+package prefer_optional_chain
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+type NodeComparisonResult int
+
+const (
+	NodeComparisonInvalid NodeComparisonResult = iota
+	NodeComparisonEqual
+	NodeComparisonSubset
+)
+
+// skipDownwards unwraps NonNullExpression and ParenthesizedExpression wrappers.
+// Reuses tsgo's SkipOuterExpressions for consistency with the compiler's semantics.
+func skipDownwards(node *ast.Node) *ast.Node {
+	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKNonNullAssertions)
+}
+
+func compareNodesUncached(nodeA *ast.Node, nodeB *ast.Node) NodeComparisonResult {
+	a := skipDownwards(nodeA)
+	b := skipDownwards(nodeB)
+
+	if a.Kind != b.Kind {
+		// Check if a is a prefix/subset of b's chain
+		if isChainPrefix(a, b) {
+			return NodeComparisonSubset
+		}
+		return NodeComparisonInvalid
+	}
+
+	switch a.Kind {
+	case ast.KindIdentifier:
+		if a.Text() == b.Text() {
+			return NodeComparisonEqual
+		}
+		return NodeComparisonInvalid
+
+	case ast.KindThisKeyword, ast.KindSuperKeyword,
+		// Type keyword nodes used in type arguments (e.g., foo<string>()).
+		// Two nodes of the same keyword kind are always structurally equal.
+		ast.KindStringKeyword, ast.KindNumberKeyword, ast.KindBooleanKeyword,
+		ast.KindAnyKeyword, ast.KindUnknownKeyword, ast.KindVoidKeyword,
+		ast.KindNeverKeyword, ast.KindObjectKeyword, ast.KindUndefinedKeyword,
+		ast.KindNullKeyword, ast.KindBigIntKeyword, ast.KindSymbolKeyword:
+		return NodeComparisonEqual
+
+	case ast.KindPropertyAccessExpression:
+		propA := a.AsPropertyAccessExpression()
+		propB := b.AsPropertyAccessExpression()
+
+		if propA.Name().Text() != propB.Name().Text() {
+			// Names differ - but a might still be a prefix of b
+			if isChainPrefix(a, b) {
+				return NodeComparisonSubset
+			}
+			return NodeComparisonInvalid
+		}
+
+		// Parenthesized optional chains like (foo?.a).b have different semantics
+		// from foo?.a.b because the parens break the optional chain propagation.
+		if isParenthesizedOptionalChain(propA.Expression) != isParenthesizedOptionalChain(propB.Expression) {
+			return NodeComparisonInvalid
+		}
+
+		exprResult := compareNodesUncached(propA.Expression, propB.Expression)
+		if exprResult != NodeComparisonEqual {
+			return exprResult
+		}
+		return NodeComparisonEqual
+
+	case ast.KindAwaitExpression:
+		return compareNodesUncached(a.AsAwaitExpression().Expression, b.AsAwaitExpression().Expression)
+
+	case ast.KindElementAccessExpression:
+		elemA := a.AsElementAccessExpression()
+		elemB := b.AsElementAccessExpression()
+
+		if isParenthesizedOptionalChain(elemA.Expression) != isParenthesizedOptionalChain(elemB.Expression) {
+			return NodeComparisonInvalid
+		}
+
+		// Check if a is a prefix of b first (different arguments)
+		argResult := compareNodesUncached(elemA.ArgumentExpression, elemB.ArgumentExpression)
+		if argResult != NodeComparisonEqual {
+			if isChainPrefix(a, b) {
+				return NodeComparisonSubset
+			}
+			return NodeComparisonInvalid
+		}
+
+		exprResult := compareNodesUncached(elemA.Expression, elemB.Expression)
+		if exprResult != NodeComparisonEqual {
+			return exprResult
+		}
+		return NodeComparisonEqual
+
+	case ast.KindCallExpression:
+		callA := a.AsCallExpression()
+		callB := b.AsCallExpression()
+
+		if isParenthesizedOptionalChain(callA.Expression) != isParenthesizedOptionalChain(callB.Expression) {
+			return NodeComparisonInvalid
+		}
+
+		// Compare type arguments (e.g., foo<a>() vs foo<a, b>())
+		var typeArgsA, typeArgsB []*ast.Node
+		if callA.TypeArguments != nil {
+			typeArgsA = callA.TypeArguments.Nodes
+		}
+		if callB.TypeArguments != nil {
+			typeArgsB = callB.TypeArguments.Nodes
+		}
+		if len(typeArgsA) != len(typeArgsB) {
+			if isChainPrefix(a, b) {
+				return NodeComparisonSubset
+			}
+			return NodeComparisonInvalid
+		}
+		for i := range typeArgsA {
+			taResult := compareNodesUncached(typeArgsA[i], typeArgsB[i])
+			if taResult != NodeComparisonEqual {
+				if isChainPrefix(a, b) {
+					return NodeComparisonSubset
+				}
+				return NodeComparisonInvalid
+			}
+		}
+
+		var argsA, argsB []*ast.Node
+		if callA.Arguments != nil {
+			argsA = callA.Arguments.Nodes
+		}
+		if callB.Arguments != nil {
+			argsB = callB.Arguments.Nodes
+		}
+		if len(argsA) != len(argsB) {
+			if isChainPrefix(a, b) {
+				return NodeComparisonSubset
+			}
+			return NodeComparisonInvalid
+		}
+
+		for i := range argsA {
+			argResult := compareNodesUncached(argsA[i], argsB[i])
+			if argResult != NodeComparisonEqual {
+				if isChainPrefix(a, b) {
+					return NodeComparisonSubset
+				}
+				return NodeComparisonInvalid
+			}
+		}
+
+		exprResult := compareNodesUncached(callA.Expression, callB.Expression)
+		if exprResult != NodeComparisonEqual {
+			return exprResult
+		}
+		return NodeComparisonEqual
+
+	case ast.KindMetaProperty:
+		// MetaProperty: new.target, import.meta
+		metaA := a.AsMetaProperty()
+		metaB := b.AsMetaProperty()
+		if metaA.KeywordToken == metaB.KeywordToken &&
+			metaA.Name().Text() == metaB.Name().Text() {
+			return NodeComparisonEqual
+		}
+		return NodeComparisonInvalid
+
+	case ast.KindTypeReference:
+		refA := a.AsTypeReferenceNode()
+		refB := b.AsTypeReferenceNode()
+		nameResult := compareNodesUncached(refA.TypeName, refB.TypeName)
+		if nameResult != NodeComparisonEqual {
+			return NodeComparisonInvalid
+		}
+		var typeArgsA, typeArgsB []*ast.Node
+		if refA.TypeArguments != nil {
+			typeArgsA = refA.TypeArguments.Nodes
+		}
+		if refB.TypeArguments != nil {
+			typeArgsB = refB.TypeArguments.Nodes
+		}
+		if len(typeArgsA) != len(typeArgsB) {
+			return NodeComparisonInvalid
+		}
+		for i := range typeArgsA {
+			if compareNodesUncached(typeArgsA[i], typeArgsB[i]) != NodeComparisonEqual {
+				return NodeComparisonInvalid
+			}
+		}
+		return NodeComparisonEqual
+
+	case ast.KindQualifiedName:
+		qualA := a.AsQualifiedName()
+		qualB := b.AsQualifiedName()
+		leftResult := compareNodesUncached(qualA.Left, qualB.Left)
+		if leftResult != NodeComparisonEqual {
+			return NodeComparisonInvalid
+		}
+		return compareNodesUncached(qualA.Right, qualB.Right)
+
+	case ast.KindStringLiteral, ast.KindNumericLiteral, ast.KindNoSubstitutionTemplateLiteral:
+		if a.Text() == b.Text() {
+			return NodeComparisonEqual
+		}
+		return NodeComparisonInvalid
+
+	case ast.KindBinaryExpression:
+		binA := a.AsBinaryExpression()
+		binB := b.AsBinaryExpression()
+		if binA.OperatorToken.Kind != binB.OperatorToken.Kind {
+			return NodeComparisonInvalid
+		}
+		if compareNodesUncached(binA.Left, binB.Left) != NodeComparisonEqual {
+			return NodeComparisonInvalid
+		}
+		return compareNodesUncached(binA.Right, binB.Right)
+
+	case ast.KindTypeOfExpression:
+		return compareNodesUncached(a.AsTypeOfExpression().Expression, b.AsTypeOfExpression().Expression)
+
+	case ast.KindAsExpression:
+		// Compare only the expression, ignore the type annotation
+		return compareNodesUncached(a.Expression(), b.Expression())
+
+	case ast.KindTemplateExpression:
+		teA := a.AsTemplateExpression()
+		teB := b.AsTemplateExpression()
+		// Compare template heads
+		if teA.Head.Text() != teB.Head.Text() {
+			return NodeComparisonInvalid
+		}
+		// Compare template spans
+		var spansA, spansB []*ast.Node
+		if teA.TemplateSpans != nil {
+			spansA = teA.TemplateSpans.Nodes
+		}
+		if teB.TemplateSpans != nil {
+			spansB = teB.TemplateSpans.Nodes
+		}
+		if len(spansA) != len(spansB) {
+			return NodeComparisonInvalid
+		}
+		for i := range spansA {
+			spanA := spansA[i].AsTemplateSpan()
+			spanB := spansB[i].AsTemplateSpan()
+			if compareNodesUncached(spanA.Expression, spanB.Expression) != NodeComparisonEqual {
+				return NodeComparisonInvalid
+			}
+			if spanA.Literal.Text() != spanB.Literal.Text() {
+				return NodeComparisonInvalid
+			}
+		}
+		return NodeComparisonEqual
+
+	case ast.KindPrefixUnaryExpression:
+		preA := a.AsPrefixUnaryExpression()
+		preB := b.AsPrefixUnaryExpression()
+		if preA.Operator != preB.Operator {
+			return NodeComparisonInvalid
+		}
+		return compareNodesUncached(preA.Operand, preB.Operand)
+
+	case ast.KindNewExpression,
+		ast.KindObjectLiteralExpression,
+		ast.KindArrayLiteralExpression,
+		ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindYieldExpression:
+		return NodeComparisonInvalid
+	}
+
+	return NodeComparisonInvalid
+}
+
+func isChainPrefix(prefix *ast.Node, chain *ast.Node) bool {
+	p := skipDownwards(prefix)
+	c := skipDownwards(chain)
+
+	// Walk down the left spine of the chain until we find a match
+	for {
+		switch c.Kind {
+		case ast.KindPropertyAccessExpression:
+			prop := c.AsPropertyAccessExpression()
+			if compareNodesUncached(p, prop.Expression) == NodeComparisonEqual {
+				return true
+			}
+			c = skipDownwards(prop.Expression)
+			continue
+
+		case ast.KindElementAccessExpression:
+			elem := c.AsElementAccessExpression()
+			if compareNodesUncached(p, elem.Expression) == NodeComparisonEqual {
+				return true
+			}
+			c = skipDownwards(elem.Expression)
+			continue
+
+		case ast.KindCallExpression:
+			call := c.AsCallExpression()
+			if compareNodesUncached(p, call.Expression) == NodeComparisonEqual {
+				return true
+			}
+			c = skipDownwards(call.Expression)
+			continue
+		}
+		break
+	}
+	return false
+}
+
+// isParenthesizedOptionalChain checks if a node is a ParenthesizedExpression
+// wrapping an optional chain access (e.g., `(foo?.bar)`). Parentheses break
+// optional chain propagation, so `(foo?.a).b` has different semantics from
+// `foo?.a.b` and they should not be compared as equal.
+func isParenthesizedOptionalChain(node *ast.Node) bool {
+	if !ast.IsParenthesizedExpression(node) {
+		return false
+	}
+	inner := node.Expression()
+	switch inner.Kind {
+	case ast.KindPropertyAccessExpression:
+		return inner.AsPropertyAccessExpression().QuestionDotToken != nil
+	case ast.KindElementAccessExpression:
+		return inner.AsElementAccessExpression().QuestionDotToken != nil
+	case ast.KindCallExpression:
+		return inner.AsCallExpression().QuestionDotToken != nil
+	}
+	return false
+}

--- a/internal/plugins/typescript/rules/prefer_optional_chain/gather_logical_operands.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/gather_logical_operands.go
@@ -1,0 +1,463 @@
+package prefer_optional_chain
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type OperandValidity int
+
+const (
+	OperandValid OperandValidity = iota
+	OperandInvalid
+)
+
+type NullishComparisonType int
+
+const (
+	ComparisonNotEqualNullOrUndefined NullishComparisonType = iota // x != null, x != undefined
+	ComparisonNotStrictEqualNull                                   // x !== null
+	ComparisonNotStrictEqualUndefined                              // x !== undefined, typeof x !== 'undefined'
+	ComparisonBoolean                                              // x (truthy check)
+	ComparisonNotBoolean                                           // !x (falsy check, for || chains)
+	ComparisonEqualNullOrUndefined                                 // x == null, x == undefined
+	ComparisonStrictEqualNull                                      // x === null
+	ComparisonStrictEqualUndefined                                 // x === undefined, typeof x === 'undefined'
+)
+
+type Operand struct {
+	Node           *ast.Node
+	ComparedNode   *ast.Node // the node being compared (e.g., `foo` in `foo != null`)
+	ComparisonType NullishComparisonType
+	Validity       OperandValidity
+	IsYoda         bool
+	IsTypeof       bool // whether this was a typeof check (typeof x !== 'undefined')
+	UsesNull       bool // for != / == comparisons, whether null was used (vs undefined)
+}
+
+type OperandAnalyzer struct {
+	ctx  rule.RuleContext
+	opts PreferOptionalChainOptions
+}
+
+func NewOperandAnalyzer(ctx rule.RuleContext, opts PreferOptionalChainOptions) *OperandAnalyzer {
+	return &OperandAnalyzer{ctx: ctx, opts: opts}
+}
+
+func (a *OperandAnalyzer) GatherLogicalOperands(node *ast.Node) ([]Operand, ast.Kind) {
+	bin := node.AsBinaryExpression()
+	operator := bin.OperatorToken.Kind
+
+	if operator != ast.KindAmpersandAmpersandToken && operator != ast.KindBarBarToken {
+		return nil, operator
+	}
+
+	operands := make([]Operand, 0, 4)
+	a.flattenLogicalOperands(node, operator, &operands)
+	return operands, operator
+}
+
+func (a *OperandAnalyzer) flattenLogicalOperands(node *ast.Node, operator ast.Kind, operands *[]Operand) {
+	// Skip parentheses to handle cases like `a && (a.b && a.b.c)`
+	unwrapped := ast.SkipParentheses(node)
+	if ast.IsBinaryExpression(unwrapped) {
+		bin := unwrapped.AsBinaryExpression()
+		if bin.OperatorToken.Kind == operator {
+			a.flattenLogicalOperands(bin.Left, operator, operands)
+			a.flattenLogicalOperands(bin.Right, operator, operands)
+			return
+		}
+	}
+
+	operand := a.classifyOperand(node, operator)
+	*operands = append(*operands, operand)
+}
+
+func (a *OperandAnalyzer) classifyOperand(node *ast.Node, chainOperator ast.Kind) Operand {
+	raw := ast.SkipParentheses(node)
+
+	// Handle `!expr` for || chains (DeMorgan)
+	if chainOperator == ast.KindBarBarToken && ast.IsPrefixUnaryExpression(raw) {
+		prefix := raw.AsPrefixUnaryExpression()
+		if prefix.Operator == ast.KindExclamationToken {
+			inner := ast.SkipParentheses(prefix.Operand)
+			if isValidChainTarget(inner, true) {
+				if a.isValidBooleanCheckType(inner) {
+					return Operand{
+						Node:           node,
+						ComparedNode:   inner,
+						ComparisonType: ComparisonNotBoolean,
+						Validity:       OperandValid,
+					}
+				}
+			}
+		}
+	}
+
+	// Handle comparison expressions: x != null, x !== undefined, etc.
+	if ast.IsBinaryExpression(raw) {
+		bin := raw.AsBinaryExpression()
+		result, ok := a.classifyComparisonOperand(bin, chainOperator)
+		if ok {
+			return result
+		}
+	}
+
+	// Handle typeof x !== 'undefined'
+	if ast.IsBinaryExpression(raw) {
+		bin := raw.AsBinaryExpression()
+		result, ok := a.classifyTypeofOperand(bin, chainOperator)
+		if ok {
+			return result
+		}
+	}
+
+	// Handle bare truthy check: `x` in && chain
+	if chainOperator == ast.KindAmpersandAmpersandToken && isValidChainTarget(raw, true) {
+		if a.isValidBooleanCheckType(raw) {
+			return Operand{
+				Node:           node,
+				ComparedNode:   raw,
+				ComparisonType: ComparisonBoolean,
+				Validity:       OperandValid,
+			}
+		}
+	}
+
+	return Operand{
+		Node:     node,
+		Validity: OperandInvalid,
+	}
+}
+
+func (a *OperandAnalyzer) classifyComparisonOperand(bin *ast.BinaryExpression, chainOperator ast.Kind) (Operand, bool) {
+	left := ast.SkipParentheses(bin.Left)
+	right := ast.SkipParentheses(bin.Right)
+	opKind := bin.OperatorToken.Kind
+
+	// Try both orientations for Yoda-style: `null != foo`
+	for _, yoda := range []bool{false, true} {
+		var testExpr, checkExpr *ast.Node
+		if yoda {
+			testExpr, checkExpr = right, left
+		} else {
+			testExpr, checkExpr = left, right
+		}
+
+		if !isValidChainTarget(testExpr, true) {
+			continue
+		}
+
+		isNull := checkExpr.Kind == ast.KindNullKeyword
+		isUndefined := ast.IsIdentifier(checkExpr) && checkExpr.Text() == "undefined"
+
+		if !isNull && !isUndefined {
+			continue
+		}
+
+		var compType NullishComparisonType
+		isNegated := isNegatedComparison(opKind, chainOperator)
+
+		switch {
+		case opKind == ast.KindExclamationEqualsToken || opKind == ast.KindEqualsEqualsToken:
+			if isNegated {
+				compType = ComparisonNotEqualNullOrUndefined
+			} else {
+				compType = ComparisonEqualNullOrUndefined
+			}
+		case (opKind == ast.KindExclamationEqualsEqualsToken || opKind == ast.KindEqualsEqualsEqualsToken) && isNull:
+			if isNegated {
+				compType = ComparisonNotStrictEqualNull
+			} else {
+				compType = ComparisonStrictEqualNull
+			}
+		case (opKind == ast.KindExclamationEqualsEqualsToken || opKind == ast.KindEqualsEqualsEqualsToken) && isUndefined:
+			if isNegated {
+				compType = ComparisonNotStrictEqualUndefined
+			} else {
+				compType = ComparisonStrictEqualUndefined
+			}
+		default:
+			continue
+		}
+
+		return Operand{
+			Node:           bin.AsNode(),
+			ComparedNode:   testExpr,
+			ComparisonType: compType,
+			Validity:       OperandValid,
+			IsYoda:         yoda,
+			UsesNull:       isNull,
+		}, true
+	}
+
+	return Operand{}, false
+}
+
+func (a *OperandAnalyzer) classifyTypeofOperand(bin *ast.BinaryExpression, chainOperator ast.Kind) (Operand, bool) {
+	left := ast.SkipParentheses(bin.Left)
+	right := ast.SkipParentheses(bin.Right)
+	opKind := bin.OperatorToken.Kind
+
+	if opKind != ast.KindExclamationEqualsEqualsToken && opKind != ast.KindEqualsEqualsEqualsToken {
+		return Operand{}, false
+	}
+
+	for _, yoda := range []bool{false, true} {
+		var typeofExpr, stringExpr *ast.Node
+		if yoda {
+			typeofExpr, stringExpr = right, left
+		} else {
+			typeofExpr, stringExpr = left, right
+		}
+
+		if !ast.IsTypeOfExpression(typeofExpr) {
+			continue
+		}
+
+		if !ast.IsStringLiteral(stringExpr) || stringExpr.Text() != "undefined" {
+			continue
+		}
+
+		inner := typeofExpr.AsTypeOfExpression().Expression
+		if !isValidChainTarget(inner, true) {
+			continue
+		}
+
+		isNegated := isNegatedComparison(opKind, chainOperator)
+		var compType NullishComparisonType
+		if isNegated {
+			compType = ComparisonNotStrictEqualUndefined
+		} else {
+			compType = ComparisonStrictEqualUndefined
+		}
+
+		return Operand{
+			Node:           bin.AsNode(),
+			ComparedNode:   inner,
+			ComparisonType: compType,
+			Validity:       OperandValid,
+			IsTypeof:       true,
+			IsYoda:         yoda,
+		}, true
+	}
+
+	return Operand{}, false
+}
+
+func isNegatedComparison(opKind ast.Kind, chainOperator ast.Kind) bool {
+	isNegatedOp := opKind == ast.KindExclamationEqualsToken || opKind == ast.KindExclamationEqualsEqualsToken
+	if chainOperator == ast.KindAmpersandAmpersandToken {
+		return isNegatedOp
+	}
+	// For || chains, the sense is reversed
+	return !isNegatedOp
+}
+
+func invertComparisonType(ct NullishComparisonType) NullishComparisonType {
+	switch ct {
+	case ComparisonBoolean:
+		return ComparisonNotBoolean
+	case ComparisonNotBoolean:
+		return ComparisonBoolean
+	case ComparisonNotEqualNullOrUndefined:
+		return ComparisonEqualNullOrUndefined
+	case ComparisonEqualNullOrUndefined:
+		return ComparisonNotEqualNullOrUndefined
+	case ComparisonNotStrictEqualNull:
+		return ComparisonStrictEqualNull
+	case ComparisonStrictEqualNull:
+		return ComparisonNotStrictEqualNull
+	case ComparisonNotStrictEqualUndefined:
+		return ComparisonStrictEqualUndefined
+	case ComparisonStrictEqualUndefined:
+		return ComparisonNotStrictEqualUndefined
+	}
+	return ct
+}
+
+func (a *OperandAnalyzer) isValidBooleanCheckType(node *ast.Node) bool {
+	if a.ctx.TypeChecker == nil {
+		return true
+	}
+
+	t := a.ctx.TypeChecker.GetTypeAtLocation(node)
+	if t == nil {
+		return true
+	}
+
+	// Check for falsy literal unions: if the type is a union containing a falsy
+	// literal (false, 0, '', 0n) alongside an object type, but NO null/undefined/void,
+	// then the truthiness check is being used as a type discriminator
+	// (e.g., `false | { a: string }`), not as a null guard.
+	// Don't suggest optional chaining in this case.
+	// Note: we require an object type in the union to distinguish discriminated unions
+	// (like `false | { a: string }`) from plain primitive types (like `boolean` = `true | false`).
+	parts := utils.UnionTypeParts(t)
+	if len(parts) > 1 {
+		hasFalsyLiteral := false
+		hasNullUndefined := false
+		hasObjectType := false
+		for _, part := range parts {
+			pFlags := checker.Type_flags(part)
+			if pFlags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0 {
+				hasNullUndefined = true
+			}
+			if pFlags&checker.TypeFlagsObject != 0 {
+				hasObjectType = true
+			}
+			if isFalsyLiteralType(part) {
+				hasFalsyLiteral = true
+			}
+		}
+		if hasFalsyLiteral && !hasNullUndefined && hasObjectType {
+			return false
+		}
+	}
+
+	opts := a.opts
+	for _, part := range parts {
+		flags := checker.Type_flags(part)
+
+		if flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0 {
+			continue
+		}
+
+		if derefBoolDefault(opts.CheckAny, true) && flags&checker.TypeFlagsAny != 0 {
+			continue
+		}
+		if derefBoolDefault(opts.CheckUnknown, true) && flags&checker.TypeFlagsUnknown != 0 {
+			continue
+		}
+		if derefBoolDefault(opts.CheckString, true) && flags&checker.TypeFlagsStringLike != 0 {
+			continue
+		}
+		if derefBoolDefault(opts.CheckNumber, true) && flags&checker.TypeFlagsNumberLike != 0 {
+			continue
+		}
+		if derefBoolDefault(opts.CheckBoolean, true) && flags&checker.TypeFlagsBooleanLike != 0 {
+			continue
+		}
+		if derefBoolDefault(opts.CheckBigInt, true) && flags&checker.TypeFlagsBigIntLike != 0 {
+			continue
+		}
+		if flags&checker.TypeFlagsTypeParameter != 0 {
+			constraint := checker.Checker_getBaseConstraintOfType(a.ctx.TypeChecker, part)
+			if constraint == nil {
+				continue
+			}
+			// Recurse into constraint
+			constraintValid := true
+			for _, cPart := range utils.UnionTypeParts(constraint) {
+				cFlags := checker.Type_flags(cPart)
+				if cFlags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0 {
+					continue
+				}
+				if !a.isTypePartValidForBoolean(cFlags) {
+					constraintValid = false
+					break
+				}
+			}
+			if constraintValid {
+				continue
+			}
+		}
+
+		if flags&checker.TypeFlagsObject != 0 {
+			// object types are always truthy (when not null/undefined),
+			// so boolean coercion is safe for null/undefined guards
+			continue
+		}
+
+		if flags&checker.TypeFlagsNever != 0 {
+			continue
+		}
+
+		if flags&checker.TypeFlagsEnum != 0 || flags&checker.TypeFlagsEnumLiteral != 0 {
+			continue
+		}
+
+		return false
+	}
+
+	return true
+}
+
+func (a *OperandAnalyzer) isTypePartValidForBoolean(flags checker.TypeFlags) bool {
+	opts := a.opts
+	if derefBoolDefault(opts.CheckAny, true) && flags&checker.TypeFlagsAny != 0 {
+		return true
+	}
+	if derefBoolDefault(opts.CheckUnknown, true) && flags&checker.TypeFlagsUnknown != 0 {
+		return true
+	}
+	if derefBoolDefault(opts.CheckString, true) && flags&checker.TypeFlagsStringLike != 0 {
+		return true
+	}
+	if derefBoolDefault(opts.CheckNumber, true) && flags&checker.TypeFlagsNumberLike != 0 {
+		return true
+	}
+	if derefBoolDefault(opts.CheckBoolean, true) && flags&checker.TypeFlagsBooleanLike != 0 {
+		return true
+	}
+	if derefBoolDefault(opts.CheckBigInt, true) && flags&checker.TypeFlagsBigIntLike != 0 {
+		return true
+	}
+	if flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid|checker.TypeFlagsNever) != 0 {
+		return true
+	}
+	return false
+}
+
+func isValidChainTarget(node *ast.Node, allowIdentifier bool) bool {
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return allowIdentifier
+	case ast.KindThisKeyword:
+		return allowIdentifier
+	case ast.KindPropertyAccessExpression:
+		// Private identifiers (#foo) cannot use optional chaining
+		prop := n.AsPropertyAccessExpression()
+		if ast.IsPrivateIdentifier(prop.Name()) {
+			return false
+		}
+		return true
+	case ast.KindElementAccessExpression:
+		return true
+	case ast.KindCallExpression:
+		return true
+	case ast.KindMetaProperty:
+		return true
+	case ast.KindNonNullExpression:
+		return isValidChainTarget(n.Expression(), allowIdentifier)
+	}
+	return false
+}
+
+// isFalsyLiteralType checks if a type is a specific falsy literal value:
+// false, 0, '', or 0n. These appear in discriminated unions like `false | { a: string }`
+// where truthiness is used as a type discriminator rather than a null guard.
+func isFalsyLiteralType(t *checker.Type) bool {
+	flags := checker.Type_flags(t)
+
+	if utils.IsFalseLiteralType(t) {
+		return true
+	}
+	if flags&checker.TypeFlagsStringLiteral != 0 {
+		if s, ok := t.AsLiteralType().Value().(string); ok {
+			return s == ""
+		}
+	}
+	if flags&checker.TypeFlagsNumberLiteral != 0 {
+		return utils.IsNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
+	}
+	if flags&checker.TypeFlagsBigIntLiteral != 0 {
+		return checker.ValueToString(t.AsLiteralType().Value()) == "0n"
+	}
+
+	return false
+}
+

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.go
@@ -1,0 +1,144 @@
+package prefer_optional_chain
+
+import (
+	"encoding/json"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type PreferOptionalChainOptions struct {
+	AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing *bool `json:"allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing"`
+	CheckAny                                                           *bool `json:"checkAny"`
+	CheckUnknown                                                       *bool `json:"checkUnknown"`
+	CheckString                                                        *bool `json:"checkString"`
+	CheckNumber                                                        *bool `json:"checkNumber"`
+	CheckBoolean                                                       *bool `json:"checkBoolean"`
+	CheckBigInt                                                        *bool `json:"checkBigInt"`
+	RequireNullish                                                     *bool `json:"requireNullish"`
+}
+
+func buildPreferOptionalChainMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferOptionalChain",
+		Description: "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+	}
+}
+
+func buildOptionalChainSuggestMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "optionalChainSuggest",
+		Description: "Change to an optional chain expression. This may change the return type of the expression and some TypeScript errors may occur.",
+	}
+}
+
+var PreferOptionalChainRule = rule.CreateRule(rule.Rule{
+	Name: "prefer-optional-chain",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts, ok := options.(PreferOptionalChainOptions)
+		if !ok {
+			opts = PreferOptionalChainOptions{}
+			if options != nil {
+				// For IPC mode, options come as []interface{} or map[string]interface{}
+				raw := options
+				if optArray, isArray := options.([]interface{}); isArray && len(optArray) > 0 {
+					raw = optArray[0]
+				}
+				if jsonBytes, err := json.Marshal(raw); err == nil {
+					_ = json.Unmarshal(jsonBytes, &opts)
+				}
+			}
+		}
+
+		// Set defaults
+		if opts.CheckAny == nil {
+			opts.CheckAny = utils.Ref(true)
+		}
+		if opts.CheckUnknown == nil {
+			opts.CheckUnknown = utils.Ref(true)
+		}
+		if opts.CheckString == nil {
+			opts.CheckString = utils.Ref(true)
+		}
+		if opts.CheckNumber == nil {
+			opts.CheckNumber = utils.Ref(true)
+		}
+		if opts.CheckBoolean == nil {
+			opts.CheckBoolean = utils.Ref(true)
+		}
+		if opts.CheckBigInt == nil {
+			opts.CheckBigInt = utils.Ref(true)
+		}
+		if opts.RequireNullish == nil {
+			opts.RequireNullish = utils.Ref(false)
+		}
+		if opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing == nil {
+			opts.AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing = utils.Ref(false)
+		}
+
+		analyzer := NewOperandAnalyzer(ctx, opts)
+		chainAnalyzer := NewChainAnalyzer(ctx, opts)
+
+		// Track visited binary expressions to avoid duplicate reports
+		visited := make(map[*ast.Node]struct{})
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				op := bin.OperatorToken.Kind
+
+				// Only handle && and || chains
+				if op != ast.KindAmpersandAmpersandToken && op != ast.KindBarBarToken {
+					return
+				}
+
+				// Skip if this node is already part of a larger chain of the same operator
+				// We only want to process from the topmost binary expression of each chain
+				// Walk up through parenthesized expressions to handle cases like `a && (a.b && a.b.c)`
+				ancestor := node.Parent
+				for ancestor != nil && ast.IsParenthesizedExpression(ancestor) {
+					ancestor = ancestor.Parent
+				}
+				if ancestor != nil && ast.IsBinaryExpression(ancestor) {
+					parentBin := ancestor.AsBinaryExpression()
+					if parentBin.OperatorToken.Kind == op {
+						return
+					}
+				}
+
+				// Skip if already visited
+				if _, ok := visited[node]; ok {
+					return
+				}
+				visited[node] = struct{}{}
+
+				// Gather and classify operands
+				operands, chainOp := analyzer.GatherLogicalOperands(node)
+				if len(operands) < 2 {
+					return
+				}
+
+				// Analyze and report chains
+				chainAnalyzer.AnalyzeChain(operands, chainOp, node)
+			},
+
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				// Check for (foo || {}).bar pattern
+				chainAnalyzer.AnalyzeOrEmptyObjectPattern(node)
+			},
+
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				// Check for (foo || {})[bar] pattern
+				chainAnalyzer.AnalyzeOrEmptyObjectPattern(node)
+			},
+		}
+	},
+})
+
+func derefBoolDefault(b *bool, defaultVal bool) bool {
+	if b == nil {
+		return defaultVal
+	}
+	return *b
+}

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.md
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain.md
@@ -1,0 +1,89 @@
+# prefer-optional-chain
+
+## Rule Details
+
+Enforce using concise optional chain expressions instead of chained logical ANDs, negated logical ORs, or empty object coalescing patterns.
+
+TypeScript 3.7 introduced optional chaining (`?.`) which provides a more concise and readable way to access deeply nested properties that may be null or undefined.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+foo && foo.bar;
+foo && foo.bar && foo.bar.baz;
+foo && foo.bar();
+foo != null && foo.bar;
+foo !== undefined && foo.bar;
+typeof foo !== 'undefined' && foo.bar;
+!foo || !foo.bar;
+(foo || {}).bar;
+(foo ?? {}).bar;
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+foo?.bar;
+foo?.bar?.baz;
+foo?.bar();
+foo?.bar;
+foo?.bar;
+foo?.bar;
+!foo?.bar;
+foo?.bar;
+foo?.bar;
+```
+
+## Options
+
+### `allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing`
+
+Type: `boolean`, default: `false`
+
+When set to `true`, the rule will provide auto-fixes even when the fix may change the return type of the expression. By default, such cases are reported as suggestions only.
+
+### `checkAny`
+
+Type: `boolean`, default: `true`
+
+When set to `true`, the rule will check operands typed as `any` when inspecting boolean expressions.
+
+### `checkUnknown`
+
+Type: `boolean`, default: `true`
+
+When set to `true`, the rule will check operands typed as `unknown` when inspecting boolean expressions.
+
+### `checkString`
+
+Type: `boolean`, default: `true`
+
+When set to `true`, the rule will check operands typed as `string` when inspecting boolean expressions.
+
+### `checkNumber`
+
+Type: `boolean`, default: `true`
+
+When set to `true`, the rule will check operands typed as `number` when inspecting boolean expressions.
+
+### `checkBoolean`
+
+Type: `boolean`, default: `true`
+
+When set to `true`, the rule will check operands typed as `boolean` when inspecting boolean expressions.
+
+### `checkBigInt`
+
+Type: `boolean`, default: `true`
+
+When set to `true`, the rule will check operands typed as `bigint` when inspecting boolean expressions.
+
+### `requireNullish`
+
+Type: `boolean`, default: `false`
+
+When set to `true`, the rule will only report on expressions where at least one operand has a type that includes `null` or `undefined`. This prevents false positives when the expression uses truthy checks for non-nullable types like `string` or `number`.
+
+## Original Documentation
+
+- [typescript-eslint prefer-optional-chain](https://typescript-eslint.io/rules/prefer-optional-chain)

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -1,0 +1,1836 @@
+package prefer_optional_chain
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func TestPreferOptionalChainRule(t *testing.T) {
+	// =====================================================================
+	// GENERATED BASE CASES (mirrors JS BaseCases invocations)
+	// =====================================================================
+	generatedValid := []rule_tester.ValidTestCase{}
+	generatedInvalid := []rule_tester.InvalidTestCase{}
+
+	// --- && operator group ---
+
+	// 1. BaseCases({ operator: '&&' }) — boolean truthy, 26 invalid cases
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+	})...)
+
+	// 2. BaseCases({ mutateCode: c => c.replace(/;$/, ' && bing;'), operator: '&&' })
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.TrimSuffix(c, ";") + " && bing;"
+		},
+	})...)
+
+	// 3. BaseCases({ mutateCode: c => c.replace(/;$/, ' && bing.bong;'), operator: '&&' })
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.TrimSuffix(c, ";") + " && bing.bong;"
+		},
+	})...)
+
+	// 4. !== null valid (guard strips undefined from type → chain already safe)
+	generatedValid = append(generatedValid, generateValidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "&&", "!== null &&")
+		},
+	})...)
+
+	// 5. !== null invalid (mutateDeclaration removes `| undefined`)
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "&&", "!== null &&")
+		},
+		mutateDeclaration: func(c string) string {
+			return strings.ReplaceAll(c, "| undefined", "")
+		},
+		mutateOutput:       identity,
+		useSuggestionFixer: true,
+	})...)
+
+	// 6. != null invalid
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "&&", "!= null &&")
+		},
+		mutateOutput:       identity,
+		useSuggestionFixer: true,
+	})...)
+
+	// 7. !== undefined valid (skipIds [20, 26])
+	generatedValid = append(generatedValid, generateValidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "&&", "!== undefined &&")
+		},
+		skipIds: []int{20, 26},
+	})...)
+
+	// 8. !== undefined invalid (mutateDeclaration removes `| null`)
+	// Skip ID 20: call chain with trailing call + strict undefined equality
+	// triggers partial fold (matches TS-ESLint's hand-crafted test cases).
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "&&", "!== undefined &&")
+		},
+		mutateDeclaration: func(c string) string {
+			return strings.ReplaceAll(c, "| null", "")
+		},
+		mutateOutput:       identity,
+		useSuggestionFixer: true,
+		skipIds:            []int{20},
+	})...)
+
+	// 9. != undefined invalid
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "&&", "!= undefined &&")
+		},
+		mutateOutput:       identity,
+		useSuggestionFixer: true,
+	})...)
+
+	// --- || operator group ---
+
+	// 10. || boolean negation invalid
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			return "!" + strings.ReplaceAll(c, "||", "|| !")
+		},
+		mutateOutput: func(c string) string {
+			return "!" + c
+		},
+	})...)
+
+	// 11. === null valid
+	generatedValid = append(generatedValid, generateValidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "||", "=== null ||")
+		},
+	})...)
+
+	// 12. === null invalid (mutateDeclaration removes `| undefined`)
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			s := strings.ReplaceAll(c, "||", "=== null ||")
+			return regexp.MustCompile(`;$`).ReplaceAllString(s, " === null;")
+		},
+		mutateDeclaration: func(c string) string {
+			return strings.ReplaceAll(c, "| undefined", "")
+		},
+		mutateOutput: func(c string) string {
+			return regexp.MustCompile(`;$`).ReplaceAllString(c, " === null;")
+		},
+		useSuggestionFixer: true,
+	})...)
+
+	// 13. == null invalid
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			s := strings.ReplaceAll(c, "||", "== null ||")
+			return regexp.MustCompile(`;$`).ReplaceAllString(s, " == null;")
+		},
+		mutateOutput: func(c string) string {
+			return regexp.MustCompile(`;$`).ReplaceAllString(c, " == null;")
+		},
+	})...)
+
+	// 14. === undefined valid (skipIds [20, 26])
+	generatedValid = append(generatedValid, generateValidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			return strings.ReplaceAll(c, "||", "=== undefined ||")
+		},
+		skipIds: []int{20, 26},
+	})...)
+
+	// 15. === undefined invalid (mutateDeclaration removes `| null`)
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			s := strings.ReplaceAll(c, "||", "=== undefined ||")
+			return regexp.MustCompile(`;$`).ReplaceAllString(s, " === undefined;")
+		},
+		mutateDeclaration: func(c string) string {
+			return strings.ReplaceAll(c, "| null", "")
+		},
+		mutateOutput: func(c string) string {
+			return regexp.MustCompile(`;$`).ReplaceAllString(c, " === undefined;")
+		},
+	})...)
+
+	// 16. == undefined invalid
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "||",
+		mutateCode: func(c string) string {
+			s := strings.ReplaceAll(c, "||", "== undefined ||")
+			return regexp.MustCompile(`;$`).ReplaceAllString(s, " == undefined;")
+		},
+		mutateOutput: func(c string) string {
+			return regexp.MustCompile(`;$`).ReplaceAllString(c, " == undefined;")
+		},
+	})...)
+
+	// 17. Whitespace sanity check
+	dotWithSpaces := regexp.MustCompile(`\.`)
+	bracketContent := regexp.MustCompile(`(\[.+\])`)
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return dotWithSpaces.ReplaceAllString(c, ".      ")
+		},
+		mutateOutput: func(c string) string {
+			return bracketContent.ReplaceAllStringFunc(c, func(m string) string {
+				return dotWithSpaces.ReplaceAllString(m, ".      ")
+			})
+		},
+	})...)
+
+	// 18. Newline sanity check
+	generatedInvalid = append(generatedInvalid, generateInvalidBaseCases(baseCaseOptions{
+		operator: "&&",
+		mutateCode: func(c string) string {
+			return dotWithSpaces.ReplaceAllString(c, ".\n")
+		},
+		mutateOutput: func(c string) string {
+			return bracketContent.ReplaceAllStringFunc(c, func(m string) string {
+				return dotWithSpaces.ReplaceAllString(m, ".\n")
+			})
+		},
+	})...)
+
+	// =====================================================================
+	// HAND-WRITTEN VALID CASES (edge cases not covered by generator)
+	// =====================================================================
+	edgeCaseValid := []rule_tester.ValidTestCase{
+		// --- Already using optional chain ---
+		{Code: `foo?.bar;`},
+		{Code: `foo?.bar?.baz;`},
+		{Code: `foo?.bar?.baz?.qux;`},
+
+		// --- Different objects - not a chain ---
+		{Code: `foo && bar.baz;`},
+		{Code: `foo.bar && baz.qux;`},
+		{Code: `foo && fooBar.baz;`},
+
+		// --- Non-chain patterns ---
+		{Code: `foo && bar;`},
+		{Code: `foo || bar;`},
+		{Code: `foo ?? bar;`},
+		{Code: `foo && foo;`},
+		{Code: `foo || foo.bar;`},
+		{Code: `foo ?? foo.bar;`},
+
+		// --- || {} valid patterns ---
+		{Code: `foo || {};`},
+		{Code: `(foo || {})?.bar;`},
+		{Code: `(foo || { bar: 1 }).bar;`},
+		{Code: `foo ?? {};`},
+		{Code: `(foo ?? {})?.bar;`},
+
+		// --- Comparison not forming a chain ---
+		{Code: `foo == bar && foo.bar == null;`},
+		{Code: `foo === 1 && foo.toFixed();`},
+		{Code: `foo !== null && foo !== undefined;`},
+
+		// --- Non-matching arguments ---
+		{Code: `foo.bar(a) && foo.bar(a, b).baz;`},
+
+		// --- Non-matching type parameters ---
+		{Code: `foo.bar<a>() && foo.bar<a, b>().baz;`},
+
+		// --- Strict null check with type that also has undefined ---
+		{
+			Code: "declare const foo: {bar: (() => number) | null | undefined};\nfoo.bar !== null && foo.bar();",
+		},
+
+		// --- Private identifiers (cannot use optional chaining) ---
+		{Code: `foo && foo.#bar;`},
+		{Code: `!foo || !foo.#bar;`},
+
+		// --- this at start (not handled as chain) ---
+		{Code: `this && this.foo;`},
+		{Code: `!this || !this.foo;`},
+
+		// --- Various non-chain patterns from official tests ---
+		{Code: `!a || !b;`},
+		{Code: `!a || a.b;`},
+		{Code: `!a && a.b;`},
+		{Code: `!a && !a.b;`},
+		{Code: `!a.b || a.b?.();`},
+		{Code: `!a.b || a.b();`},
+		{Code: `foo ||= bar;`},
+		{Code: `foo ||= bar?.baz;`},
+		{Code: `result && this.options.shouldPreserveNodeMaps;`},
+		{Code: `match && match$1 !== undefined;`},
+
+		// --- Short-circuiting chains (already optional in guard) ---
+		{Code: `(foo?.a).b && foo.a.b.c;`},
+		{Code: `(foo?.a)() && foo.a().b;`},
+		{Code: `(foo?.a)() && foo.a()();`},
+
+		// --- Computed property mismatch ---
+		{Code: `!foo[1 + 1] || !foo[1 + 2];`},
+		{Code: `!foo[1 + 1] || !foo[1 + 2].foo;`},
+
+		// --- Weird non-constant cases ---
+		{Code: "({}) && {}.toString();"},
+		{Code: `[] && [].length;`},
+
+		// --- Various operator patterns ---
+		{Code: "typeof foo === 'number' && foo.toFixed();"},
+		{Code: "foo === 'undefined' && foo.length;"},
+
+		// --- Assignment patterns ---
+		{Code: `(x = {}) && (x.y = true) != null && x.y.toString();`},
+
+		// --- Falsy unions: discriminated falsy union without null/undefined ---
+		{Code: "declare const x: false | { a: string };\nx && x.a;"},
+		{Code: "declare const x: false | { a: string };\n!x || x.a;"},
+		{Code: "declare const x: '' | { a: string };\nx && x.a;"},
+		{Code: "declare const x: '' | { a: string };\n!x || x.a;"},
+		{Code: "declare const x: 0 | { a: string };\nx && x.a;"},
+		{Code: "declare const x: 0 | { a: string };\n!x || x.a;"},
+		{Code: "declare const x: 0n | { a: string };\nx && x.a;"},
+		{Code: "declare const x: 0n | { a: string };\n!x || x.a;"},
+
+		// --- import.meta / new.target valid patterns ---
+		{Code: `import.meta || true;`},
+		{Code: `import.meta || import.meta.foo;`},
+		{Code: `!import.meta && false;`},
+		{Code: `!import.meta && !import.meta.foo;`},
+		{Code: `new.target || new.target.length;`},
+		{Code: `!new.target || true;`},
+
+		// --- Template literals (different instances, not a valid chain) ---
+		{Code: "`x` && `x`.length;"},
+
+		// --- Strict null check: data && data.value !== null should be valid ---
+		{Code: `data && data.value !== null;`},
+
+		// --- Strict null pair without chain ---
+		{Code: `foo !== null && foo !== undefined;`},
+		{Code: "x['y'] !== undefined && x['y'] !== null;"},
+
+		// --- Private identifiers in inner chain ---
+		{Code: `a.#foo?.bar;`},
+		{Code: `!a.#foo?.bar;`},
+
+		// --- Options: checkAny=false ---
+		{
+			Code:    "declare const x: any;\nx && x.length;",
+			Options: PreferOptionalChainOptions{CheckAny: utils.Ref(false)},
+		},
+		// --- Options: checkString=false ---
+		{
+			Code:    "declare const x: string;\nx && x.length;",
+			Options: PreferOptionalChainOptions{CheckString: utils.Ref(false)},
+		},
+		// --- Options: checkNumber=false ---
+		{
+			Code:    "declare const x: number;\nx && x.length;",
+			Options: PreferOptionalChainOptions{CheckNumber: utils.Ref(false)},
+		},
+		// --- Options: checkBoolean=false ---
+		{
+			Code:    "declare const x: boolean;\nx && x.length;",
+			Options: PreferOptionalChainOptions{CheckBoolean: utils.Ref(false)},
+		},
+		// --- Options: checkBigInt=false ---
+		{
+			Code:    "declare const x: bigint;\nx && x.length;",
+			Options: PreferOptionalChainOptions{CheckBigInt: utils.Ref(false)},
+		},
+		// --- Options: checkUnknown=false ---
+		{
+			Code:    "declare const x: unknown;\nx && x.length;",
+			Options: PreferOptionalChainOptions{CheckUnknown: utils.Ref(false)},
+		},
+
+		// --- requireNullish valid cases ---
+		{
+			Code:    "declare const x: string;\nx && x.length;",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo: string;\nfoo && foo.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo: { bar: string };\nfoo && foo.bar && foo.bar.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo: string;\n(foo || {}).toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		// --- Additional valid patterns (false positive prevention) ---
+		{Code: `foo || ({} as any);`},
+		{Code: `foo ||= bar || {};`},
+		{Code: `foo ||= bar?.baz?.buzz;`},
+		{Code: "file !== 'index.ts' && file.endsWith('.ts');"},
+		{Code: `!foo().#a || a;`},
+		{Code: `!a.b.#a || a;`},
+		{Code: "!(foo as any).bar || 'anything';"},
+		{Code: "(() => {}) && (() => {}).name;"},
+		{Code: "(function () {}) && function () {}.name;"},
+		{Code: "new Map().get('a') && new Map().get('a').what;"},
+		{Code: `foo[x++] && foo[x++].bar;`},
+		{Code: `a = b && (a = b).wtf;`},
+		{Code: `(x || y) != null && (x || y).foo;`},
+		{Code: `(await foo) && (await foo).bar;`},
+		// Falsy literal unions (discriminated unions, not null guards)
+		{Code: "declare const x: false | { a: string };\nx && x.a;"},
+		{Code: "declare const x: '' | { a: string };\nx && x.a;"},
+		{Code: "declare const x: 0 | { a: string };\nx && x.a;"},
+		{Code: "declare const x: 0n | { a: string };\nx && x.a;"},
+		// || {} / ?? {} valid patterns
+		{Code: `(undefined && (foo || {})).bar;`},
+		{Code: `(foo1 ? foo2 : foo3 || {}).foo4;`},
+		{Code: `(foo = 2 || {}).bar;`},
+		{Code: `func(foo || {}).bar;`},
+		{Code: `foo ||= bar ?? {};`},
+		// Private identifiers
+		{Code: `this.#a && this.#b;`},
+		{Code: `!this.#a || !this.#b;`},
+		{Code: `!new A().#b || a;`},
+		{Code: `!(await a).#b || a;`},
+		// Various non-chain patterns
+		{Code: `nextToken && sourceCode.isSpaceBetweenTokens(prevToken, nextToken);`},
+		{Code: `!entity.__helper!.__initialized || options.refresh;`},
+		{Code: `[1, 2].length && [1, 2, 3].length.toFixed();`},
+		{Code: `(class Foo {}) && class Foo {}.constructor;`},
+		{Code: `foo[yield x] && foo[yield x].bar;`},
+		// Template literal / type assertion patterns
+		{Code: "`x${a}` && `x${a}`.length;"},
+		{Code: "('x' as `${'x'}`) && ('x' as `${'x'}`).length;"},
+		// JSX valid patterns
+		{Code: `<div /> && (<div />).wtf;`, Tsx: true},
+		{Code: `<></> && (<></>).wtf;`, Tsx: true},
+		// globalThis typeof (valid: no chain formed)
+		{Code: "typeof globalThis !== 'undefined' && globalThis.Array();"},
+		// Issue #8380: cross-variable null/undefined checks (not optional chain candidates)
+		{Code: "const a = null;\nconst b = 0;\na === undefined || b === null || b === undefined;"},
+		{Code: "const a = 0;\nconst b = 0;\na === undefined || b === undefined || b === null;"},
+		{Code: "const b = 0;\nb === null || b === undefined;"},
+		{Code: "const a = 0;\nconst b = 0;\nb === null || a === undefined || b === undefined;"},
+		{Code: "const a = 0;\nconst b = 0;\nb != null && a !== null && a !== undefined;"},
+		{Code: `foo ||= bar?.baz || {};`},
+		{Code: "[1,].length && [1, 2].length.toFixed();"},
+		// requireNullish additional valid
+		{
+			Code:    "declare const x: string | number | boolean | object;\nx && x.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo: string;\nfoo && foo.toString() && foo.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo: { bar: string };\nfoo && foo.bar && foo.bar.toString() && foo.bar.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo1: { bar: string | null };\nfoo1 && foo1.bar;",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+		{
+			Code:    "declare const foo: string | null;\n(foo || 'a' || {}).toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+		},
+	}
+
+	// =====================================================================
+	// HAND-WRITTEN INVALID CASES (edge cases not covered by generator)
+	// =====================================================================
+	edgeCaseInvalid := []rule_tester.InvalidTestCase{
+		// =================================================================
+		// Category 5: (foo || {}).bar patterns (→ suggestions)
+		// =================================================================
+		{
+			Code: `(foo || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo?.bar;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(foo ?? {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo?.bar;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(foo || {})[bar];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo?.[bar];`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(foo.bar || {})[baz];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo.bar?.[baz];`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(foo1?.foo2 || {}).foo3;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo1?.foo2?.foo3;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `const foo = (bar || {}).baz;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Column:    13,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `const foo = bar?.baz;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(foo ?? {})[baz];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Column:    1,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo?.[baz];`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(foo1?.foo2 ?? {}).foo3;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `foo1?.foo2?.foo3;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `(this || {}).foo;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `this?.foo;`},
+					},
+				},
+			},
+		},
+
+		// =================================================================
+		// Category 2: Nullish comparisons (hand-crafted, non-base-case)
+		// =================================================================
+		// foo != null && foo.bar != null
+		{
+			Code:   `foo != null && foo.bar != null;`,
+			Output: []string{`foo?.bar != null;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		// foo && foo.bar != null (truthy + nullish last operand)
+		{
+			Code:   "declare const foo: { bar: number } | null | undefined;\nfoo && foo.bar != null;",
+			Output: []string{"declare const foo: { bar: number } | null | undefined;\nfoo?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		// foo && foo.bar != undefined
+		{
+			Code:   `foo && foo.bar != undefined;`,
+			Output: []string{`foo?.bar != undefined;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 3: typeof checks
+		// =================================================================
+		{
+			Code:   "declare const foo: { bar: number } | undefined;\nfoo && typeof foo.bar !== 'undefined';",
+			Output: []string{"declare const foo: { bar: number } | undefined;\ntypeof foo?.bar !== 'undefined';"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "declare const foo: { bar: number } | undefined;\nfoo && 'undefined' !== typeof foo.bar;",
+			Output: []string{"declare const foo: { bar: number } | undefined;\n'undefined' !== typeof foo?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 13: Parenthesized expressions
+		// =================================================================
+		{
+			Code:   "a && (a.b && a.b.c)",
+			Output: []string{"a?.b?.c"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 1},
+			},
+		},
+		{
+			Code:   "(a && a.b) && a.b.c",
+			Output: []string{"a?.b?.c"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 1},
+			},
+		},
+		{
+			Code:   "((a && a.b)) && a.b.c",
+			Output: []string{"a?.b?.c"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 1},
+			},
+		},
+		{
+			Code:   "foo(a && (a.b && a.b.c))",
+			Output: []string{"foo(a?.b?.c)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 5},
+			},
+		},
+		{
+			Code:   "foo(a && a.b && a.b.c)",
+			Output: []string{"foo(a?.b?.c)"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 5},
+			},
+		},
+		{
+			Code:   "!foo || !foo.bar || ((((!foo.bar.baz || !foo.bar.baz()))));",
+			Output: []string{"!foo?.bar?.baz?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 1},
+			},
+		},
+		{
+			Code:   "a !== undefined && ((a !== null && a.prop));",
+			Output: []string{"a?.prop;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 1},
+			},
+		},
+
+		// =================================================================
+		// Category 14: Two-error (multi-chain) cases
+		// =================================================================
+		{
+			Code:   "foo && foo.bar && foo.bar.baz || baz && baz.bar && baz.bar.foo",
+			Output: []string{"foo?.bar?.baz || baz?.bar?.foo"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo && foo.a && bar && bar.a;",
+			Output: []string{"foo?.a && bar?.a;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo1 != null && foo1.bar != null && foo2 != null && foo2.bar != null;",
+			Output: []string{"foo1?.bar != null && foo2?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "(!foo || !foo.bar || !foo.bar.baz) && (!baz || !baz.bar || !baz.bar.foo);",
+			Output: []string{"(!foo?.bar?.baz) && (!baz?.bar?.foo);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 15: this.bar chains (not bare this)
+		// =================================================================
+		{
+			Code:   "this.bar && this.bar.baz;",
+			Output: []string{"this.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "!this.bar || !this.bar.baz;",
+			Output: []string{"!this.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 16: import.meta and new.target chains
+		// =================================================================
+		{
+			Code:   "import.meta && import.meta?.baz;",
+			Output: []string{"import.meta?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "!import.meta || !import.meta?.baz;",
+			Output: []string{"!import.meta?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "import.meta && import.meta?.() && import.meta?.().baz;",
+			Output: []string{"import.meta?.()?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 16b: new.target chains
+		// =================================================================
+		{
+			Code: "class Foo {\n  constructor() {\n    new.target && new.target.length;\n  }\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: "class Foo {\n  constructor() {\n    new.target?.length;\n  }\n}"},
+					},
+				},
+			},
+		},
+
+		// =================================================================
+		// Category 17: || negated chains (more patterns)
+		// =================================================================
+		{
+			Code:   "!foo[bar] || !foo[bar]?.[baz];",
+			Output: []string{"!foo[bar]?.[baz];"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "!foo || !foo?.bar.baz;",
+			Output: []string{"!foo?.bar.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "!foo() || !foo().bar;",
+			Output: []string{"!foo()?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 18: Non-null assertion chains
+		// =================================================================
+		{
+			Code:   "!foo!.bar!.baz || !foo!.bar!.baz!.paz;",
+			Output: []string{"!foo!.bar!.baz?.paz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "!foo.bar!.baz || !foo.bar!.baz!.paz;",
+			Output: []string{"!foo.bar!.baz?.paz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 19: String/template literal element access
+		// =================================================================
+		{
+			Code:   "foo && foo['some long string'] && foo['some long string'].baz;",
+			Output: []string{"foo?.['some long string']?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo && foo[`some long string`] && foo[`some long string`].baz;",
+			Output: []string{"foo?.[`some long string`]?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 20: Complex computed properties
+		// =================================================================
+		{
+			Code:   "foo && foo[1 + 2] && foo[1 + 2].baz;",
+			Output: []string{"foo?.[1 + 2]?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo && foo[typeof bar] && foo[typeof bar].baz;",
+			Output: []string{"foo?.[typeof bar]?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 21: Mixed binary checks (long chains)
+		// =================================================================
+		{
+			Code:   "a &&\n  a.b != null &&\n  a.b.c !== undefined &&\n  a.b.c !== null &&\n  a.b.c.d != null &&\n  a.b.c.d.e !== null &&\n  a.b.c.d.e !== undefined &&\n  a.b.c.d.e.f != undefined &&\n  typeof a.b.c.d.e.f.g !== 'undefined' &&\n  a.b.c.d.e.f.g !== null &&\n  a.b.c.d.e.f.g.h;",
+			Output: []string{"a?.b?.c?.d?.e?.f?.g?.h;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "!a ||\n  a.b == null ||\n  a.b.c === undefined ||\n  a.b.c === null ||\n  a.b.c.d == null ||\n  a.b.c.d.e === null ||\n  a.b.c.d.e === undefined ||\n  a.b.c.d.e.f == undefined ||\n  typeof a.b.c.d.e.f.g === 'undefined' ||\n  a.b.c.d.e.f.g === null ||\n  !a.b.c.d.e.f.g.h;",
+			Output: []string{"!a?.b?.c?.d?.e?.f?.g?.h;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 22: Yoda checks
+		// =================================================================
+		{
+			Code:   "undefined !== foo && null !== foo && null != foo.bar && foo.bar.baz;",
+			Output: []string{"foo?.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "null != foo &&\n  'undefined' !== typeof foo.bar &&\n  null !== foo.bar &&\n  foo.bar.baz;",
+			Output: []string{"foo?.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 23: foo && foo?.() patterns
+		// =================================================================
+		{
+			Code:   "foo && foo?.();",
+			Output: []string{"foo?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo() && foo()(bar);",
+			Output: []string{"foo()?.(bar);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 24: Type parameter chains
+		// =================================================================
+		{
+			Code:   "foo && foo<string>() && foo<string>().bar;",
+			Output: []string{"foo?.<string>()?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo && foo<string>() && foo<string, number>().bar;",
+			Output: []string{"foo?.<string>() && foo<string, number>().bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		// Type reference (non-keyword) type arguments
+		{
+			Code:   "foo && foo<T>() && foo<T>().bar;",
+			Output: []string{"foo?.<T>()?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo && foo<T>() && foo<U>().bar;",
+			Output: []string{"foo?.<T>() && foo<U>().bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 25: Chain breaking with inconsistent checks
+		// =================================================================
+		// Inconsistent checks (loose != null then strict !== undefined) break chain
+		{
+			Code:   "foo && foo.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+			Output: []string{"foo?.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 26: Await expression chains
+		// =================================================================
+		{
+			Code:   "(await foo).bar && (await foo).bar.baz;",
+			Output: []string{"(await foo).bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 27: Optional chain tokens in earlier operands
+		// =================================================================
+		// Existing ?. from guard operands are preserved in output by scanning
+		// the guard's source text via GetSourceTextOfNodeFromSourceFile.
+		{
+			Code:   "foo.bar.baz != null && foo?.bar?.baz.bam != null;",
+			Output: []string{"foo.bar.baz?.bam != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo?.bar.baz != null && foo.bar?.baz.bam != null;",
+			Output: []string{"foo?.bar.baz?.bam != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo?.bar?.baz != null && foo.bar.baz.bam != null;",
+			Output: []string{"foo?.bar?.baz?.bam != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 28: Non-null assertions from earlier operands
+		// =================================================================
+		// Non-null assertions: the output uses the GUARD's text for the base portion,
+		// preserving ! assertions from the guard, not the target.
+		{
+			Code:   "foo!.bar.baz != null && foo.bar!.baz.bam != null;",
+			Output: []string{"foo!.bar.baz?.bam != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "foo!.bar!.baz != null && foo.bar.baz.bam != null;",
+			Output: []string{"foo!.bar!.baz?.bam != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 29: Unrelated prefix with chain
+		// =================================================================
+		{
+			Code:   "unrelated != null && foo != null && foo.bar != null;",
+			Output: []string{"unrelated != null && foo?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "unrelated1 != null && unrelated2 != null && foo != null && foo.bar != null;",
+			Output: []string{"unrelated1 != null && unrelated2 != null && foo?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 30: globalThis typeof pattern
+		// =================================================================
+		{
+			Code:   "function foo(globalThis?: { Array: Function }) {\n  typeof globalThis !== 'undefined' && globalThis.Array();\n}",
+			Output: []string{"function foo(globalThis?: { Array: Function }) {\n  globalThis?.Array();\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 6: || negated chains (hand-crafted with declarations)
+		// =================================================================
+		{
+			Code:   "declare const foo: {bar: {baz: number} | null | undefined};\n!foo.bar || !foo.bar.baz;",
+			Output: []string{"declare const foo: {bar: {baz: number} | null | undefined};\n!foo.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "declare const a: {b: (() => number) | null | undefined};\n!a.b || !a.b();",
+			Output: []string{"declare const a: {b: (() => number) | null | undefined};\n!a.b?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 7: Element access chains (hand-crafted with declarations)
+		// =================================================================
+		{
+			Code:   "declare const bar: string;\ndeclare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;\nfoo && foo[bar] && foo[bar].baz && foo[bar].baz.buzz;",
+			Output: []string{"declare const bar: string;\ndeclare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;\nfoo?.[bar]?.baz?.buzz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "declare const bar: {baz: string};\ndeclare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;\nfoo && foo[bar.baz] && foo[bar.baz].buzz;",
+			Output: []string{"declare const bar: {baz: string};\ndeclare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;\nfoo?.[bar.baz]?.buzz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 8: this.bar chains (with declaration)
+		// =================================================================
+		{
+			Code:   "declare const _this: {bar: {baz: number} | null | undefined};\n_this.bar && _this.bar.baz;",
+			Output: []string{"declare const _this: {bar: {baz: number} | null | undefined};\n_this.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 9: Non-null expression chains
+		// =================================================================
+		{
+			Code:   "declare const foo: {bar: {baz: number} | null | undefined};\n!foo!.bar || !foo!.bar.baz;",
+			Output: []string{"declare const foo: {bar: {baz: number} | null | undefined};\n!foo!.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 10: requireNullish option
+		// =================================================================
+		{
+			Code:    "declare const thing1: string | null;\nthing1 && thing1.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: "declare const thing1: string | null;\nthing1?.toString();"},
+					},
+				},
+			},
+		},
+		{
+			Code:    "declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo && foo.bar && foo.bar.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Output:  []string{"declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo?.bar?.toString();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:    "declare const foo: string | null;\n(foo || {}).toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: "declare const foo: string | null;\nfoo?.toString();"},
+					},
+				},
+			},
+		},
+
+		// =================================================================
+		// Category 11: allowPotentiallyUnsafeFixesThatModifyTheReturnType
+		// =================================================================
+		{
+			Code:    "declare const foo: { bar: number } | null | undefined;\nfoo != undefined && foo.bar;",
+			Options: PreferOptionalChainOptions{AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing: utils.Ref(true)},
+			Output:  []string{"declare const foo: { bar: number } | null | undefined;\nfoo?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:    "declare const foo: { bar: number } | null | undefined;\nfoo != undefined && foo.bar;",
+			Options: PreferOptionalChainOptions{AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing: utils.Ref(false)},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: "declare const foo: { bar: number } | null | undefined;\nfoo?.bar;"},
+					},
+				},
+			},
+		},
+
+		// =================================================================
+		// Category 12: Already-optional partial chains
+		// =================================================================
+		{
+			Code:   "declare const foo: {bar: (() => number) | null | undefined};\nfoo.bar && foo.bar?.();",
+			Output: []string{"declare const foo: {bar: (() => number) | null | undefined};\nfoo.bar?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 1: Basic && truthy chains (hand-crafted with declarations)
+		// =================================================================
+		{
+			Code:   `declare const foo: {bar: number} | null | undefined; foo && foo.bar;`,
+			Output: []string{`declare const foo: {bar: number} | null | undefined; foo?.bar;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   `declare const foo: {bar: {baz: number} | null | undefined}; foo.bar && foo.bar.baz;`,
+			Output: []string{`declare const foo: {bar: {baz: number} | null | undefined}; foo.bar?.baz;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   `declare const foo: {bar: {baz: number} | null | undefined} | null | undefined; foo && foo.bar && foo.bar.baz;`,
+			Output: []string{`declare const foo: {bar: {baz: number} | null | undefined} | null | undefined; foo?.bar?.baz;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;\nfoo && foo.bar && foo.bar.baz && foo.bar.baz.buzz;",
+			Output: []string{"declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;\nfoo?.bar?.baz?.buzz;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   "declare const foo: (() => number) | null | undefined;\nfoo && foo();",
+			Output: []string{"declare const foo: (() => number) | null | undefined;\nfoo?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+		{
+			Code:   `declare const foo: {bar: (() => number) | null | undefined}; foo.bar && foo.bar();`,
+			Output: []string{`declare const foo: {bar: (() => number) | null | undefined}; foo.bar?.();`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain"},
+			},
+		},
+
+		// =================================================================
+		// Category 2b: Nullish comparisons with declarations (suggestion-only)
+		// =================================================================
+		{
+			Code: `declare const foo: {bar: number} | null; foo != null && foo.bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `declare const foo: {bar: number} | null; foo?.bar;`},
+					},
+				},
+			},
+		},
+		{
+			Code: `declare const foo: {bar: number} | undefined; foo !== undefined && foo.bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `declare const foo: {bar: number} | undefined; foo?.bar;`},
+					},
+				},
+			},
+		},
+
+		// =================================================================
+		// Category 3b: typeof checks with declarations (suggestion-only)
+		// =================================================================
+		{
+			Code: `declare const foo: {bar: number} | undefined; typeof foo !== 'undefined' && foo.bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `declare const foo: {bar: number} | undefined; foo?.bar;`},
+					},
+				},
+			},
+		},
+
+		// =================================================================
+		// Category 4: Yoda conditions (suggestion-only)
+		// =================================================================
+		{
+			Code: `declare const foo: {bar: number} | null; null != foo && foo.bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "optionalChainSuggest", Output: `declare const foo: {bar: number} | null; foo?.bar;`},
+					},
+				},
+			},
+		},
+		// =================================================================
+		// Additional || {} / ?? {} patterns (from TS test suite)
+		// =================================================================
+		{
+			Code: `(foo || ({})).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `foo?.bar;`},
+				}},
+			},
+		},
+		{
+			Code: `(await foo || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(await foo)?.bar;`},
+				}},
+			},
+		},
+		{
+			Code: `(foo || undefined || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo || undefined)?.bar;`},
+				}},
+			},
+		},
+		{
+			Code: `(foo() || bar || {}).baz;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo() || bar)?.baz;`},
+				}},
+			},
+		},
+		{
+			Code: `((foo1 ? foo2 : foo3) || {}).foo4;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo1 ? foo2 : foo3)?.foo4;`},
+				}},
+			},
+		},
+		// ?? {} variants
+		{
+			Code: `(foo ?? ({})).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `foo?.bar;`},
+				}},
+			},
+		},
+		{
+			Code: `(await foo ?? {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(await foo)?.bar;`},
+				}},
+			},
+		},
+		{
+			Code: `(foo.bar ?? {})[baz];`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `foo.bar?.[baz];`},
+				}},
+			},
+		},
+
+		// =================================================================
+		// Additional && chain patterns
+		// =================================================================
+		// Arrow with typeof in argument
+		{
+			Code:   "foo && foo.bar(baz => typeof baz);",
+			Output: []string{"foo?.bar(baz => typeof baz);"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// JSX whitespace preservation
+		{
+			Code:   "foo && foo.bar(baz => <This Requires Spaces />);",
+			Tsx:    true,
+			Output: []string{"foo?.bar(baz => <This Requires Spaces />);"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Template literal with interpolation in computed property
+		{
+			Code:   "foo && foo[`some ${long} string`] && foo[`some ${long} string`].baz;",
+			Output: []string{"foo?.[`some ${long} string`]?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Type assertion in computed property
+		{
+			Code:   "foo && foo[bar as string] && foo[bar as string].baz;",
+			Output: []string{"foo?.[bar as string]?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Mismatched arguments break chain
+		{
+			Code:   "foo && foo.bar(a) && foo.bar(a, b).baz;",
+			Output: []string{"foo?.bar(a) && foo.bar(a, b).baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Comments in call expression preserved
+		{
+			Code:   "foo && foo.bar(/* comment */a,\n  // comment2\n  b);",
+			Output: []string{"foo?.bar(/* comment */a,\n  // comment2\n  b);"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// foo && foo.bar != null && baz (trailing unrelated)
+		{
+			Code:   "foo && foo.bar != null && baz;",
+			Output: []string{"foo?.bar != null && baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// foo.bar && foo.bar?.() without declaration
+		{
+			Code:   "foo.bar && foo.bar?.();",
+			Output: []string{"foo.bar?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// !foo!.bar || !foo!.bar.baz without declaration
+		{
+			Code:   "!foo!.bar || !foo!.bar.baz;",
+			Output: []string{"!foo!.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Type parameters: matching
+		{
+			Code:   "foo && foo<string>() && foo<string>().bar;",
+			Output: []string{"foo?.<string>()?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Type parameters: mismatching stops chain
+		{
+			Code:   "foo && foo<string>() && foo<string, number>().bar;",
+			Output: []string{"foo?.<string>() && foo<string, number>().bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Type parameters: reference type
+		{
+			Code:   "foo && foo<T>() && foo<T>().bar;",
+			Output: []string{"foo?.<T>()?.bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// Deep mixed checks (long chains with mixed operators)
+		// =================================================================
+		{
+			Code: "a &&\n  a.b != null &&\n  a.b.c !== undefined &&\n  a.b.c !== null &&\n  a.b.c.d != null &&\n  a.b.c.d.e !== null &&\n  a.b.c.d.e !== undefined &&\n  a.b.c.d.e.f != undefined &&\n  typeof a.b.c.d.e.f.g !== 'undefined' &&\n  a.b.c.d.e.f.g !== null &&\n  a.b.c.d.e.f.g.h;",
+			Output: []string{"a?.b?.c?.d?.e?.f?.g?.h;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// || chain variant
+		{
+			Code:   "!a ||\n  a.b == null ||\n  a.b.c === undefined ||\n  a.b.c === null ||\n  a.b.c.d == null ||\n  a.b.c.d.e === null ||\n  a.b.c.d.e === undefined ||\n  a.b.c.d.e.f == undefined ||\n  typeof a.b.c.d.e.f.g === 'undefined' ||\n  a.b.c.d.e.f.g === null ||\n  !a.b.c.d.e.f.g.h;",
+			Output: []string{"!a?.b?.c?.d?.e?.f?.g?.h;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// Yoda with typeof
+		// =================================================================
+		{
+			Code:   "undefined !== foo && null !== foo && null != foo.bar && foo.bar.baz;",
+			Output: []string{"foo?.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		{
+			Code:   "null != foo &&\n  'undefined' !== typeof foo.bar &&\n  null !== foo.bar &&\n  foo.bar.baz;",
+			Output: []string{"foo?.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// Additional || {} patterns (IIFE, nested, complex LHS)
+		// =================================================================
+		{
+			Code: `((() => foo())() || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(() => foo())()?.bar;`},
+			}}},
+		},
+		{
+			Code: `((foo1 || {}).foo2 || {}).foo3;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo1 || {}).foo2?.foo3;`},
+				}},
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo1?.foo2 || {}).foo3;`},
+				}},
+			},
+		},
+		{
+			Code: `(undefined && foo || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(undefined && foo)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(a > b || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(a > b)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(void foo() || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(void foo())?.bar;`},
+			}}},
+		},
+		{
+			Code: `((a instanceof Error) || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(a instanceof Error)?.bar;`},
+			}}},
+		},
+		{
+			Code: `((a << b) || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(a << b)?.bar;`},
+			}}},
+		},
+		{
+			Code: `((foo ** 2) || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(foo ** 2)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(foo ** 2 || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(foo ** 2)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(foo++ || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(foo++)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(+foo || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(+foo)?.bar;`},
+			}}},
+		},
+
+		// =================================================================
+		// Additional ?? {} patterns
+		// =================================================================
+		{
+			Code: `((() => foo())() ?? {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(() => foo())()?.bar;`},
+			}}},
+		},
+		{
+			Code: `const foo = (bar ?? {}).baz;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `const foo = bar?.baz;`},
+			}}},
+		},
+		{
+			Code: `((foo1 ?? {}).foo2 ?? {}).foo3;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo1 ?? {}).foo2?.foo3;`},
+				}},
+				{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "optionalChainSuggest", Output: `(foo1?.foo2 ?? {}).foo3;`},
+				}},
+			},
+		},
+		{
+			Code: `(foo ?? undefined ?? {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(foo ?? undefined)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(foo() ?? bar ?? {}).baz;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(foo() ?? bar)?.baz;`},
+			}}},
+		},
+		{
+			Code: `((foo1 ? foo2 : foo3) ?? {}).foo4;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(foo1 ? foo2 : foo3)?.foo4;`},
+			}}},
+		},
+
+		// =================================================================
+		// Additional bare && chains (no declarations)
+		// =================================================================
+		{
+			Code:   "foo && foo.bar != null;",
+			Output: []string{"foo?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		{
+			Code:   "!foo.bar || !foo.bar.baz;",
+			Output: []string{"!foo.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		{
+			Code:   "!a.b || !a.b();",
+			Output: []string{"!a.b?.();"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		{
+			Code:   "foo.bar.baz != null && foo!.bar!.baz.bam != null;",
+			Output: []string{"foo.bar.baz?.bam != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// Chain-breaking: multi-line inconsistent check
+		// =================================================================
+		{
+			Code:   "foo.bar &&\n  foo.bar.baz != null &&\n  foo.bar.baz.qux !== undefined &&\n  foo.bar.baz.qux.buzz;",
+			Output: []string{"foo.bar?.baz != null &&\n  foo.bar.baz.qux !== undefined &&\n  foo.bar.baz.qux.buzz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// || chain: reordered null/undefined variant
+		// =================================================================
+		{
+			Code:   "!a ||\n  a.b == null ||\n  a.b.c === null ||\n  a.b.c === undefined ||\n  a.b.c.d == null ||\n  a.b.c.d.e === null ||\n  a.b.c.d.e === undefined ||\n  a.b.c.d.e.f == undefined ||\n  typeof a.b.c.d.e.f.g === 'undefined' ||\n  a.b.c.d.e.f.g === null ||\n  !a.b.c.d.e.f.g.h;",
+			Output: []string{"!a?.b?.c?.d?.e?.f?.g?.h;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// Strict null checks with declarations
+		// =================================================================
+		{
+			Code: "declare const foo: { bar: string } | null;\nfoo !== null && foo.bar !== null;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const foo: { bar: string } | null;\nfoo?.bar !== null;"},
+			}}},
+		},
+		{
+			Code:   "declare const foo: { bar: string | null } | null;\nfoo !== null && foo.bar != null;",
+			Output: []string{"declare const foo: { bar: string | null } | null;\nfoo?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// typeof on bare identifier preserves the typeof prefix, chain starts after
+		{
+			Code: "typeof globalThis !== 'undefined' && globalThis.Array && globalThis.Array();",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "typeof globalThis !== 'undefined' && globalThis.Array?.();"},
+			}}},
+		},
+
+		// =================================================================
+		// allowPotentiallyUnsafe with acceptsBoolean
+		// =================================================================
+		{
+			Code:    "declare const foo: { bar: boolean } | null | undefined;\ndeclare function acceptsBoolean(arg: boolean): void;\nacceptsBoolean(foo != null && foo.bar);",
+			Options: PreferOptionalChainOptions{AllowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing: utils.Ref(true)},
+			Output:  []string{"declare const foo: { bar: boolean } | null | undefined;\ndeclare function acceptsBoolean(arg: boolean): void;\nacceptsBoolean(foo?.bar);"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// requireNullish additional invalid
+		// =================================================================
+		{
+			Code:    "declare const thing1: string | null;\nthing1 && thing1.toString() && true;",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const thing1: string | null;\nthing1?.toString() && true;"},
+			}}},
+		},
+		// Chains with duplicate last operands stop before the duplicate
+		{
+			Code:    "declare const foo: string | null;\nfoo && foo.toString() && foo.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const foo: string | null;\nfoo?.toString() && foo.toString();"},
+			}}},
+		},
+		{
+			Code:    "declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo && foo.bar && foo.bar.toString() && foo.bar.toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Output:  []string{"declare const foo: { bar: string | null | undefined } | null | undefined;\nfoo?.bar?.toString() && foo.bar.toString();"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// || {} / ?? {} inside if statements
+		// =================================================================
+		{
+			Code: "(foo1?.foo2 || ({})).foo3;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "foo1?.foo2?.foo3;"},
+			}}},
+		},
+		{
+			Code: "if (foo) {\n  (foo || {}).bar;\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "if (foo) {\n  foo?.bar;\n}"},
+			}}},
+		},
+		{
+			Code: "if ((foo || {}).bar) {\n  foo.bar;\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "if (foo?.bar) {\n  foo.bar;\n}"},
+			}}},
+		},
+		{
+			Code: `if (foo) { (foo ?? {}).bar; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `if (foo) { foo?.bar; }`},
+			}}},
+		},
+		{
+			Code: `if ((foo ?? {}).bar) { foo.bar; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `if (foo?.bar) { foo.bar; }`},
+			}}},
+		},
+		{
+			Code: `(undefined && foo ?? {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(undefined && foo)?.bar;`},
+			}}},
+		},
+		{
+			Code: `(((typeof x) as string) || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `((typeof x) as string)?.bar;`},
+			}}},
+		},
+		{
+			Code: `((a ? b : c) || {}).bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: `(a ? b : c)?.bar;`},
+			}}},
+		},
+
+		// =================================================================
+		// Nullish comparison with declarations
+		// =================================================================
+		{
+			Code: "declare const foo: { bar: string | null } | null;\nfoo != null && foo.bar !== null;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const foo: { bar: string | null } | null;\nfoo?.bar !== null;"},
+			}}},
+		},
+
+		// =================================================================
+		// Yoda: null != foo?.bar?.baz
+		// =================================================================
+		{
+			Code:   "null != foo &&\n  'undefined' !== typeof foo.bar &&\n  null !== foo.bar &&\n  null != foo.bar.baz;",
+			Output: []string{"null != foo?.bar?.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// Retain split strict equals at end of chain
+		// =================================================================
+		{
+			Code: "null != foo &&\n  'undefined' !== typeof foo.bar &&\n  null !== foo.bar &&\n  null !== foo.bar.baz &&\n  'undefined' !== typeof foo.bar.baz;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "null !== foo?.bar?.baz &&\n  'undefined' !== typeof foo.bar.baz;"},
+			}}},
+		},
+		{
+			Code: "foo != null &&\n  typeof foo.bar !== 'undefined' &&\n  foo.bar !== null &&\n  foo.bar.baz !== null &&\n  typeof foo.bar.baz !== 'undefined';",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "foo?.bar?.baz !== null &&\n  typeof foo.bar.baz !== 'undefined';"},
+			}}},
+		},
+		{
+			Code: "null != foo &&\n  'undefined' !== typeof foo.bar &&\n  null !== foo.bar &&\n  null !== foo.bar.baz &&\n  undefined !== foo.bar.baz;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "null !== foo?.bar?.baz &&\n  undefined !== foo.bar.baz;"},
+			}}},
+		},
+		{
+			Code: "foo != null &&\n  typeof foo.bar !== 'undefined' &&\n  foo.bar !== null &&\n  foo.bar.baz !== null &&\n  foo.bar.baz !== undefined;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "foo?.bar?.baz !== null &&\n  foo.bar.baz !== undefined;"},
+			}}},
+		},
+		{
+			Code:   "null != foo &&\n  'undefined' !== typeof foo.bar &&\n  null !== foo.bar &&\n  undefined !== foo.bar.baz &&\n  null !== foo.bar.baz;",
+			Output: []string{"undefined !== foo?.bar?.baz &&\n  null !== foo.bar.baz;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		{
+			Code:   "foo != null &&\n  typeof foo.bar !== 'undefined' &&\n  foo.bar !== null &&\n  foo.bar.baz !== undefined &&\n  foo.bar.baz !== null;",
+			Output: []string{"foo?.bar?.baz !== undefined &&\n  foo.bar.baz !== null;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// || chain: == null before final operand
+		// =================================================================
+		{
+			Code:   "!a ||\n  a.b == null ||\n  a.b.c === undefined ||\n  a.b.c === null ||\n  a.b.c.d == null ||\n  a.b.c.d.e === null ||\n  a.b.c.d.e === undefined ||\n  a.b.c.d.e.f == undefined ||\n  a.b.c.d.e.f.g == null ||\n  a.b.c.d.e.f.g.h;",
+			Output: []string{"a?.b?.c?.d?.e?.f?.g == null ||\n  a.b.c.d.e.f.g.h;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+
+		// =================================================================
+		// requireNullish: (foo || undefined || {}).toString()
+		// =================================================================
+		{
+			Code:    "declare const foo: string;\n(foo || undefined || {}).toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const foo: string;\n(foo || undefined)?.toString();"},
+			}}},
+		},
+		{
+			Code:    "declare const foo: string | null;\n(foo || undefined || {}).toString();",
+			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const foo: string | null;\n(foo || undefined)?.toString();"},
+			}}},
+		},
+
+		// =================================================================
+		// Extra: !== undefined / === undefined call chains
+		// When the last operand is a bare call/negation and the chain includes
+		// strict equality guards on call results, trim to avoid changing call count.
+		// =================================================================
+		// Cases with !== undefined / === undefined call chains.
+		// Aligned with TS-ESLint: strict equality on call expression result stops
+		// optional chain extension because each call is a separate invocation.
+		// Case 1: trailing bare call → partial fold (suggestion)
+		{
+			Code: "declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar !== undefined &&\n  foo.bar() !== undefined &&\n  foo.bar().baz !== undefined &&\n  foo.bar().baz.buzz !== undefined &&\n  foo.bar().baz.buzz();",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain", Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+				{MessageId: "optionalChainSuggest", Output: "declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar?.() !== undefined &&\n  foo.bar().baz !== undefined &&\n  foo.bar().baz.buzz !== undefined &&\n  foo.bar().baz.buzz();"},
+			}}},
+		},
+		// Case 2: trailing comparison (auto-fix: !== undefined preserves boolean result)
+		{
+			Code:   "declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar !== undefined &&\n  foo.bar() !== undefined &&\n  foo.bar().baz !== undefined &&\n  foo.bar().baz.buzz !== undefined;",
+			Output: []string{"declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar?.()?.baz?.buzz !== undefined;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Case 3: || trailing negated call → partial fold (auto-fix)
+		{
+			Code:   "declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar === undefined ||\n  foo.bar() === undefined ||\n  foo.bar().baz === undefined ||\n  foo.bar().baz.buzz === undefined ||\n  !foo.bar().baz.buzz();",
+			Output: []string{"declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar?.() === undefined ||\n  foo.bar().baz === undefined ||\n  foo.bar().baz.buzz === undefined ||\n  !foo.bar().baz.buzz();"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+		// Case 4: || trailing comparison (auto-fix, full fold)
+		{
+			Code:   "declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar === undefined ||\n  foo.bar() === undefined ||\n  foo.bar().baz === undefined ||\n  foo.bar().baz.buzz === undefined;",
+			Output: []string{"declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};\nfoo.bar?.()?.baz?.buzz === undefined;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferOptionalChain"}},
+		},
+	}
+
+	// Combine generated and hand-written cases
+	allValid := append(generatedValid, edgeCaseValid...)
+	allInvalid := append(generatedInvalid, edgeCaseInvalid...)
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferOptionalChainRule,
+		allValid, allInvalid)
+}

--- a/internal/utils/ts_api_utils.go
+++ b/internal/utils/ts_api_utils.go
@@ -423,10 +423,10 @@ func isJsxElementOrFragment(node *ast.Node) bool {
 	return node.Kind == ast.KindJsxElement || node.Kind == ast.KindJsxFragment
 }
 
-// isNumberLiteralZeroOrNaN checks if a number literal type value is 0 or NaN.
+// IsNumberLiteralZeroOrNaN checks if a number literal type value is 0 or NaN.
 // tsgo stores number literal values as a named float64 type,
 // so we use ValueToString for reliable string conversion and then parse.
-func isNumberLiteralZeroOrNaN(val interface{}) bool {
+func IsNumberLiteralZeroOrNaN(val interface{}) bool {
 	s := checker.ValueToString(val)
 	if s == "0" || s == "-0" || s == "NaN" {
 		return true
@@ -471,7 +471,7 @@ func isConstituentPossiblyFalsy(t *checker.Type) bool {
 		return true
 	}
 	if flags&checker.TypeFlagsNumberLiteral != 0 {
-		return isNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
+		return IsNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
 	}
 	if flags&checker.TypeFlagsNumber != 0 {
 		return true
@@ -527,7 +527,7 @@ func isConstituentPossiblyTruthy(t *checker.Type) bool {
 		return true
 	}
 	if flags&checker.TypeFlagsNumberLiteral != 0 {
-		return !isNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
+		return !IsNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
 	}
 	if flags&checker.TypeFlagsNumber != 0 {
 		return true

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -218,7 +218,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/prefer-literal-enum-member.test.ts',
     './tests/typescript-eslint/rules/prefer-namespace-keyword.test.ts',
     // './tests/typescript-eslint/rules/prefer-nullish-coalescing.test.ts',
-    // './tests/typescript-eslint/rules/prefer-optional-chain/prefer-optional-chain.test.ts',
+    './tests/typescript-eslint/rules/prefer-optional-chain/prefer-optional-chain.test.ts',
     // './tests/typescript-eslint/rules/prefer-promise-reject-errors.test.ts',
     // './tests/typescript-eslint/rules/prefer-readonly-parameter-types.test.ts',
     './tests/typescript-eslint/rules/prefer-readonly.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-optional-chain/__snapshots__/prefer-optional-chain.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-optional-chain/__snapshots__/prefer-optional-chain.test.ts.snap
@@ -1,0 +1,15221 @@
+// Rstest Snapshot v1
+
+exports[`|| {} > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "(foo || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "(foo || ({})).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "(await foo || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "(foo1?.foo2 || {}).foo3;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "(foo1?.foo2 || ({})).foo3;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "((() => foo())() || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "const foo = (bar || {}).baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "(foo.bar || {})[baz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "((foo1 || {}).foo2 || {}).foo3;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "(foo || undefined || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "(foo() || bar || {}).baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "((foo1 ? foo2 : foo3) || {}).foo4;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "
+          if (foo) {
+            (foo || {}).bar;
+          }
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "
+          if ((foo || {}).bar) {
+            foo.bar;
+          }
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "(undefined && foo || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "(foo ?? {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "(foo ?? ({})).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "(await foo ?? {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "(foo1?.foo2 ?? {}).foo3;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "((() => foo())() ?? {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "const foo = (bar ?? {}).baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "(foo.bar ?? {})[baz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "((foo1 ?? {}).foo2 ?? {}).foo3;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "(foo ?? undefined ?? {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "(foo() ?? bar ?? {}).baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "((foo1 ? foo2 : foo3) ?? {}).foo4;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 27`] = `
+{
+  "code": "if (foo) { (foo ?? {}).bar; }",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 28`] = `
+{
+  "code": "if ((foo ?? {}).bar) { foo.bar; }",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 29`] = `
+{
+  "code": "(undefined && foo ?? {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 30`] = `
+{
+  "code": "(a > b || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 31`] = `
+{
+  "code": "(((typeof x) as string) || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 32`] = `
+{
+  "code": "(void foo() || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 33`] = `
+{
+  "code": "((a ? b : c) || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 34`] = `
+{
+  "code": "((a instanceof Error) || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 35`] = `
+{
+  "code": "((a << b) || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 36`] = `
+{
+  "code": "((foo ** 2) || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 37`] = `
+{
+  "code": "(foo ** 2 || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 38`] = `
+{
+  "code": "(foo++ || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 39`] = `
+{
+  "code": "(+foo || {}).bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`|| {} > prefer-optional-chain > invalid 40`] = `
+{
+  "code": "(this || {}).foo;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo && foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar && foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo && foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+foo?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar && foo.bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar && foo.bar.baz && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar] && foo[bar].baz && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar].baz && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo && foo[bar.baz] && foo[bar.baz].buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.baz]?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar && foo.bar() && foo.bar().baz && foo.bar().baz.buzz && foo.bar().baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz] && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo?.bar && foo?.bar.baz && foo?.bar.baz[buzz] && foo?.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo && foo?.bar.baz && foo?.bar.baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo && foo?.() && foo?.().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar && foo.bar?.() && foo.bar?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 27`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo && foo.bar && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 28`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar && foo.bar.baz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 29`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo && foo() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+foo?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 30`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar && foo.bar() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 31`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 32`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar && foo.bar.baz && foo.bar.baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 33`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 34`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar && foo.bar.baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 35`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 36`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 37`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar] && foo[bar].baz && foo[bar].baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 38`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar].baz && foo[bar].baz.buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 39`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo && foo[bar.baz] && foo[bar.baz].buzz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.baz]?.buzz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 40`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 41`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 42`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 43`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 44`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar && foo.bar.baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 45`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz && foo.bar.baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 46`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar && foo.bar() && foo.bar().baz && foo.bar().baz.buzz && foo.bar().baz.buzz() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 47`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz]() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 48`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz] && foo.bar.baz[buzz]() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 49`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo?.bar && foo?.bar.baz && foo?.bar.baz[buzz] && foo?.bar.baz[buzz]() && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 50`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo && foo?.bar.baz && foo?.bar.baz[buzz] && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz] && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 51`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo && foo?.() && foo?.().bar && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 52`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar && foo.bar?.() && foo.bar?.().baz && bing;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz && bing;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 53`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo && foo.bar && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 54`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar && foo.bar.baz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 55`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo && foo() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+foo?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 56`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar && foo.bar() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 57`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 58`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar && foo.bar.baz && foo.bar.baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 59`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 60`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar && foo.bar.baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 61`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 62`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar && foo.bar.baz && foo.bar.baz && foo.bar.baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 63`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar] && foo[bar].baz && foo[bar].baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 64`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar].baz && foo[bar].baz.buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 65`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo && foo[bar.baz] && foo[bar.baz].buzz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.baz]?.buzz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 66`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 67`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 68`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar && foo.bar.baz && foo.bar.baz.buzz && foo.bar.baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 69`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 70`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar && foo.bar.baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 71`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz.buzz && foo.bar.baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 72`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar && foo.bar() && foo.bar().baz && foo.bar().baz.buzz && foo.bar().baz.buzz() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 73`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz]() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 74`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.bar && foo.bar.baz && foo.bar.baz[buzz] && foo.bar.baz[buzz]() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 75`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo?.bar && foo?.bar.baz && foo?.bar.baz[buzz] && foo?.bar.baz[buzz]() && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 76`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo && foo?.bar.baz && foo?.bar.baz[buzz] && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz] && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 77`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo && foo?.() && foo?.().bar && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > boolean > prefer-optional-chain > invalid 78`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar && foo.bar?.() && foo.bar?.().baz && bing.bong;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz && bing.bong;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo != null && foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar != null && foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo != null && foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar != null && foo.bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz != null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar != null && foo.bar.baz != null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar != null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz != null && foo.bar.baz != null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 97,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar != null && foo.bar.baz != null && foo.bar.baz != null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 82,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo[bar] != null && foo[bar].baz != null && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo[bar].baz != null && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo != null && foo[bar.baz] != null && foo[bar.baz].buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz != null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz != null && foo.bar.baz.buzz != null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 104,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar != null && foo.bar.baz != null && foo.bar.baz.buzz != null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar != null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz.buzz != null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar != null && foo.bar() != null && foo.bar().baz != null && foo.bar().baz.buzz != null && foo.bar().baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 116,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz != null && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo.bar != null && foo.bar.baz != null && foo.bar.baz[buzz] != null && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 106,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo != null && foo?.bar != null && foo?.bar.baz != null && foo?.bar.baz[buzz] != null && foo?.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 110,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo != null && foo?.bar.baz != null && foo?.bar.baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo != null && foo?.() != null && foo?.().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != null > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar != null && foo.bar?.() != null && foo.bar?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo != undefined && foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar != undefined && foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo != undefined && foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar != undefined && foo.bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar != undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 117,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 97,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo[bar] != undefined && foo[bar].baz != undefined && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo[bar].baz != undefined && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo != undefined && foo[bar.baz] != undefined && foo[bar.baz].buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 91,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz != undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 124,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz.buzz != undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 104,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar != undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz.buzz != undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar != undefined && foo.bar() != undefined && foo.bar().baz != undefined && foo.bar().baz.buzz != undefined && foo.bar().baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 136,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo.bar != undefined && foo.bar.baz != undefined && foo.bar.baz[buzz] != undefined && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 126,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo != undefined && foo?.bar != undefined && foo?.bar.baz != undefined && foo?.bar.baz[buzz] != undefined && foo?.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 130,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo != undefined && foo?.bar.baz != undefined && foo?.bar.baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo != undefined && foo?.() != undefined && foo?.().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > != undefined > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar != undefined && foo.bar?.() != undefined && foo.bar?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null ;
+foo !== null && foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null };
+foo.bar !== null && foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null ;
+foo !== null && foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null };
+foo.bar !== null && foo.bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null } | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz !== null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null } | null };
+foo.bar !== null && foo.bar.baz !== null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null };
+foo.bar !== null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null } | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz !== null && foo.bar.baz !== null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 101,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null } | null } | null ;
+foo.bar !== null && foo.bar.baz !== null && foo.bar.baz !== null && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null } | null } | null ;
+foo !== null && foo[bar] !== null && foo[bar].baz !== null && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null } | null } | null ;
+foo !== null && foo[bar].baz !== null && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null } | null ;
+foo !== null && foo[bar.baz] !== null && foo[bar.baz].buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null } | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz !== null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 79,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null } | null } | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz !== null && foo.bar.baz.buzz !== null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 108,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null } | null } | null };
+foo.bar !== null && foo.bar.baz !== null && foo.bar.baz.buzz !== null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null };
+foo.bar !== null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null }} | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz.buzz !== null && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null } | null }) | null };
+foo.bar !== null && foo.bar() !== null && foo.bar().baz !== null && foo.bar().baz.buzz !== null && foo.bar().baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 120,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null } | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz !== null && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null } | null } | null } | null ;
+foo !== null && foo.bar !== null && foo.bar.baz !== null && foo.bar.baz[buzz] !== null && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 110,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null } | null } | null } | null ;
+foo !== null && foo?.bar !== null && foo?.bar.baz !== null && foo?.bar.baz[buzz] !== null && foo?.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 114,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null }} | null ;
+foo !== null && foo?.bar.baz !== null && foo?.bar.baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null )) | null ;
+foo !== null && foo?.() !== null && foo?.().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== null > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null )};
+foo.bar !== null && foo.bar?.() !== null && foo.bar?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number}  | undefined;
+foo !== undefined && foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number}  | undefined};
+foo.bar !== undefined && foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number)  | undefined;
+foo !== undefined && foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number)  | undefined};
+foo.bar !== undefined && foo.bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined};
+foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}}  | undefined};
+foo.bar !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 121,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 100,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo[bar] !== undefined && foo[bar].baz !== undefined && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 95,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo[bar].baz !== undefined && foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number}  | undefined}  | undefined;
+foo !== undefined && foo[bar.baz] !== undefined && foo[bar.baz].buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz !== undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 128,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}  | undefined}  | undefined};
+foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz.buzz !== undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 107,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}}  | undefined};
+foo.bar !== undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz.buzz !== undefined && foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 99,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number)  | undefined}  | undefined})  | undefined};
+foo.bar !== undefined && foo.bar() !== undefined && foo.bar().baz !== undefined && foo.bar().baz.buzz !== undefined && foo.bar().baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 140,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 95,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo.bar !== undefined && foo.bar.baz !== undefined && foo.bar.baz[buzz] !== undefined && foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 130,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo !== undefined && foo?.bar !== undefined && foo?.bar.baz !== undefined && foo?.bar.baz[buzz] !== undefined && foo?.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 134,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number}  | undefined}}  | undefined;
+foo !== undefined && foo?.bar.baz !== undefined && foo?.bar.baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number}  | undefined))  | undefined;
+foo !== undefined && foo?.() !== undefined && foo?.().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number}  | undefined)};
+foo.bar !== undefined && foo.bar?.() !== undefined && foo.bar?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 27`] = `
+{
+  "code": "
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};
+                foo.bar !== undefined &&
+                  foo.bar() !== undefined &&
+                  foo.bar().baz !== undefined &&
+                  foo.bar().baz.buzz !== undefined &&
+                  foo.bar().baz.buzz();
+              ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 7,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > and > strict nullish equality checks > !== undefined > prefer-optional-chain > invalid 28`] = `
+{
+  "code": "
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};
+                foo.bar !== undefined &&
+                  foo.bar() !== undefined &&
+                  foo.bar().baz !== undefined &&
+                  foo.bar().baz.buzz !== undefined;
+              ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 6,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+!foo || ! foo.bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+!foo?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+!foo.bar || ! foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+!foo.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+!foo || ! foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+!foo?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+!foo.bar || ! foo.bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+!foo.bar?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz || ! foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+!foo.bar || ! foo.bar.baz || ! foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+!foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+!foo?.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+!foo.bar || ! foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+!foo.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz || ! foo.bar.baz || ! foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo.bar || ! foo.bar.baz || ! foo.bar.baz || ! foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo[bar] || ! foo[bar].baz || ! foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo?.[bar]?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo[bar].baz || ! foo[bar].baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+!foo?.[bar].baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+!foo || ! foo[bar.baz] || ! foo[bar.baz].buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+!foo?.[bar.baz]?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz || ! foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz || ! foo.bar.baz.buzz || ! foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+!foo.bar || ! foo.bar.baz || ! foo.bar.baz.buzz || ! foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+!foo.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+!foo?.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+!foo.bar || ! foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+!foo.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz.buzz || ! foo.bar.baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+!foo?.bar?.baz.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+!foo.bar || ! foo.bar() || ! foo.bar().baz || ! foo.bar().baz.buzz || ! foo.bar().baz.buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 93,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+!foo.bar?.()?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz || ! foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.[buzz]();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo.bar || ! foo.bar.baz || ! foo.bar.baz[buzz] || ! foo.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+!foo || ! foo?.bar || ! foo?.bar.baz || ! foo?.bar.baz[buzz] || ! foo?.bar.baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 87,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+!foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+!foo || ! foo?.bar.baz || ! foo?.bar.baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+!foo?.bar.baz?.[buzz];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+!foo || ! foo?.() || ! foo?.().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+!foo?.()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > boolean > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+!foo.bar || ! foo.bar?.() || ! foo.bar?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+!foo.bar?.()?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo == null || foo.bar == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar == null || foo.bar.baz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo == null || foo() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+foo?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar == null || foo.bar() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz == null || foo.bar.baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 82,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar == null || foo.bar.baz == null || foo.bar.baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar == null || foo.bar.baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz == null || foo.bar.baz == null || foo.bar.baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 105,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar == null || foo.bar.baz == null || foo.bar.baz == null || foo.bar.baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 90,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo[bar] == null || foo[bar].baz == null || foo[bar].baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo[bar].baz == null || foo[bar].baz.buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo == null || foo[bar.baz] == null || foo[bar.baz].buzz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.baz]?.buzz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz == null || foo.bar.baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz == null || foo.bar.baz.buzz == null || foo.bar.baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 112,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar == null || foo.bar.baz == null || foo.bar.baz.buzz == null || foo.bar.baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 97,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar == null || foo.bar.baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz.buzz == null || foo.bar.baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar == null || foo.bar() == null || foo.bar().baz == null || foo.bar().baz.buzz == null || foo.bar().baz.buzz() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 124,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz == null || foo.bar.baz[buzz]() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo.bar == null || foo.bar.baz == null || foo.bar.baz[buzz] == null || foo.bar.baz[buzz]() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 114,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo == null || foo?.bar == null || foo?.bar.baz == null || foo?.bar.baz[buzz] == null || foo?.bar.baz[buzz]() == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 118,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo == null || foo?.bar.baz == null || foo?.bar.baz[buzz] == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz] == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo == null || foo?.() == null || foo?.().bar == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == null > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar == null || foo.bar?.() == null || foo.bar?.().baz == null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz == null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo == undefined || foo.bar == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar == undefined || foo.bar.baz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo == undefined || foo() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+foo?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar == undefined || foo.bar() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 102,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 82,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar == undefined || foo.bar.baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 130,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 110,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo[bar] == undefined || foo[bar].baz == undefined || foo[bar].baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 105,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo[bar].baz == undefined || foo[bar].baz.buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo == undefined || foo[bar.baz] == undefined || foo[bar.baz].buzz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.baz]?.buzz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 104,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz == undefined || foo.bar.baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 137,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz.buzz == undefined || foo.bar.baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 117,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar == undefined || foo.bar.baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz.buzz == undefined || foo.bar.baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 109,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar == undefined || foo.bar() == undefined || foo.bar().baz == undefined || foo.bar().baz.buzz == undefined || foo.bar().baz.buzz() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 149,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz[buzz]() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 105,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo.bar == undefined || foo.bar.baz == undefined || foo.bar.baz[buzz] == undefined || foo.bar.baz[buzz]() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 139,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo == undefined || foo?.bar == undefined || foo?.bar.baz == undefined || foo?.bar.baz[buzz] == undefined || foo?.bar.baz[buzz]() == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 143,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.() == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo == undefined || foo?.bar.baz == undefined || foo?.bar.baz[buzz] == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz] == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo == undefined || foo?.() == undefined || foo?.().bar == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > == undefined > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar == undefined || foo.bar?.() == undefined || foo.bar?.().baz == undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz == undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null ;
+foo === null || foo.bar === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null };
+foo.bar === null || foo.bar.baz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null ;
+foo === null || foo() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null };
+foo.bar === null || foo.bar() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null } | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz === null || foo.bar.baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 86,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null } | null };
+foo.bar === null || foo.bar.baz === null || foo.bar.baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null };
+foo.bar === null || foo.bar.baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null } | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz === null || foo.bar.baz === null || foo.bar.baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 110,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null } | null } | null ;
+foo.bar === null || foo.bar.baz === null || foo.bar.baz === null || foo.bar.baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null } | null } | null ;
+foo === null || foo[bar] === null || foo[bar].baz === null || foo[bar].baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null } | null } | null ;
+foo === null || foo[bar].baz === null || foo[bar].baz.buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null } | null ;
+foo === null || foo[bar.baz] === null || foo[bar.baz].buzz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null } | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz === null || foo.bar.baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 88,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null } | null } | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz === null || foo.bar.baz.buzz === null || foo.bar.baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 117,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null } | null } | null };
+foo.bar === null || foo.bar.baz === null || foo.bar.baz.buzz === null || foo.bar.baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 101,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null };
+foo.bar === null || foo.bar.baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null }} | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz.buzz === null || foo.bar.baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 93,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null } | null }) | null };
+foo.bar === null || foo.bar() === null || foo.bar().baz === null || foo.bar().baz.buzz === null || foo.bar().baz.buzz() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 129,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null } | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz === null || foo.bar.baz[buzz]() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null } | null } | null } | null ;
+foo === null || foo.bar === null || foo.bar.baz === null || foo.bar.baz[buzz] === null || foo.bar.baz[buzz]() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 119,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null } | null } | null } | null ;
+foo === null || foo?.bar === null || foo?.bar.baz === null || foo?.bar.baz[buzz] === null || foo?.bar.baz[buzz]() === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 123,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null }} | null ;
+foo === null || foo?.bar.baz === null || foo?.bar.baz[buzz] === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null )) | null ;
+foo === null || foo?.() === null || foo?.().bar === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === null > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null )};
+foo.bar === null || foo.bar?.() === null || foo.bar?.().baz === null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number}  | undefined;
+foo === undefined || foo.bar === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number}  | undefined;
+foo?.bar === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number}  | undefined};
+foo.bar === undefined || foo.bar.baz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number}  | undefined};
+foo.bar?.baz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number)  | undefined;
+foo === undefined || foo() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number)  | undefined;
+foo?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number)  | undefined};
+foo.bar === undefined || foo.bar() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number)  | undefined};
+foo.bar?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 106,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined};
+foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 85,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined};
+foo.bar?.baz?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}}  | undefined}  | undefined;
+foo?.bar?.baz.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}}  | undefined};
+foo.bar === undefined || foo.bar.baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}}  | undefined};
+foo.bar?.baz.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 135,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 114,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo.bar?.baz?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo[bar] === undefined || foo[bar].baz === undefined || foo[bar].baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 109,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo?.[bar]?.baz?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo[bar].baz === undefined || foo[bar].baz.buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number}  | undefined}  | undefined}  | undefined;
+foo?.[bar].baz?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number}  | undefined}  | undefined;
+foo === undefined || foo[bar.baz] === undefined || foo[bar.baz].buzz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number}  | undefined}  | undefined;
+foo?.[bar.baz]?.buzz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 108,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.buzz() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz === undefined || foo.bar.baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 142,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.buzz?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}  | undefined}  | undefined};
+foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz.buzz === undefined || foo.bar.baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 121,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}  | undefined}  | undefined};
+foo.bar?.baz?.buzz?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 79,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}}  | undefined}  | undefined;
+foo?.bar?.baz.buzz() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}}  | undefined};
+foo.bar === undefined || foo.bar.baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}}  | undefined};
+foo.bar?.baz.buzz() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz.buzz === undefined || foo.bar.baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 113,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number)  | undefined}}  | undefined}  | undefined;
+foo?.bar?.baz.buzz?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number)  | undefined}  | undefined})  | undefined};
+foo.bar === undefined || foo.bar() === undefined || foo.bar().baz === undefined || foo.bar().baz.buzz === undefined || foo.bar().baz.buzz() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 154,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number)  | undefined}  | undefined})  | undefined};
+foo.bar?.()?.baz?.buzz?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz[buzz]() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 109,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.[buzz]() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo.bar === undefined || foo.bar.baz === undefined || foo.bar.baz[buzz] === undefined || foo.bar.baz[buzz]() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 144,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.[buzz]?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo === undefined || foo?.bar === undefined || foo?.bar.baz === undefined || foo?.bar.baz[buzz] === undefined || foo?.bar.baz[buzz]() === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 148,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number)  | undefined}  | undefined}  | undefined}  | undefined;
+foo?.bar?.baz?.[buzz]?.() === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number}  | undefined}}  | undefined;
+foo === undefined || foo?.bar.baz === undefined || foo?.bar.baz[buzz] === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number}  | undefined}}  | undefined;
+foo?.bar.baz?.[buzz] === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number}  | undefined))  | undefined;
+foo === undefined || foo?.() === undefined || foo?.().bar === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number}  | undefined))  | undefined;
+foo?.()?.bar === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number}  | undefined)};
+foo.bar === undefined || foo.bar?.() === undefined || foo.bar?.().baz === undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number}  | undefined)};
+foo.bar?.()?.baz === undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 27`] = `
+{
+  "code": "
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};
+                foo.bar === undefined ||
+                  foo.bar() === undefined ||
+                  foo.bar().baz === undefined ||
+                  foo.bar().baz.buzz === undefined ||
+                  !foo.bar().baz.buzz();
+              ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 7,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};
+                foo.bar?.() === undefined ||
+                  foo.bar().baz === undefined ||
+                  foo.bar().baz.buzz === undefined ||
+                  !foo.bar().baz.buzz();
+              ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > or > strict nullish equality checks > === undefined > prefer-optional-chain > invalid 28`] = `
+{
+  "code": "
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};
+                foo.bar === undefined ||
+                  foo.bar() === undefined ||
+                  foo.bar().baz === undefined ||
+                  foo.bar().baz.buzz === undefined;
+              ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 6,
+        },
+        "start": {
+          "column": 17,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+                declare const foo: {bar: () => ({baz: {buzz: (() => number) | undefined} | undefined}) | undefined};
+                foo.bar?.()?.baz?.buzz === undefined;
+              ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo && foo.      bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.      bar && foo.      bar.      baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "// 3
+declare const foo: (() => number) | null | undefined;
+foo && foo();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 3
+declare const foo: (() => number) | null | undefined;
+foo?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.      bar && foo.      bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz && foo.      bar.      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 86,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.      bar && foo.      bar.      baz && foo.      bar.      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 79,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.      bar && foo.      bar.      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz && foo.      bar.      baz && foo.      bar.      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 113,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.      bar && foo.      bar.      baz && foo.      bar.      baz && foo.      bar.      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 106,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar] && foo[bar].      baz && foo[bar].      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar].      baz && foo[bar].      baz.      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo && foo[bar.      baz] && foo[bar.      baz].      buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.      baz]?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz && foo.      bar.      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 88,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz && foo.      bar.      baz.      buzz && foo.      bar.      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 126,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.      bar && foo.      bar.      baz && foo.      bar.      baz.      buzz && foo.      bar.      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 119,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.      bar && foo.      bar.      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz.      buzz && foo.      bar.      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 99,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.      bar && foo.      bar() && foo.      bar().      baz && foo.      bar().      baz.      buzz && foo.      bar().      baz.      buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 144,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz && foo.      bar.      baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.      bar && foo.      bar.      baz && foo.      bar.      baz[buzz] && foo.      bar.      baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 116,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo?.      bar && foo?.      bar.      baz && foo?.      bar.      baz[buzz] && foo?.      bar.      baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 120,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo && foo?.      bar.      baz && foo?.      bar.      baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo && foo?.      () && foo?.      ().      bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.      bar && foo.      bar?.      () && foo.      bar?.      ().      baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 27`] = `
+{
+  "code": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo && foo.
+bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 1
+declare const foo: {bar: number} | null | undefined;
+foo?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 28`] = `
+{
+  "code": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.
+bar && foo.
+bar.
+baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 2
+declare const foo: {bar: {baz: number} | null | undefined};
+foo.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 29`] = `
+{
+  "code": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.
+bar && foo.
+bar();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 4
+declare const foo: {bar: (() => number) | null | undefined};
+foo.bar?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 30`] = `
+{
+  "code": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 9,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 5
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 31`] = `
+{
+  "code": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 9,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 6
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 32`] = `
+{
+  "code": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 7
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 33`] = `
+{
+  "code": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.
+bar && foo.
+bar.
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 8
+declare const foo: {bar: {baz: {buzz: number}} | null | undefined};
+foo.bar?.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 34`] = `
+{
+  "code": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 11,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 9
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 35`] = `
+{
+  "code": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 11,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 10
+declare const foo: {bar: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo.bar?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 36`] = `
+{
+  "code": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar] && foo[bar].
+baz && foo[bar].
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 11
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar]?.baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 37`] = `
+{
+  "code": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo[bar].
+baz && foo[bar].
+baz.
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 12
+declare const bar: string;
+declare const foo: {[k: string]: {baz: {buzz: number} | null | undefined} | null | undefined} | null | undefined;
+foo?.[bar].baz?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 38`] = `
+{
+  "code": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo && foo[bar.
+baz] && foo[bar.
+baz].
+buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 13
+declare const bar: {baz: string};
+declare const foo: {[k: string]: {buzz: number} | null | undefined} | null | undefined;
+foo?.[bar.
+baz]?.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 39`] = `
+{
+  "code": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 9,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 14
+declare const foo: {bar: {baz: {buzz: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 40`] = `
+{
+  "code": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz && foo.
+bar.
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 12,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 15
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 41`] = `
+{
+  "code": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz.
+buzz && foo.
+bar.
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 12,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 16
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined} | null | undefined} | null | undefined};
+foo.bar?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 42`] = `
+{
+  "code": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 17
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 43`] = `
+{
+  "code": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.
+bar && foo.
+bar.
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 18
+declare const foo: {bar: {baz: {buzz: () => number}} | null | undefined};
+foo.bar?.baz.buzz();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 44`] = `
+{
+  "code": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz.
+buzz && foo.
+bar.
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 10,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 19
+declare const foo: {bar: {baz: {buzz: (() => number) | null | undefined}} | null | undefined} | null | undefined;
+foo?.bar?.baz.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 45`] = `
+{
+  "code": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.
+bar && foo.
+bar() && foo.
+bar().
+baz && foo.
+bar().
+baz.
+buzz && foo.
+bar().
+baz.
+buzz();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 13,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 20
+declare const foo: {bar: () => ({baz: {buzz: (() => number) | null | undefined} | null | undefined}) | null | undefined};
+foo.bar?.()?.baz?.buzz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 46`] = `
+{
+  "code": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 9,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 21
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: () => number} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 47`] = `
+{
+  "code": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo.
+bar && foo.
+bar.
+baz && foo.
+bar.
+baz[buzz] && foo.
+bar.
+baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 11,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 22
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 48`] = `
+{
+  "code": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo && foo?.
+bar && foo?.
+bar.
+baz && foo?.
+bar.
+baz[buzz] && foo?.
+bar.
+baz[buzz]();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 11,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 23
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: (() => number) | null | undefined} | null | undefined} | null | undefined} | null | undefined;
+foo?.bar?.baz?.[buzz]?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 49`] = `
+{
+  "code": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo && foo?.
+bar.
+baz && foo?.
+bar.
+baz[buzz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 24
+declare const buzz: string;
+declare const foo: {bar: {baz: {[k: string]: number} | null | undefined}} | null | undefined;
+foo?.bar.baz?.[buzz];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 50`] = `
+{
+  "code": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo && foo?.
+() && foo?.
+().
+bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 25
+declare const foo: (() => ({bar: number} | null | undefined)) | null | undefined;
+foo?.()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`base cases > should ignore spacing sanity checks > prefer-optional-chain > invalid 51`] = `
+{
+  "code": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.
+bar && foo.
+bar?.
+() && foo.
+bar?.
+().
+baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 9,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "// 26
+declare const foo: {bar: () => ({baz: number} | null | undefined)};
+foo.bar?.()?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 1`] = `
+{
+  "code": "foo && foo.bar && foo.bar.baz || baz && baz.bar && baz.bar.foo",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "foo?.bar?.baz || baz?.bar?.foo",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 2`] = `
+{
+  "code": "foo && foo.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar != null && foo.bar.baz !== undefined && foo.bar.baz.buzz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 3`] = `
+{
+  "code": "
+          foo.bar &&
+            foo.bar.baz != null &&
+            foo.bar.baz.qux !== undefined &&
+            foo.bar.baz.qux.buzz;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          foo.bar?.baz != null &&
+            foo.bar.baz.qux !== undefined &&
+            foo.bar.baz.qux.buzz;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 4`] = `
+{
+  "code": "foo && foo.bar(baz => <This Requires Spaces />);",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar(baz => <This Requires Spaces />);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 5`] = `
+{
+  "code": "foo && foo.bar(baz => typeof baz);",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar(baz => typeof baz);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 6`] = `
+{
+  "code": "foo && foo['some long string'] && foo['some long string'].baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.['some long string']?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 7`] = `
+{
+  "code": "foo && foo[\`some long string\`] && foo[\`some long string\`].baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.[\`some long string\`]?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 8`] = `
+{
+  "code": "foo && foo[\`some \${long} string\`] && foo[\`some \${long} string\`].baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.[\`some \${long} string\`]?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 9`] = `
+{
+  "code": "foo && foo[bar as string] && foo[bar as string].baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.[bar as string]?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 10`] = `
+{
+  "code": "foo && foo[1 + 2] && foo[1 + 2].baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.[1 + 2]?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 11`] = `
+{
+  "code": "foo && foo[typeof bar] && foo[typeof bar].baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.[typeof bar]?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 12`] = `
+{
+  "code": "foo && foo.bar(a) && foo.bar(a, b).baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar(a) && foo.bar(a, b).baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 13`] = `
+{
+  "code": "foo() && foo()(bar);",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo()?.(bar);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 14`] = `
+{
+  "code": "foo && foo<string>() && foo<string>().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.<string>()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 15`] = `
+{
+  "code": "foo && foo<string>() && foo<string, number>().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.<string>() && foo<string, number>().bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 16`] = `
+{
+  "code": "foo && foo<T>() && foo<T>().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.<T>()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 17`] = `
+{
+  "code": "foo && foo<T>() && foo<U>().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.<T>() && foo<U>().bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 18`] = `
+{
+  "code": "
+          foo && foo.bar(/* comment */a,
+            // comment2
+            b, );
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          foo?.bar(/* comment */a,
+            // comment2
+            b, );
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 19`] = `
+{
+  "code": "foo && foo.bar != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 20`] = `
+{
+  "code": "foo && foo.bar != undefined;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar != undefined;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 21`] = `
+{
+  "code": "foo && foo.bar != null && baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar != null && baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 22`] = `
+{
+  "code": "this.bar && this.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "this.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 23`] = `
+{
+  "code": "foo && foo?.();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 24`] = `
+{
+  "code": "foo.bar && foo.bar?.();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo.bar?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 25`] = `
+{
+  "code": "foo && foo.bar(baz => <This Requires Spaces />);",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar(baz => <This Requires Spaces />);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 26`] = `
+{
+  "code": "!this.bar || !this.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!this.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 27`] = `
+{
+  "code": "!a.b || !a.b();",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!a.b?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 28`] = `
+{
+  "code": "!foo.bar || !foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 29`] = `
+{
+  "code": "!foo[bar] || !foo[bar]?.[baz];",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo[bar]?.[baz];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 30`] = `
+{
+  "code": "!foo || !foo?.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo?.bar.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 31`] = `
+{
+  "code": "(!foo || !foo.bar || !foo.bar.baz) && (!baz || !baz.bar || !baz.bar.foo);",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "(!foo?.bar?.baz) && (!baz?.bar?.foo);",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 32`] = `
+{
+  "code": "
+          class Foo {
+            constructor() {
+              new.target && new.target.length;
+            }
+          }
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 33`] = `
+{
+  "code": "import.meta && import.meta?.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "import.meta?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 34`] = `
+{
+  "code": "!import.meta || !import.meta?.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!import.meta?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 35`] = `
+{
+  "code": "import.meta && import.meta?.() && import.meta?.().baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "import.meta?.()?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 36`] = `
+{
+  "code": "!foo() || !foo().bar;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo()?.bar;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 37`] = `
+{
+  "code": "!foo!.bar || !foo!.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo!.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 38`] = `
+{
+  "code": "!foo!.bar!.baz || !foo!.bar!.baz!.paz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo!.bar!.baz?.paz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 39`] = `
+{
+  "code": "!foo.bar!.baz || !foo.bar!.baz!.paz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo.bar!.baz?.paz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 40`] = `
+{
+  "code": "
+          declare const foo: { bar: string } | null;
+          foo !== null && foo.bar !== null;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 41`] = `
+{
+  "code": "foo != null && foo.bar != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 42`] = `
+{
+  "code": "
+          declare const foo: { bar: string | null } | null;
+          foo != null && foo.bar !== null;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 43`] = `
+{
+  "code": "
+          declare const foo: { bar: string | null } | null;
+          foo !== null && foo.bar != null;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: string | null } | null;
+          foo?.bar != null;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 44`] = `
+{
+  "code": "unrelated != null && foo != null && foo.bar != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "unrelated != null && foo?.bar != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 45`] = `
+{
+  "code": "unrelated1 != null && unrelated2 != null && foo != null && foo.bar != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "unrelated1 != null && unrelated2 != null && foo?.bar != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 46`] = `
+{
+  "code": "foo1 != null && foo1.bar != null && foo2 != null && foo2.bar != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "foo1?.bar != null && foo2?.bar != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 47`] = `
+{
+  "code": "foo && foo.a && bar && bar.a;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "foo?.a && bar?.a;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 48`] = `
+{
+  "code": "foo.bar.baz != null && foo?.bar?.baz.bam != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo.bar.baz?.bam != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 49`] = `
+{
+  "code": "foo?.bar.baz != null && foo.bar?.baz.bam != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar.baz?.bam != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 50`] = `
+{
+  "code": "foo?.bar?.baz != null && foo.bar.baz.bam != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar?.baz?.bam != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 51`] = `
+{
+  "code": "foo.bar.baz != null && foo!.bar!.baz.bam != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo.bar.baz?.bam != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 52`] = `
+{
+  "code": "foo!.bar.baz != null && foo.bar!.baz.bam != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo!.bar.baz?.bam != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 53`] = `
+{
+  "code": "foo!.bar!.baz != null && foo.bar.baz.bam != null;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo!.bar!.baz?.bam != null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 54`] = `
+{
+  "code": "
+          a &&
+            a.b != null &&
+            a.b.c !== undefined &&
+            a.b.c !== null &&
+            a.b.c.d != null &&
+            a.b.c.d.e !== null &&
+            a.b.c.d.e !== undefined &&
+            a.b.c.d.e.f != undefined &&
+            typeof a.b.c.d.e.f.g !== 'undefined' &&
+            a.b.c.d.e.f.g !== null &&
+            a.b.c.d.e.f.g.h;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 12,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          a?.b?.c?.d?.e?.f?.g?.h;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 55`] = `
+{
+  "code": "
+          !a ||
+            a.b == null ||
+            a.b.c === undefined ||
+            a.b.c === null ||
+            a.b.c.d == null ||
+            a.b.c.d.e === null ||
+            a.b.c.d.e === undefined ||
+            a.b.c.d.e.f == undefined ||
+            typeof a.b.c.d.e.f.g === 'undefined' ||
+            a.b.c.d.e.f.g === null ||
+            !a.b.c.d.e.f.g.h;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 12,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          !a?.b?.c?.d?.e?.f?.g?.h;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 56`] = `
+{
+  "code": "
+          !a ||
+            a.b == null ||
+            a.b.c === null ||
+            a.b.c === undefined ||
+            a.b.c.d == null ||
+            a.b.c.d.e === null ||
+            a.b.c.d.e === undefined ||
+            a.b.c.d.e.f == undefined ||
+            typeof a.b.c.d.e.f.g === 'undefined' ||
+            a.b.c.d.e.f.g === null ||
+            !a.b.c.d.e.f.g.h;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 12,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          !a?.b?.c?.d?.e?.f?.g?.h;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 57`] = `
+{
+  "code": "undefined !== foo && null !== foo && null != foo.bar && foo.bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo?.bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 58`] = `
+{
+  "code": "
+          null != foo &&
+            'undefined' !== typeof foo.bar &&
+            null !== foo.bar &&
+            foo.bar.baz;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          foo?.bar?.baz;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 59`] = `
+{
+  "code": "
+          null != foo &&
+            'undefined' !== typeof foo.bar &&
+            null !== foo.bar &&
+            null != foo.bar.baz;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          null != foo?.bar?.baz;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 60`] = `
+{
+  "code": "
+          null != foo &&
+            'undefined' !== typeof foo.bar &&
+            null !== foo.bar &&
+            null !== foo.bar.baz &&
+            'undefined' !== typeof foo.bar.baz;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 61`] = `
+{
+  "code": "
+          foo != null &&
+            typeof foo.bar !== 'undefined' &&
+            foo.bar !== null &&
+            foo.bar.baz !== null &&
+            typeof foo.bar.baz !== 'undefined';
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 62`] = `
+{
+  "code": "
+          null != foo &&
+            'undefined' !== typeof foo.bar &&
+            null !== foo.bar &&
+            null !== foo.bar.baz &&
+            undefined !== foo.bar.baz;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 63`] = `
+{
+  "code": "
+          foo != null &&
+            typeof foo.bar !== 'undefined' &&
+            foo.bar !== null &&
+            foo.bar.baz !== null &&
+            foo.bar.baz !== undefined;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 64`] = `
+{
+  "code": "
+          null != foo &&
+            'undefined' !== typeof foo.bar &&
+            null !== foo.bar &&
+            undefined !== foo.bar.baz &&
+            null !== foo.bar.baz;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          undefined !== foo?.bar?.baz &&
+            null !== foo.bar.baz;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 65`] = `
+{
+  "code": "
+          foo != null &&
+            typeof foo.bar !== 'undefined' &&
+            foo.bar !== null &&
+            foo.bar.baz !== undefined &&
+            foo.bar.baz !== null;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          foo?.bar?.baz !== undefined &&
+            foo.bar.baz !== null;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 66`] = `
+{
+  "code": "(await foo).bar && (await foo).bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "(await foo).bar?.baz;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 67`] = `
+{
+  "code": "
+          !a ||
+            a.b == null ||
+            a.b.c === undefined ||
+            a.b.c === null ||
+            a.b.c.d == null ||
+            a.b.c.d.e === null ||
+            a.b.c.d.e === undefined ||
+            a.b.c.d.e.f == undefined ||
+            a.b.c.d.e.f.g == null ||
+            a.b.c.d.e.f.g.h;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 10,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          a?.b?.c?.d?.e?.f?.g == null ||
+            a.b.c.d.e.f.g.h;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 68`] = `
+{
+  "code": "
+          declare const foo: { bar: number } | null | undefined;
+          foo && foo.bar != null;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: number } | null | undefined;
+          foo?.bar != null;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 69`] = `
+{
+  "code": "
+          declare const foo: { bar: number } | undefined;
+          foo && typeof foo.bar !== 'undefined';
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: number } | undefined;
+          typeof foo?.bar !== 'undefined';
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 70`] = `
+{
+  "code": "
+          declare const foo: { bar: number } | undefined;
+          foo && 'undefined' !== typeof foo.bar;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: number } | undefined;
+          'undefined' !== typeof foo?.bar;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 71`] = `
+{
+  "code": "
+          declare const thing1: string | null;
+          thing1 && thing1.toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 72`] = `
+{
+  "code": "
+          declare const thing1: string | null;
+          thing1 && thing1.toString() && true;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 73`] = `
+{
+  "code": "
+          declare const foo: string | null;
+          foo && foo.toString() && foo.toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 74`] = `
+{
+  "code": "
+          declare const foo: { bar: string | null | undefined } | null | undefined;
+          foo && foo.bar && foo.bar.toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: string | null | undefined } | null | undefined;
+          foo?.bar?.toString();
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 75`] = `
+{
+  "code": "
+          declare const foo: { bar: string | null | undefined } | null | undefined;
+          foo && foo.bar && foo.bar.toString() && foo.bar.toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: string | null | undefined } | null | undefined;
+          foo?.bar?.toString() && foo.bar.toString();
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 76`] = `
+{
+  "code": "
+          declare const foo: string | null;
+          (foo || {}).toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 77`] = `
+{
+  "code": "
+          declare const foo: string;
+          (foo || undefined || {}).toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 78`] = `
+{
+  "code": "
+          declare const foo: string | null;
+          (foo || undefined || {}).toString();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 79`] = `
+{
+  "code": "
+          declare const foo: { bar: number } | null | undefined;
+          foo != undefined && foo.bar;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: number } | null | undefined;
+          foo?.bar;
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 80`] = `
+{
+  "code": "
+          declare const foo: { bar: number } | null | undefined;
+          foo != undefined && foo.bar;
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 81`] = `
+{
+  "code": "
+          declare const foo: { bar: boolean } | null | undefined;
+          declare function acceptsBoolean(arg: boolean): void;
+          acceptsBoolean(foo != null && foo.bar);
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 4,
+        },
+        "start": {
+          "column": 26,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          declare const foo: { bar: boolean } | null | undefined;
+          declare function acceptsBoolean(arg: boolean): void;
+          acceptsBoolean(foo?.bar);
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 82`] = `
+{
+  "code": "
+          function foo(globalThis?: { Array: Function }) {
+            typeof globalThis !== 'undefined' && globalThis.Array();
+          }
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+          function foo(globalThis?: { Array: Function }) {
+            globalThis?.Array();
+          }
+        ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 83`] = `
+{
+  "code": "
+          typeof globalThis !== 'undefined' && globalThis.Array && globalThis.Array();
+        ",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 86,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 84`] = `
+{
+  "code": "a && (a.b && a.b.c)",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a?.b?.c",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 85`] = `
+{
+  "code": "(a && a.b) && a.b.c",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a?.b?.c",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 86`] = `
+{
+  "code": "((a && a.b)) && a.b.c",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a?.b?.c",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 87`] = `
+{
+  "code": "foo(a && (a.b && a.b.c))",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo(a?.b?.c)",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 88`] = `
+{
+  "code": "foo(a && a.b && a.b.c)",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "foo(a?.b?.c)",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 89`] = `
+{
+  "code": "!foo || !foo.bar || ((((!foo.bar.baz || !foo.bar.baz()))));",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "!foo?.bar?.baz?.();",
+  "ruleCount": 1,
+}
+`;
+
+exports[`hand-crafted cases > prefer-optional-chain > invalid 90`] = `
+{
+  "code": "a !== undefined && ((a !== null && a.prop));",
+  "diagnostics": [
+    {
+      "message": "Prefer using an optional chain expression instead, as it's more concise and easier to read.",
+      "messageId": "preferOptionalChain",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-optional-chain",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a?.prop;",
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/prefer-optional-chain` rule from TypeScript-ESLint to Go.

This rule enforces using concise optional chain expressions (`?.`) instead of chained logical ANDs (`&&`), negated logical ORs (`||`), or empty object coalescing patterns (`(foo || {}).bar`).

### Implementation highlights

- **Operand gathering & classification**: Flattens `&&`/`||` chains into operands, classifying each as boolean, strict/loose null/undefined equality, typeof, or negation
- **Node comparison**: Recursive AST structural comparison for optional chain candidates. Supports `PropertyAccess`/`ElementAccess`/`Call`/`NonNull`/`QualifiedName`/`MetaProperty`, as well as complex computed properties (`BinaryExpression`, `TypeOfExpression`, `AsExpression`, `TemplateExpression`, `PrefixUnaryExpression`) and type arguments
- **DeMorgan inversion**: For `||` chains, correctly inverts comparison operators during classification and restores original operators for output generation
- **Guard sufficiency**: Strict equality guards (`!== null`/`!== undefined`) are checked against the node's type; paired complementary guards (e.g. `!== undefined && !== null`) are recognized as together covering both nullish values
- **Impure call protection**: When the chain trails with a bare call and a guard uses strict `!==/=== undefined` on a call expression result, the rule generates a partial fold to preserve original call count and semantics
- **`?.` & `!` preservation**: Uses `scanner.GetSourceTextOfNodeFromSourceFile` to preserve existing optional chain tokens and non-null assertions from the source
- **Comment preservation**: Call arguments are extracted with leading trivia to preserve original comments in the output
- **Fix vs suggestion**: Type-aware decision — auto-fix when the transformation preserves the expression's result type and semantics; suggestion otherwise (e.g., `!== null` on `T | null` changes `false` short-circuit to `true`)
- **Options support**: All 8 options from the original rule (`checkAny`, `checkUnknown`, `checkString`, `checkNumber`, `checkBoolean`, `checkBigInt`, `requireNullish`, `allowPotentiallyUnsafeFixesThatModifyTheReturnTypeIKnowWhatImDoing`)

### Test coverage

- Full Go unit tests (300+ hand-crafted cases + 26 BaseCases × multiple comparison mutations = 800+ generated cases)
- TypeScript integration tests aligned with `@typescript-eslint` official tests (26/26 pass)
- Validated on real-world projects (rsbuild, rspack, portal) — detects genuine candidates with no false positives

### Implementation notes

- Reuses shared utilities: `utils.IsTypeFlagSetWithUnion`, `utils.TrimmedNodeText`, `utils.IsFalseLiteralType`, `utils.IsNumberLiteralZeroOrNaN`, `utils.Ref`, `scanner.GetSourceTextOfNodeFromSourceFile`
- `isNumberLiteralZeroOrNaN` exported in `internal/utils/ts_api_utils.go` for reuse

## Related Links

- Original rule: https://typescript-eslint.io/rules/prefer-optional-chain
- Related Issue: https://github.com/web-infra-dev/rslint/issues/37

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).