### PR TITLE
feat: port rule no-useless-catch

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,6 +184,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
@@ -605,6 +606,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("require-atomic-updates", require_atomic_updates.RequireAtomicUpdatesRule)
 	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
+	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_useless_catch/no_useless_catch.go
+++ b/internal/rules/no_useless_catch/no_useless_catch.go
@@ -1,0 +1,94 @@
+package no_useless_catch
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-useless-catch
+var NoUselessCatchRule = rule.Rule{
+	Name: "no-useless-catch",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCatchClause: func(node *ast.Node) {
+				catchClause := node.AsCatchClause()
+				if catchClause == nil {
+					return
+				}
+
+				// The catch must have a parameter
+				if catchClause.VariableDeclaration == nil {
+					return
+				}
+
+				// The parameter must be a simple identifier (not destructured)
+				varDecl := catchClause.VariableDeclaration.AsVariableDeclaration()
+				if varDecl == nil || varDecl.Name() == nil {
+					return
+				}
+				paramName := varDecl.Name()
+				if paramName.Kind != ast.KindIdentifier {
+					return
+				}
+				catchParamText := paramName.AsIdentifier().Text
+
+				// The body must have at least one statement and the first must
+				// be a ThrowStatement (matches ESLint's `body.body.length &&
+				// body.body[0].type === 'ThrowStatement'`).
+				if catchClause.Block == nil {
+					return
+				}
+				block := catchClause.Block.AsBlock()
+				if block == nil || block.Statements == nil || len(block.Statements.Nodes) == 0 {
+					return
+				}
+
+				stmt := block.Statements.Nodes[0]
+				if stmt == nil || stmt.Kind != ast.KindThrowStatement {
+					return
+				}
+
+				// The throw argument must be an Identifier. Unwrap parentheses
+				// because standard ESTree (and typescript-eslint) flattens them,
+				// so ESLint fires on `throw (err);`.
+				throwStmt := stmt.AsThrowStatement()
+				if throwStmt == nil || throwStmt.Expression == nil {
+					return
+				}
+				thrown := ast.SkipParentheses(throwStmt.Expression)
+				if thrown == nil || thrown.Kind != ast.KindIdentifier {
+					return
+				}
+
+				// The thrown identifier must match the catch parameter name
+				if thrown.AsIdentifier().Text != catchParamText {
+					return
+				}
+
+				// Determine whether the parent TryStatement has a finally block
+				tryStmt := node.Parent
+				if tryStmt == nil || tryStmt.Kind != ast.KindTryStatement {
+					return
+				}
+				tryData := tryStmt.AsTryStatement()
+				if tryData == nil {
+					return
+				}
+
+				if tryData.FinallyBlock != nil {
+					// Has finally: report on the catch clause
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "unnecessaryCatchClause",
+						Description: "Unnecessary catch clause.",
+					})
+				} else {
+					// No finally: report on the try statement
+					ctx.ReportNode(tryStmt, rule.RuleMessage{
+						Id:          "unnecessaryCatch",
+						Description: "Unnecessary try/catch wrapper.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_useless_catch/no_useless_catch.md
+++ b/internal/rules/no_useless_catch/no_useless_catch.md
@@ -1,0 +1,50 @@
+# no-useless-catch
+
+## Rule Details
+
+Disallows catch clauses that only rethrow the caught error. A catch clause that only rethrows the original error is redundant, and has no effect on the runtime behavior of the program. These redundant clauses can be a source of confusion and code bloat, so it is better to disallow them.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  throw e;
+}
+
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  throw e;
+} finally {
+  cleanUp();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  doSomethingBeforeRethrow();
+  throw e;
+}
+
+try {
+  doSomethingThatMightThrow();
+} catch (e) {
+  handleError(e);
+}
+
+try {
+  doSomethingThatMightThrow();
+} catch ({ message }) {
+  throw message;
+}
+```
+
+## Original Documentation
+
+- [ESLint no-useless-catch](https://eslint.org/docs/latest/rules/no-useless-catch)

--- a/internal/rules/no_useless_catch/no_useless_catch_test.go
+++ b/internal/rules/no_useless_catch/no_useless_catch_test.go
@@ -1,0 +1,78 @@
+package no_useless_catch
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessCatchRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessCatchRule,
+		// Valid cases - ported from ESLint
+		[]rule_tester.ValidTestCase{
+			{Code: `try { foo(); } catch (err) { console.error(err); }`},
+			{Code: `try { foo(); } catch (err) { console.error(err); } finally { bar(); }`},
+			{Code: `try { foo(); } catch (err) { doSomethingBeforeRethrow(); throw err; }`},
+			{Code: `try { foo(); } catch (err) { throw err.msg; }`},
+			{Code: `try { foo(); } catch (err) { throw new Error("whoops!"); }`},
+			{Code: `try { foo(); } catch (err) { throw bar; }`},
+			{Code: `try { foo(); } catch (err) { }`},
+			{Code: `try { foo(); } catch ({ err }) { throw err; }`},
+			{Code: `try { foo(); } catch ([ err ]) { throw err; }`},
+			// Optional catch binding (ES2019): no param means rule can't match.
+			{Code: `try { throw new Error('foo'); } catch { throw new Error('foo'); }`},
+			// Non-null assertion wraps the identifier, so it's not a plain rethrow.
+			{Code: `try { foo(); } catch (err) { throw err!; }`},
+			// `as` expression wraps the identifier.
+			{Code: `try { foo(); } catch (err) { throw err as Error; }`},
+		},
+		// Invalid cases - ported from ESLint
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `try { foo(); } catch (err) { throw err; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCatch", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `try { foo(); } catch (err) { throw err; } finally { foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCatchClause", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `try { foo(); } catch (err) { /* comment */ throw err; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCatch", Line: 1, Column: 1},
+				},
+			},
+			// Type annotation on the catch param: still an Identifier name.
+			{
+				Code: `try { foo(); } catch (err: unknown) { throw err; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCatch", Line: 1, Column: 1},
+				},
+			},
+			// Parentheses around the thrown identifier are flattened in ESTree.
+			{
+				Code: `try { foo(); } catch (err) { throw (err); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCatch", Line: 1, Column: 1},
+				},
+			},
+			// ESLint fires when the first statement is the rethrow, even if
+			// later statements exist (they are unreachable).
+			{
+				Code: `try { foo(); } catch (err) { throw err; unreachable(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCatch", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -266,6 +266,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unsafe-finally.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
+    './tests/eslint/rules/no-useless-catch.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',
     './tests/eslint/rules/valid-typeof.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-catch.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-catch.test.ts.snap
@@ -1,0 +1,157 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-catch > invalid 1`] = `
+{
+  "code": "try { foo(); } catch (err) { throw err; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary try/catch wrapper.",
+      "messageId": "unnecessaryCatch",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-catch",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-catch > invalid 2`] = `
+{
+  "code": "try { foo(); } catch (err) { throw err; } finally { foo(); }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary catch clause.",
+      "messageId": "unnecessaryCatchClause",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-catch",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-catch > invalid 3`] = `
+{
+  "code": "try { foo(); } catch (err) { /* comment */ throw err; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary try/catch wrapper.",
+      "messageId": "unnecessaryCatch",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-catch",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-catch > invalid 4`] = `
+{
+  "code": "try { foo(); } catch (err: unknown) { throw err; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary try/catch wrapper.",
+      "messageId": "unnecessaryCatch",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-catch",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-catch > invalid 5`] = `
+{
+  "code": "try { foo(); } catch (err) { throw (err); }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary try/catch wrapper.",
+      "messageId": "unnecessaryCatch",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-catch",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-catch > invalid 6`] = `
+{
+  "code": "try { foo(); } catch (err) { throw err; unreachable(); }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary try/catch wrapper.",
+      "messageId": "unnecessaryCatch",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-catch",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-catch.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-catch.test.ts
@@ -1,0 +1,46 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-catch', {
+  valid: [
+    'try { foo(); } catch (err) { console.error(err); }',
+    'try { foo(); } catch (err) { console.error(err); } finally { bar(); }',
+    'try { foo(); } catch (err) { doSomethingBeforeRethrow(); throw err; }',
+    'try { foo(); } catch (err) { throw err.msg; }',
+    'try { foo(); } catch (err) { throw new Error("whoops!"); }',
+    'try { foo(); } catch (err) { throw bar; }',
+    'try { foo(); } catch (err) { }',
+    'try { foo(); } catch ({ err }) { throw err; }',
+    'try { foo(); } catch ([ err ]) { throw err; }',
+    "try { throw new Error('foo'); } catch { throw new Error('foo'); }",
+    'try { foo(); } catch (err) { throw err!; }',
+    'try { foo(); } catch (err) { throw err as Error; }',
+  ],
+  invalid: [
+    {
+      code: 'try { foo(); } catch (err) { throw err; }',
+      errors: [{ messageId: 'unnecessaryCatch' }],
+    },
+    {
+      code: 'try { foo(); } catch (err) { throw err; } finally { foo(); }',
+      errors: [{ messageId: 'unnecessaryCatchClause' }],
+    },
+    {
+      code: 'try { foo(); } catch (err) { /* comment */ throw err; }',
+      errors: [{ messageId: 'unnecessaryCatch' }],
+    },
+    {
+      code: 'try { foo(); } catch (err: unknown) { throw err; }',
+      errors: [{ messageId: 'unnecessaryCatch' }],
+    },
+    {
+      code: 'try { foo(); } catch (err) { throw (err); }',
+      errors: [{ messageId: 'unnecessaryCatch' }],
+    },
+    {
+      code: 'try { foo(); } catch (err) { throw err; unreachable(); }',
+      errors: [{ messageId: 'unnecessaryCatch' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-useless-catch` rule from ESLint to rslint.

Disallow unnecessary catch clauses

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-catch

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).