### PR TITLE
feat: port rule no-unsafe-optional-chaining

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
@@ -517,6 +518,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("eqeqeq", eqeqeq.EqeqeqRule)
 	GlobalRuleRegistry.Register("no-fallthrough", no_fallthrough.NoFallthroughRule)
 	GlobalRuleRegistry.Register("valid-typeof", valid_typeof.ValidTypeofRule)
+	GlobalRuleRegistry.Register("no-unsafe-optional-chaining", no_unsafe_optional_chaining.NoUnsafeOptionalChainingRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_unsafe_optional_chaining/no_unsafe_optional_chaining.go
+++ b/internal/rules/no_unsafe_optional_chaining/no_unsafe_optional_chaining.go
@@ -1,0 +1,234 @@
+package no_unsafe_optional_chaining
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining
+var NoUnsafeOptionalChainingRule = rule.Rule{
+	Name: "no-unsafe-optional-chaining",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		unsafeOptionalChainMsg := rule.RuleMessage{
+			Id:          "unsafeOptionalChain",
+			Description: "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+		}
+
+		unsafeArithmeticMsg := rule.RuleMessage{
+			Id:          "unsafeArithmetic",
+			Description: "Unsafe arithmetic operation on optional chaining. It can result in NaN.",
+		}
+
+		checkUnsafeUsage := func(expr *ast.Node) {
+			checkUndefinedShortCircuit(expr, func(chainNode *ast.Node) {
+				ctx.ReportNode(chainNode, unsafeOptionalChainMsg)
+			})
+		}
+
+		checkUnsafeArithmetic := func(expr *ast.Node) {
+			checkUndefinedShortCircuit(expr, func(chainNode *ast.Node) {
+				ctx.ReportNode(chainNode, unsafeArithmeticMsg)
+			})
+		}
+
+		listeners := rule.RuleListeners{}
+
+		// CallExpression: (obj?.foo)()
+		listeners[ast.KindCallExpression] = func(node *ast.Node) {
+			if ast.IsOptionalChain(node) {
+				return
+			}
+			checkUnsafeUsage(node.AsCallExpression().Expression)
+		}
+
+		// NewExpression: new (obj?.foo)()
+		listeners[ast.KindNewExpression] = func(node *ast.Node) {
+			checkUnsafeUsage(node.AsNewExpression().Expression)
+		}
+
+		// TaggedTemplateExpression: (obj?.foo)`text`
+		listeners[ast.KindTaggedTemplateExpression] = func(node *ast.Node) {
+			checkUnsafeUsage(node.AsTaggedTemplateExpression().Tag)
+		}
+
+		// PropertyAccessExpression: (obj?.foo).bar
+		listeners[ast.KindPropertyAccessExpression] = func(node *ast.Node) {
+			if ast.IsOptionalChain(node) {
+				return
+			}
+			checkUnsafeUsage(node.AsPropertyAccessExpression().Expression)
+		}
+
+		// ElementAccessExpression: (obj?.foo)[0]
+		listeners[ast.KindElementAccessExpression] = func(node *ast.Node) {
+			if ast.IsOptionalChain(node) {
+				return
+			}
+			checkUnsafeUsage(node.AsElementAccessExpression().Expression)
+		}
+
+		// BinaryExpression: in/instanceof, destructuring assignment, arithmetic
+		listeners[ast.KindBinaryExpression] = func(node *ast.Node) {
+			bin := node.AsBinaryExpression()
+			if bin == nil || bin.OperatorToken == nil {
+				return
+			}
+
+			// Destructuring assignment: ({x} = obj?.foo)
+			if ast.IsDestructuringAssignment(node) {
+				checkUnsafeUsage(bin.Right)
+				return
+			}
+
+			op := bin.OperatorToken.Kind
+
+			switch op {
+			case ast.KindInKeyword, ast.KindInstanceOfKeyword:
+				checkUnsafeUsage(bin.Right)
+
+			case ast.KindPlusToken, ast.KindMinusToken, ast.KindAsteriskToken,
+				ast.KindSlashToken, ast.KindPercentToken, ast.KindAsteriskAsteriskToken:
+				if opts.disallowArithmeticOperators {
+					checkUnsafeArithmetic(bin.Left)
+					checkUnsafeArithmetic(bin.Right)
+				}
+
+			case ast.KindPlusEqualsToken, ast.KindMinusEqualsToken,
+				ast.KindAsteriskEqualsToken, ast.KindAsteriskAsteriskEqualsToken,
+				ast.KindSlashEqualsToken, ast.KindPercentEqualsToken:
+				if opts.disallowArithmeticOperators {
+					checkUnsafeArithmetic(bin.Right)
+				}
+			}
+		}
+
+		// PrefixUnaryExpression: +obj?.foo, -obj?.foo
+		if opts.disallowArithmeticOperators {
+			listeners[ast.KindPrefixUnaryExpression] = func(node *ast.Node) {
+				pue := node.AsPrefixUnaryExpression()
+				if pue.Operator == ast.KindPlusToken || pue.Operator == ast.KindMinusToken {
+					checkUnsafeArithmetic(pue.Operand)
+				}
+			}
+		}
+
+		// SpreadElement: [...obj?.foo] is unsafe, but {...obj?.foo} is safe
+		listeners[ast.KindSpreadElement] = func(node *ast.Node) {
+			if node.Parent != nil && node.Parent.Kind == ast.KindObjectLiteralExpression {
+				return
+			}
+			checkUnsafeUsage(node.AsSpreadElement().Expression)
+		}
+
+		// ForOfStatement: for (const x of obj?.foo)
+		listeners[ast.KindForOfStatement] = func(node *ast.Node) {
+			checkUnsafeUsage(node.AsForInOrOfStatement().Expression)
+		}
+
+		// VariableDeclaration: const {x} = obj?.foo
+		listeners[ast.KindVariableDeclaration] = func(node *ast.Node) {
+			vd := node.AsVariableDeclaration()
+			if name := vd.Name(); name != nil && ast.IsBindingPattern(name) {
+				checkUnsafeUsage(vd.Initializer)
+			}
+		}
+
+		// BindingElement: const {x: {y} = obj?.foo} = obj, function f({x: {y} = obj?.foo}) {}
+		listeners[ast.KindBindingElement] = func(node *ast.Node) {
+			be := node.AsBindingElement()
+			if name := be.Name(); name != nil && ast.IsBindingPattern(name) {
+				checkUnsafeUsage(be.Initializer)
+			}
+		}
+
+		// WithStatement: with (obj?.foo) {}
+		listeners[ast.KindWithStatement] = func(node *ast.Node) {
+			checkUnsafeUsage(node.AsWithStatement().Expression)
+		}
+
+		// Class extends: class Foo extends obj?.foo {}
+		classHandler := func(node *ast.Node) {
+			extendsElement := ast.GetClassExtendsHeritageElement(node)
+			if extendsElement == nil {
+				return
+			}
+			exprWithType := extendsElement.AsExpressionWithTypeArguments()
+			if exprWithType == nil {
+				return
+			}
+			checkUnsafeUsage(exprWithType.Expression)
+		}
+		listeners[ast.KindClassDeclaration] = classHandler
+		listeners[ast.KindClassExpression] = classHandler
+
+		return listeners
+	},
+}
+
+// checkUndefinedShortCircuit recursively traverses expression wrappers to find optional chain
+// nodes that could short-circuit with undefined, calling report for each one found.
+// Matches ESLint's checkUndefinedShortCircuit behavior.
+func checkUndefinedShortCircuit(node *ast.Node, report func(chainNode *ast.Node)) {
+	if node == nil {
+		return
+	}
+
+	node = ast.SkipParentheses(node)
+
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindCallExpression:
+		if ast.IsOptionalChain(node) {
+			report(node)
+		}
+
+	case ast.KindAwaitExpression:
+		checkUndefinedShortCircuit(node.AsAwaitExpression().Expression, report)
+
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin == nil || bin.OperatorToken == nil {
+			return
+		}
+		switch bin.OperatorToken.Kind {
+		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+			// || and ?? — only right side; left provides fallback
+			checkUndefinedShortCircuit(bin.Right, report)
+		case ast.KindAmpersandAmpersandToken:
+			// && — both sides can propagate undefined
+			checkUndefinedShortCircuit(bin.Left, report)
+			checkUndefinedShortCircuit(bin.Right, report)
+		case ast.KindCommaToken:
+			// Comma/sequence — only last (right) expression matters
+			checkUndefinedShortCircuit(bin.Right, report)
+		}
+
+	case ast.KindConditionalExpression:
+		ce := node.AsConditionalExpression()
+		checkUndefinedShortCircuit(ce.WhenTrue, report)
+		checkUndefinedShortCircuit(ce.WhenFalse, report)
+	}
+}
+
+type noUnsafeOptionalChainingOptions struct {
+	disallowArithmeticOperators bool
+}
+
+func parseOptions(opts any) noUnsafeOptionalChainingOptions {
+	result := noUnsafeOptionalChainingOptions{
+		disallowArithmeticOperators: false,
+	}
+
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap != nil {
+		if disallow, ok := optsMap["disallowArithmeticOperators"].(bool); ok {
+			result.disallowArithmeticOperators = disallow
+		}
+	}
+
+	return result
+}

--- a/internal/rules/no_unsafe_optional_chaining/no_unsafe_optional_chaining.md
+++ b/internal/rules/no_unsafe_optional_chaining/no_unsafe_optional_chaining.md
@@ -1,0 +1,49 @@
+# no-unsafe-optional-chaining
+
+## Rule Details
+
+Disallows using optional chaining in contexts where the `undefined` value is not allowed. Optional chaining (`?.`) can short-circuit to `undefined`. When the result is used in a position where `undefined` causes a TypeError or unexpected behavior, this rule reports it.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+(obj?.foo)(); // TypeError if obj?.foo is undefined
+(obj?.foo).bar; // TypeError
+new (obj?.foo)(); // TypeError
+const { a } = obj?.foo; // TypeError (destructuring undefined)
+[...obj?.foo]; // TypeError (spreading undefined)
+for (const x of obj?.foo) {
+} // TypeError (iterating undefined)
+'foo' in obj?.bar; // TypeError
+foo instanceof obj?.bar; // TypeError
+class Foo extends obj?.bar {} // TypeError
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+obj?.foo; // standalone is fine
+obj?.foo(); // optional call is fine
+(obj?.foo ?? bar)(); // fallback via ??
+(obj?.foo || bar).baz; // fallback via ||
+obj?.foo?.bar; // chaining is fine
+```
+
+## Options
+
+### `disallowArithmeticOperators`
+
+When set to `true`, also reports arithmetic operations on optional chaining results, which can produce `NaN`. Default is `false`.
+
+Examples of **incorrect** code with `{ "disallowArithmeticOperators": true }`:
+
+```javascript
+obj?.foo + bar; // may be NaN
++obj?.foo; // may be NaN
+-obj?.foo; // may be NaN
+obj?.foo * bar; // may be NaN
+```
+
+## Original Documentation
+
+- [ESLint no-unsafe-optional-chaining](https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining)

--- a/internal/rules/no_unsafe_optional_chaining/no_unsafe_optional_chaining_test.go
+++ b/internal/rules/no_unsafe_optional_chaining/no_unsafe_optional_chaining_test.go
@@ -1,0 +1,490 @@
+package no_unsafe_optional_chaining
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnsafeOptionalChainingRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnsafeOptionalChainingRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// Standalone optional chaining
+			{Code: `obj?.foo;`},
+			{Code: `obj?.foo();`},
+			{Code: `obj?.foo.bar;`},
+			{Code: `obj?.foo?.bar;`},
+			{Code: `obj?.foo?.bar();`},
+			{Code: `obj?.foo?.bar?.();`},
+
+			// Fallback operators neutralize the chain
+			{Code: `(obj?.foo ?? bar)();`},
+			{Code: `(obj?.foo ?? bar).baz;`},
+			{Code: `(obj?.foo ?? bar)[0];`},
+			{Code: `new (obj?.foo ?? bar)();`},
+			{Code: `(obj?.foo || bar)();`},
+			{Code: `(obj?.foo || bar).baz;`},
+
+			// Arithmetic without option is valid
+			{Code: `obj?.foo + bar;`},
+			{Code: `+obj?.foo;`},
+
+			// Spread in object literal is safe
+			{Code: `({...obj?.foo});`},
+			{Code: `({...obj?.foo, x: 1});`},
+
+			// Sequence: chain is NOT last — only last element matters
+			{Code: `(obj?.foo, bar)();`},
+			{Code: `(obj?.foo, bar).baz;`},
+
+			// for-in tolerates undefined (not for-of)
+			{Code: `for (const x in obj?.foo) {}`},
+
+			// Non-destructuring binding defaults are safe
+			{Code: `const {x = obj?.foo} = obj;`},
+			{Code: `function f({x = obj?.foo}: any) {}`},
+			{Code: `const [a = obj?.foo] = arr;`},
+
+			// Non-null assertion — developer explicitly asserts
+			{Code: `(obj?.foo)!.bar;`},
+			{Code: `(obj?.foo)!();`},
+			{Code: `new (obj?.foo)!();`},
+
+			// && left is chain but consumed by ||/?? fallback
+			{Code: `((obj?.foo && bar) ?? fallback)();`},
+			{Code: `((obj?.foo && bar) || fallback).baz;`},
+
+			// Nested fallbacks
+			{Code: `(obj?.foo ?? (obj?.bar ?? baz))();`},
+			{Code: `((obj?.foo || a) ?? b).bar;`},
+
+			// Non-optional access on non-chain
+			{Code: `obj.foo.bar;`},
+			{Code: `new obj.Foo();`},
+
+			// Arithmetic with fallback (with option)
+			{
+				Code:    `(obj?.foo ?? 0) + bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+			},
+			{
+				Code:    `+(obj?.foo ?? 0);`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+			},
+			{
+				Code:    `bar -= (obj?.foo ?? 0);`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+			},
+
+			// Class extends with non-optional
+			{Code: `class Foo extends Bar {}`},
+
+			// in/instanceof with non-optional
+			{Code: `"foo" in obj;`},
+			{Code: `obj instanceof Foo;`},
+
+			// Spread with non-optional
+			{Code: `[...arr];`},
+
+			// Destructuring with non-optional
+			{Code: `const {foo} = obj;`},
+			{Code: `const [a] = arr;`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// === BASIC CONTEXTS ===
+			{
+				Code: `(obj?.foo)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code: `(obj?.foo).bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code: `(obj?.foo)[0];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code: `new (obj?.foo)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: "(obj?.foo)`text`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code: `[...obj?.foo];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 5},
+				},
+			},
+			// Spread in function call args
+			{
+				Code: `foo(...obj?.foo);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `for (const x of obj?.foo) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `"foo" in obj?.bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `foo instanceof obj?.bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 16},
+				},
+			},
+
+			// === DESTRUCTURING ===
+			{
+				Code: `const {foo} = obj?.bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `const [a] = obj?.bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 13},
+				},
+			},
+			// Destructuring assignment
+			{
+				Code: `({foo} = obj?.bar);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `([a] = obj?.bar);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 8},
+				},
+			},
+			// Nested binding element: object pattern default
+			{
+				Code: `const {x: {y} = obj?.foo} = obj;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 17},
+				},
+			},
+			// Nested binding element: array pattern default
+			{
+				Code: `const [, [a] = obj?.foo] = arr;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 16},
+				},
+			},
+			// Function parameter binding element
+			{
+				Code: `function f({x: {y} = obj?.foo}: any) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 22},
+				},
+			},
+			// Arrow parameter binding element
+			{
+				Code: `const g = ({x: [y] = obj?.foo}: any) => {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 22},
+				},
+			},
+
+			// === CLASS EXTENDS ===
+			{
+				Code: `class Foo extends obj?.bar {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 19},
+				},
+			},
+			// Class expression
+			{
+				Code: `const C = class extends obj?.bar {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 25},
+				},
+			},
+
+			// === checkUndefinedShortCircuit TRAVERSAL ===
+			// Deep parentheses
+			{
+				Code: `((((obj?.foo))))();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 5},
+				},
+			},
+			// Ternary: both branches — 2 errors
+			{
+				Code: `(cond ? obj?.foo : obj?.bar)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 9},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 20},
+				},
+			},
+			// Ternary: only consequent
+			{
+				Code: `(cond ? obj?.foo : bar)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 9},
+				},
+			},
+			// Ternary: only alternate
+			{
+				Code: `(cond ? bar : obj?.foo)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 15},
+				},
+			},
+			// Nested ternary — 3 errors
+			{
+				Code: `(cond ? (cond ? obj?.a : obj?.b) : obj?.c)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 17},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 26},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 36},
+				},
+			},
+			// && propagates both sides — 2 errors
+			{
+				Code: `(obj?.foo && obj?.bar)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 2},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 14},
+				},
+			},
+			// && left only
+			{
+				Code: `(obj?.foo && bar)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 2},
+				},
+			},
+			// && right only
+			{
+				Code: `(a && obj?.foo)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 7},
+				},
+			},
+			// Sequence: chain IS last
+			{
+				Code: `(a, b, obj?.foo)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 8},
+				},
+			},
+			// Await
+			{
+				Code: `async function h() { (await obj?.foo)(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 29},
+				},
+			},
+			// Await in ternary — 2 errors
+			{
+				Code: `async function h2() { (cond ? await obj?.foo : obj?.bar)(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 37},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 48},
+				},
+			},
+			// Mixed: && inside ||, chain on && left — safe via ||, but && right has chain
+			{
+				Code: `(((obj?.foo && a) || b) && obj?.bar)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 28},
+				},
+			},
+			// Deeply nested parens + ternary + await — 2 errors
+			{
+				Code: `async function h3() { (cond ? ((await obj?.foo)) : ((obj?.bar)))(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 39},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 54},
+				},
+			},
+
+			// === ARITHMETIC (with disallowArithmeticOperators) ===
+			// Both sides — 2 errors
+			{
+				Code:    `obj?.foo + obj?.bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 1},
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 12},
+				},
+			},
+			// All arithmetic operators
+			{
+				Code:    `obj?.foo - bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `obj?.foo * bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `obj?.foo / bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `obj?.foo % bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `obj?.foo ** bar;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 1},
+				},
+			},
+			// Unary +/-
+			{
+				Code:    `+obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code:    `-obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 2},
+				},
+			},
+			// All compound assignments
+			{
+				Code:    `x += obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:    `x -= obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:    `x *= obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:    `x /= obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:    `x %= obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:    `x **= obj?.foo;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 7},
+				},
+			},
+			// Arithmetic with ternary chain — 2 errors
+			{
+				Code:    `(cond ? obj?.a : obj?.b) + 1;`,
+				Options: map[string]interface{}{"disallowArithmeticOperators": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 9},
+					{MessageId: "unsafeArithmetic", Line: 1, Column: 18},
+				},
+			},
+
+			// === COMPLEX COMBINATIONS ===
+			// in with ternary — 2 errors
+			{
+				Code: `"key" in (cond ? obj?.a : obj?.b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 18},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 27},
+				},
+			},
+			// for-of with conditional — 2 errors
+			{
+				Code: `for (const v of (cond ? obj?.a : obj?.b)) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 25},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 34},
+				},
+			},
+			// Spread with conditional — 2 errors
+			{
+				Code: `[...(cond ? obj?.a : obj?.b)];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 13},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 22},
+				},
+			},
+			// Destructuring with conditional — 2 errors
+			{
+				Code: `const {w} = (cond ? obj?.a : obj?.b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 21},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 30},
+				},
+			},
+			// Class extends with conditional — 2 errors
+			{
+				Code: `class Bar extends (cond ? obj?.a : obj?.b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 27},
+					{MessageId: "unsafeOptionalChain", Line: 1, Column: 36},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -238,6 +238,7 @@ export default defineConfig({
     './tests/eslint/rules/no-obj-calls.test.ts',
     './tests/eslint/rules/no-setter-return.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
+    './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',
     './tests/eslint/rules/valid-typeof.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unsafe-optional-chaining.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unsafe-optional-chaining.test.ts.snap
@@ -1,0 +1,607 @@
+// Rstest Snapshot v1
+
+exports[`no-unsafe-optional-chaining > invalid 1`] = `
+{
+  "code": "(obj?.foo)();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 2`] = `
+{
+  "code": "(obj?.foo).bar;",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 3`] = `
+{
+  "code": "new (obj?.foo)();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 4`] = `
+{
+  "code": "(obj?.foo)\`text\`;",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 5`] = `
+{
+  "code": "[...obj?.foo];",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 6`] = `
+{
+  "code": "foo(...obj?.foo);",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 7`] = `
+{
+  "code": "const {foo} = obj?.bar;",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 8`] = `
+{
+  "code": "({foo} = obj?.bar);",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 9`] = `
+{
+  "code": "const {x: {y} = obj?.foo} = obj;",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 10`] = `
+{
+  "code": "function f({x: {y} = obj?.foo}: any) {}",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 11`] = `
+{
+  "code": "const [, [a] = obj?.foo] = arr;",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 12`] = `
+{
+  "code": "class Foo extends obj?.bar {}",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 13`] = `
+{
+  "code": "const C = class extends obj?.bar {};",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 14`] = `
+{
+  "code": "(cond ? obj?.foo : obj?.bar)();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 15`] = `
+{
+  "code": "(obj?.foo && obj?.bar)();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 16`] = `
+{
+  "code": "(obj?.foo && bar)();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 17`] = `
+{
+  "code": "(a, b, obj?.foo)();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 18`] = `
+{
+  "code": "((((obj?.foo))))();",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 19`] = `
+{
+  "code": "async function h() { (await obj?.foo)(); }",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 20`] = `
+{
+  "code": ""key" in (cond ? obj?.a : obj?.b);",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-optional-chaining > invalid 21`] = `
+{
+  "code": "[...(cond ? obj?.a : obj?.b)];",
+  "diagnostics": [
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+    {
+      "message": "Unsafe usage of optional chaining. If it short-circuits with 'undefined' the evaluation will throw TypeError.",
+      "messageId": "unsafeOptionalChain",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unsafe-optional-chaining",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unsafe-optional-chaining.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unsafe-optional-chaining.test.ts
@@ -1,0 +1,138 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unsafe-optional-chaining', {
+  valid: [
+    'obj?.foo;',
+    'obj?.foo();',
+    '(obj?.foo ?? bar)();',
+    '(obj?.foo || bar)();',
+    // Spread in object literal is safe
+    '({...obj?.foo});',
+    // Sequence: chain is NOT last
+    '(obj?.foo, bar)();',
+    // for-in tolerates undefined
+    'for (const x in obj?.foo) {}',
+    // Non-destructuring binding defaults
+    'const {x = obj?.foo} = obj;',
+    'function f({x = obj?.foo}: any) {}',
+    // Non-null assertion — developer asserts
+    '(obj?.foo)!.bar;',
+    '(obj?.foo)!();',
+    'new (obj?.foo)!();',
+    // && consumed by ||/?? fallback
+    '((obj?.foo && bar) ?? fallback)();',
+    '((obj?.foo && bar) || fallback).baz;',
+  ],
+  invalid: [
+    // Basic contexts
+    {
+      code: '(obj?.foo)();',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: '(obj?.foo).bar;',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: 'new (obj?.foo)();',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: '(obj?.foo)`text`;',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: '[...obj?.foo];',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: 'foo(...obj?.foo);',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Destructuring
+    {
+      code: 'const {foo} = obj?.bar;',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: '({foo} = obj?.bar);',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Binding element (nested destructuring defaults)
+    {
+      code: 'const {x: {y} = obj?.foo} = obj;',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: 'function f({x: {y} = obj?.foo}: any) {}',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: 'const [, [a] = obj?.foo] = arr;',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Class extends
+    {
+      code: 'class Foo extends obj?.bar {}',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    {
+      code: 'const C = class extends obj?.bar {};',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Ternary: both branches — 2 errors
+    {
+      code: '(cond ? obj?.foo : obj?.bar)();',
+      errors: [
+        { messageId: 'unsafeOptionalChain' },
+        { messageId: 'unsafeOptionalChain' },
+      ],
+    },
+    // && propagates both sides — 2 errors
+    {
+      code: '(obj?.foo && obj?.bar)();',
+      errors: [
+        { messageId: 'unsafeOptionalChain' },
+        { messageId: 'unsafeOptionalChain' },
+      ],
+    },
+    // && left only
+    {
+      code: '(obj?.foo && bar)();',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Sequence: chain IS last
+    {
+      code: '(a, b, obj?.foo)();',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Deep parentheses
+    {
+      code: '((((obj?.foo))))();',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Await
+    {
+      code: 'async function h() { (await obj?.foo)(); }',
+      errors: [{ messageId: 'unsafeOptionalChain' }],
+    },
+    // Complex: in with ternary — 2 errors
+    {
+      code: '"key" in (cond ? obj?.a : obj?.b);',
+      errors: [
+        { messageId: 'unsafeOptionalChain' },
+        { messageId: 'unsafeOptionalChain' },
+      ],
+    },
+    // Complex: spread with conditional — 2 errors
+    {
+      code: '[...(cond ? obj?.a : obj?.b)];',
+      errors: [
+        { messageId: 'unsafeOptionalChain' },
+        { messageId: 'unsafeOptionalChain' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unsafe-optional-chaining` rule from ESLint to rslint.

Disallow use of optional chaining in contexts where the undefined value is not allowed

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/no-unsafe-optional-chaining

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).