### PR TITLE
feat: port rule no-dupe-else-if

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,6 +137,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_debugger"
 	"github.com/web-infra-dev/rslint/internal/rules/no_delete_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_args"
+	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_else_if"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_keys"
 	"github.com/web-infra-dev/rslint/internal/rules/no_duplicate_case"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty"
@@ -601,6 +602,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-unreachable", no_unreachable.NoUnreachableRule)
 	GlobalRuleRegistry.Register("require-atomic-updates", require_atomic_updates.RequireAtomicUpdatesRule)
 	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
+	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_dupe_else_if/no_dupe_else_if.go
+++ b/internal/rules/no_dupe_else_if/no_dupe_else_if.go
@@ -1,0 +1,194 @@
+package no_dupe_else_if
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-dupe-else-if
+var NoDupeElseIfRule = rule.Rule{
+	Name: "no-dupe-else-if",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		sf := ctx.SourceFile
+		return rule.RuleListeners{
+			ast.KindIfStatement: func(node *ast.Node) {
+				ifStmt := node.AsIfStatement()
+				if ifStmt == nil || ifStmt.Expression == nil {
+					return
+				}
+				test := ifStmt.Expression
+
+				// ESLint: when the current test is a top-level `&&`, each AND
+				// operand is also checked independently. A branch is dead if
+				// any of {whole test, A, B, ...} becomes fully covered.
+				conditionsToCheck := []*ast.Node{test}
+				if isLogicalOp(test, ast.KindAmpersandAmpersandToken) {
+					conditionsToCheck = append(conditionsToCheck, splitByAnd(test)...)
+				}
+
+				// For each condition to check: list of OR-operands, each an AND-set.
+				listToCheck := make([][][]*ast.Node, len(conditionsToCheck))
+				for i, c := range conditionsToCheck {
+					listToCheck[i] = toOrAndMatrix(c)
+				}
+
+				current := node
+				for current.Parent != nil && current.Parent.Kind == ast.KindIfStatement {
+					parent := current.Parent
+					parentIf := parent.AsIfStatement()
+					if parentIf == nil || parentIf.ElseStatement != current {
+						break
+					}
+					current = parent
+					if parentIf.Expression == nil {
+						break
+					}
+
+					priorOrAnd := toOrAndMatrix(parentIf.Expression)
+
+					// Cumulative filter: drop OR-operands already covered by
+					// any ancestor's OR-operand (i.e. an ancestor operand that
+					// is an AND-subset of ours implies ours).
+					anyEmpty := false
+					for i, orOperands := range listToCheck {
+						filtered := orOperands[:0]
+						for _, orOp := range orOperands {
+							covered := false
+							for _, priorOp := range priorOrAnd {
+								if andSetIsSubset(priorOp, orOp, sf) {
+									covered = true
+									break
+								}
+							}
+							if !covered {
+								filtered = append(filtered, orOp)
+							}
+						}
+						listToCheck[i] = filtered
+						if len(filtered) == 0 {
+							anyEmpty = true
+						}
+					}
+
+					if anyEmpty {
+						ctx.ReportNode(ast.SkipParentheses(test), rule.RuleMessage{
+							Id:          "unexpected",
+							Description: "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+						})
+						return
+					}
+				}
+			},
+		}
+	},
+}
+
+// toOrAndMatrix splits `node` by top-level `||` into OR-operands, then splits
+// each OR-operand by top-level `&&` into AND-operands.
+func toOrAndMatrix(node *ast.Node) [][]*ast.Node {
+	orOps := splitByOr(node)
+	matrix := make([][]*ast.Node, len(orOps))
+	for i, o := range orOps {
+		matrix[i] = splitByAnd(o)
+	}
+	return matrix
+}
+
+func splitByOr(node *ast.Node) []*ast.Node {
+	return splitByLogicalOp(node, ast.KindBarBarToken)
+}
+
+func splitByAnd(node *ast.Node) []*ast.Node {
+	return splitByLogicalOp(node, ast.KindAmpersandAmpersandToken)
+}
+
+// splitByLogicalOp flattens a binary expression tree along a single logical
+// operator. Parentheses at the root are transparent to the split (matching
+// ESLint's ESTree-based behavior, where parens don't appear as nodes).
+func splitByLogicalOp(node *ast.Node, op ast.Kind) []*ast.Node {
+	if node == nil {
+		return nil
+	}
+	inner := ast.SkipParentheses(node)
+	if inner.Kind == ast.KindBinaryExpression {
+		bin := inner.AsBinaryExpression()
+		if bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == op {
+			return append(splitByLogicalOp(bin.Left, op), splitByLogicalOp(bin.Right, op)...)
+		}
+	}
+	return []*ast.Node{node}
+}
+
+// isLogicalOp reports whether `node` (ignoring outer parentheses) is a binary
+// expression with the given logical operator.
+func isLogicalOp(node *ast.Node, op ast.Kind) bool {
+	inner := ast.SkipParentheses(node)
+	if inner == nil || inner.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := inner.AsBinaryExpression()
+	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == op
+}
+
+// nodesEqual mirrors ESLint's recursive `equal`: `||` and `&&` are treated as
+// commutative at any depth; everything else falls back to token equality.
+func nodesEqual(a, b *ast.Node, sf *ast.SourceFile) bool {
+	ua := ast.SkipParentheses(a)
+	ub := ast.SkipParentheses(b)
+	if ua.Kind != ub.Kind {
+		return false
+	}
+	if ua.Kind == ast.KindBinaryExpression {
+		ba := ua.AsBinaryExpression()
+		bb := ub.AsBinaryExpression()
+		if ba != nil && bb != nil && ba.OperatorToken != nil && bb.OperatorToken != nil &&
+			ba.OperatorToken.Kind == bb.OperatorToken.Kind &&
+			(ba.OperatorToken.Kind == ast.KindBarBarToken ||
+				ba.OperatorToken.Kind == ast.KindAmpersandAmpersandToken) {
+			return (nodesEqual(ba.Left, bb.Left, sf) && nodesEqual(ba.Right, bb.Right, sf)) ||
+				(nodesEqual(ba.Left, bb.Right, sf) && nodesEqual(ba.Right, bb.Left, sf))
+		}
+	}
+	return tokenSignature(sf, ua) == tokenSignature(sf, ub)
+}
+
+// andSetIsSubset reports whether every element of `sub` has a structurally
+// equal element in `super`, per nodesEqual semantics.
+func andSetIsSubset(sub, super []*ast.Node, sf *ast.SourceFile) bool {
+	for _, s := range sub {
+		found := false
+		for _, t := range super {
+			if nodesEqual(s, t, sf) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// tokenSignature produces a canonical whitespace-delimited token string used
+// for structural equality of leaf expressions. Matches ESLint's equalTokens
+// approach of comparing token streams, ignoring trivia.
+func tokenSignature(sf *ast.SourceFile, expr *ast.Node) string {
+	var b strings.Builder
+	src := sf.Text()
+	first := true
+	utils.ForEachToken(expr, func(token *ast.Node) {
+		r := utils.TrimNodeTextRange(sf, token)
+		if r.Pos() < r.End() {
+			if !first {
+				b.WriteByte(' ')
+			}
+			b.WriteString(src[r.Pos():r.End()])
+			first = false
+		}
+	}, sf)
+	return b.String()
+}

--- a/internal/rules/no_dupe_else_if/no_dupe_else_if.md
+++ b/internal/rules/no_dupe_else_if/no_dupe_else_if.md
@@ -1,0 +1,51 @@
+# no-dupe-else-if
+
+## Rule Details
+
+Disallow duplicate conditions in if-else-if chains. If an `else if` condition is identical to a previous condition in the same chain, the branch can never execute.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (a) {
+  foo();
+} else if (a) {
+  bar();
+}
+
+if (a) {
+  foo();
+} else if (b) {
+  bar();
+} else if (a) {
+  baz();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (a) {
+  foo();
+} else if (b) {
+  bar();
+}
+
+if (a === 1) {
+  foo();
+} else if (a === 2) {
+  bar();
+}
+
+if (a) {
+  foo();
+} else if (b) {
+  bar();
+} else {
+  baz();
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-dupe-else-if

--- a/internal/rules/no_dupe_else_if/no_dupe_else_if_test.go
+++ b/internal/rules/no_dupe_else_if/no_dupe_else_if_test.go
@@ -1,0 +1,387 @@
+package no_dupe_else_if
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDupeElseIfRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDupeElseIfRule,
+		[]rule_tester.ValidTestCase{
+			// different test conditions
+			{Code: `if (a) {} else if (b) {}`},
+			{Code: `if (a); else if (b); else if (c);`},
+			{Code: `if (true) {} else if (false) {} else {}`},
+			{Code: `if (1) {} else if (2) {}`},
+			{Code: `if (f) {} else if (f()) {}`},
+			{Code: `if (f(a)) {} else if (g(a)) {}`},
+			{Code: `if (f(a)) {} else if (f(b)) {}`},
+			{Code: `if (a === 1) {} else if (a === 2) {}`},
+			{Code: `if (a === 1) {} else if (b === 1) {}`},
+
+			// not an if-else-if chain
+			{Code: `if (a) {}`},
+			{Code: `if (a);`},
+			{Code: `if (a) {} else {}`},
+			{Code: `if (a) if (a) {}`},
+			{Code: `if (a) if (a);`},
+			{Code: `if (a) { if (a) {} }`},
+			{Code: `if (a) {} else { if (a) {} }`},
+			{Code: `if (a) {} if (a) {}`},
+			{Code: `if (a); if (a);`},
+			{Code: `while (a) if (a);`},
+			{Code: `if (a); else a ? a : a;`},
+
+			// not same conditions in the chain
+			{Code: `if (a) { if (b) {} } else if (b) {}`},
+			{Code: `if (a) if (b); else if (a);`},
+
+			// not equal tokens
+			{Code: `if (a) {} else if (!!a) {}`},
+			{Code: `if (a === 1) {} else if (a === (1)) {}`},
+
+			// more complex valid chains
+			{Code: `if (a || b) {} else if (c || d) {}`},
+			{Code: `if (a || b) {} else if (a || c) {}`},
+			{Code: `if (a) {} else if (a || b) {}`},
+			{Code: `if (a) {} else if (b) {} else if (a || b || c) {}`},
+			{Code: `if (a && b) {} else if (a) {} else if (b) {}`},
+			{Code: `if (a && b) {} else if (b && c) {} else if (a && c) {}`},
+			{Code: `if (a && b) {} else if (b || c) {}`},
+			{Code: `if (a) {} else if (b && (a || c)) {}`},
+			{Code: `if (a) {} else if (b && (c || d && a)) {}`},
+			{Code: `if (a && b && c) {} else if (a && b && (c || d)) {}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// basic
+			{
+				Code: `if (a) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `if (a); else if (a);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `if (a) {} else if (a) {} else {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (a) {} else if (c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (c) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 50},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+
+			// multiple duplicates
+			{
+				Code: `if (a) {} else if (a) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+					{MessageId: "unexpected", Line: 1, Column: 50},
+					{MessageId: "unexpected", Line: 1, Column: 65},
+				},
+			},
+
+			// inner if statements do not affect chain
+			{
+				Code: `if (a) { if (b) {} } else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+
+			// various kinds of test conditions
+			{
+				Code: `if (a === 1) {} else if (a === 1) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `if (1 < a) {} else if (1 < a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `if (true) {} else if (true) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `if (a && b) {} else if (a && b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a && b || c)  {} else if (a && b || c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `if (f(a)) {} else if (f(a)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+
+			// spaces and comments do not affect comparison
+			{
+				Code: `if (a === 1) {} else if (a===1) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `if (a === 1) {} else if (a === /* comment */ 1) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+
+			// extra parens around the whole test condition
+			{
+				Code: `if (a === 1) {} else if ((a === 1)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+
+			// more complex errors with || and &&
+			{
+				Code: `if (a || b) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if (a) {} else if (b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+					{MessageId: "unexpected", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if (b || a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (a || b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if (c || d) {} else if (a || d) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 45},
+				},
+			},
+			{
+				Code: `if ((a === b && fn(c)) || d) {} else if (fn(c) && a === b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code: `if (a) {} else if (a && b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `if (a && b) {} else if (b && a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a && b) {} else if (a && b && c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a || c) {} else if (a && b || c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (c && a || b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (c && (a || b)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b && c) {} else if (d && (a || e && c && b)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `if (a || b && c) {} else if (b && c && d) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 30},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if (b && c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if ((a || b) && c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if ((a && (b || c)) || d) {} else if ((c || b) && e && a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 39},
+				},
+			},
+			{
+				Code: `if (a && b || b && c) {} else if (a && b && c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b && c) {} else if (d && (c && e && b || a)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `if (a || (b && (c || d))) {} else if ((d || c) && b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 39},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if ((b || a) && c) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if (c) {} else if (d) {} else if (b && (a || c)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 55},
+				},
+			},
+			{
+				Code: `if (a || b || c) {} else if (a || (b && d) || (c && e)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 30},
+				},
+			},
+			{
+				Code: `if (a || (b || c)) {} else if (a || (b && c)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code: `if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 55},
+				},
+			},
+			{
+				Code: `if (a) {} else if (b) {} else if (c && (a || d && b)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `if (a) {} else if (a || a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `if (a || a) {} else if (a || a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a || a) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a) {} else if (a && a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `if (a && a) {} else if (a && a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `if (a && a) {} else if (a) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -252,6 +252,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/unified-signatures.test.ts',
     // './tests/typescript-eslint/rules/use-unknown-in-catch-callback-variable.test.ts',
     './tests/eslint/rules/no-control-regex.test.ts',
+    './tests/eslint/rules/no-dupe-else-if.test.ts',
     './tests/eslint/rules/no-extra-boolean-cast.test.ts',
     './tests/eslint/rules/no-empty-character-class.test.ts',
     './tests/eslint/rules/no-fallthrough.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-dupe-else-if.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-dupe-else-if.test.ts.snap
@@ -1,0 +1,1387 @@
+// Rstest Snapshot v1
+
+exports[`no-dupe-else-if > invalid 1`] = `
+{
+  "code": "if (a) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 2`] = `
+{
+  "code": "if (a); else if (a);",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 3`] = `
+{
+  "code": "if (a) {} else if (a) {} else {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 4`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (a) {} else if (c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 5`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 6`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (c) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 7`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 8`] = `
+{
+  "code": "if (a) {} else if (a) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 9`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 65,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 10`] = `
+{
+  "code": "if (a) { if (b) {} } else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 11`] = `
+{
+  "code": "if (a === 1) {} else if (a === 1) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 12`] = `
+{
+  "code": "if (1 < a) {} else if (1 < a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 13`] = `
+{
+  "code": "if (true) {} else if (true) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 14`] = `
+{
+  "code": "if (a && b) {} else if (a && b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 15`] = `
+{
+  "code": "if (a && b || c)  {} else if (a && b || c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 16`] = `
+{
+  "code": "if (f(a)) {} else if (f(a)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 17`] = `
+{
+  "code": "if (a === 1) {} else if (a===1) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 18`] = `
+{
+  "code": "if (a === 1) {} else if (a === /* comment */ 1) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 19`] = `
+{
+  "code": "if (a === 1) {} else if ((a === 1)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 20`] = `
+{
+  "code": "if (a || b) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 21`] = `
+{
+  "code": "if (a || b) {} else if (a) {} else if (b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 22`] = `
+{
+  "code": "if (a || b) {} else if (b || a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 23`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (a || b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 24`] = `
+{
+  "code": "if (a || b) {} else if (c || d) {} else if (a || d) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 25`] = `
+{
+  "code": "if ((a === b && fn(c)) || d) {} else if (fn(c) && a === b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 26`] = `
+{
+  "code": "if (a) {} else if (a && b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 27`] = `
+{
+  "code": "if (a && b) {} else if (b && a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 28`] = `
+{
+  "code": "if (a && b) {} else if (a && b && c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 29`] = `
+{
+  "code": "if (a || c) {} else if (a && b || c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 30`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (c && a || b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 31`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (c && (a || b)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 32`] = `
+{
+  "code": "if (a) {} else if (b && c) {} else if (d && (a || e && c && b)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 33`] = `
+{
+  "code": "if (a || b && c) {} else if (b && c && d) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 34`] = `
+{
+  "code": "if (a || b) {} else if (b && c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 35`] = `
+{
+  "code": "if (a) {} else if (b) {} else if ((a || b) && c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 36`] = `
+{
+  "code": "if ((a && (b || c)) || d) {} else if ((c || b) && e && a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 37`] = `
+{
+  "code": "if (a && b || b && c) {} else if (a && b && c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 38`] = `
+{
+  "code": "if (a) {} else if (b && c) {} else if (d && (c && e && b || a)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 39`] = `
+{
+  "code": "if (a || (b && (c || d))) {} else if ((d || c) && b) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 40`] = `
+{
+  "code": "if (a || b) {} else if ((b || a) && c) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 41`] = `
+{
+  "code": "if (a || b) {} else if (c) {} else if (d) {} else if (b && (a || c)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 42`] = `
+{
+  "code": "if (a || b || c) {} else if (a || (b && d) || (c && e)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 43`] = `
+{
+  "code": "if (a || (b || c)) {} else if (a || (b && c)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 44`] = `
+{
+  "code": "if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 45`] = `
+{
+  "code": "if (a) {} else if (b) {} else if (c && (a || d && b)) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 46`] = `
+{
+  "code": "if (a) {} else if (a || a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 47`] = `
+{
+  "code": "if (a || a) {} else if (a || a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 48`] = `
+{
+  "code": "if (a || a) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 49`] = `
+{
+  "code": "if (a) {} else if (a && a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 50`] = `
+{
+  "code": "if (a && a) {} else if (a && a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-else-if > invalid 51`] = `
+{
+  "code": "if (a && a) {} else if (a) {}",
+  "diagnostics": [
+    {
+      "message": "This branch can never execute. Its condition is a duplicate or covered by previous conditions in the if-else-if chain.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-else-if",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-dupe-else-if.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-dupe-else-if.test.ts
@@ -1,0 +1,280 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-dupe-else-if', {
+  valid: [
+    // different test conditions
+    'if (a) {} else if (b) {}',
+    'if (a); else if (b); else if (c);',
+    'if (true) {} else if (false) {} else {}',
+    'if (1) {} else if (2) {}',
+    'if (f) {} else if (f()) {}',
+    'if (f(a)) {} else if (g(a)) {}',
+    'if (f(a)) {} else if (f(b)) {}',
+    'if (a === 1) {} else if (a === 2) {}',
+    'if (a === 1) {} else if (b === 1) {}',
+
+    // not an if-else-if chain
+    'if (a) {}',
+    'if (a);',
+    'if (a) {} else {}',
+    'if (a) if (a) {}',
+    'if (a) if (a);',
+    'if (a) { if (a) {} }',
+    'if (a) {} else { if (a) {} }',
+    'if (a) {} if (a) {}',
+    'if (a); if (a);',
+    'while (a) if (a);',
+    'if (a); else a ? a : a;',
+
+    // not same conditions in the chain
+    'if (a) { if (b) {} } else if (b) {}',
+    'if (a) if (b); else if (a);',
+
+    // not equal tokens
+    'if (a) {} else if (!!a) {}',
+    'if (a === 1) {} else if (a === (1)) {}',
+
+    // more complex valid chains
+    'if (a || b) {} else if (c || d) {}',
+    'if (a || b) {} else if (a || c) {}',
+    'if (a) {} else if (a || b) {}',
+    'if (a) {} else if (b) {} else if (a || b || c) {}',
+    'if (a && b) {} else if (a) {} else if (b) {}',
+    'if (a && b) {} else if (b && c) {} else if (a && c) {}',
+    'if (a && b) {} else if (b || c) {}',
+    'if (a) {} else if (b && (a || c)) {}',
+    'if (a) {} else if (b && (c || d && a)) {}',
+    'if (a && b && c) {} else if (a && b && (c || d)) {}',
+  ],
+  invalid: [
+    // basic
+    {
+      code: 'if (a) {} else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 20 }],
+    },
+    {
+      code: 'if (a); else if (a);',
+      errors: [{ messageId: 'unexpected', column: 18 }],
+    },
+    {
+      code: 'if (a) {} else if (a) {} else {}',
+      errors: [{ messageId: 'unexpected', column: 20 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (a) {} else if (c) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (c) {} else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 50 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (b) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+
+    // multiple duplicates
+    {
+      code: 'if (a) {} else if (a) {} else if (a) {}',
+      errors: [
+        { messageId: 'unexpected', column: 20 },
+        { messageId: 'unexpected', column: 35 },
+      ],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (a) {} else if (b) {} else if (a) {}',
+      errors: [
+        { messageId: 'unexpected', column: 35 },
+        { messageId: 'unexpected', column: 50 },
+        { messageId: 'unexpected', column: 65 },
+      ],
+    },
+
+    // inner if statements do not affect chain
+    {
+      code: 'if (a) { if (b) {} } else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 31 }],
+    },
+
+    // various kinds of test conditions
+    {
+      code: 'if (a === 1) {} else if (a === 1) {}',
+      errors: [{ messageId: 'unexpected', column: 26 }],
+    },
+    {
+      code: 'if (1 < a) {} else if (1 < a) {}',
+      errors: [{ messageId: 'unexpected', column: 24 }],
+    },
+    {
+      code: 'if (true) {} else if (true) {}',
+      errors: [{ messageId: 'unexpected', column: 23 }],
+    },
+    {
+      code: 'if (a && b) {} else if (a && b) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a && b || c)  {} else if (a && b || c) {}',
+      errors: [{ messageId: 'unexpected', column: 31 }],
+    },
+    {
+      code: 'if (f(a)) {} else if (f(a)) {}',
+      errors: [{ messageId: 'unexpected', column: 23 }],
+    },
+
+    // spaces and comments do not affect comparison
+    {
+      code: 'if (a === 1) {} else if (a===1) {}',
+      errors: [{ messageId: 'unexpected', column: 26 }],
+    },
+    {
+      code: 'if (a === 1) {} else if (a === /* comment */ 1) {}',
+      errors: [{ messageId: 'unexpected', column: 26 }],
+    },
+
+    // extra parens around the whole test condition
+    {
+      code: 'if (a === 1) {} else if ((a === 1)) {}',
+      errors: [{ messageId: 'unexpected', column: 27 }],
+    },
+
+    // more complex errors with || and &&
+    {
+      code: 'if (a || b) {} else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a || b) {} else if (a) {} else if (b) {}',
+      errors: [
+        { messageId: 'unexpected', column: 25 },
+        { messageId: 'unexpected', column: 40 },
+      ],
+    },
+    {
+      code: 'if (a || b) {} else if (b || a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (a || b) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a || b) {} else if (c || d) {} else if (a || d) {}',
+      errors: [{ messageId: 'unexpected', column: 45 }],
+    },
+    {
+      code: 'if ((a === b && fn(c)) || d) {} else if (fn(c) && a === b) {}',
+      errors: [{ messageId: 'unexpected', column: 42 }],
+    },
+    {
+      code: 'if (a) {} else if (a && b) {}',
+      errors: [{ messageId: 'unexpected', column: 20 }],
+    },
+    {
+      code: 'if (a && b) {} else if (b && a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a && b) {} else if (a && b && c) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a || c) {} else if (a && b || c) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (c && a || b) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (c && (a || b)) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a) {} else if (b && c) {} else if (d && (a || e && c && b)) {}',
+      errors: [{ messageId: 'unexpected', column: 40 }],
+    },
+    {
+      code: 'if (a || b && c) {} else if (b && c && d) {}',
+      errors: [{ messageId: 'unexpected', column: 30 }],
+    },
+    {
+      code: 'if (a || b) {} else if (b && c) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if ((a || b) && c) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if ((a && (b || c)) || d) {} else if ((c || b) && e && a) {}',
+      errors: [{ messageId: 'unexpected', column: 39 }],
+    },
+    {
+      code: 'if (a && b || b && c) {} else if (a && b && c) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a) {} else if (b && c) {} else if (d && (c && e && b || a)) {}',
+      errors: [{ messageId: 'unexpected', column: 40 }],
+    },
+    {
+      code: 'if (a || (b && (c || d))) {} else if ((d || c) && b) {}',
+      errors: [{ messageId: 'unexpected', column: 39 }],
+    },
+    {
+      code: 'if (a || b) {} else if ((b || a) && c) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a || b) {} else if (c) {} else if (d) {} else if (b && (a || c)) {}',
+      errors: [{ messageId: 'unexpected', column: 55 }],
+    },
+    {
+      code: 'if (a || b || c) {} else if (a || (b && d) || (c && e)) {}',
+      errors: [{ messageId: 'unexpected', column: 30 }],
+    },
+    {
+      code: 'if (a || (b || c)) {} else if (a || (b && c)) {}',
+      errors: [{ messageId: 'unexpected', column: 32 }],
+    },
+    {
+      code: 'if (a || b) {} else if (c) {} else if (d) {} else if ((a || c) && (b || d)) {}',
+      errors: [{ messageId: 'unexpected', column: 55 }],
+    },
+    {
+      code: 'if (a) {} else if (b) {} else if (c && (a || d && b)) {}',
+      errors: [{ messageId: 'unexpected', column: 35 }],
+    },
+    {
+      code: 'if (a) {} else if (a || a) {}',
+      errors: [{ messageId: 'unexpected', column: 20 }],
+    },
+    {
+      code: 'if (a || a) {} else if (a || a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a || a) {} else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a) {} else if (a && a) {}',
+      errors: [{ messageId: 'unexpected', column: 20 }],
+    },
+    {
+      code: 'if (a && a) {} else if (a && a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+    {
+      code: 'if (a && a) {} else if (a) {}',
+      errors: [{ messageId: 'unexpected', column: 25 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-dupe-else-if` rule from ESLint to rslint.

Disallow duplicate conditions in if-else-if chains

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-dupe-else-if

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).