### PR TITLE
feat: port rule valid-typeof

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -147,6 +147,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
+	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
 
 // RslintConfig represents the top-level configuration array
@@ -515,6 +516,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("use-isnan", use_isnan.UseIsNaNRule)
 	GlobalRuleRegistry.Register("eqeqeq", eqeqeq.EqeqeqRule)
 	GlobalRuleRegistry.Register("no-fallthrough", no_fallthrough.NoFallthroughRule)
+	GlobalRuleRegistry.Register("valid-typeof", valid_typeof.ValidTypeofRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/valid_typeof/valid_typeof.go
+++ b/internal/rules/valid_typeof/valid_typeof.go
@@ -1,0 +1,155 @@
+package valid_typeof
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// validTypes is the set of strings that are valid results of the typeof operator.
+var validTypes = map[string]bool{
+	"undefined": true,
+	"object":    true,
+	"boolean":   true,
+	"number":    true,
+	"string":    true,
+	"function":  true,
+	"symbol":    true,
+	"bigint":    true,
+}
+
+func invalidValueMsg() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "invalidValue",
+		Description: "Invalid typeof comparison value.",
+	}
+}
+
+func notStringMsg() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "notString",
+		Description: "Typeof comparisons should be to string literals.",
+	}
+}
+
+func suggestStringMsg() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "suggestString",
+		Description: `Use "undefined" instead of undefined.`,
+	}
+}
+
+type validTypeofOptions struct {
+	requireStringLiterals bool
+}
+
+func parseOptions(opts any) validTypeofOptions {
+	result := validTypeofOptions{
+		requireStringLiterals: false,
+	}
+
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap != nil {
+		if req, ok := optsMap["requireStringLiterals"].(bool); ok {
+			result.requireStringLiterals = req
+		}
+	}
+
+	return result
+}
+
+// isEqualityOperator checks if the operator kind is ==, ===, !=, or !==.
+func isEqualityOperator(kind ast.Kind) bool {
+	return ast.GetBinaryOperatorPrecedence(kind) == ast.OperatorPrecedenceEquality
+}
+
+// https://eslint.org/docs/latest/rules/valid-typeof
+var ValidTypeofRule = rule.Rule{
+	Name: "valid-typeof",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		return rule.RuleListeners{
+			ast.KindTypeOfExpression: func(node *ast.Node) {
+				// Walk up through parenthesized expressions to find the enclosing
+				// binary expression. The TS parser creates ParenthesizedExpression
+				// nodes for parentheses, so we must skip them.
+				parent := node.Parent
+				for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+					parent = parent.Parent
+				}
+				if parent == nil || parent.Kind != ast.KindBinaryExpression {
+					return
+				}
+
+				bin := parent.AsBinaryExpression()
+				if bin == nil || bin.OperatorToken == nil {
+					return
+				}
+
+				if !isEqualityOperator(bin.OperatorToken.Kind) {
+					return
+				}
+
+				// Determine which operand is the sibling (not the typeof side).
+				// Use SkipParentheses on both sides to match against the typeof node
+				// since either side may be wrapped in parentheses.
+				var sibling *ast.Node
+				if ast.SkipParentheses(bin.Left) == node {
+					sibling = ast.SkipParentheses(bin.Right)
+				} else {
+					sibling = ast.SkipParentheses(bin.Left)
+				}
+
+				if sibling == nil {
+					return
+				}
+
+				switch {
+				case ast.IsStringLiteralLike(sibling):
+					// String literal or static template literal — check value.
+					value := sibling.LiteralLikeData().Text
+					if !validTypes[value] {
+						ctx.ReportNode(sibling, invalidValueMsg())
+					}
+
+				case sibling.Kind == ast.KindNumericLiteral,
+					sibling.Kind == ast.KindBigIntLiteral,
+					sibling.Kind == ast.KindRegularExpressionLiteral,
+					ast.IsBooleanLiteral(sibling),
+					utils.IsNullLiteral(sibling):
+					// Non-string literals can never be valid typeof results.
+					ctx.ReportNode(sibling, invalidValueMsg())
+
+				case sibling.Kind == ast.KindIdentifier:
+					if sibling.Text() == "undefined" && !utils.IsShadowed(sibling, "undefined") {
+						// Bare `undefined` referencing the global variable:
+						// report with suggestion to use "undefined" string.
+						msg := invalidValueMsg()
+						if opts.requireStringLiterals {
+							msg = notStringMsg()
+						}
+						ctx.ReportNodeWithSuggestions(sibling, msg, rule.RuleSuggestion{
+							Message: suggestStringMsg(),
+							FixesArr: []rule.RuleFix{
+								rule.RuleFixReplace(ctx.SourceFile, sibling, `"undefined"`),
+							},
+						})
+					} else if opts.requireStringLiterals {
+						// Any other identifier (including shadowed `undefined`)
+						// is not a string literal.
+						ctx.ReportNode(sibling, notStringMsg())
+					}
+
+				case sibling.Kind == ast.KindTypeOfExpression:
+					// typeof === typeof is always valid
+
+				default:
+					if opts.requireStringLiterals {
+						ctx.ReportNode(sibling, notStringMsg())
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/valid_typeof/valid_typeof.md
+++ b/internal/rules/valid_typeof/valid_typeof.md
@@ -1,0 +1,45 @@
+<!-- cspell:ignore strnig undefned nunber fucntion -->
+
+# valid-typeof
+
+## Rule Details
+
+Enforces comparing `typeof` expressions against valid string literals. The `typeof` operator can only return one of the following strings: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"`, `"symbol"`, `"bigint"`. Comparing a `typeof` expression against any other value is almost certainly a bug.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+typeof foo === 'strnig';
+typeof foo == 'undefned';
+typeof bar != 'nunber';
+typeof bar !== 'fucntion';
+typeof foo === undefined;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+typeof foo === 'string';
+typeof bar == 'undefined';
+typeof baz === 'object';
+typeof qux !== 'function';
+typeof foo === typeof bar;
+```
+
+## Options
+
+### `requireStringLiterals`
+
+When set to `true`, requires that `typeof` expressions are only compared to string literals or other `typeof` expressions, and disallows comparisons to any other value.
+
+Examples of additional **incorrect** code with `{ "requireStringLiterals": true }`:
+
+```javascript
+typeof foo === undefined;
+typeof foo === Object;
+typeof foo === someVariable;
+```
+
+## Original Documentation
+
+- [ESLint valid-typeof](https://eslint.org/docs/latest/rules/valid-typeof)

--- a/internal/rules/valid_typeof/valid_typeof_test.go
+++ b/internal/rules/valid_typeof/valid_typeof_test.go
@@ -1,0 +1,236 @@
+//nolint:misspell // cspell:ignore strnig undefned nunber fucntion
+package valid_typeof
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestValidTypeofRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ValidTypeofRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// All valid typeof comparison values
+			{Code: `typeof foo === "string"`},
+			{Code: `typeof foo === "object"`},
+			{Code: `typeof foo === "function"`},
+			{Code: `typeof foo === "undefined"`},
+			{Code: `typeof foo === "boolean"`},
+			{Code: `typeof foo === "number"`},
+			{Code: `typeof foo === "bigint"`},
+			{Code: `typeof foo === "symbol"`},
+
+			// Reversed operands
+			{Code: `"string" === typeof foo`},
+			{Code: `"object" === typeof foo`},
+
+			// typeof compared to typeof (always valid)
+			{Code: `typeof foo === typeof bar`},
+
+			// Non-equality operators are not checked
+			{Code: `typeof foo > "string"`},
+
+			// Without requireStringLiterals, non-string comparisons are OK (except bare undefined)
+			{Code: `typeof foo === baz`},
+			{Code: `typeof foo === Object`},
+
+			// Not a comparison (typeof in other contexts)
+			{Code: `var x = typeof foo`},
+			{Code: `typeof foo`},
+
+			// With requireStringLiterals: valid cases still valid
+			{Code: `typeof foo === "string"`, Options: map[string]interface{}{"requireStringLiterals": true}},
+			{Code: `typeof foo === typeof bar`, Options: map[string]interface{}{"requireStringLiterals": true}},
+			{Code: `"undefined" === typeof foo`, Options: map[string]interface{}{"requireStringLiterals": true}},
+
+			// != and !== with valid strings
+			{Code: `typeof foo !== "string"`},
+			{Code: `typeof foo != "function"`},
+			{Code: `typeof foo == "number"`},
+
+			// Static template literals with valid values
+			{Code: "typeof foo === `string`"},
+			{Code: "typeof foo === `object`"},
+			{Code: "typeof foo === `undefined`"},
+
+			// Parenthesized expressions with valid values
+			{Code: `(typeof foo) === "string"`},
+			{Code: `typeof foo === ("string")`},
+			{Code: `((typeof foo)) === "string"`},
+			{Code: `(typeof foo) === ("string")`},
+
+			// Locally shadowed undefined — not reported without requireStringLiterals
+			{Code: `function f(undefined: string) { typeof foo === undefined }`},
+			{Code: `{ const undefined = "test"; typeof foo === undefined }`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// Invalid typeof comparison value (misspelled)
+			{
+				Code: `typeof foo === "strnig"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// Reversed operands with invalid value
+			{
+				Code: `"strnig" === typeof foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 1},
+				},
+			},
+			// !== with invalid value
+			{
+				Code: `typeof foo !== "strnig"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// == with invalid value
+			{
+				Code: `typeof foo == "strnig"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 15},
+				},
+			},
+			// != with invalid value
+			{
+				Code: `typeof foo != "strnig"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 15},
+				},
+			},
+			// Bare undefined identifier without requireStringLiterals → invalidValue + suggestion
+			{
+				Code: `typeof foo === undefined`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestString", Output: `typeof foo === "undefined"`},
+					}},
+				},
+			},
+			// Bare undefined identifier with requireStringLiterals → notString + suggestion
+			{
+				Code:    `typeof foo === undefined`,
+				Options: map[string]interface{}{"requireStringLiterals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notString", Line: 1, Column: 16, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestString", Output: `typeof foo === "undefined"`},
+					}},
+				},
+			},
+			// Non-string identifier with requireStringLiterals → notString
+			{
+				Code:    `typeof foo === Object`,
+				Options: map[string]interface{}{"requireStringLiterals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notString", Line: 1, Column: 16},
+				},
+			},
+			// Completely invalid string
+			{
+				Code: `typeof foo === "foobar"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// Empty string
+			{
+				Code: `typeof foo === ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// Static template literal with invalid value
+			{
+				Code: "typeof foo === `strnig`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// Static template literal with completely invalid value
+			{
+				Code: "typeof foo === `foobar`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// Non-string literals: null, number, boolean, regex
+			{
+				Code: `typeof foo === null`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `typeof foo === 42`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `typeof foo === true`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `typeof foo === false`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `typeof foo === /regex/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 16},
+				},
+			},
+			// Shadowed undefined with requireStringLiterals → notString (no suggestion)
+			{
+				Code:    `function f(undefined: string) { typeof foo === undefined }`,
+				Options: map[string]interface{}{"requireStringLiterals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "notString", Line: 1, Column: 48},
+				},
+			},
+			// Parenthesized expressions with invalid values
+			{
+				Code: `(typeof foo) === "strnig"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `typeof foo === ("strnig")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `((typeof foo)) === "strnig"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `typeof foo === (("strnig"))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `(typeof foo) === ("strnig")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidValue", Line: 1, Column: 19},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -240,6 +240,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',
+    './tests/eslint/rules/valid-typeof.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-disabled-tests.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/valid-typeof.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/valid-typeof.test.ts.snap
@@ -1,0 +1,573 @@
+// Rstest Snapshot v1
+
+exports[`valid-typeof > invalid 1`] = `
+{
+  "code": "typeof foo === 'strnig'",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 2`] = `
+{
+  "code": "'strnig' === typeof foo",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 3`] = `
+{
+  "code": "typeof foo !== 'strnig'",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 4`] = `
+{
+  "code": "typeof foo == 'strnig'",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 5`] = `
+{
+  "code": "typeof foo != 'strnig'",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 6`] = `
+{
+  "code": "typeof foo === undefined",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 7`] = `
+{
+  "code": "typeof foo === undefined",
+  "diagnostics": [
+    {
+      "message": "Typeof comparisons should be to string literals.",
+      "messageId": "notString",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 8`] = `
+{
+  "code": "typeof foo === Object",
+  "diagnostics": [
+    {
+      "message": "Typeof comparisons should be to string literals.",
+      "messageId": "notString",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 9`] = `
+{
+  "code": "typeof foo === 'foobar'",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 10`] = `
+{
+  "code": "typeof foo === ''",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 11`] = `
+{
+  "code": "typeof foo === \`strnig\`",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 12`] = `
+{
+  "code": "typeof foo === \`foobar\`",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 13`] = `
+{
+  "code": "typeof foo === null",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 14`] = `
+{
+  "code": "typeof foo === 42",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 15`] = `
+{
+  "code": "typeof foo === true",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 16`] = `
+{
+  "code": "typeof foo === false",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 17`] = `
+{
+  "code": "function f(undefined: string) { typeof foo === undefined }",
+  "diagnostics": [
+    {
+      "message": "Typeof comparisons should be to string literals.",
+      "messageId": "notString",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 18`] = `
+{
+  "code": "(typeof foo) === "strnig"",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 19`] = `
+{
+  "code": "typeof foo === ("strnig")",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 20`] = `
+{
+  "code": "((typeof foo)) === "strnig"",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 21`] = `
+{
+  "code": "typeof foo === (("strnig"))",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`valid-typeof > invalid 22`] = `
+{
+  "code": "(typeof foo) === ("strnig")",
+  "diagnostics": [
+    {
+      "message": "Invalid typeof comparison value.",
+      "messageId": "invalidValue",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "valid-typeof",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/valid-typeof.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/valid-typeof.test.ts
@@ -1,0 +1,177 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('valid-typeof', {
+  valid: [
+    // All valid typeof comparison values
+    "typeof foo === 'string'",
+    "typeof foo === 'object'",
+    "typeof foo === 'function'",
+    "typeof foo === 'undefined'",
+    "typeof foo === 'boolean'",
+    "typeof foo === 'number'",
+    "typeof foo === 'bigint'",
+    "typeof foo === 'symbol'",
+
+    // Reversed operands
+    "'string' === typeof foo",
+    "'object' === typeof foo",
+
+    // typeof compared to typeof (always valid)
+    'typeof foo === typeof bar',
+
+    // Non-equality operators are not checked
+    "typeof foo > 'string'",
+
+    // Without requireStringLiterals, non-string comparisons are OK
+    'typeof foo === baz',
+    'typeof foo === Object',
+
+    // Not a comparison
+    'var x = typeof foo',
+    'typeof foo',
+
+    // With requireStringLiterals: valid cases still valid
+    {
+      code: "typeof foo === 'string'",
+      options: { requireStringLiterals: true },
+    },
+    {
+      code: 'typeof foo === typeof bar',
+      options: { requireStringLiterals: true },
+    },
+    {
+      code: "'undefined' === typeof foo",
+      options: { requireStringLiterals: true },
+    },
+
+    // != and !== with valid strings
+    "typeof foo !== 'string'",
+    "typeof foo != 'function'",
+    "typeof foo == 'number'",
+
+    // Static template literals with valid values
+    'typeof foo === `string`',
+    'typeof foo === `object`',
+    'typeof foo === `undefined`',
+
+    // Parenthesized expressions with valid values
+    '(typeof foo) === "string"',
+    'typeof foo === ("string")',
+    '((typeof foo)) === "string"',
+    '(typeof foo) === ("string")',
+
+    // Locally shadowed undefined — not reported without requireStringLiterals
+    'function f(undefined: string) { typeof foo === undefined }',
+    '{ const undefined = "test"; typeof foo === undefined }',
+  ],
+  invalid: [
+    // Invalid typeof comparison value (misspelled)
+    {
+      code: "typeof foo === 'strnig'",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Reversed operands with invalid value
+    {
+      code: "'strnig' === typeof foo",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // !== with invalid value
+    {
+      code: "typeof foo !== 'strnig'",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // == with invalid value
+    {
+      code: "typeof foo == 'strnig'",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // != with invalid value
+    {
+      code: "typeof foo != 'strnig'",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Bare undefined identifier without requireStringLiterals → invalidValue
+    {
+      code: 'typeof foo === undefined',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Bare undefined identifier with requireStringLiterals → notString
+    {
+      code: 'typeof foo === undefined',
+      options: { requireStringLiterals: true },
+      errors: [{ messageId: 'notString' }],
+    },
+    // Non-string identifier with requireStringLiterals → notString
+    {
+      code: 'typeof foo === Object',
+      options: { requireStringLiterals: true },
+      errors: [{ messageId: 'notString' }],
+    },
+    // Completely invalid string
+    {
+      code: "typeof foo === 'foobar'",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Empty string
+    {
+      code: "typeof foo === ''",
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Static template literal with invalid value
+    {
+      code: 'typeof foo === `strnig`',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Static template literal with completely invalid value
+    {
+      code: 'typeof foo === `foobar`',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Non-string literals: null, number, boolean, regex
+    {
+      code: 'typeof foo === null',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: 'typeof foo === 42',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: 'typeof foo === true',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: 'typeof foo === false',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    // Shadowed undefined with requireStringLiterals → notString (no suggestion)
+    {
+      code: 'function f(undefined: string) { typeof foo === undefined }',
+      options: { requireStringLiterals: true },
+      errors: [{ messageId: 'notString' }],
+    },
+    // Parenthesized expressions with invalid values
+    {
+      code: '(typeof foo) === "strnig"',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: 'typeof foo === ("strnig")',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: '((typeof foo)) === "strnig"',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: 'typeof foo === (("strnig"))',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: '(typeof foo) === ("strnig")',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `valid-typeof` rule from ESLint to rslint.

Enforce comparing typeof expressions against valid strings

## Related Links

- Tracking issue: https://github.com/web-infra-dev/rslint/issues/223

- ESLint rule: https://eslint.org/docs/latest/rules/valid-typeof

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).