### PR TITLE
feat: port rule no-unsafe-finally

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -142,6 +142,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
@@ -519,6 +520,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-fallthrough", no_fallthrough.NoFallthroughRule)
 	GlobalRuleRegistry.Register("valid-typeof", valid_typeof.ValidTypeofRule)
 	GlobalRuleRegistry.Register("no-unsafe-optional-chaining", no_unsafe_optional_chaining.NoUnsafeOptionalChainingRule)
+	GlobalRuleRegistry.Register("no-unsafe-finally", no_unsafe_finally.NoUnsafeFinallyRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_unsafe_finally/no_unsafe_finally.go
+++ b/internal/rules/no_unsafe_finally/no_unsafe_finally.go
@@ -1,0 +1,107 @@
+package no_unsafe_finally
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// buildUnsafeUsageMessage creates the diagnostic message for unsafe finally usage
+func buildUnsafeUsageMessage(nodeType string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unsafeUsage",
+		Description: "Unsafe usage of " + nodeType + ".",
+	}
+}
+
+// isReturnThrowSentinel checks if a node is a sentinel for return/throw statements
+// and labeled break statements. These are only stopped by function and class boundaries.
+func isReturnThrowSentinel(node *ast.Node) bool {
+	return ast.IsFunctionLikeDeclaration(node) || ast.IsClassLike(node)
+}
+
+// isBreakSentinel checks if a node is a sentinel for unlabeled break statements.
+// Unlabeled break is stopped by function boundaries, class boundaries, loops, and switch.
+func isBreakSentinel(node *ast.Node) bool {
+	return ast.IsFunctionLikeDeclaration(node) || ast.IsClassLike(node) ||
+		ast.IsIterationStatement(node, false) || ast.IsSwitchStatement(node)
+}
+
+// isContinueSentinel checks if a node is a sentinel for continue statements (labeled or not).
+// Continue is stopped by function boundaries, class boundaries, and loops (NOT switch).
+func isContinueSentinel(node *ast.Node) bool {
+	return ast.IsFunctionLikeDeclaration(node) || ast.IsClassLike(node) ||
+		ast.IsIterationStatement(node, false)
+}
+
+// isInFinally walks up the parent chain and checks if the node is inside a finally block
+// of a try statement. If a sentinel node is encountered first, the node is considered safe.
+// For labeled break/continue, the label target must be outside the finally block for it to be unsafe.
+func isInFinally(node *ast.Node, isSentinel func(*ast.Node) bool, label *ast.Node) bool {
+	return ast.FindAncestorOrQuit(node.Parent, func(current *ast.Node) ast.FindAncestorResult {
+		if isSentinel(current) {
+			return ast.FindAncestorQuit
+		}
+
+		// For labeled break/continue: if we find the matching label inside the
+		// finally block, the break/continue is safe (targets something inside finally)
+		if label != nil && ast.IsLabeledStatement(current) {
+			labeledStmt := current.AsLabeledStatement()
+			if labeledStmt.Label != nil && labeledStmt.Label.Text() == label.Text() {
+				return ast.FindAncestorQuit
+			}
+		}
+
+		// Check if we're in a finally block of a try statement
+		if current.Parent != nil && ast.IsTryStatement(current.Parent) {
+			tryStmt := current.Parent.AsTryStatement()
+			if tryStmt.FinallyBlock != nil && tryStmt.FinallyBlock == current {
+				return ast.FindAncestorTrue
+			}
+		}
+
+		return ast.FindAncestorFalse
+	}) != nil
+}
+
+// NoUnsafeFinallyRule disallows control flow statements in finally blocks
+var NoUnsafeFinallyRule = rule.Rule{
+	Name: "no-unsafe-finally",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindReturnStatement: func(node *ast.Node) {
+				if isInFinally(node, isReturnThrowSentinel, nil) {
+					ctx.ReportNode(node, buildUnsafeUsageMessage("ReturnStatement"))
+				}
+			},
+			ast.KindThrowStatement: func(node *ast.Node) {
+				if isInFinally(node, isReturnThrowSentinel, nil) {
+					ctx.ReportNode(node, buildUnsafeUsageMessage("ThrowStatement"))
+				}
+			},
+			ast.KindBreakStatement: func(node *ast.Node) {
+				breakStmt := node.AsBreakStatement()
+				if breakStmt.Label != nil {
+					if isInFinally(node, isReturnThrowSentinel, breakStmt.Label) {
+						ctx.ReportNode(node, buildUnsafeUsageMessage("BreakStatement"))
+					}
+				} else {
+					if isInFinally(node, isBreakSentinel, nil) {
+						ctx.ReportNode(node, buildUnsafeUsageMessage("BreakStatement"))
+					}
+				}
+			},
+			ast.KindContinueStatement: func(node *ast.Node) {
+				continueStmt := node.AsContinueStatement()
+				if continueStmt.Label != nil {
+					if isInFinally(node, isContinueSentinel, continueStmt.Label) {
+						ctx.ReportNode(node, buildUnsafeUsageMessage("ContinueStatement"))
+					}
+				} else {
+					if isInFinally(node, isContinueSentinel, nil) {
+						ctx.ReportNode(node, buildUnsafeUsageMessage("ContinueStatement"))
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_unsafe_finally/no_unsafe_finally.md
+++ b/internal/rules/no_unsafe_finally/no_unsafe_finally.md
@@ -1,0 +1,74 @@
+# no-unsafe-finally
+
+## Rule Details
+
+Disallows control flow statements (`return`, `throw`, `break`, `continue`) inside `finally` blocks. When control flow statements are used inside `finally` blocks, they override the control flow of `try` and `catch` blocks, which can lead to unexpected behavior and make code harder to understand.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo() {
+  try {
+    return 1;
+  } catch (err) {
+    return 2;
+  } finally {
+    return 3; // overrides the return in try/catch
+  }
+}
+
+function bar() {
+  try {
+    doSomething();
+  } finally {
+    throw new Error(); // overrides any error thrown in try
+  }
+}
+
+label: try {
+  return 0;
+} finally {
+  break label; // overrides the return in try
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function foo() {
+  try {
+    return 1;
+  } catch (err) {
+    return 2;
+  } finally {
+    console.log('done');
+  }
+}
+
+function bar() {
+  try {
+    doSomething();
+  } finally {
+    // control flow inside nested functions is fine
+    function cleanup(x) {
+      return x;
+    }
+    cleanup();
+  }
+}
+
+function baz() {
+  try {
+    doSomething();
+  } finally {
+    // break/continue inside loops within finally is fine
+    while (condition) {
+      break;
+    }
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint no-unsafe-finally](https://eslint.org/docs/latest/rules/no-unsafe-finally)

--- a/internal/rules/no_unsafe_finally/no_unsafe_finally_test.go
+++ b/internal/rules/no_unsafe_finally/no_unsafe_finally_test.go
@@ -1,0 +1,442 @@
+package no_unsafe_finally
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnsafeFinallyRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnsafeFinallyRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// ====================================================================
+			// No control flow in finally
+			// ====================================================================
+			{Code: `var foo = function() { try { return 1; } catch(err) { return 2; } finally { console.log("hola!") } }`},
+
+			// ====================================================================
+			// Function-like boundaries: all 7 kinds stop return/throw propagation
+			// ====================================================================
+			// FunctionDeclaration
+			{Code: `var foo = function() { try {} finally { function a(x) { return x } } }`},
+			// FunctionExpression
+			{Code: `var foo = function() { try {} finally { var a = function(x) { return x } } }`},
+			// ArrowFunction
+			{Code: `var foo = function() { try {} finally { var a = (x) => { return x } } }`},
+			// MethodDeclaration (object literal)
+			{Code: `var foo = function() { try {} finally { var obj = { method() { return 1 } } } }`},
+			// GetAccessor
+			{Code: `var foo = function() { try {} finally { var obj = { get x() { return 1 } } } }`},
+			// SetAccessor
+			{Code: `var foo = function() { try {} finally { var obj = { set x(v) { return } } } }`},
+			// Constructor
+			{Code: `var foo = function() { try {} finally { class C { constructor() { return } } } }`},
+
+			// Special function variants
+			// async function
+			{Code: `var foo = function() { try {} finally { async function a() { return 1 } } }`},
+			// generator function
+			{Code: `var foo = function() { try {} finally { function* gen() { return 1 } } }`},
+			// async generator
+			{Code: `var foo = function() { try {} finally { async function* gen() { return 1 } } }`},
+			// async arrow
+			{Code: `var foo = function() { try {} finally { var a = async () => { return 1 } } }`},
+
+			// Throw inside nested function
+			{Code: `var foo = function() { try {} finally { function a() { throw new Error() } } }`},
+			// Complex control flow inside nested function (from ESLint original tests)
+			{Code: `var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { if(!x) { throw new Error() } } } }`},
+			{Code: `var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { while(true) { if(x) { break } else { continue } } } } }`},
+			{Code: `var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { label: while(true) { if(x) { break label; } else { continue } } } } }`},
+			// Arrow function body expression (no control flow statement)
+			{Code: `var foo = function() { try { return 1; } catch(err) { return 2 } finally { (x) => x } }`},
+
+			// ====================================================================
+			// Class-like boundaries: ClassDeclaration and ClassExpression
+			// ====================================================================
+			// ClassDeclaration — return in method
+			{Code: `var foo = function() { try {} finally { class C { method() { return 1 } } } }`},
+			// ClassExpression — return in method
+			{Code: `var foo = function() { try {} finally { var C = class { method() { return 1 } } } }`},
+			// ClassDeclaration — throw in static method
+			{Code: `var foo = function() { try {} finally { class C { static fail() { throw new Error() } } } }`},
+			// Multi-level: arrow function inside class method inside finally
+			{Code: `var foo = function() { try {} finally { class C { method() { var fn = () => { return 1 } } } } }`},
+
+			// ====================================================================
+			// Loop (iteration) boundaries for unlabeled break: all 5 kinds
+			// ====================================================================
+			{Code: `var foo = function() { try {} finally { while (true) break; } }`},
+			{Code: `var foo = function() { try {} finally { for (var i = 0; i < 10; i++) break; } }`},
+			{Code: `var foo = function() { try {} finally { for (var x in obj) break; } }`},
+			{Code: `var foo = function() { try {} finally { for (var x of arr) break; } }`},
+			{Code: `var foo = function() { try {} finally { do { break; } while (true); } }`},
+
+			// ====================================================================
+			// Loop boundaries for unlabeled continue: all 5 kinds
+			// ====================================================================
+			{Code: `var foo = function() { try {} finally { while (true) continue; } }`},
+			{Code: `var foo = function() { try {} finally { for (var i = 0; i < 10; i++) continue; } }`},
+			{Code: `var foo = function() { try {} finally { for (var x in obj) continue; } }`},
+			{Code: `var foo = function() { try {} finally { for (var x of arr) continue; } }`},
+			{Code: `var foo = function() { try {} finally { do { continue; } while (true); } }`},
+
+			// ====================================================================
+			// Switch boundary for unlabeled break (NOT for continue)
+			// ====================================================================
+			{Code: `var foo = function() { try {} finally { switch (true) { case true: break; } } }`},
+
+			// ====================================================================
+			// Labeled break/continue with label INSIDE finally (safe)
+			// ====================================================================
+			// Label on loop
+			{Code: `var foo = function() { try {} finally { label: while (true) { break label; } } }`},
+			{Code: `var foo = function() { try {} finally { label: while (true) { continue label; } } }`},
+			{Code: `var foo = function() { try {} finally { label: for (var i = 0; i < 10; i++) { break label; } } }`},
+			{Code: `var foo = function() { try {} finally { label: for (var i = 0; i < 10; i++) { continue label; } } }`},
+			{Code: `var foo = function() { try {} finally { label: for (var x in obj) { break label; } } }`},
+			{Code: `var foo = function() { try {} finally { label: for (var x of arr) { continue label; } } }`},
+			{Code: `var foo = function() { try {} finally { label: do { break label; } while (true); } }`},
+			// Label on plain block (break only, continue on block is invalid syntax)
+			{Code: `var foo = function() { try {} finally { label: { break label; } } }`},
+
+			// ====================================================================
+			// Labeled continue with intermediate loop in finally
+			// (loop is sentinel per ESLint behavior — all 5 loop types)
+			// ====================================================================
+			{Code: `label: while (true) { try {} finally { while (true) { continue label; } } }`},
+			{Code: `label: while (true) { try {} finally { for (var i = 0; i < 10; i++) { continue label; } } }`},
+			{Code: `label: while (true) { try {} finally { for (var x in obj) { continue label; } } }`},
+			{Code: `label: while (true) { try {} finally { for (var x of arr) { continue label; } } }`},
+			{Code: `label: while (true) { try {} finally { do { continue label; } while (true); } }`},
+
+			// ====================================================================
+			// No finally block at all
+			// ====================================================================
+			{Code: `var foo = function() { try { return 1 } catch(err) { return 2 } }`},
+
+			// Control flow in try/catch but not finally
+			{Code: `var foo = function() { try { throw new Error() } catch(err) { return 2 } finally { console.log("done") } }`},
+			{Code: `var foo = function() { try { return 1 } catch(err) { throw new Error() } finally { console.log("done") } }`},
+
+			// ====================================================================
+			// Deep nesting — safe due to function/class boundaries
+			// ====================================================================
+			// Return in arrow inside if inside finally
+			{Code: `var foo = function() { try {} finally { if (true) { var fn = () => { return 1 }; } } }`},
+			// Return in function inside loop inside finally
+			{Code: `var foo = function() { try {} finally { while (true) { (function() { return 1 })(); break; } } }`},
+			// Break in loop inside nested try (safe because loop is sentinel)
+			{Code: `var foo = function() { try {} finally { try { while (true) { break; } } catch(e) {} } }`},
+			// Deeply nested: function → class → arrow
+			{Code: `var foo = function() { try {} finally { (function() { class C { method() { return (() => { return 1 })() } } })() } }`},
+
+			// ====================================================================
+			// Nested try-finally — only inner finally matters
+			// ====================================================================
+			// Inner try-finally with no control flow in either finally
+			{Code: `var foo = function() { try {} finally { try { console.log(1) } finally { console.log(2) } } }`},
+			// Return in inner try body (not in any finally)
+			{Code: `var foo = function() { try {} finally { var fn = function() { try { return 1 } finally { console.log(2) } } } }`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// ====================================================================
+			// Basic: return in finally
+			// ====================================================================
+			{
+				Code: `var foo = function() { try { return 1; } catch(err) { return 2; } finally { return 3; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 77},
+				},
+			},
+			{
+				Code: `var foo = function() { try { return 1; } finally { return 3; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 52},
+				},
+			},
+
+			// ====================================================================
+			// Basic: throw in finally
+			// ====================================================================
+			{
+				Code: `var foo = function() { try { return 1 } catch(err) { return 2 } finally { throw new Error() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 75},
+				},
+			},
+			{
+				Code: `var foo = function() { try {} finally { throw new Error() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 41},
+				},
+			},
+
+			// ====================================================================
+			// Unlabeled break/continue — targeting loop/switch OUTSIDE finally
+			// ====================================================================
+			{
+				Code: `while (true) try {} finally { break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `while (true) try {} finally { continue; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `for (;;) try {} finally { break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			{
+				Code: `for (var x in obj) try {} finally { continue; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			{
+				Code: `for (var x of arr) try {} finally { break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			{
+				Code: `do { try {} finally { break; } } while (true)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Labeled break — label OUTSIDE finally
+			// ====================================================================
+			{
+				Code: `label: try { return 0; } finally { break label; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `label: try {} finally { break label; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 25},
+				},
+			},
+			// Labeled break — inner label exists but targets outer
+			{
+				Code: `outer: { try {} finally { inner: { break outer; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Labeled continue — label OUTSIDE finally (no intermediate loop)
+			// ====================================================================
+			{
+				Code: `label: while (true) try {} finally { continue label; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: `label: for (;;) try {} finally { continue label; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Continue passes through switch (switch is NOT sentinel for continue)
+			// ====================================================================
+			{
+				Code: `while (true) try {} finally { switch (true) { case true: continue; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 58},
+				},
+			},
+
+			// ====================================================================
+			// Control flow inside non-boundary constructs in finally
+			// (if/else, blocks, conditional — these are NOT sentinels)
+			// ====================================================================
+			// Return inside if in finally
+			{
+				Code: `var foo = function() { try {} finally { if (true) { return 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Return inside if-else in finally
+			{
+				Code: `var foo = function() { try {} finally { if (true) { return 1; } else { return 2; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Throw inside conditional in finally
+			{
+				Code: `var foo = function() { try {} finally { if (cond) throw new Error() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Return inside nested blocks in finally
+			{
+				Code: `var foo = function() { try {} finally { { { return 1; } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Control flow in try/catch body INSIDE outer finally
+			// (the whole try-catch is inside the outer finally block)
+			// ====================================================================
+			// Return in inner try body
+			{
+				Code: `var foo = function() { try {} finally { try { return 1; } catch(e) {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Return in inner catch body
+			{
+				Code: `var foo = function() { try {} finally { try { x } catch(e) { return 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Throw in inner catch body inside outer finally
+			{
+				Code: `var foo = function() { try {} finally { try { x } catch(e) { throw e; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Nested try-finally — inner finally
+			// ====================================================================
+			{
+				Code: `var foo = function() { try {} finally { try {} finally { return 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 58},
+				},
+			},
+			// Throw in nested inner finally
+			{
+				Code: `var foo = function() { try {} finally { try {} finally { throw new Error(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Triple nesting — return in innermost finally
+			{
+				Code: `var foo = function() { try {} finally { try {} finally { try {} finally { return 1; } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Multiple unsafe statements in one finally
+			// ====================================================================
+			{
+				Code: `var foo = function() { try {} finally { return 1; return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1, Column: 41},
+					{MessageId: "unsafeUsage", Line: 1, Column: 51},
+				},
+			},
+			// Mixed statement types in finally
+			{
+				Code: `var foo = function() { try {} finally { return 1; throw new Error(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// Complex nesting — unsafe despite intermediate non-boundary constructs
+			// ====================================================================
+			// Return in for-loop body inside finally (loop doesn't stop return)
+			{
+				Code: `var foo = function() { try {} finally { for (var i = 0; i < 1; i++) { return 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Throw in switch case inside finally (switch doesn't stop throw)
+			{
+				Code: `var foo = function() { try {} finally { switch (x) { case 1: throw new Error(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Return deep in if → for → switch inside finally (none are sentinels for return)
+			{
+				Code: `var foo = function() { try {} finally { if (true) { for (var i = 0; i < 1; i++) { switch (x) { default: return 1; } } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// From ESLint original tests — return value contains function/object
+			// (the outer return is still unsafe even though inner returns are safe)
+			// ====================================================================
+			{
+				Code: `var foo = function() { try { return 1 } catch(err) { return 2 } finally { return function(x) { return y } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			{
+				Code: `var foo = function() { try { return 1 } catch(err) { return 2 } finally { return { x: function(c) { return c } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+
+			// ====================================================================
+			// From ESLint original tests — break/continue across switch boundaries
+			// ====================================================================
+			// Unlabeled break in finally inside switch case (switch is OUTSIDE finally)
+			{
+				Code: `var foo = function() { switch (true) { case true: try {} finally { break; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Labeled break from switch case inside finally to outer label
+			{
+				Code: `var foo = function() { a: while (true) try {} finally { switch (true) { case true: break a; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+			// Labeled break across nested switches (outer switch label)
+			{
+				Code: `var foo = function() { a: switch (true) { case true: try {} finally { switch (true) { case true: break a; } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeUsage", Line: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -237,6 +237,7 @@ export default defineConfig({
     './tests/eslint/rules/no-new-symbol.test.ts',
     './tests/eslint/rules/no-obj-calls.test.ts',
     './tests/eslint/rules/no-setter-return.test.ts',
+    './tests/eslint/rules/no-unsafe-finally.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unsafe-finally.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unsafe-finally.test.ts.snap
@@ -1,0 +1,982 @@
+// Rstest Snapshot v1
+
+exports[`no-unsafe-finally > invalid 1`] = `
+{
+  "code": "var foo = function() { try { return 1; } catch(err) { return 2; } finally { return 3; } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 86,
+          "line": 1,
+        },
+        "start": {
+          "column": 77,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 2`] = `
+{
+  "code": "var foo = function() { try { return 1; } finally { return 3; } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 3`] = `
+{
+  "code": "var foo = function() { try { return 1 } catch(err) { return 2 } finally { throw new Error() } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 1,
+        },
+        "start": {
+          "column": 75,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 4`] = `
+{
+  "code": "var foo = function() { try {} finally { throw new Error() } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 5`] = `
+{
+  "code": "while (true) try {} finally { break; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 6`] = `
+{
+  "code": "while (true) try {} finally { continue; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ContinueStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 7`] = `
+{
+  "code": "for (;;) try {} finally { break; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 8`] = `
+{
+  "code": "for (var x in obj) try {} finally { continue; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ContinueStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 9`] = `
+{
+  "code": "for (var x of arr) try {} finally { break; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 10`] = `
+{
+  "code": "do { try {} finally { break; } } while (true)",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 11`] = `
+{
+  "code": "label: try { return 0; } finally { break label; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 12`] = `
+{
+  "code": "label: try {} finally { break label; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 13`] = `
+{
+  "code": "outer: { try {} finally { inner: { break outer; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 14`] = `
+{
+  "code": "label: while (true) try {} finally { continue label; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ContinueStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 15`] = `
+{
+  "code": "label: for (;;) try {} finally { continue label; }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ContinueStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 16`] = `
+{
+  "code": "while (true) try {} finally { switch (true) { case true: continue; } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ContinueStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 17`] = `
+{
+  "code": "var foo = function() { try {} finally { if (true) { return 1; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 18`] = `
+{
+  "code": "var foo = function() { try {} finally { if (true) { return 1; } else { return 2; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 81,
+          "line": 1,
+        },
+        "start": {
+          "column": 72,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 19`] = `
+{
+  "code": "var foo = function() { try {} finally { if (cond) throw new Error() } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 20`] = `
+{
+  "code": "var foo = function() { try {} finally { { { return 1; } } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 21`] = `
+{
+  "code": "var foo = function() { try {} finally { try { return 1; } catch(e) {} } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 22`] = `
+{
+  "code": "var foo = function() { try {} finally { try { x } catch(e) { return 1; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 23`] = `
+{
+  "code": "var foo = function() { try {} finally { try { x } catch(e) { throw e; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 24`] = `
+{
+  "code": "var foo = function() { try {} finally { try {} finally { return 1; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 25`] = `
+{
+  "code": "var foo = function() { try {} finally { try {} finally { throw new Error(); } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 26`] = `
+{
+  "code": "var foo = function() { try {} finally { try {} finally { try {} finally { return 1; } } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 1,
+        },
+        "start": {
+          "column": 75,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 27`] = `
+{
+  "code": "var foo = function() { try {} finally { return 1; return 2; } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 28`] = `
+{
+  "code": "var foo = function() { try {} finally { return 1; throw new Error(); } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 29`] = `
+{
+  "code": "var foo = function() { try {} finally { for (var i = 0; i < 1; i++) { return 1; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 71,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 30`] = `
+{
+  "code": "var foo = function() { try {} finally { switch (x) { case 1: throw new Error(); } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ThrowStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 31`] = `
+{
+  "code": "var foo = function() { try {} finally { if (true) { for (var i = 0; i < 1; i++) { switch (x) { default: return 1; } } } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 114,
+          "line": 1,
+        },
+        "start": {
+          "column": 105,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 32`] = `
+{
+  "code": "var foo = function() { try { return 1 } catch(err) { return 2 } finally { return function(x) { return y } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 106,
+          "line": 1,
+        },
+        "start": {
+          "column": 75,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 33`] = `
+{
+  "code": "var foo = function() { try { return 1 } catch(err) { return 2 } finally { return { x: function(c) { return c } } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of ReturnStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 113,
+          "line": 1,
+        },
+        "start": {
+          "column": 75,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 34`] = `
+{
+  "code": "var foo = function() { switch (true) { case true: try {} finally { break; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 68,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 35`] = `
+{
+  "code": "var foo = function() { a: while (true) try {} finally { switch (true) { case true: break a; } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 1,
+        },
+        "start": {
+          "column": 84,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-finally > invalid 36`] = `
+{
+  "code": "var foo = function() { a: switch (true) { case true: try {} finally { switch (true) { case true: break a; } } } }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of BreakStatement.",
+      "messageId": "unsafeUsage",
+      "range": {
+        "end": {
+          "column": 106,
+          "line": 1,
+        },
+        "start": {
+          "column": 98,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-finally",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unsafe-finally.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unsafe-finally.test.ts
@@ -1,0 +1,322 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unsafe-finally', {
+  valid: [
+    // ====================================================================
+    // No control flow in finally
+    // ====================================================================
+    'var foo = function() { try { return 1; } catch(err) { return 2; } finally { console.log("hola!") } }',
+
+    // ====================================================================
+    // Function-like boundaries: all 7 kinds stop return/throw propagation
+    // ====================================================================
+    // FunctionDeclaration
+    'var foo = function() { try {} finally { function a(x) { return x } } }',
+    // FunctionExpression
+    'var foo = function() { try {} finally { var a = function(x) { return x } } }',
+    // ArrowFunction
+    'var foo = function() { try {} finally { var a = (x) => { return x } } }',
+    // MethodDeclaration (object literal)
+    'var foo = function() { try {} finally { var obj = { method() { return 1 } } } }',
+    // GetAccessor
+    'var foo = function() { try {} finally { var obj = { get x() { return 1 } } } }',
+    // SetAccessor
+    'var foo = function() { try {} finally { var obj = { set x(v) { return } } } }',
+    // Constructor
+    'var foo = function() { try {} finally { class C { constructor() { return } } } }',
+
+    // Special function variants
+    'var foo = function() { try {} finally { async function a() { return 1 } } }',
+    'var foo = function() { try {} finally { function* gen() { return 1 } } }',
+    'var foo = function() { try {} finally { async function* gen() { return 1 } } }',
+    'var foo = function() { try {} finally { var a = async () => { return 1 } } }',
+
+    // Throw inside nested function
+    'var foo = function() { try {} finally { function a() { throw new Error() } } }',
+    // Complex control flow inside nested function (from ESLint original tests)
+    'var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { if(!x) { throw new Error() } } } }',
+    'var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { while(true) { if(x) { break } else { continue } } } } }',
+    'var foo = function() { try { return 1 } catch(err) { return 2 } finally { var a = function(x) { label: while(true) { if(x) { break label; } else { continue } } } } }',
+    // Arrow expression body (no control flow statement)
+    'var foo = function() { try { return 1; } catch(err) { return 2 } finally { (x) => x } }',
+
+    // ====================================================================
+    // Class-like boundaries: ClassDeclaration and ClassExpression
+    // ====================================================================
+    'var foo = function() { try {} finally { class C { method() { return 1 } } } }',
+    'var foo = function() { try {} finally { var C = class { method() { return 1 } } } }',
+    'var foo = function() { try {} finally { class C { static fail() { throw new Error() } } } }',
+    // Multi-level: arrow function inside class method inside finally
+    'var foo = function() { try {} finally { class C { method() { var fn = () => { return 1 } } } } }',
+
+    // ====================================================================
+    // Loop boundaries for unlabeled break: all 5 kinds
+    // ====================================================================
+    'var foo = function() { try {} finally { while (true) break; } }',
+    'var foo = function() { try {} finally { for (var i = 0; i < 10; i++) break; } }',
+    'var foo = function() { try {} finally { for (var x in obj) break; } }',
+    'var foo = function() { try {} finally { for (var x of arr) break; } }',
+    'var foo = function() { try {} finally { do { break; } while (true); } }',
+
+    // ====================================================================
+    // Loop boundaries for unlabeled continue: all 5 kinds
+    // ====================================================================
+    'var foo = function() { try {} finally { while (true) continue; } }',
+    'var foo = function() { try {} finally { for (var i = 0; i < 10; i++) continue; } }',
+    'var foo = function() { try {} finally { for (var x in obj) continue; } }',
+    'var foo = function() { try {} finally { for (var x of arr) continue; } }',
+    'var foo = function() { try {} finally { do { continue; } while (true); } }',
+
+    // ====================================================================
+    // Switch boundary for unlabeled break
+    // ====================================================================
+    'var foo = function() { try {} finally { switch (true) { case true: break; } } }',
+
+    // ====================================================================
+    // Labeled break/continue with label INSIDE finally
+    // ====================================================================
+    'var foo = function() { try {} finally { label: while (true) { break label; } } }',
+    'var foo = function() { try {} finally { label: while (true) { continue label; } } }',
+    'var foo = function() { try {} finally { label: for (var i = 0; i < 10; i++) { break label; } } }',
+    'var foo = function() { try {} finally { label: for (var i = 0; i < 10; i++) { continue label; } } }',
+    'var foo = function() { try {} finally { label: for (var x in obj) { break label; } } }',
+    'var foo = function() { try {} finally { label: for (var x of arr) { continue label; } } }',
+    'var foo = function() { try {} finally { label: do { break label; } while (true); } }',
+    // Label on plain block
+    'var foo = function() { try {} finally { label: { break label; } } }',
+
+    // ====================================================================
+    // Labeled continue with intermediate loop (all 5 loop types)
+    // ====================================================================
+    'label: while (true) { try {} finally { while (true) { continue label; } } }',
+    'label: while (true) { try {} finally { for (var i = 0; i < 10; i++) { continue label; } } }',
+    'label: while (true) { try {} finally { for (var x in obj) { continue label; } } }',
+    'label: while (true) { try {} finally { for (var x of arr) { continue label; } } }',
+    'label: while (true) { try {} finally { do { continue label; } while (true); } }',
+
+    // ====================================================================
+    // No finally block at all / control flow in try-catch only
+    // ====================================================================
+    'var foo = function() { try { return 1 } catch(err) { return 2 } }',
+    'var foo = function() { try { throw new Error() } catch(err) { return 2 } finally { console.log("done") } }',
+    'var foo = function() { try { return 1 } catch(err) { throw new Error() } finally { console.log("done") } }',
+
+    // ====================================================================
+    // Deep nesting — safe due to boundaries
+    // ====================================================================
+    'var foo = function() { try {} finally { if (true) { var fn = () => { return 1 }; } } }',
+    'var foo = function() { try {} finally { while (true) { (function() { return 1 })(); break; } } }',
+    'var foo = function() { try {} finally { try { while (true) { break; } } catch(e) {} } }',
+    'var foo = function() { try {} finally { (function() { class C { method() { return (() => { return 1 })() } } })() } }',
+
+    // ====================================================================
+    // Nested try-finally — safe
+    // ====================================================================
+    'var foo = function() { try {} finally { try { console.log(1) } finally { console.log(2) } } }',
+    'var foo = function() { try {} finally { var fn = function() { try { return 1 } finally { console.log(2) } } } }',
+  ],
+  invalid: [
+    // ====================================================================
+    // Basic: return in finally
+    // ====================================================================
+    {
+      code: 'var foo = function() { try { return 1; } catch(err) { return 2; } finally { return 3; } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try { return 1; } finally { return 3; } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Basic: throw in finally
+    // ====================================================================
+    {
+      code: 'var foo = function() { try { return 1 } catch(err) { return 2 } finally { throw new Error() } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { throw new Error() } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Unlabeled break/continue — targeting loop OUTSIDE finally
+    // ====================================================================
+    {
+      code: 'while (true) try {} finally { break; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'while (true) try {} finally { continue; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'for (;;) try {} finally { break; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'for (var x in obj) try {} finally { continue; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'for (var x of arr) try {} finally { break; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'do { try {} finally { break; } } while (true)',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Labeled break — label OUTSIDE finally
+    // ====================================================================
+    {
+      code: 'label: try { return 0; } finally { break label; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'label: try {} finally { break label; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    // Inner label exists but targets outer
+    {
+      code: 'outer: { try {} finally { inner: { break outer; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Labeled continue — label OUTSIDE finally (no intermediate loop)
+    // ====================================================================
+    {
+      code: 'label: while (true) try {} finally { continue label; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'label: for (;;) try {} finally { continue label; }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Continue passes through switch (switch is NOT sentinel for continue)
+    // ====================================================================
+    {
+      code: 'while (true) try {} finally { switch (true) { case true: continue; } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Control flow inside non-boundary constructs in finally
+    // ====================================================================
+    {
+      code: 'var foo = function() { try {} finally { if (true) { return 1; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { if (true) { return 1; } else { return 2; } } }',
+      errors: [{ messageId: 'unsafeUsage' }, { messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { if (cond) throw new Error() } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { { { return 1; } } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Control flow in try/catch body INSIDE outer finally
+    // ====================================================================
+    {
+      code: 'var foo = function() { try {} finally { try { return 1; } catch(e) {} } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { try { x } catch(e) { return 1; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { try { x } catch(e) { throw e; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Nested try-finally
+    // ====================================================================
+    {
+      code: 'var foo = function() { try {} finally { try {} finally { return 1; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { try {} finally { throw new Error(); } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    // Triple nesting
+    {
+      code: 'var foo = function() { try {} finally { try {} finally { try {} finally { return 1; } } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Multiple unsafe statements
+    // ====================================================================
+    {
+      code: 'var foo = function() { try {} finally { return 1; return 2; } }',
+      errors: [{ messageId: 'unsafeUsage' }, { messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { return 1; throw new Error(); } }',
+      errors: [{ messageId: 'unsafeUsage' }, { messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // Complex nesting — loops/switch/if don't stop return/throw
+    // ====================================================================
+    {
+      code: 'var foo = function() { try {} finally { for (var i = 0; i < 1; i++) { return 1; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { switch (x) { case 1: throw new Error(); } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try {} finally { if (true) { for (var i = 0; i < 1; i++) { switch (x) { default: return 1; } } } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // From ESLint original tests — return value contains function/object
+    // ====================================================================
+    {
+      code: 'var foo = function() { try { return 1 } catch(err) { return 2 } finally { return function(x) { return y } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    {
+      code: 'var foo = function() { try { return 1 } catch(err) { return 2 } finally { return { x: function(c) { return c } } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+
+    // ====================================================================
+    // From ESLint original tests — break/continue across switch boundaries
+    // ====================================================================
+    // Unlabeled break in finally inside switch case (switch is OUTSIDE finally)
+    {
+      code: 'var foo = function() { switch (true) { case true: try {} finally { break; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    // Labeled break from switch case inside finally to outer label
+    {
+      code: 'var foo = function() { a: while (true) try {} finally { switch (true) { case true: break a; } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+    // Labeled break across nested switches (outer switch label)
+    {
+      code: 'var foo = function() { a: switch (true) { case true: try {} finally { switch (true) { case true: break a; } } } }',
+      errors: [{ messageId: 'unsafeUsage' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unsafe-finally` rule from ESLint to rslint.

Disallow control flow statements in finally blocks

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-unsafe-finally

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).