### PR TITLE
chore: add workflow permissions for update-rule-manifest

### DIFF
--- a/.github/workflows/update-rule-manifest.yml
+++ b/.github/workflows/update-rule-manifest.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-rule-manifest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add `contents: write` and `pull-requests: write` permissions to the `update-rule-manifest` workflow, so that `github-actions[bot]` can push the auto branch and create PRs.

## Related Links

- https://github.com/web-infra-dev/rslint/actions/runs/21737554536/job/62705807128

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).