### PR TITLE
feat: port rule no-unreachable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
@@ -523,6 +524,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-unsafe-optional-chaining", no_unsafe_optional_chaining.NoUnsafeOptionalChainingRule)
 	GlobalRuleRegistry.Register("no-unsafe-finally", no_unsafe_finally.NoUnsafeFinallyRule)
 	GlobalRuleRegistry.Register("no-unmodified-loop-condition", no_unmodified_loop_condition.NoUnmodifiedLoopConditionRule)
+	GlobalRuleRegistry.Register("no-unreachable", no_unreachable.NoUnreachableRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_fallthrough/no_fallthrough.go
+++ b/internal/rules/no_fallthrough/no_fallthrough.go
@@ -223,12 +223,12 @@ func isTryASTTerminal(node *ast.Node) bool {
 	}
 
 	// If finally has a terminal, it overrides try/catch completion.
-	if ts.FinallyBlock != nil && blockEndsWithTerminal(ts.FinallyBlock) {
+	if ts.FinallyBlock != nil && utils.BlockEndsWithTerminal(ts.FinallyBlock) {
 		return true
 	}
 
 	// If the try body cannot throw before its terminal, catch is unreachable.
-	if ts.TryBlock != nil && !canBlockThrow(ts.TryBlock) {
+	if ts.TryBlock != nil && !utils.CanBlockThrow(ts.TryBlock) {
 		return true
 	}
 
@@ -300,55 +300,6 @@ func hasBreakInLoopBody(loopNode *ast.Node) bool {
 		return true
 	})
 	return found
-}
-
-// canBlockThrow checks if a block can throw before reaching a non-throwing
-// terminal. Used to determine if a catch clause is reachable.
-func canBlockThrow(block *ast.Node) bool {
-	statements := block.Statements()
-	if len(statements) == 0 {
-		return false
-	}
-	for _, stmt := range statements {
-		switch stmt.Kind {
-		case ast.KindBreakStatement, ast.KindContinueStatement:
-			return false
-		case ast.KindReturnStatement:
-			rs := stmt.AsReturnStatement()
-			return rs != nil && rs.Expression != nil
-		case ast.KindEmptyStatement:
-			continue
-		case ast.KindBlock:
-			return canBlockThrow(stmt)
-		case ast.KindTryStatement:
-			ts := stmt.AsTryStatement()
-			if ts != nil && ts.FinallyBlock != nil && blockEndsWithTerminal(ts.FinallyBlock) {
-				return false
-			}
-			return true
-		default:
-			return true
-		}
-	}
-	return true
-}
-
-// blockEndsWithTerminal checks if a block's last statement is a control flow
-// terminal (break/return/throw/continue).
-func blockEndsWithTerminal(block *ast.Node) bool {
-	nodes := block.Statements()
-	if len(nodes) == 0 {
-		return false
-	}
-	last := nodes[len(nodes)-1]
-	switch last.Kind {
-	case ast.KindBreakStatement, ast.KindContinueStatement,
-		ast.KindReturnStatement, ast.KindThrowStatement:
-		return true
-	case ast.KindBlock:
-		return blockEndsWithTerminal(last)
-	}
-	return false
 }
 
 // forEachDescendant walks all descendants of a node depth-first.

--- a/internal/rules/no_unreachable/no_unreachable.go
+++ b/internal/rules/no_unreachable/no_unreachable.go
@@ -1,0 +1,198 @@
+package no_unreachable
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-unreachable
+
+// isUnreachable checks if a statement is unreachable using the binder's flow analysis.
+// The binder sets FlowNode on each reachable statement; unreachable statements have nil FlowNode.
+func isUnreachable(node *ast.Node) bool {
+	flowData := node.FlowNodeData()
+	return flowData == nil || flowData.FlowNode == nil
+}
+
+// isHoistedOrEmpty returns true if the statement is safe to appear
+// after a terminal statement because it is hoisted or has no runtime effect.
+// - FunctionDeclaration: hoisted
+// - ClassDeclaration: NOT hoisted (has temporal dead zone), should be reported
+// - EmptyStatement: no effect
+// - var declarations without initializers: the declaration is hoisted
+// - TypeAliasDeclaration, InterfaceDeclaration: type-only, erased at compile time
+func isHoistedOrEmpty(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration:
+		return true
+	case ast.KindEmptyStatement:
+		return true
+	case ast.KindTypeAliasDeclaration,
+		ast.KindInterfaceDeclaration:
+		return true
+	case ast.KindVariableStatement:
+		return isVarWithoutInitializer(node)
+	}
+	return false
+}
+
+// isVarWithoutInitializer checks if a VariableStatement is a `var` declaration
+// where none of the declarators have initializers. `let` and `const` are not
+// hoisted in the same way, so they are always reported.
+func isVarWithoutInitializer(node *ast.Node) bool {
+	varStmt := node.AsVariableStatement()
+	if varStmt == nil || varStmt.DeclarationList == nil {
+		return false
+	}
+
+	declList := varStmt.DeclarationList.AsVariableDeclarationList()
+	if declList == nil {
+		return false
+	}
+
+	// If it's let, const, or using, it's not hoisted like var
+	flags := varStmt.DeclarationList.Flags
+	if flags&ast.NodeFlagsLet != 0 || flags&ast.NodeFlagsConst != 0 || flags&ast.NodeFlagsUsing != 0 {
+		return false
+	}
+
+	// Check that all declarations have no initializer
+	if declList.Declarations == nil {
+		return true
+	}
+	for _, decl := range declList.Declarations.Nodes {
+		if decl.Kind != ast.KindVariableDeclaration {
+			continue
+		}
+		varDecl := decl.AsVariableDeclaration()
+		if varDecl != nil && varDecl.Initializer != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// NoUnreachableRule disallows unreachable code after return, throw, break, and continue statements.
+var NoUnreachableRule = rule.Rule{
+	Name: "no-unreachable",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		msg := rule.RuleMessage{
+			Id:          "unreachableCode",
+			Description: "Unreachable code.",
+		}
+
+		checkStatements := func(statements []*ast.Node) {
+			if len(statements) == 0 {
+				return
+			}
+
+			// If the first statement is already unreachable, this container is
+			// either inside unreachable code reported by a parent, or a dead
+			// branch from a constant condition (e.g. else of if(true)). In both
+			// cases, skip to avoid noise and double-reporting.
+			if isUnreachable(statements[0]) {
+				return
+			}
+
+			var rangeStart *ast.Node // first unreachable stmt in current consecutive group
+			var rangeEnd *ast.Node   // last unreachable stmt in current consecutive group
+
+			flush := func() {
+				if rangeStart != nil {
+					// Trim leading trivia on the start node (same as ReportNode)
+					startRange := utils.TrimNodeTextRange(ctx.SourceFile, rangeStart)
+					ctx.ReportRange(
+						core.NewTextRange(startRange.Pos(), rangeEnd.End()),
+						msg,
+					)
+					rangeStart = nil
+					rangeEnd = nil
+				}
+			}
+
+			for _, stmt := range statements {
+				if stmt == nil {
+					continue
+				}
+				if isUnreachable(stmt) {
+					if isHoistedOrEmpty(stmt) {
+						// Hoisted/empty statements break the consecutive chain
+						// but are not reported themselves
+						flush()
+					} else {
+						if rangeStart == nil {
+							rangeStart = stmt
+						}
+						rangeEnd = stmt
+					}
+				} else {
+					flush()
+				}
+			}
+			flush()
+		}
+
+		// Check SourceFile top-level statements directly, since the linter
+		// visits SourceFile's children (not the SourceFile node itself),
+		// so a KindSourceFile listener would never fire.
+		if sf := ctx.SourceFile; sf != nil && sf.Statements != nil {
+			checkStatements(sf.Statements.Nodes)
+		}
+
+		return rule.RuleListeners{
+			ast.KindBlock: func(node *ast.Node) {
+				block := node.AsBlock()
+				if block == nil || block.Statements == nil {
+					return
+				}
+				checkStatements(block.Statements.Nodes)
+			},
+			ast.KindCaseClause: func(node *ast.Node) {
+				clause := node.AsCaseOrDefaultClause()
+				if clause == nil || clause.Statements == nil {
+					return
+				}
+				checkStatements(clause.Statements.Nodes)
+			},
+			ast.KindDefaultClause: func(node *ast.Node) {
+				clause := node.AsCaseOrDefaultClause()
+				if clause == nil || clause.Statements == nil {
+					return
+				}
+				checkStatements(clause.Statements.Nodes)
+			},
+			ast.KindTryStatement: func(node *ast.Node) {
+				ts := node.AsTryStatement()
+				if ts == nil || ts.CatchClause == nil || ts.TryBlock == nil {
+					return
+				}
+				// If the try block is itself unreachable, skip — the parent
+				// already reported it.
+				if isUnreachable(node) {
+					return
+				}
+				// If the try block cannot throw before reaching a terminal,
+				// the catch clause is unreachable.
+				if !utils.CanBlockThrow(ts.TryBlock) {
+					cc := ts.CatchClause.AsCatchClause()
+					if cc != nil && cc.Block != nil {
+						startRange := utils.TrimNodeTextRange(ctx.SourceFile, ts.CatchClause)
+						ctx.ReportRange(
+							core.NewTextRange(startRange.Pos(), ts.CatchClause.End()),
+							msg,
+						)
+					}
+				}
+			},
+			ast.KindModuleBlock: func(node *ast.Node) {
+				mb := node.AsModuleBlock()
+				if mb == nil || mb.Statements == nil {
+					return
+				}
+				checkStatements(mb.Statements.Nodes)
+			},
+		}
+	},
+}

--- a/internal/rules/no_unreachable/no_unreachable.md
+++ b/internal/rules/no_unreachable/no_unreachable.md
@@ -1,0 +1,63 @@
+# no-unreachable
+
+## Rule Details
+
+Disallows unreachable code after `return`, `throw`, `break`, and `continue` statements. Because these statements unconditionally exit a block of code, any statements after them cannot be executed and are therefore unreachable.
+
+Function declarations are allowed after terminal statements because they are hoisted. Similarly, `var` declarations without initializers are allowed because the declaration itself is hoisted, even though the assignment would be unreachable.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo() {
+  return true;
+  console.log('done');
+}
+
+function bar() {
+  throw new Error('oops');
+  console.log('done');
+}
+
+while (value) {
+  break;
+  console.log('done');
+}
+
+while (value) {
+  continue;
+  console.log('done');
+}
+
+function baz() {
+  return;
+  var x = 1;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function foo() {
+  return bar();
+  function bar() {
+    return 1;
+  }
+}
+
+function baz() {
+  return;
+  var x;
+}
+
+function qux() {
+  if (condition) {
+    return;
+  }
+  doSomething();
+}
+```
+
+## Original Documentation
+
+- [ESLint no-unreachable](https://eslint.org/docs/latest/rules/no-unreachable)

--- a/internal/rules/no_unreachable/no_unreachable_test.go
+++ b/internal/rules/no_unreachable/no_unreachable_test.go
@@ -1,0 +1,432 @@
+package no_unreachable
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnreachableRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnreachableRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// --- Function hoisting ---
+			{Code: `function foo() { function bar() { return 1; } return bar(); }`},
+			{Code: `function foo() { return bar(); function bar() { return 1; } }`},
+
+			// --- var without init after terminal (hoisted) ---
+			{Code: `function foo() { return x; var x; }`},
+			{Code: `function foo() { return; var x; }`},
+			{Code: `function foo() { return; var x, y, z; }`},
+			{Code: `while (true) { break; var x; }`},
+			{Code: `while (true) { continue; var x, y; }`},
+			{Code: `while (true) { throw 'message'; var x; }`},
+
+			// --- Empty statement after terminal ---
+			{Code: `function foo() { return; ; }`},
+
+			// --- Function declaration after terminal ---
+			{Code: `function foo() { throw new Error(); function bar() {} }`},
+
+			// --- Conditional terminals (not all paths terminate) ---
+			{Code: `function foo() { if (x) { return; } bar(); }`},
+			{Code: `function foo() { if (x) { } else { return; } x = 2; }`},
+			{Code: `function foo() { if (x) { return; } else { bar(); } baz(); }`},
+			{Code: `function foo() { switch (x) { case 0: break; default: return; } x = 2; }`},
+			{Code: `function foo() { while (x) { return; } x = 2; }`},
+			{Code: `function foo() { for (x in {}) { return; } x = 2; }`},
+			{Code: `function foo() { for (;;) { if (x) break; } x = 2; }`},
+
+			// --- Try/finally where finally doesn't terminate ---
+			{Code: `function foo() { try { return; } finally { x = 2; } }`},
+
+			// --- Switch patterns ---
+			{Code: `switch (x) { case 1: break; }`},
+			{Code: `function foo() { switch(x) { case 1: return; } bar(); }`},
+			{Code: `while (true) { switch (foo) { case 1: x = 1; x = 2; } }`},
+			{Code: `switch (foo) { case 1: break; var x; }`},
+
+			// --- Labeled block break ---
+			{Code: `function foo() { A: { break A; } bar(); }`},
+
+			// --- Top-level throw with var (no init) after ---
+			{Code: `var x = 1; throw 'uh oh'; var y;`},
+
+			// --- Single statement loops ---
+			{Code: `while (true) continue;`},
+
+			// --- Try/catch where try can throw (catch is reachable) ---
+			{Code: `function foo() { try { bar(); return; } catch (err) { return err; } }`},
+			{Code: `function foo() { try { a.b.c = 1; return; } catch (err) { return err; } }`},
+
+			// --- TypeScript: type-only declarations after return (erased) ---
+			{Code: `function foo() { return; type A = string; }`},
+			{Code: `function foo() { return; interface B {} }`},
+
+			// --- Nested function scopes (inner function is independent) ---
+			{Code: `function foo() { return; function bar() { var x = 1; } }`},
+
+			// --- Arrow function body is independent scope ---
+			{Code: `function foo() { var f = () => { return 1; }; bar(); }`},
+
+			// --- Binder evaluates false keyword → code after if(false){return} is reachable ---
+			{Code: `function foo() { if (false) { return; } bar(); }`},
+
+			// --- Binder does NOT evaluate numeric/string literals ---
+			{Code: `function foo() { if (1) { return; } bar(); }`},
+			{Code: `function foo() { if (0) { return; } bar(); }`},
+			{Code: `function foo() { if ("x") { return; } bar(); }`},
+			{Code: `function foo() { if (null) { return; } bar(); }`},
+
+			// --- for-of/for-in: loop body may not execute → code after is reachable ---
+			{Code: `function foo() { for (const x of arr) { return; } bar(); }`},
+			{Code: `function foo() { for (const x in obj) { return; } bar(); }`},
+
+			// --- do-while(false): body executes once then exits → code after reachable ---
+			{Code: `function foo() { do { break; } while (false); bar(); }`},
+
+			// --- Async/generator functions: inner return is scoped ---
+			{Code: `async function foo() { var f = async () => { return 1; }; bar(); }`},
+			{Code: `function foo() { var f = function*() { return 1; }; bar(); }`},
+
+			// --- Class method: unreachable code is inside method scope ---
+			{Code: `class C { foo() { return bar(); function bar() { return 1; } } }`},
+
+			// --- Deeply nested: try inside if inside switch → still valid ---
+			{Code: `function foo() { switch(x) { default: if (y) { try { return; } finally {} } } bar(); }`},
+
+			// --- Dead branch from constant condition: binder marks as unreachable,
+			// but we don't report entire dead branches (not unreachable "after" a terminal) ---
+			{Code: `function foo() { if (false) { return; } bar(); }`},
+			{Code: `function foo() { if (true) { return; } else { bar(); } }`},
+
+			// --- Generator try/yield: catch IS reachable (yield can throw) ---
+			{Code: `function* foo() { try { yield 1; return; } catch (err) { return err; } }`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// --- Basic terminals ---
+			{
+				Code:   `function foo() { return; x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+			{
+				Code:   `function foo() { throw new Error(); x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 37}},
+			},
+			{
+				Code:   `while (true) { break; x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 23}},
+			},
+			{
+				Code:   `while (true) { continue; x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+
+			// --- var with initializer after return IS reported ---
+			{
+				Code:   `function foo() { return; var x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+			// var with partial initializer (some declarators have init)
+			{
+				Code:   `function foo() { return x; var x, y = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// var with init after continue
+			{
+				Code:   `while (true) { continue; var x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Consecutive grouping (multiple statements → one report) ---
+			{
+				Code:   `function foo() { return; x = 1; y = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+			// Multi-line consecutive grouping
+			{
+				Code:   "function foo() {\n  return;\n  a();\n  b();\n  c();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 3, Column: 3}},
+			},
+			// Consecutive with if block included
+			{
+				Code:   "function foo() {\n  return;\n  a();\n  if (b()) {\n    c()\n  } else {\n    d()\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 3, Column: 3}},
+			},
+
+			// --- Switch case terminals ---
+			{
+				Code:   `switch (x) { case 1: return; foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 30}},
+			},
+			{
+				Code:   `switch (x) { default: return; foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 31}},
+			},
+			// Switch case with throw
+			{
+				Code:   `function foo() { switch (foo) { case 1: throw e; x = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// Switch in while: break exits switch, not loop
+			{
+				Code:   `while (true) { switch (foo) { case 1: break; x = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// Switch in while: continue exits loop iteration
+			{
+				Code:   `while (true) { switch (foo) { case 1: continue; x = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- let/const/class after return ---
+			{
+				Code:   `function foo() { return; let x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+			{
+				Code:   `function foo() { return; const x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+			{
+				Code:   `function foo() { return; class Bar {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 26}},
+			},
+
+			// --- Top-level throw with var WITH init ---
+			{
+				Code:   `var x = 1; throw 'uh oh'; var y = 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- if/else both terminate ---
+			{
+				Code:   `function foo() { if (x) { return; } else { throw e; } x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// if/else without braces
+			{
+				Code:   `function foo() { if (x) return; else throw -1; x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// Unreachable after if/else where both branches return
+			{
+				Code:   "function foo() { if (x) { return 1; } else { return 2; } bar(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 58}},
+			},
+
+			// --- Try/finally patterns ---
+			{
+				Code:   `function foo() { try { return; } finally {} x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			{
+				Code:   `function foo() { try { } finally { return; } x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// try/catch where both terminate
+			{
+				Code:   "function foo() { try { return 1; } catch(e) { return 2; } bar(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// try/finally where finally returns
+			{
+				Code:   `function foo() { try { console.log('x'); } finally { return 1; } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Loop patterns ---
+			// do-while with return
+			{
+				Code:   `function foo() { do { return; } while (x); x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// do-while: unreachable inside body after return
+			{
+				Code:   `function foo() { do { return; x = 1; } while(true); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 1, Column: 31}},
+			},
+			// while with if/else both break/continue → unreachable inside loop
+			{
+				Code:   `function foo() { while (x) { if (x) break; else continue; x = 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// for(;;) with only continue (no break) → infinite loop
+			{
+				Code:   `function foo() { for (;;) { if (x) continue; } x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// while(true) empty body → infinite loop
+			{
+				Code:   `function foo() { while (true) { } x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// while(true) infinite loop
+			{
+				Code:   `function foo() { while(true) { doSomething(); } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// for(;;) infinite loop
+			{
+				Code:   `function foo() { for(;;) { doSomething(); } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Labeled break ---
+			{
+				Code:   `outer: while(true) { while(true) { break outer; } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Switch with default, all cases return ---
+			{
+				Code:   `function foo() { switch(x) { case 1: return 1; default: return 2; } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Nested if/else all returning ---
+			{
+				Code:   `function foo() { if (a) { if (b) { return; } else { return; } } else { return; } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Multiple unreachable blocks in same function ---
+			{
+				Code: "function foo() {\n  if (a) {\n    return\n    b();\n    c();\n  } else {\n    throw err\n    d();\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unreachableCode", Line: 4},
+					{MessageId: "unreachableCode", Line: 8},
+				},
+			},
+			// Both branches unreachable + code after if/else
+			// Note: outer block reports e() first, then inner blocks report b() and d()
+			{
+				Code: "function foo() {\n  if (a) {\n    return\n    b();\n  } else {\n    throw err\n    d();\n  }\n  e();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unreachableCode", Line: 9},
+					{MessageId: "unreachableCode", Line: 4},
+					{MessageId: "unreachableCode", Line: 7},
+				},
+			},
+
+			// --- Arrow function with unreachable ---
+			{
+				Code:   `var f = (arrow) => { switch (arrow) { default: throw new Error(); }; g() }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- TypeScript: enum after return (has runtime effect) ---
+			{
+				Code:   `function foo() { return; enum Color { Red } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Multiline with precise position ---
+			{
+				Code:   "function foo() {\n  return;\n  x = 1;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode", Line: 3, Column: 3}},
+			},
+
+			// --- Binder constant condition: if(true) break inside while ---
+			// Binder evaluates if(true) → break always executes → var x = 1 unreachable
+			{
+				Code:   `while (true) { if (true) break; var x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Class method/getter unreachable ---
+			{
+				Code:   `class C { foo() { return; bar(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			{
+				Code:   `class C { get x() { return 1; bar(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Async/generator unreachable ---
+			{
+				Code:   `async function foo() { return; bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			{
+				Code:   `function* foo() { return; bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			{
+				Code:   `async function* foo() { return; bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Deeply nested: try inside if inside switch, all terminate ---
+			{
+				Code:   `function foo() { switch(x) { default: if (y) { return; } else { try { throw e; } catch(e) { return; } } } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Namespace/module block unreachable ---
+			{
+				Code:   "namespace Foo { throw new Error(); var x = 1; }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Multiple switch cases all returning with default ---
+			{
+				Code:   `function foo() { switch(x) { case 1: return 1; case 2: return 2; case 3: return 3; default: return 0; } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+
+			// --- Catch unreachable: try block can't throw ---
+			{
+				Code: "function foo() {\n  try {\n    return;\n  } catch (err) {\n    return err;\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unreachableCode", Line: 4},
+				},
+			},
+			// Generator: try { return; } catch → catch unreachable
+			{
+				Code: "function* foo() {\n  try {\n    return;\n  } catch (err) {\n    return err;\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unreachableCode", Line: 4},
+				},
+			},
+			// try { return; let a = 1; } catch → both let and catch unreachable
+			// TryStatement listener reports catch (line 5) first, then Block reports let (line 4)
+			{
+				Code: "function foo() {\n  try {\n    return;\n    let a = 1;\n  } catch (err) {\n    return err;\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unreachableCode", Line: 5},
+					{MessageId: "unreachableCode", Line: 4},
+				},
+			},
+
+			// --- Catch reachability edge cases ---
+			// try { ; return; } catch → empty stmt before return, still can't throw
+			{
+				Code:   `function foo() { try { ; return; } catch (err) { return err; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// try { break; } catch inside while → catch unreachable (break can't throw)
+			{
+				Code:   `function foo() { while (true) { try { break; } catch (err) { return err; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// try { { return; } } catch → nested block, still can't throw
+			{
+				Code:   `function foo() { try { { return; } } catch (err) { return err; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// try with finally that terminates, catch unreachable
+			{
+				Code:   `function foo() { try { foo(); } catch (err) {} finally { return; } bar(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+		},
+	)
+}

--- a/internal/utils/flow.go
+++ b/internal/utils/flow.go
@@ -58,3 +58,66 @@ func IsFunctionEndReachable(node *ast.Node) bool {
 	}
 	return node.Flags&ast.NodeFlagsHasImplicitReturn != 0
 }
+
+// CanBlockThrow checks if a block can throw before reaching a non-throwing
+// terminal. Used to determine if a catch clause is reachable.
+//
+// A block "can throw" if it contains any statement that may raise an exception
+// before control reaches a guaranteed non-throwing terminal (break, continue,
+// or return without expression). Specifically:
+//   - break / continue: non-throwing terminals → returns false
+//   - return (no expression): non-throwing → returns false
+//   - return (with expression): expression evaluation may throw → returns true
+//   - throw: always throws → returns true
+//   - empty statement: no effect → continues checking
+//   - nested block: recurses
+//   - try with finally that terminates: finally overrides → returns false
+//   - any other statement (expression, if, for, etc.): may throw → returns true
+func CanBlockThrow(block *ast.Node) bool {
+	statements := block.Statements()
+	if len(statements) == 0 {
+		return false
+	}
+	for _, stmt := range statements {
+		switch stmt.Kind {
+		case ast.KindBreakStatement, ast.KindContinueStatement:
+			return false
+		case ast.KindReturnStatement:
+			rs := stmt.AsReturnStatement()
+			return rs != nil && rs.Expression != nil
+		case ast.KindThrowStatement:
+			return true
+		case ast.KindEmptyStatement:
+			continue
+		case ast.KindBlock:
+			return CanBlockThrow(stmt)
+		case ast.KindTryStatement:
+			ts := stmt.AsTryStatement()
+			if ts != nil && ts.FinallyBlock != nil && BlockEndsWithTerminal(ts.FinallyBlock) {
+				return false
+			}
+			return true
+		default:
+			return true
+		}
+	}
+	return true
+}
+
+// BlockEndsWithTerminal checks if a block's last statement is a control flow
+// terminal (break/return/throw/continue), possibly nested in inner blocks.
+func BlockEndsWithTerminal(block *ast.Node) bool {
+	nodes := block.Statements()
+	if len(nodes) == 0 {
+		return false
+	}
+	last := nodes[len(nodes)-1]
+	switch last.Kind {
+	case ast.KindBreakStatement, ast.KindContinueStatement,
+		ast.KindReturnStatement, ast.KindThrowStatement:
+		return true
+	case ast.KindBlock:
+		return BlockEndsWithTerminal(last)
+	}
+	return false
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -237,6 +237,7 @@ export default defineConfig({
     './tests/eslint/rules/no-new-symbol.test.ts',
     './tests/eslint/rules/no-obj-calls.test.ts',
     './tests/eslint/rules/no-setter-return.test.ts',
+    './tests/eslint/rules/no-unreachable.test.ts',
     './tests/eslint/rules/no-unsafe-finally.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unreachable.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unreachable.test.ts.snap
@@ -1,0 +1,443 @@
+// Rstest Snapshot v1
+
+exports[`no-unreachable > invalid 1`] = `
+{
+  "code": "function foo() { return; x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 2`] = `
+{
+  "code": "function foo() { throw error; x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 3`] = `
+{
+  "code": "while (true) { break; x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 4`] = `
+{
+  "code": "while (true) { continue; x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 5`] = `
+{
+  "code": "function foo() { return; var x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 6`] = `
+{
+  "code": "function foo() { return; x = 1; y = 2; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 7`] = `
+{
+  "code": "function foo() { return; let x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 8`] = `
+{
+  "code": "function foo() { return; const x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 9`] = `
+{
+  "code": "function foo() { return; class Bar {} }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 10`] = `
+{
+  "code": "function foo() { if (x) { return 1; } else { return 2; } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 11`] = `
+{
+  "code": "function foo() { try { return 1; } catch(e) { return 2; } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 1,
+        },
+        "start": {
+          "column": 59,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 12`] = `
+{
+  "code": "function foo() { while(true) { doSomething(); } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 13`] = `
+{
+  "code": "function foo() { for(;;) { doSomething(); } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 14`] = `
+{
+  "code": "function foo() { try { console.log('x'); } finally { return 1; } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 66,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 15`] = `
+{
+  "code": "outer: while(true) { while(true) { break outer; } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 16`] = `
+{
+  "code": "function foo() { switch(x) { case 1: return 1; default: return 2; } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unreachable > invalid 17`] = `
+{
+  "code": "function foo() { if (a) { if (b) { return; } else { return; } } else { return; } bar(); }",
+  "diagnostics": [
+    {
+      "message": "Unreachable code.",
+      "messageId": "unreachableCode",
+      "range": {
+        "end": {
+          "column": 88,
+          "line": 1,
+        },
+        "start": {
+          "column": 82,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unreachable",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unreachable.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unreachable.test.ts
@@ -1,0 +1,113 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unreachable', {
+  valid: [
+    // Function declaration after return is hoisted
+    'function foo() { return bar(); function bar() { return 1; } }',
+    // Normal code before return
+    'function foo() { var x = 1; return x; }',
+    // if without else: not fully terminal
+    'function foo() { if (x) { return; } bar(); }',
+    // var without initializer after return is hoisted
+    'function foo() { return; var x; }',
+    // Empty statement after return is allowed
+    'function foo() { return; ; }',
+    // Multiple var declarations without initializers
+    'function foo() { return; var x, y, z; }',
+    // Function declaration after throw
+    'function foo() { throw new Error(); function bar() {} }',
+    // Switch without default is not terminal
+    'function foo() { switch(x) { case 1: return; } bar(); }',
+    // Try with finally (no catch) - try returns
+    'function foo() { try { return; } finally { cleanup(); } }',
+  ],
+  invalid: [
+    // Unreachable after return
+    {
+      code: 'function foo() { return; x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after throw
+    {
+      code: 'function foo() { throw error; x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after break
+    {
+      code: 'while (true) { break; x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after continue
+    {
+      code: 'while (true) { continue; x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // var with initializer after return IS reported
+    {
+      code: 'function foo() { return; var x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Multiple unreachable statements - grouped into one report
+    {
+      code: 'function foo() { return; x = 1; y = 2; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // let after return
+    {
+      code: 'function foo() { return; let x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // const after return
+    {
+      code: 'function foo() { return; const x = 1; }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Class declaration after return
+    {
+      code: 'function foo() { return; class Bar {} }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after if/else where both return
+    {
+      code: 'function foo() { if (x) { return 1; } else { return 2; } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after try/catch where both return
+    {
+      code: 'function foo() { try { return 1; } catch(e) { return 2; } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after while(true) infinite loop
+    {
+      code: 'function foo() { while(true) { doSomething(); } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after for(;;) infinite loop
+    {
+      code: 'function foo() { for(;;) { doSomething(); } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after try/finally where finally returns
+    {
+      code: "function foo() { try { console.log('x'); } finally { return 1; } bar(); }",
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after labeled break
+    {
+      code: 'outer: while(true) { while(true) { break outer; } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after switch with default where all cases return
+    {
+      code: 'function foo() { switch(x) { case 1: return 1; default: return 2; } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+    // Unreachable after nested if/else all returning
+    {
+      code: 'function foo() { if (a) { if (b) { return; } else { return; } } else { return; } bar(); }',
+      errors: [{ messageId: 'unreachableCode' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unreachable` rule from ESLint to rslint.

Disallow unreachable code after return, throw, continue, and break statements

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-unreachable

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).