### PR TITLE
feat: port rule no-extra-boolean-cast

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
+	"github.com/web-infra-dev/rslint/internal/rules/no_extra_boolean_cast"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
@@ -573,6 +574,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
 	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)
+	GlobalRuleRegistry.Register("no-extra-boolean-cast", no_extra_boolean_cast.NoExtraBooleanCastRule)
 	GlobalRuleRegistry.Register("no-undef", no_undef.NoUndefRule)
 	GlobalRuleRegistry.Register("no-undef-init", no_undef_init.NoUndefInitRule)
 	GlobalRuleRegistry.Register("prefer-const", prefer_const.PreferConstRule)

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.go
@@ -1,0 +1,432 @@
+package no_extra_boolean_cast
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-extra-boolean-cast
+
+type options struct {
+	enforceForLogicalOperands  bool
+	enforceForInnerExpressions bool
+}
+
+func parseOptions(opts any) options {
+	result := options{}
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap == nil {
+		return result
+	}
+	if v, ok := optsMap["enforceForLogicalOperands"].(bool); ok {
+		result.enforceForLogicalOperands = v
+	}
+	if v, ok := optsMap["enforceForInnerExpressions"].(bool); ok {
+		result.enforceForInnerExpressions = v
+	}
+	return result
+}
+
+// effectiveParent returns the first non-parenthesized ancestor of node,
+// along with the direct child of that ancestor (either node itself or the
+// outermost ParenthesizedExpression wrapping it).
+func effectiveParent(node *ast.Node) (parent, child *ast.Node) {
+	child = node
+	for child.Parent != nil && ast.IsParenthesizedExpression(child.Parent) {
+		child = child.Parent
+	}
+	return child.Parent, child
+}
+
+// isBooleanFunctionOrConstructorCall reports whether node is a
+// Boolean(...) call or new Boolean(...) construction.
+func isBooleanFunctionOrConstructorCall(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	var callee *ast.Node
+	switch node.Kind {
+	case ast.KindCallExpression:
+		callee = node.AsCallExpression().Expression
+	case ast.KindNewExpression:
+		callee = node.AsNewExpression().Expression
+	default:
+		return false
+	}
+	if callee == nil || callee.Kind != ast.KindIdentifier {
+		return false
+	}
+	return callee.AsIdentifier().Text == "Boolean"
+}
+
+// firstArgument returns the first argument node of a Boolean(...) /
+// new Boolean(...) call, or nil when absent.
+func firstArgument(node *ast.Node) *ast.Node {
+	var args *ast.NodeList
+	switch node.Kind {
+	case ast.KindCallExpression:
+		args = node.AsCallExpression().Arguments
+	case ast.KindNewExpression:
+		args = node.AsNewExpression().Arguments
+	default:
+		return nil
+	}
+	if args == nil || len(args.Nodes) == 0 {
+		return nil
+	}
+	return args.Nodes[0]
+}
+
+// isInBooleanContext reports whether node sits in a position that
+// already coerces to boolean: the test of if / while / do-while / for,
+// the condition of a ternary, the operand of `!`, or the first argument
+// to Boolean() / new Boolean().
+func isInBooleanContext(node *ast.Node) bool {
+	parent, child := effectiveParent(node)
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindIfStatement:
+		return parent.AsIfStatement().Expression == child
+	case ast.KindWhileStatement:
+		return parent.AsWhileStatement().Expression == child
+	case ast.KindDoStatement:
+		return parent.AsDoStatement().Expression == child
+	case ast.KindForStatement:
+		return parent.AsForStatement().Condition == child
+	case ast.KindConditionalExpression:
+		return parent.AsConditionalExpression().Condition == child
+	case ast.KindPrefixUnaryExpression:
+		return parent.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken
+	case ast.KindCallExpression, ast.KindNewExpression:
+		if !isBooleanFunctionOrConstructorCall(parent) {
+			return false
+		}
+		return firstArgument(parent) == child
+	}
+	return false
+}
+
+// isInFlaggedContext reports whether node is in a context where a
+// redundant boolean cast should be flagged. When the legacy
+// `enforceForLogicalOperands` or the current `enforceForInnerExpressions`
+// option is set, recurses through logical / nullish / conditional /
+// sequence (comma) parents to reach an outer boolean context.
+func isInFlaggedContext(node *ast.Node, opts options) bool {
+	parent, child := effectiveParent(node)
+	if parent == nil {
+		return false
+	}
+
+	if opts.enforceForLogicalOperands || opts.enforceForInnerExpressions {
+		if parent.Kind == ast.KindBinaryExpression {
+			bin := parent.AsBinaryExpression()
+			if bin.OperatorToken != nil {
+				op := bin.OperatorToken.Kind
+				if op == ast.KindBarBarToken || op == ast.KindAmpersandAmpersandToken {
+					return isInFlaggedContext(parent, opts)
+				}
+				if opts.enforceForInnerExpressions && op == ast.KindQuestionQuestionToken && bin.Right == child {
+					return isInFlaggedContext(parent, opts)
+				}
+			}
+		}
+	}
+
+	if opts.enforceForInnerExpressions {
+		if parent.Kind == ast.KindConditionalExpression {
+			cond := parent.AsConditionalExpression()
+			if cond.WhenTrue == child || cond.WhenFalse == child {
+				return isInFlaggedContext(parent, opts)
+			}
+		}
+		// TypeScript parses `a, b, c` as a left-associative nested
+		// BinaryExpression tree. The "last expression" — the only one
+		// whose value propagates — is always the Right operand of the
+		// outermost comma binary.
+		if parent.Kind == ast.KindBinaryExpression {
+			bin := parent.AsBinaryExpression()
+			if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken && bin.Right == child {
+				return isInFlaggedContext(parent, opts)
+			}
+		}
+	}
+
+	return isInBooleanContext(node)
+}
+
+// ---------------------------------------------------------------------
+// Fixer helpers
+// ---------------------------------------------------------------------
+
+// isCommaSequence reports whether node is a `a, b` comma binary.
+func isCommaSequence(node *ast.Node) bool {
+	if !ast.IsBinaryExpression(node) {
+		return false
+	}
+	op := node.AsBinaryExpression().OperatorToken
+	return op != nil && op.Kind == ast.KindCommaToken
+}
+
+// isLogicalOrCoalesceOp reports whether op is `||`, `&&`, or `??`.
+func isLogicalOrCoalesceOp(op ast.Kind) bool {
+	return op == ast.KindBarBarToken || op == ast.KindAmpersandAmpersandToken || op == ast.KindQuestionQuestionToken
+}
+
+// isMixedLogicalAndCoalesce returns true when a replacement node and its
+// new binary parent combine `??` with `||`/`&&` — a combination that is
+// a syntax error without grouping parens.
+func isMixedLogicalAndCoalesce(node, parent *ast.Node) bool {
+	if !ast.IsBinaryExpression(node) || !ast.IsBinaryExpression(parent) {
+		return false
+	}
+	nOp := node.AsBinaryExpression().OperatorToken
+	pOp := parent.AsBinaryExpression().OperatorToken
+	if nOp == nil || pOp == nil {
+		return false
+	}
+	nodeCoalesce := nOp.Kind == ast.KindQuestionQuestionToken
+	nodeLogical := nOp.Kind == ast.KindBarBarToken || nOp.Kind == ast.KindAmpersandAmpersandToken
+	parentCoalesce := pOp.Kind == ast.KindQuestionQuestionToken
+	parentLogical := pOp.Kind == ast.KindBarBarToken || pOp.Kind == ast.KindAmpersandAmpersandToken
+	return (nodeCoalesce && parentLogical) || (nodeLogical && parentCoalesce)
+}
+
+// needsParens reports whether inserting `replacement`'s text in place of
+// `previousNode` would require wrapping it in grouping parentheses to
+// preserve semantics. Mirrors ESLint's `needsParens` helper.
+func needsParens(previousNode, replacement *ast.Node) bool {
+	// If previousNode is already wrapped in parens, those parens stay
+	// around the replacement text, so no additional parens are needed.
+	if previousNode.Parent != nil && ast.IsParenthesizedExpression(previousNode.Parent) {
+		return false
+	}
+	parent := previousNode.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindCallExpression, ast.KindNewExpression:
+		// A bare comma expression as an argument would be read as
+		// separate positional arguments — wrap it.
+		return isCommaSequence(replacement)
+	case ast.KindIfStatement, ast.KindDoStatement, ast.KindWhileStatement, ast.KindForStatement:
+		return false
+	case ast.KindConditionalExpression:
+		cond := parent.AsConditionalExpression()
+		if cond.Condition == previousNode {
+			return ast.GetExpressionPrecedence(replacement) <= ast.GetExpressionPrecedence(parent)
+		}
+		if cond.WhenTrue == previousNode || cond.WhenFalse == previousNode {
+			// ESLint compares against AssignmentExpression precedence:
+			// a comma expression is the only thing that needs parens
+			// here.
+			return ast.GetExpressionPrecedence(replacement) < ast.OperatorPrecedenceAssignment
+		}
+		return false
+	case ast.KindPrefixUnaryExpression:
+		return ast.GetExpressionPrecedence(replacement) < ast.GetExpressionPrecedence(parent)
+	case ast.KindBinaryExpression:
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken == nil {
+			return false
+		}
+		op := bin.OperatorToken.Kind
+		if op == ast.KindCommaToken {
+			// ESLint's SequenceExpression branch — no extra parens.
+			return false
+		}
+		if isLogicalOrCoalesceOp(op) && isMixedLogicalAndCoalesce(replacement, parent) {
+			return true
+		}
+		if bin.Left == previousNode {
+			return ast.GetExpressionPrecedence(replacement) < ast.GetExpressionPrecedence(parent)
+		}
+		return ast.GetExpressionPrecedence(replacement) <= ast.GetExpressionPrecedence(parent)
+	}
+	return false
+}
+
+// maybePrefixSpace returns replacement with a single leading space
+// prepended when inserting it at trimStart would merge with the
+// preceding token into a single identifier/keyword.
+func maybePrefixSpace(sourceFile *ast.SourceFile, replaceRange core.TextRange, replacement string) string {
+	if utils.NeedsLeadingSpaceForReplacement(sourceFile.Text(), replaceRange.Pos(), replacement) {
+		return " " + replacement
+	}
+	return replacement
+}
+
+// hasCommentsInSpan reports whether any `//` or `/*` sequence appears in
+// the half-open source range [start, end). `utils.HasCommentsInRange`
+// only surfaces comments anchored at the range start, so a raw text
+// scan is required to catch comments sprinkled *between* children
+// (e.g. `!!/* keep */foo`).
+func hasCommentsInSpan(src string, start, end int) bool {
+	if start < 0 {
+		start = 0
+	}
+	if end > len(src) {
+		end = len(src)
+	}
+	for i := start; i+1 < end; i++ {
+		if src[i] == '/' && (src[i+1] == '/' || src[i+1] == '*') {
+			return true
+		}
+	}
+	return false
+}
+
+// buildNegationFix returns the fix for a redundant `!!expr`. outerUnary
+// is the outer `!` of `!!expr`.
+func buildNegationFix(ctx rule.RuleContext, outerUnary *ast.Node) []rule.RuleFix {
+	innerUnary := outerUnary.AsPrefixUnaryExpression().Operand
+	if innerUnary == nil {
+		return nil
+	}
+	argument := innerUnary.AsPrefixUnaryExpression().Operand
+	if argument == nil {
+		return nil
+	}
+
+	replaceRange := utils.TrimNodeTextRange(ctx.SourceFile, outerUnary)
+	if hasCommentsInSpan(ctx.SourceFile.Text(), replaceRange.Pos(), replaceRange.End()) {
+		return nil
+	}
+
+	// ESLint's AST has no parenthesized-expression nodes — the argument
+	// of `!!` is whatever the parens wrap. Match that by peeling any
+	// ParenthesizedExpression wrappers before computing the replacement
+	// text so `!!(a19)` → `a19` (not `(a19)`).
+	inner := ast.SkipParentheses(argument)
+	argText := utils.TrimmedNodeText(ctx.SourceFile, inner)
+
+	if needsParens(outerUnary, inner) {
+		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, outerUnary, "("+argText+")")}
+	}
+
+	return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, outerUnary, maybePrefixSpace(ctx.SourceFile, replaceRange, argText))}
+}
+
+// buildCallFix returns the fix for a redundant `Boolean(...)` call.
+func buildCallFix(ctx rule.RuleContext, callNode *ast.Node) []rule.RuleFix {
+	call := callNode.AsCallExpression()
+	args := call.Arguments
+
+	argCount := 0
+	if args != nil {
+		argCount = len(args.Nodes)
+	}
+
+	callRange := utils.TrimNodeTextRange(ctx.SourceFile, callNode)
+
+	if argCount == 0 {
+		// `Boolean()` alone is `false`. `!Boolean()` collapses to `true`
+		// — we replace the parent unary in that case so the `!` goes
+		// away together.
+		parent, _ := effectiveParent(callNode)
+		if parent != nil && parent.Kind == ast.KindPrefixUnaryExpression &&
+			parent.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken {
+			parentRange := utils.TrimNodeTextRange(ctx.SourceFile, parent)
+			if hasCommentsInSpan(ctx.SourceFile.Text(), parentRange.Pos(), parentRange.End()) {
+				return nil
+			}
+			return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, parent, maybePrefixSpace(ctx.SourceFile, parentRange, "true"))}
+		}
+
+		if hasCommentsInSpan(ctx.SourceFile.Text(), callRange.Pos(), callRange.End()) {
+			return nil
+		}
+		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, callNode, maybePrefixSpace(ctx.SourceFile, callRange, "false"))}
+	}
+
+	if argCount == 1 {
+		arg := args.Nodes[0]
+		if ast.IsSpreadElement(arg) {
+			return nil
+		}
+		if hasCommentsInSpan(ctx.SourceFile.Text(), callRange.Pos(), callRange.End()) {
+			return nil
+		}
+		// Peel parens to match ESLint's paren-less AST; see buildNegationFix.
+		inner := ast.SkipParentheses(arg)
+		argText := utils.TrimmedNodeText(ctx.SourceFile, inner)
+		if needsParens(callNode, inner) {
+			return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, callNode, "("+argText+")")}
+		}
+		return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, callNode, maybePrefixSpace(ctx.SourceFile, callRange, argText))}
+	}
+
+	// Two or more arguments: unsafe to drop, skip the fix.
+	return nil
+}
+
+// NoExtraBooleanCastRule disallows unnecessary boolean casts.
+// Reports `!!expr` (double negation) and `Boolean(expr)` calls in
+// contexts that already coerce to boolean.
+var NoExtraBooleanCastRule = rule.Rule{
+	Name: "no-extra-boolean-cast",
+	Run: func(ctx rule.RuleContext, ruleOptions any) rule.RuleListeners {
+		opts := parseOptions(ruleOptions)
+
+		negationMsg := rule.RuleMessage{
+			Id:          "unexpectedNegation",
+			Description: "Redundant double negation.",
+		}
+		callMsg := rule.RuleMessage{
+			Id:          "unexpectedCall",
+			Description: "Redundant Boolean call.",
+		}
+
+		return rule.RuleListeners{
+			// Detect !!expr (double negation) in a flagged context.
+			ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+				prefix := node.AsPrefixUnaryExpression()
+				if prefix == nil || prefix.Operator != ast.KindExclamationToken {
+					return
+				}
+				operand := prefix.Operand
+				if operand == nil || !ast.IsPrefixUnaryExpression(operand) {
+					return
+				}
+				if operand.AsPrefixUnaryExpression().Operator != ast.KindExclamationToken {
+					return
+				}
+				if !isInFlaggedContext(node, opts) {
+					return
+				}
+				if fixes := buildNegationFix(ctx, node); fixes != nil {
+					ctx.ReportNodeWithFixes(node, negationMsg, fixes...)
+				} else {
+					ctx.ReportNode(node, negationMsg)
+				}
+			},
+
+			// Detect Boolean(expr) in a flagged context.
+			//
+			// `new Boolean(...)` is intentionally NOT listened to here —
+			// matching ESLint. `new Boolean(x)` creates a Boolean object,
+			// which is always truthy in a boolean context, so it is not
+			// equivalent to a plain `x` and cannot be called "redundant".
+			// `isBooleanFunctionOrConstructorCall` is still used when
+			// determining whether an inner expression is in a boolean
+			// context (argument to `new Boolean(...)`).
+			ast.KindCallExpression: func(node *ast.Node) {
+				if !isBooleanFunctionOrConstructorCall(node) {
+					return
+				}
+				if !isInFlaggedContext(node, opts) {
+					return
+				}
+				if fixes := buildCallFix(ctx, node); fixes != nil {
+					ctx.ReportNodeWithFixes(node, callMsg, fixes...)
+				} else {
+					ctx.ReportNode(node, callMsg)
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.md
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.md
@@ -1,0 +1,71 @@
+# no-extra-boolean-cast
+
+## Rule Details
+
+Disallows unnecessary boolean casts. Using `!!` (double negation) or `Boolean()` to convert a value to boolean is redundant when the value is already in a boolean context, such as the test of an `if` statement.
+
+`new Boolean(x)` is never flagged because it produces a Boolean **object** (always truthy) rather than a primitive, so replacing it with a plain value would change semantics.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+if (!!foo) {
+}
+while (!!foo) {}
+do {} while (!!foo);
+for (; !!foo; ) {}
+!!foo ? bar : baz;
+!!!foo;
+if (Boolean(foo)) {
+}
+!Boolean(foo);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+if (foo) {
+}
+while (foo) {}
+var bar = !!foo;
+var bar = Boolean(foo);
+function baz() {
+  return !!foo;
+}
+if (new Boolean(foo)) {
+} // always truthy — not equivalent to `if (foo)`
+```
+
+## Options
+
+This rule accepts a single options object.
+
+### `enforceForLogicalOperands` (legacy)
+
+When `true`, the rule also reports redundant boolean casts that are operands of `||` or `&&` when the overall logical expression is used in a boolean context.
+
+```javascript
+/* eslint no-extra-boolean-cast: ["error", { "enforceForLogicalOperands": true }] */
+
+if (x || !!y) {
+} // reported
+```
+
+### `enforceForInnerExpressions`
+
+A superset of `enforceForLogicalOperands`. Additionally reports redundant casts on the right-hand side of `??`, on the branches of ternaries, and on the last expression of a sequence (`a, b, c`).
+
+```javascript
+/* eslint no-extra-boolean-cast: ["error", { "enforceForInnerExpressions": true }] */
+
+if (x ?? !!y) {
+} // reported
+if (cond ? Boolean(a) : b) {
+} // reported
+if ((a, b, Boolean(c))) {
+} // reported
+```
+
+## Original Documentation
+
+- [ESLint no-extra-boolean-cast](https://eslint.org/docs/latest/rules/no-extra-boolean-cast)

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast_test.go
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast_test.go
@@ -1,0 +1,338 @@
+package no_extra_boolean_cast
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExtraBooleanCastRule(t *testing.T) {
+	enforceLogicalOperands := map[string]any{"enforceForLogicalOperands": true}
+	enforceInnerExpressions := map[string]any{"enforceForInnerExpressions": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoExtraBooleanCastRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// !! not in boolean context
+			{Code: `var foo = !!bar;`},
+			{Code: `function foo() { return !!bar; }`},
+			// Boolean() not in boolean context
+			{Code: `var foo = Boolean(bar);`},
+			// No extra cast
+			{Code: `if (foo) {}`},
+			// !! in for initializer (not condition)
+			{Code: `for(!!foo;;) {}`},
+			// new Boolean() outside boolean context is fine
+			{Code: `var x = new Boolean(foo);`},
+			// new Boolean() is never flagged — it produces a truthy
+			// object, so it is not equivalent to a plain value in a
+			// boolean context (matches ESLint).
+			{Code: `if (new Boolean(foo)) {}`},
+			{Code: `while (new Boolean(foo)) {}`},
+			{Code: `!new Boolean(foo)`},
+			// Boolean identifier alone is not a call
+			{Code: `var x = Boolean;`},
+			// Single negation is not redundant
+			{Code: `if (!foo) {}`},
+			// Non-Boolean named function should not trigger
+			{Code: `if (Foo(bar)) {}`},
+			// Not flagged when enforceForLogicalOperands is off
+			{Code: `if (x || !!y) {}`},
+			{Code: `if (x && Boolean(y)) {}`},
+			// Not flagged when enforceForInnerExpressions is off
+			{Code: `if (x ? !!y : z) {}`},
+			{Code: `if (x ?? !!y) {}`},
+			{Code: `if ((x, !!y, z)) {}`}, // not the last expression, Boolean() form
+			// enforceForLogicalOperands: ?? is not included (only with enforceForInnerExpressions)
+			{Code: `if (x ?? !!y) {}`, Options: []any{enforceLogicalOperands}},
+			// enforceForInnerExpressions: ?? but !! is on the LEFT (not reached)
+			{Code: `if (!!x ?? y) {}`, Options: []any{enforceInnerExpressions}},
+			// enforceForInnerExpressions: not the last expression in a sequence
+			{Code: `if ((Boolean(a), b)) {}`, Options: []any{enforceInnerExpressions}},
+			// Inner parentheses wrapping !! or Boolean() outside boolean context
+			{Code: `var x = (!!foo);`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// !! in if test
+			{
+				Code:   `if (!!foo) {}`,
+				Output: []string{`if (foo) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 5},
+				},
+			},
+			// !! in while test
+			{
+				Code:   `while (!!foo) {}`,
+				Output: []string{`while (foo) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 8},
+				},
+			},
+			// !! in do-while test
+			{
+				Code:   `do {} while (!!foo)`,
+				Output: []string{`do {} while (foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 14},
+				},
+			},
+			// !! in for condition
+			{
+				Code:   `for (;!!foo;) {}`,
+				Output: []string{`for (;foo;) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 7},
+				},
+			},
+			// Boolean() in if test
+			{
+				Code:   `if (Boolean(foo)) {}`,
+				Output: []string{`if (foo) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 5},
+				},
+			},
+			// Boolean() in while test
+			{
+				Code:   `while (Boolean(foo)) {}`,
+				Output: []string{`while (foo) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 8},
+				},
+			},
+			// Boolean() as operand of !
+			{
+				Code:   `!Boolean(foo)`,
+				Output: []string{`!foo`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 2},
+				},
+			},
+			// !! in ternary condition
+			{
+				Code:   `!!foo ? bar : baz`,
+				Output: []string{`foo ? bar : baz`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 1},
+				},
+			},
+			// !!! - inner !! is operand of outer !
+			{
+				Code:   `!!!foo`,
+				Output: []string{`!foo`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 2},
+				},
+			},
+			// !! nested inside Boolean() call
+			{
+				Code:   `Boolean(!!foo)`,
+				Output: []string{`Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 9},
+				},
+			},
+			// Boolean() nested inside new Boolean() — the argument
+			// position of new Boolean() is treated as a boolean context
+			// (for recursion), so the inner Boolean() is flagged.
+			{
+				Code:   `new Boolean(Boolean(foo))`,
+				Output: []string{`new Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 13},
+				},
+			},
+			// !! nested inside new Boolean() — inner !! is flagged, outer
+			// new Boolean() is not.
+			{
+				Code:   `new Boolean(!!foo)`,
+				Output: []string{`new Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 13},
+				},
+			},
+			// Parenthesized !! in boolean context — wrapping parens stay.
+			{
+				Code:   `if ((!!foo)) {}`,
+				Output: []string{`if ((foo)) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `if ((Boolean(foo))) {}`,
+				Output: []string{`if ((foo)) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 6},
+				},
+			},
+			// Double parens
+			{
+				Code:   `if (((!!foo))) {}`,
+				Output: []string{`if (((foo))) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 7},
+				},
+			},
+			// Boolean() with no arguments in boolean context (via `!`).
+			{
+				Code:   `!Boolean()`,
+				Output: []string{`true`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 2},
+				},
+			},
+			// Boolean() with no args as argument of Boolean() — collapses
+			// to `false` (the inner call is replaced, the outer then goes
+			// away in a second pass because Boolean(false) is still flagged
+			// until fixed).
+			{
+				Code:   `if (Boolean()) {}`,
+				Output: []string{`if (false) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 5},
+				},
+			},
+			// Boolean(expr) with spread: fix is skipped, still reported.
+			{
+				Code:   `if (Boolean(...args)) {}`,
+				Output: nil,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 5},
+				},
+			},
+			// Boolean(a, b): two arguments, fix is skipped.
+			{
+				Code:   `if (Boolean(a, b)) {}`,
+				Output: nil,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 5},
+				},
+			},
+			// Comments inside — skip fix.
+			{
+				Code:   `if (!!/* keep */foo) {}`,
+				Output: nil,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code:   `if (Boolean(/* keep */foo)) {}`,
+				Output: nil,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 5},
+				},
+			},
+
+			// enforceForLogicalOperands: !! inside ||
+			{
+				Code:    `if (x || !!y) {}`,
+				Output:  []string{`if (x || y) {}`},
+				Options: []any{enforceLogicalOperands},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 10},
+				},
+			},
+			// enforceForLogicalOperands: Boolean() inside &&
+			{
+				Code:    `while (x && Boolean(y)) {}`,
+				Output:  []string{`while (x && y) {}`},
+				Options: []any{enforceLogicalOperands},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 13},
+				},
+			},
+			// enforceForLogicalOperands: deeply nested ||
+			{
+				Code:    `if (a || (b && !!c)) {}`,
+				Output:  []string{`if (a || (b && c)) {}`},
+				Options: []any{enforceLogicalOperands},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 16},
+				},
+			},
+			// enforceForLogicalOperands: Boolean() as left of ||
+			{
+				Code:    `if (Boolean(a) || b) {}`,
+				Output:  []string{`if (a || b) {}`},
+				Options: []any{enforceLogicalOperands},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 5},
+				},
+			},
+
+			// enforceForInnerExpressions: !! inside ?? right operand
+			{
+				Code:    `if (x ?? !!y) {}`,
+				Output:  []string{`if (x ?? y) {}`},
+				Options: []any{enforceInnerExpressions},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 10},
+				},
+			},
+			// enforceForInnerExpressions: Boolean() inside ternary consequent
+			{
+				Code:    `if (cond ? Boolean(a) : b) {}`,
+				Output:  []string{`if (cond ? a : b) {}`},
+				Options: []any{enforceInnerExpressions},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 12},
+				},
+			},
+			// enforceForInnerExpressions: !! inside ternary alternate
+			{
+				Code:    `if (cond ? a : !!b) {}`,
+				Output:  []string{`if (cond ? a : b) {}`},
+				Options: []any{enforceInnerExpressions},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 16},
+				},
+			},
+			// enforceForInnerExpressions: last expression of a sequence
+			{
+				Code:    `if ((a, b, Boolean(c))) {}`,
+				Output:  []string{`if ((a, b, c)) {}`},
+				Options: []any{enforceInnerExpressions},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 12},
+				},
+			},
+			// enforceForInnerExpressions also handles ||/&&
+			{
+				Code:    `if (x || !!y) {}`,
+				Output:  []string{`if (x || y) {}`},
+				Options: []any{enforceInnerExpressions},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 10},
+				},
+			},
+			// enforceForInnerExpressions: composed logical + ternary chain
+			{
+				Code:    `if (a ? (b || !!c) : d) {}`,
+				Output:  []string{`if (a ? (b || c) : d) {}`},
+				Options: []any{enforceInnerExpressions},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedNegation", Line: 1, Column: 15},
+				},
+			},
+			// Mixed logical + coalesce: replacement keeps its own parens
+			// to avoid a syntax error (`a && b ?? c` is not valid).
+			{
+				Code:    `if (a && Boolean(b ?? c)) {}`,
+				Output:  []string{`if (a && (b ?? c)) {}`},
+				Options: []any{enforceLogicalOperands},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCall", Line: 1, Column: 10},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -252,6 +252,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/unified-signatures.test.ts',
     // './tests/typescript-eslint/rules/use-unknown-in-catch-callback-variable.test.ts',
     './tests/eslint/rules/no-control-regex.test.ts',
+    './tests/eslint/rules/no-extra-boolean-cast.test.ts',
     './tests/eslint/rules/no-empty-character-class.test.ts',
     './tests/eslint/rules/no-fallthrough.test.ts',
     './tests/eslint/rules/no-invalid-regexp.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extra-boolean-cast.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extra-boolean-cast.test.ts.snap
@@ -1,0 +1,313 @@
+// Rstest Snapshot v1
+
+exports[`no-extra-boolean-cast > invalid 1`] = `
+{
+  "code": "if (!!foo) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 2`] = `
+{
+  "code": "if (Boolean(foo)) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant Boolean call.",
+      "messageId": "unexpectedCall",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 3`] = `
+{
+  "code": "while (!!foo) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 4`] = `
+{
+  "code": "Boolean(!!foo)",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 5`] = `
+{
+  "code": "new Boolean(!!foo)",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 6`] = `
+{
+  "code": "if ((!!foo)) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 7`] = `
+{
+  "code": "if (x || !!y) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 8`] = `
+{
+  "code": "while (x && Boolean(y)) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant Boolean call.",
+      "messageId": "unexpectedCall",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 9`] = `
+{
+  "code": "if (x ?? !!y) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 10`] = `
+{
+  "code": "if (cond ? Boolean(a) : b) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant Boolean call.",
+      "messageId": "unexpectedCall",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 11`] = `
+{
+  "code": "if (cond ? a : !!b) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant double negation.",
+      "messageId": "unexpectedNegation",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-boolean-cast > invalid 12`] = `
+{
+  "code": "if ((a, b, Boolean(c))) {}",
+  "diagnostics": [
+    {
+      "message": "Redundant Boolean call.",
+      "messageId": "unexpectedCall",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-boolean-cast",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-extra-boolean-cast.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-extra-boolean-cast.test.ts
@@ -1,0 +1,104 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const enforceLogicalOperands = [{ enforceForLogicalOperands: true }] as any;
+const enforceInnerExpressions = [{ enforceForInnerExpressions: true }] as any;
+
+ruleTester.run('no-extra-boolean-cast', {
+  valid: [
+    // !! not in boolean context
+    'var foo = !!bar;',
+    'function foo() { return !!bar; }',
+    // Boolean() not in boolean context
+    'var foo = Boolean(bar);',
+    // No extra cast
+    'if (foo) {}',
+    // new Boolean is never flagged — it produces a truthy object,
+    // so it is not equivalent to the plain value (matches ESLint).
+    'var x = new Boolean(foo);',
+    'if (new Boolean(foo)) {}',
+    '!new Boolean(foo)',
+    // Not flagged when enforceForLogicalOperands / enforceForInnerExpressions are off
+    'if (x || !!y) {}',
+    'if (x && Boolean(y)) {}',
+    'if (x ? !!y : z) {}',
+    'if (x ?? !!y) {}',
+    // enforceForLogicalOperands does NOT cover `??`
+    { code: 'if (x ?? !!y) {}', options: enforceLogicalOperands },
+    // enforceForInnerExpressions: not the last expression of a sequence
+    { code: 'if ((Boolean(a), b)) {}', options: enforceInnerExpressions },
+    // enforceForInnerExpressions: !! is the LEFT side of ??
+    { code: 'if (!!x ?? y) {}', options: enforceInnerExpressions },
+  ],
+  invalid: [
+    // !! in if test
+    {
+      code: 'if (!!foo) {}',
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // Boolean() in if test
+    {
+      code: 'if (Boolean(foo)) {}',
+      errors: [{ messageId: 'unexpectedCall' }],
+    },
+    // !! in while test
+    {
+      code: 'while (!!foo) {}',
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // !! inside Boolean() call
+    {
+      code: 'Boolean(!!foo)',
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // !! nested inside new Boolean() — inner !! is flagged
+    {
+      code: 'new Boolean(!!foo)',
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // Parenthesized !! in boolean context
+    {
+      code: 'if ((!!foo)) {}',
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+
+    // enforceForLogicalOperands: !! inside ||
+    {
+      code: 'if (x || !!y) {}',
+      options: enforceLogicalOperands,
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // enforceForLogicalOperands: Boolean() inside &&
+    {
+      code: 'while (x && Boolean(y)) {}',
+      options: enforceLogicalOperands,
+      errors: [{ messageId: 'unexpectedCall' }],
+    },
+
+    // enforceForInnerExpressions: !! on the right of ??
+    {
+      code: 'if (x ?? !!y) {}',
+      options: enforceInnerExpressions,
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // enforceForInnerExpressions: Boolean() in ternary consequent
+    {
+      code: 'if (cond ? Boolean(a) : b) {}',
+      options: enforceInnerExpressions,
+      errors: [{ messageId: 'unexpectedCall' }],
+    },
+    // enforceForInnerExpressions: !! in ternary alternate
+    {
+      code: 'if (cond ? a : !!b) {}',
+      options: enforceInnerExpressions,
+      errors: [{ messageId: 'unexpectedNegation' }],
+    },
+    // enforceForInnerExpressions: last expression of a sequence
+    {
+      code: 'if ((a, b, Boolean(c))) {}',
+      options: enforceInnerExpressions,
+      errors: [{ messageId: 'unexpectedCall' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-extra-boolean-cast` rule from ESLint to rslint.

Disallow unnecessary boolean casts

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-extra-boolean-cast

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).