### PR TITLE
feat: port rule no-unmodified-loop-condition

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,6 +142,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
@@ -521,6 +522,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("valid-typeof", valid_typeof.ValidTypeofRule)
 	GlobalRuleRegistry.Register("no-unsafe-optional-chaining", no_unsafe_optional_chaining.NoUnsafeOptionalChainingRule)
 	GlobalRuleRegistry.Register("no-unsafe-finally", no_unsafe_finally.NoUnsafeFinallyRule)
+	GlobalRuleRegistry.Register("no-unmodified-loop-condition", no_unmodified_loop_condition.NoUnmodifiedLoopConditionRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.go
@@ -1,0 +1,324 @@
+package no_unmodified_loop_condition
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildLoopConditionNotModifiedMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "loopConditionNotModified",
+		Description: fmt.Sprintf("'%s' is not modified in this loop.", name),
+	}
+}
+
+// hasDynamicExpression checks if an expression contains any dynamic sub-expression
+// (call, member access, new, tagged template, yield) that could have side effects.
+// Skips traversal into function/class expressions (matching ESLint's SKIP_PATTERN).
+func hasDynamicExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindCallExpression,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindNewExpression,
+		ast.KindTaggedTemplateExpression,
+		ast.KindYieldExpression:
+		return true
+	// Skip function/class expressions — side effects inside them
+	// don't execute during condition evaluation.
+	case ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindClassExpression:
+		return false
+	}
+
+	found := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if hasDynamicExpression(child) {
+			found = true
+			return true
+		}
+		return false
+	})
+	return found
+}
+
+// identifierRef holds an identifier's symbol and AST node for reporting.
+type identifierRef struct {
+	symbol *ast.Symbol
+	node   *ast.Node
+}
+
+// extractGroups walks a condition expression and returns groups of sub-expressions.
+// Logical operators (||, &&, ??) split operands into independent groups.
+// Comparison/arithmetic BinaryExpressions and ConditionalExpressions form a single group.
+func extractGroups(node *ast.Node) []*ast.Node {
+	if node == nil {
+		return nil
+	}
+	node = ast.SkipParentheses(node)
+	if node.Kind == ast.KindBinaryExpression {
+		bin := node.AsBinaryExpression()
+		if bin != nil && bin.OperatorToken != nil && ast.IsLogicalOrCoalescingBinaryOperator(bin.OperatorToken.Kind) {
+			// Logical operators split into independent groups
+			left := extractGroups(bin.Left)
+			right := extractGroups(bin.Right)
+			return append(left, right...)
+		}
+	}
+	// Everything else (comparison binary, conditional, single identifier, etc.)
+	// is a single group.
+	return []*ast.Node{node}
+}
+
+// collectIdentifierSymbols collects unique identifier references (by symbol) from a node.
+// Returns nil if any dynamic expression is found.
+func collectIdentifierSymbols(node *ast.Node, tc *checker.Checker) []identifierRef {
+	if node == nil {
+		return nil
+	}
+	if hasDynamicExpression(node) {
+		return nil
+	}
+	var refs []identifierRef
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			sym := tc.GetSymbolAtLocation(n)
+			if sym != nil {
+				// Deduplicate by symbol
+				dup := false
+				for _, r := range refs {
+					if r.symbol == sym {
+						dup = true
+						break
+					}
+				}
+				if !dup {
+					refs = append(refs, identifierRef{symbol: sym, node: n})
+				}
+			}
+			return
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(node)
+	return refs
+}
+
+// isSymbolWrittenInBody walks the body (and optionally the incrementor) looking for
+// any write reference to the given symbol. Does NOT skip function boundaries —
+// ESLint uses range-based checking where any write within the loop's text range
+// counts as a modification, even inside nested functions.
+func isSymbolWrittenInBody(body *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+	if body == nil {
+		return false
+	}
+
+	found := false
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			refSym := tc.GetSymbolAtLocation(n)
+			if refSym == sym && utils.IsWriteReference(n) {
+				found = true
+				return
+			}
+		}
+		// ShorthandPropertyAssignment in destructuring: ({x} = {x: 1})
+		// TypeChecker resolves shorthand name to property symbol, not variable symbol.
+		// Use GetShorthandAssignmentValueSymbol to get the variable symbol.
+		if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
+			valSym := tc.GetShorthandAssignmentValueSymbol(n)
+			if valSym == sym {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(body)
+	return found
+}
+
+// isModifiedByCalledFunction checks if the symbol is modified inside a
+// FunctionDeclaration that is called within the loop (body or incrementor).
+// This matches ESLint's secondary check: if a write reference to the variable
+// is inside a FunctionDeclaration, and that function's name is referenced
+// within the loop, the variable counts as modified.
+func isModifiedByCalledFunction(loopBody *ast.Node, incrementor *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+	scope := utils.FindEnclosingScope(loopBody)
+	if scope == nil {
+		return false
+	}
+
+	// Step 1: find FunctionDeclarations that write to sym anywhere in scope.
+	var modifyingFuncSymbols []*ast.Symbol
+	var findFuncs func(n *ast.Node)
+	findFuncs = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if ast.IsFunctionDeclaration(n) && n.Name() != nil {
+			if functionBodyWritesSymbol(n, sym, tc) {
+				funcSym := tc.GetSymbolAtLocation(n.Name())
+				if funcSym != nil {
+					modifyingFuncSymbols = append(modifyingFuncSymbols, funcSym)
+				}
+			}
+			return
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			findFuncs(child)
+			return false
+		})
+	}
+	findFuncs(scope)
+
+	if len(modifyingFuncSymbols) == 0 {
+		return false
+	}
+
+	// Step 2: check if any of those functions are referenced in the loop
+	// (body or incrementor). ESLint uses range-based checking — any reference
+	// (not just calls) to the function within the loop counts.
+	if nodeReferencesAnySymbol(loopBody, modifyingFuncSymbols, tc) {
+		return true
+	}
+	if incrementor != nil && nodeReferencesAnySymbol(incrementor, modifyingFuncSymbols, tc) {
+		return true
+	}
+	return false
+}
+
+// functionBodyWritesSymbol checks if a function body contains a write to sym.
+// Does NOT skip nested functions — ESLint uses range-based scope analysis.
+func functionBodyWritesSymbol(funcNode *ast.Node, sym *ast.Symbol, tc *checker.Checker) bool {
+	body := funcNode.Body()
+	if body == nil {
+		return false
+	}
+	return isSymbolWrittenInBody(body, sym, tc)
+}
+
+// nodeReferencesAnySymbol checks if a node tree contains any identifier
+// referencing one of the given symbols. Does not skip function boundaries
+// (ESLint uses range-based checking).
+func nodeReferencesAnySymbol(node *ast.Node, symbols []*ast.Symbol, tc *checker.Checker) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || found {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			refSym := tc.GetSymbolAtLocation(n)
+			if refSym != nil {
+				for _, s := range symbols {
+					if refSym == s {
+						found = true
+						return
+					}
+				}
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(node)
+	return found
+}
+
+// checkLoopCondition checks identifiers in a loop condition and reports those
+// that are not modified in the loop body (or incrementor for for-statements).
+func checkLoopCondition(ctx rule.RuleContext, condition *ast.Node, body *ast.Node, incrementor *ast.Node) {
+	if condition == nil || body == nil {
+		return
+	}
+
+	tc := ctx.TypeChecker
+	groups := extractGroups(condition)
+
+	for _, group := range groups {
+		refs := collectIdentifierSymbols(group, tc)
+		if refs == nil {
+			continue // dynamic expression found, skip this group
+		}
+
+		// Check if any identifier in this group is modified
+		anyModified := false
+		for _, ref := range refs {
+			if isSymbolWrittenInBody(body, ref.symbol, tc) ||
+				(incrementor != nil && isSymbolWrittenInBody(incrementor, ref.symbol, tc)) ||
+				isModifiedByCalledFunction(body, incrementor, ref.symbol, tc) {
+				anyModified = true
+				break
+			}
+		}
+
+		if !anyModified {
+			for _, ref := range refs {
+				ctx.ReportNode(ref.node, buildLoopConditionNotModifiedMessage(ref.node.Text()))
+			}
+		}
+	}
+}
+
+// NoUnmodifiedLoopConditionRule disallows variables in loop conditions that are not modified in the loop
+var NoUnmodifiedLoopConditionRule = rule.Rule{
+	Name: "no-unmodified-loop-condition",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+
+		return rule.RuleListeners{
+			ast.KindWhileStatement: func(node *ast.Node) {
+				whileStmt := node.AsWhileStatement()
+				if whileStmt == nil {
+					return
+				}
+				checkLoopCondition(ctx, whileStmt.Expression, whileStmt.Statement, nil)
+			},
+			ast.KindDoStatement: func(node *ast.Node) {
+				doStmt := node.AsDoStatement()
+				if doStmt == nil {
+					return
+				}
+				checkLoopCondition(ctx, doStmt.Expression, doStmt.Statement, nil)
+			},
+			ast.KindForStatement: func(node *ast.Node) {
+				forStmt := node.AsForStatement()
+				if forStmt == nil {
+					return
+				}
+				checkLoopCondition(ctx, forStmt.Condition, forStmt.Statement, forStmt.Incrementor)
+			},
+		}
+	},
+}

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.md
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition.md
@@ -1,0 +1,59 @@
+# no-unmodified-loop-condition
+
+## Rule Details
+
+Disallows variables in loop conditions that are not modified inside the loop body. If a variable used in a loop's test condition is never assigned to, incremented, or decremented within the loop, it is likely a bug that leads to an infinite loop or incorrect termination.
+
+Conditions that contain function calls, member access expressions, `new` expressions, or tagged template expressions are skipped, since those may have side effects that modify the condition indirectly.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var foo = 0;
+while (foo) {
+  // foo is never modified
+  doSomething();
+}
+
+var bar = 0;
+do {
+  doSomething();
+} while (bar);
+
+for (var i = 0; i < 10; ) {
+  // i is never modified, no incrementor
+  doSomething();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var foo = 0;
+while (foo) {
+  foo++;
+}
+
+var bar = 0;
+do {
+  bar = getNextValue();
+} while (bar);
+
+for (var i = 0; i < 10; i++) {
+  doSomething();
+}
+
+// Function calls in condition are allowed (side effects possible)
+while (hasNext()) {
+  process();
+}
+
+// Member access in condition is allowed
+while (obj.ready) {
+  process();
+}
+```
+
+## Original Documentation
+
+- [ESLint no-unmodified-loop-condition](https://eslint.org/docs/latest/rules/no-unmodified-loop-condition)

--- a/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition_test.go
+++ b/internal/rules/no_unmodified_loop_condition/no_unmodified_loop_condition_test.go
@@ -1,0 +1,254 @@
+package no_unmodified_loop_condition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnmodifiedLoopConditionRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnmodifiedLoopConditionRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// === Basic modifications ===
+			{Code: `var foo = 0; while (foo) { ++foo; }`},
+			{Code: `var foo = 0; while (foo) { foo += 1; }`},
+			{Code: `var foo = 0; while (foo) { foo = bar(); }`},
+			{Code: `var foo = 0; while (foo < 10) { foo++; }`},
+			{Code: `var foo = 0; while (foo < 10) { --foo; }`},
+			{Code: `var foo = 0; while (foo < 10) { foo -= 1; }`},
+
+			// === Do-while ===
+			{Code: `var foo = 0; do { foo++; } while (foo < 10)`},
+			{Code: `var foo = 0; do { foo = next(); } while (foo)`},
+
+			// === For statement: incrementor ===
+			{Code: `for (var i = 0; i < 10; i++) {}`},
+			{Code: `for (var i = 0; i < 10; ++i) {}`},
+			{Code: `for (var i = 10; i > 0; i--) {}`},
+			{Code: `for (var i = 0; i < 10; i += 1) {}`},
+
+			// === For statement: body modification ===
+			{Code: `for (var i = 0; i < 10; ) { i++; }`},
+
+			// === Dynamic expressions in condition — skip check ===
+			{Code: `while (ok(foo)) { }`},
+			{Code: `while (foo.ok) { }`},
+			{Code: `while (foo[0]) { }`},
+			{Code: `while (new Foo()) { }`},
+			{Code: "while (tag`template`) { }"},
+			{Code: `while (a.b.c) { }`},
+			{Code: `for (var i = 0; f(i) < 10; ) { }`},
+
+			// === Comparison group semantics ===
+			// a < b is one group: if a is modified, b is OK too
+			{Code: `var a = 0, b = 0; while (a < b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a > b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a <= b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a >= b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a == b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a === b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a != b) { a++; }`},
+			{Code: `var a = 0, b = 0; while (a !== b) { a++; }`},
+
+			// === Logical literals / no identifiers ===
+			{Code: `while (true) { break; }`},
+			{Code: `do { break; } while (true)`},
+			{Code: `for (;;) { break; }`},
+
+			// === || groups: both sides modified ===
+			{Code: `var a = 0, b = 0; while (a || b) { a++; b++; }`},
+
+			// === Modification via function call ===
+			{Code: `var x = 0; function inc() { x++; } while (x < 10) { inc(); }`},
+			{Code: `var x = 0; function update() { x = next(); } while (x) { update(); }`},
+
+			// === Function call in for incrementor ===
+			{Code: `var x = 0; function inc() { x++; } for (var i = 0; x < 10; inc()) { i++; }`},
+
+			// === Destructuring write ===
+			{Code: `var x = 0; while (x < 10) { ({x} = {x: 1}); }`},
+			{Code: `var x = 0; while (x < 10) { [x] = [1]; }`},
+
+			// === Arrow/function expression in condition: not "dynamic" ===
+			{Code: `var x = 0; while (x || (() => foo())) { x++; }`},
+
+			// === Modification in nested function DOES count (ESLint range-based) ===
+			{Code: `var foo = 0; while (foo) { function f() { foo = 1; } }`},
+			{Code: `var foo = 0; while (foo) { var f = () => { foo = 1; }; }`},
+			{Code: `var foo = 0; while (foo) { var f = function() { foo = 1; }; }`},
+
+			// === Modification in nested non-function block ===
+			{Code: `var x = 0; while (x < 10) { if (true) { x++; } }`},
+			{Code: `var x = 0; while (x < 10) { { x++; } }`},
+			{Code: `var x = 0; while (x < 10) { try { x++; } catch(e) {} }`},
+
+			// === Modification in nested loop body (not function boundary) ===
+			{Code: `var x = 0; while (x < 10) { for (var i = 0; i < 1; i++) { x++; } }`},
+			{Code: `var x = 0; while (x < 10) { while (false) { x++; } }`},
+
+			// === For-in/for-of as write target inside loop ===
+			{Code: `var x = ""; while (x) { for (x in {a: 1}) {} }`},
+			{Code: `var x = 0; while (x) { for (x of [1, 2]) {} }`},
+
+			// === ConditionalExpression (ternary) as group ===
+			{Code: `var a = 0, b = 0; while (a ? b : 0) { a++; }`},
+
+			// === Complex nesting: (a < b) || c — group a<b OK, c independent ===
+			{Code: `var a = 0, b = 10, c = 0; while ((a < b) || c) { a++; c++; }`},
+
+			// === Compound assignment operators ===
+			{Code: `var x = 0; while (x < 10) { x *= 2; }`},
+			{Code: `var x = 0; while (x < 10) { x /= 2; }`},
+			{Code: `var x = 0; while (x < 10) { x %= 2; }`},
+			{Code: `var x = 0; while (x < 10) { x **= 2; }`},
+			{Code: `var x = 0; while (x < 10) { x <<= 1; }`},
+			{Code: `var x = 0; while (x < 10) { x >>= 1; }`},
+			{Code: `var x = 0; while (x < 10) { x >>>= 1; }`},
+			{Code: `var x = 0; while (x < 10) { x &= 1; }`},
+			{Code: `var x = 0; while (x < 10) { x |= 1; }`},
+			{Code: `var x = 0; while (x < 10) { x ^= 1; }`},
+			{Code: `var x: any = 0; while (x < 10) { x ||= 1; }`},
+			{Code: `var x: any = 0; while (x < 10) { x &&= 1; }`},
+			{Code: `var x: any = 0; while (x < 10) { x ??= 1; }`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// === Basic: simple identifier not modified ===
+			{
+				Code: `var foo = 0; while (foo) { } foo = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 21},
+				},
+			},
+
+			// === Comparison group: both unmodified ===
+			{
+				Code: `var a = 0, b = 0; while (a < b) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 26},
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 30},
+				},
+			},
+
+			// === Do-while: identifier not modified ===
+			{
+				Code: `var foo = 0; do { } while (foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 28},
+				},
+			},
+
+			// === For: no incrementor, not modified in body ===
+			{
+				Code: `for (var i = 0; i < 10; ) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 17},
+				},
+			},
+
+			// === Modified outside loop but not inside ===
+			{
+				Code: `var foo = 0; while (foo) { } foo++;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 21},
+				},
+			},
+
+			// === || groups: both unmodified ===
+			{
+				Code: `var a = 0, b = 0; while (a || b) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 26},
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 31},
+				},
+			},
+
+			// === Variable shadowing: inner let shadows outer ===
+			{
+				Code: `var foo = 0; while (foo) { let foo = 1; foo++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 21},
+				},
+			},
+
+			// === && operands are independent (not grouped) ===
+			{
+				Code: `var a = 0, b = 10; while (a && b) { a++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 32},
+				},
+			},
+
+			// === || partial: only a modified, b should be reported ===
+			{
+				Code: `var a = 0, b = 0; while (a || b) { a++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 31},
+				},
+			},
+
+			// === ?? (nullish coalescing) operands independent ===
+			{
+				Code: `var a: any = 0, b: any = 0; while (a ?? b) { a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 41},
+				},
+			},
+
+			// === Nested logical: a || b && c — all independent ===
+			{
+				Code: `var a = 0, b = 0, c = 0; while (a || b && c) { a++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 38},
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 43},
+				},
+			},
+
+			// === Complex: (a < b) && c — a<b group OK, c independent ===
+			{
+				Code: `var a = 0, b = 10, c = 0; while ((a < b) && c) { a++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 45},
+				},
+			},
+
+			// === Shadowing via const ===
+			{
+				Code: `var x = 0; while (x) { const x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 19},
+				},
+			},
+
+			// === Shadowing via function declaration ===
+			{
+				Code: `var x = 0; while (x) { function x() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 19},
+				},
+			},
+
+			// === Shadowing via catch clause ===
+			{
+				Code: `var e = 0; while (e) { try {} catch(e) { e = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 19},
+				},
+			},
+
+			// === Function declared but NOT called in loop ===
+			{
+				Code: `var x = 0; function inc() { x++; } while (x < 10) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "loopConditionNotModified", Line: 1, Column: 43},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -243,6 +243,7 @@ export default defineConfig({
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',
     './tests/eslint/rules/valid-typeof.test.ts',
+    './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unmodified-loop-condition.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unmodified-loop-condition.test.ts.snap
@@ -1,0 +1,172 @@
+// Rstest Snapshot v1
+
+exports[`no-unmodified-loop-condition > invalid 1`] = `
+{
+  "code": "var foo = 0; while (foo) { }",
+  "diagnostics": [
+    {
+      "message": "'foo' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unmodified-loop-condition > invalid 2`] = `
+{
+  "code": "var a = 0, b = 0; while (a < b) { }",
+  "diagnostics": [
+    {
+      "message": "'a' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+    {
+      "message": "'b' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unmodified-loop-condition > invalid 3`] = `
+{
+  "code": "var foo = 0; while (foo) { let foo = 1; foo++; }",
+  "diagnostics": [
+    {
+      "message": "'foo' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unmodified-loop-condition > invalid 4`] = `
+{
+  "code": "var a = 0, b = 10; while (a && b) { a++; }",
+  "diagnostics": [
+    {
+      "message": "'b' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unmodified-loop-condition > invalid 5`] = `
+{
+  "code": "var a = 0, b = 0; while (a || b) { a++; }",
+  "diagnostics": [
+    {
+      "message": "'b' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unmodified-loop-condition > invalid 6`] = `
+{
+  "code": "var x = 0; function inc() { x++; } while (x < 10) { }",
+  "diagnostics": [
+    {
+      "message": "'x' is not modified in this loop.",
+      "messageId": "loopConditionNotModified",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unmodified-loop-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unmodified-loop-condition.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unmodified-loop-condition.test.ts
@@ -1,0 +1,78 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unmodified-loop-condition', {
+  valid: [
+    // Basic modifications
+    'var foo = 0; while (foo) { ++foo; }',
+    'var foo = 0; while (foo) { foo += 1; }',
+    'var foo = 0; while (foo < 10) { foo++; }',
+
+    // Dynamic expressions in condition — skip check
+    'while (ok(foo)) { }',
+    'while (foo.ok) { }',
+    'while (foo[0]) { }',
+
+    // Comparison group: a < b is one group, a modified → OK
+    'var a = 0, b = 10; while (a < b) { a++; }',
+
+    // Modification via function call
+    'var x = 0; function inc() { x++; } while (x < 10) { inc(); }',
+
+    // Destructuring write
+    'var x = 0; while (x < 10) { ({x} = {x: 1}); }',
+    'var x = 0; while (x < 10) { [x] = [1]; }',
+
+    // Arrow function in condition: not "dynamic"
+    'var x = 0; while (x || (() => foo())) { x++; }',
+
+    // Modification inside nested function DOES count (ESLint range-based)
+    'var foo = 0; while (foo) { function f() { foo = 1; } }',
+    'var foo = 0; while (foo) { var f = () => { foo = 1; }; }',
+
+    // Modification in nested blocks (not function boundaries)
+    'var x = 0; while (x < 10) { if (true) { x++; } }',
+    'var x = 0; while (x < 10) { for (var i = 0; i < 1; i++) { x++; } }',
+
+    // For-in/for-of as write target
+    'var x = ""; while (x) { for (x in {a: 1}) {} }',
+
+    // ConditionalExpression (ternary) as group
+    'var a = 0, b = 0; while (a ? b : 0) { a++; }',
+  ],
+  invalid: [
+    {
+      code: 'var foo = 0; while (foo) { }',
+      errors: [{ messageId: 'loopConditionNotModified' }],
+    },
+    // Both unmodified in comparison group
+    {
+      code: 'var a = 0, b = 0; while (a < b) { }',
+      errors: [
+        { messageId: 'loopConditionNotModified' },
+        { messageId: 'loopConditionNotModified' },
+      ],
+    },
+    // Variable shadowing
+    {
+      code: 'var foo = 0; while (foo) { let foo = 1; foo++; }',
+      errors: [{ messageId: 'loopConditionNotModified' }],
+    },
+    // && — operands independent
+    {
+      code: 'var a = 0, b = 10; while (a && b) { a++; }',
+      errors: [{ messageId: 'loopConditionNotModified' }],
+    },
+    // || partial — only a modified
+    {
+      code: 'var a = 0, b = 0; while (a || b) { a++; }',
+      errors: [{ messageId: 'loopConditionNotModified' }],
+    },
+    // Function declared but NOT called in loop
+    {
+      code: 'var x = 0; function inc() { x++; } while (x < 10) { }',
+      errors: [{ messageId: 'loopConditionNotModified' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unmodified-loop-condition` rule from ESLint to rslint.

Disallow unmodified conditions of loops

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-unmodified-loop-condition

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).