### PR TITLE
fix(lsp): align type-aware rule scope with CLI behavior

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -555,7 +555,7 @@ func runCMD() int {
 			// config matching, dir scoping, and gitignore checks.
 			// Edge cases (e.g. user passes a symlink-resolved absolute path)
 			// are handled by isFileAllowed's os.SameFile fallback in linter.go
-			// and buildProgramFileSet's Realpath'd keys in programs.go.
+			// and CollectProgramFiles's Realpath'd keys in create_program.go.
 			normalized := tspath.NormalizePath(absPath)
 			info, statErr := os.Stat(absPath)
 			if statErr == nil && info.IsDir() {
@@ -772,7 +772,7 @@ func runCMD() int {
 	var capturedGapFiles []string // retained for --fix rebuild
 
 	{
-		programFiles := buildProgramFileSet(programs)
+		programFiles := utils.CollectProgramFiles(programs, fs)
 
 		var gapFiles []string
 		if configMap != nil {
@@ -816,7 +816,7 @@ func runCMD() int {
 		if gapFiles != nil {
 			// Build type-info set from existing (tsconfig) Programs BEFORE
 			// appending the fallback, so fallback files are NOT in this set.
-			typeInfoFiles = buildProgramFileSet(programs)
+			typeInfoFiles = utils.CollectProgramFiles(programs, fs)
 			capturedGapFiles = gapFiles
 
 			if len(gapFiles) > 0 {
@@ -879,25 +879,14 @@ func runCMD() int {
 	enforcePlugins := configStdin // JS/TS configs loaded via stdin require plugin declarations
 	getRulesForFile := func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 		filePath := sourceFile.FileName()
-		var activeRules []linter.ConfiguredRule
 		if configMap != nil {
 			cfgDir, cfg := rslintconfig.FindNearestConfig(filePath, configMap)
 			if cfg == nil {
 				return nil
 			}
-			activeRules, _ = rslintconfig.GlobalRuleRegistry.GetEnabledRules(cfg, filePath, cfgDir, enforcePlugins)
-		} else {
-			activeRules, _ = rslintconfig.GlobalRuleRegistry.GetEnabledRules(rslintConfig, filePath, currentDirectory, enforcePlugins)
+			return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(cfg, filePath, cfgDir, enforcePlugins, typeInfoFiles)
 		}
-
-		// For gap files (not in typeInfoFiles), filter out type-aware rules.
-		if typeInfoFiles != nil {
-			if _, hasTypeInfo := typeInfoFiles[filePath]; !hasTypeInfo {
-				activeRules = linter.FilterNonTypeAwareRules(activeRules)
-			}
-		}
-
-		return activeRules
+		return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(rslintConfig, filePath, currentDirectory, enforcePlugins, typeInfoFiles)
 	}
 
 	// Build per-program file ownership filters for multi-config deduplication.

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -9,7 +9,6 @@ import (
 	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
-	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	rslintconfig "github.com/web-infra-dev/rslint/internal/config"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -25,19 +24,10 @@ func createProgramsForConfig(
 	fsys vfs.FS,
 	seenTsConfigs map[string]struct{},
 ) ([]*compiler.Program, int) {
-	loader := rslintconfig.NewConfigLoader(fsys, configDir)
-	tsConfigs, err := loader.LoadTsConfigsFromRslintConfig(entries, configDir)
+	tsConfigs, err := rslintconfig.ResolveTsConfigPaths(entries, configDir, fsys)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error: %v\n", err)
 		return nil, 1
-	}
-
-	// Auto-detect tsconfig.json if none specified in config
-	if len(tsConfigs) == 0 {
-		defaultTsConfig := tspath.ResolvePath(configDir, "tsconfig.json")
-		if fsys.FileExists(defaultTsConfig) {
-			tsConfigs = []string{defaultTsConfig}
-		}
 	}
 
 	var programs []*compiler.Program
@@ -115,29 +105,6 @@ func createFallbackProgram(
 		return nil, 0
 	}
 	return program, 0
-}
-
-// buildProgramFileSet collects all source file paths from the given programs
-// into a set for fast lookup.
-func buildProgramFileSet(programs []*compiler.Program) map[string]struct{} {
-	fileSet := make(map[string]struct{})
-	realFS := osvfs.FS()
-	for _, prog := range programs {
-		for _, sf := range prog.GetSourceFiles() {
-			name := sf.FileName()
-			if _, ok := fileSet[name]; ok {
-				continue
-			}
-			fileSet[name] = struct{}{}
-			// Also store the resolved path so lookups from filepath.EvalSymlinks
-			// match even when os.Getwd() returns 8.3 short names (Windows) or
-			// unresolved symlinks (macOS /tmp → /private/tmp).
-			if resolved := realFS.Realpath(name); resolved != name {
-				fileSet[resolved] = struct{}{}
-			}
-		}
-	}
-	return fileSet
 }
 
 // buildFileOwnerMap determines which config directory "owns" each file across

--- a/cmd/rslint/programs_test.go
+++ b/cmd/rslint/programs_test.go
@@ -85,7 +85,7 @@ func TestRequiresTypeInfo_Propagation(t *testing.T) {
 	}
 }
 
-// createTestProgram creates a Program from temp files for testing buildProgramFileSet.
+// createTestProgram creates a Program from temp files for testing utils.CollectProgramFiles.
 func createTestProgram(t *testing.T, files map[string]string) *compiler.Program {
 	t.Helper()
 	tmpDir := t.TempDir()
@@ -119,7 +119,7 @@ func TestBuildProgramFileSet_ContainsSourceFiles(t *testing.T) {
 		"b.ts": "const b = 2;",
 	})
 
-	fileSet := buildProgramFileSet([]*compiler.Program{program})
+	fileSet := utils.CollectProgramFiles([]*compiler.Program{program}, bundled.WrapFS(cachedvfs.From(osvfs.FS())))
 
 	// Should contain user source files
 	found := 0
@@ -135,7 +135,7 @@ func TestBuildProgramFileSet_ContainsSourceFiles(t *testing.T) {
 
 func TestBuildProgramFileSet_RealpathKeyForSymlinks(t *testing.T) {
 	// On macOS, /tmp is a symlink to /private/tmp.
-	// Verify that buildProgramFileSet adds the resolved path as an alternate key.
+	// Verify that utils.CollectProgramFiles adds the resolved path as an alternate key.
 	tmpDir := t.TempDir()
 	realTmpDir, err := filepath.EvalSymlinks(tmpDir)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestBuildProgramFileSet_RealpathKeyForSymlinks(t *testing.T) {
 		t.Fatalf("Failed to create program: %v", err)
 	}
 
-	fileSet := buildProgramFileSet([]*compiler.Program{program})
+	fileSet := utils.CollectProgramFiles([]*compiler.Program{program}, bundled.WrapFS(cachedvfs.From(osvfs.FS())))
 
 	// The file should be findable via BOTH the original and resolved paths
 	resolvedFilePath := tspath.NormalizePath(filepath.Join(realTmpDir, "test.ts"))

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -155,6 +155,29 @@ func (loader *ConfigLoader) LoadTsConfigsFromRslintConfig(rslintConfig RslintCon
 	return tsConfigs, nil
 }
 
+// ResolveTsConfigPaths extracts tsconfig paths from a rslint config's parserOptions.project,
+// with an auto-detection fallback to tsconfig.json in the config directory.
+// Returns (nil, nil) when no tsconfigs are found. Returns (nil, err) when
+// config validation fails (e.g. glob matched no files, tsconfig doesn't exist).
+func ResolveTsConfigPaths(rslintConfig RslintConfig, cwd string, fs vfs.FS) ([]string, error) {
+	if fs == nil {
+		return nil, nil
+	}
+	loader := NewConfigLoader(fs, cwd)
+	tsConfigs, err := loader.LoadTsConfigsFromRslintConfig(rslintConfig, cwd)
+	if err != nil {
+		return nil, err
+	}
+	if len(tsConfigs) == 0 {
+		defaultTsConfig := tspath.ResolvePath(cwd, "tsconfig.json")
+		if fs.FileExists(defaultTsConfig) {
+			return []string{defaultTsConfig}, nil
+		}
+		return nil, nil
+	}
+	return tsConfigs, nil
+}
+
 func appendUniqueConfigPath(paths []string, seenPaths map[string]struct{}, configPath string) []string {
 	normalizedPath := tspath.NormalizePath(configPath)
 	if _, exists := seenPaths[normalizedPath]; exists {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -382,3 +382,72 @@ func createTestFile(t *testing.T, path string) {
 	assert.NilError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	assert.NilError(t, os.WriteFile(path, []byte(`{}`), 0o644))
 }
+
+func TestResolveTsConfigPaths_ReturnsConfiguredPaths(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTestFile(t, filepath.Join(tmpDir, "packages/foo/tsconfig.json"))
+
+	cfg := RslintConfig{
+		{
+			LanguageOptions: &LanguageOptions{
+				ParserOptions: &ParserOptions{
+					Project: []string{"./packages/foo/tsconfig.json"},
+				},
+			},
+		},
+	}
+
+	paths, err := ResolveTsConfigPaths(cfg, tmpDir, osvfs.FS())
+	assert.NilError(t, err)
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path, got %d", len(paths))
+	}
+	expected := filepath.ToSlash(filepath.Join(tmpDir, "packages/foo/tsconfig.json"))
+	if paths[0] != expected {
+		t.Errorf("expected path %q, got %q", expected, paths[0])
+	}
+}
+
+func TestResolveTsConfigPaths_FallbackToDefaultTsConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTestFile(t, filepath.Join(tmpDir, "tsconfig.json"))
+
+	// No parserOptions.project → auto-detect tsconfig.json
+	cfg := RslintConfig{{}}
+
+	paths, err := ResolveTsConfigPaths(cfg, tmpDir, osvfs.FS())
+	assert.NilError(t, err)
+	if len(paths) != 1 {
+		t.Fatalf("expected 1 path (auto-detected), got %d", len(paths))
+	}
+	expected := filepath.ToSlash(filepath.Join(tmpDir, "tsconfig.json"))
+	if paths[0] != expected {
+		t.Errorf("expected auto-detected path %q, got %q", expected, paths[0])
+	}
+}
+
+func TestResolveTsConfigPaths_NilFS(t *testing.T) {
+	paths, err := ResolveTsConfigPaths(RslintConfig{{}}, "/any", nil)
+	assert.NilError(t, err)
+	if paths != nil {
+		t.Errorf("expected nil paths for nil FS, got %v", paths)
+	}
+}
+
+func TestResolveTsConfigPaths_ErrorOnNonExistentTsConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := RslintConfig{
+		{
+			LanguageOptions: &LanguageOptions{
+				ParserOptions: &ParserOptions{
+					Project: []string{"./nonexistent/tsconfig.json"},
+				},
+			},
+		},
+	}
+
+	_, err := ResolveTsConfigPaths(cfg, tmpDir, osvfs.FS())
+	if err == nil {
+		t.Error("expected error for non-existent tsconfig")
+	}
+}

--- a/internal/config/rule_registry.go
+++ b/internal/config/rule_registry.go
@@ -77,6 +77,26 @@ func (r *RuleRegistry) GetEnabledRules(config RslintConfig, filePath string, cwd
 	return enabledRules, mergedConfig
 }
 
+// GetActiveRulesForFile returns the lint rules that should run on a file.
+// It resolves the config, gets enabled rules, and filters out type-aware rules
+// for files not covered by parserOptions.project tsconfigs. This encapsulates
+// the rule selection logic shared by both CLI and LSP.
+func (r *RuleRegistry) GetActiveRulesForFile(
+	rslintConfig RslintConfig,
+	filePath string,
+	cwd string,
+	enforcePlugins bool,
+	typeInfoFiles map[string]struct{},
+) []linter.ConfiguredRule {
+	activeRules, _ := r.GetEnabledRules(rslintConfig, filePath, cwd, enforcePlugins)
+	if typeInfoFiles != nil {
+		if _, hasTypeInfo := typeInfoFiles[filePath]; !hasTypeInfo {
+			activeRules = linter.FilterNonTypeAwareRules(activeRules)
+		}
+	}
+	return activeRules
+}
+
 func CloneSettings(settings map[string]interface{}) map[string]interface{} {
 	if len(settings) == 0 {
 		return nil

--- a/internal/config/rule_registry_test.go
+++ b/internal/config/rule_registry_test.go
@@ -560,3 +560,82 @@ func TestGetEnabledRules_EnforcePlugins_OffRuleNotBlocked(t *testing.T) {
 		}
 	}
 }
+
+func TestGetActiveRulesForFile_FiltersTypeAwareWhenNotInTypeInfoFiles(t *testing.T) {
+	RegisterAllRules()
+
+	cfg := RslintConfig{
+		{
+			Rules: Rules{
+				"@typescript-eslint/require-await": "error", // type-aware
+				"no-console":                       "error", // not type-aware
+			},
+		},
+	}
+
+	typeInfoFiles := map[string]struct{}{
+		"src/covered.ts": {},
+	}
+
+	// File IN typeInfoFiles — both rules returned
+	covered := GlobalRuleRegistry.GetActiveRulesForFile(cfg, "src/covered.ts", "", false, typeInfoFiles)
+	if len(covered) != 2 {
+		t.Fatalf("Expected 2 rules for covered file, got %d: %v", len(covered), ruleNames(covered))
+	}
+	coveredNames := ruleNameSet(covered)
+	if !coveredNames["@typescript-eslint/require-await"] {
+		t.Error("Expected require-await for covered file")
+	}
+	if !coveredNames["no-console"] {
+		t.Error("Expected no-console for covered file")
+	}
+
+	// File NOT in typeInfoFiles — type-aware filtered, only non-type-aware remains
+	uncovered := GlobalRuleRegistry.GetActiveRulesForFile(cfg, "src/uncovered.ts", "", false, typeInfoFiles)
+	if len(uncovered) != 1 {
+		t.Fatalf("Expected 1 rule for uncovered file (only non-type-aware), got %d: %v", len(uncovered), ruleNames(uncovered))
+	}
+	if uncovered[0].Name != "no-console" {
+		t.Errorf("Expected only no-console for uncovered file, got %q", uncovered[0].Name)
+	}
+}
+
+func TestGetActiveRulesForFile_NilTypeInfoFilesNoFiltering(t *testing.T) {
+	RegisterAllRules()
+
+	cfg := RslintConfig{
+		{
+			Rules: Rules{
+				"@typescript-eslint/require-await": "error",
+			},
+		},
+	}
+
+	// nil typeInfoFiles → no filtering, all rules enabled
+	rules := GlobalRuleRegistry.GetActiveRulesForFile(cfg, "src/any.ts", "", false, nil)
+	found := false
+	for _, r := range rules {
+		if r.Name == "@typescript-eslint/require-await" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Expected require-await when typeInfoFiles is nil (no filtering)")
+	}
+}
+
+func ruleNames(rules []linter.ConfiguredRule) []string {
+	names := make([]string, len(rules))
+	for i, r := range rules {
+		names[i] = r.Name
+	}
+	return names
+}
+
+func ruleNameSet(rules []linter.ConfiguredRule) map[string]bool {
+	set := make(map[string]bool, len(rules))
+	for _, r := range rules {
+		set[r.Name] = true
+	}
+	return set
+}

--- a/internal/lsp/config_watch_test.go
+++ b/internal/lsp/config_watch_test.go
@@ -40,6 +40,66 @@ func TestIsRslintConfigURI(t *testing.T) {
 	}
 }
 
+// ======== isTsConfigURI tests ========
+
+func TestIsTsConfigURI(t *testing.T) {
+	tests := []struct {
+		uri      string
+		expected bool
+	}{
+		{"file:///project/tsconfig.json", true},
+		{"file:///project/jsconfig.json", true},
+		{"file:///project/tsconfig.build.json", true},
+		{"file:///project/tsconfig.app.json", true},
+		{"file:///project/sub/tsconfig.json", true},
+		{"file:///project/package.json", false},
+		{"file:///project/rslint.json", false},
+		{"file:///project/src/some.ts", false},
+		{"file:///project/other-config.json", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.uri, func(t *testing.T) {
+			if got := isTsConfigURI(tt.uri); got != tt.expected {
+				t.Errorf("isTsConfigURI(%q) = %v, want %v", tt.uri, got, tt.expected)
+			}
+		})
+	}
+}
+
+// ======== reloadConfigAndRelint guard tests ========
+
+func TestReloadConfigAndRelint_SkipsWhenJSConfigsActive(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{"/project/rslint.json": true}}
+	s.cwd = "/project"
+	// Simulate JS configs being active
+	s.jsConfigs["file:///project"] = config.RslintConfig{{}}
+
+	s.reloadConfigAndRelint()
+
+	// Should NOT load JSON config because JS configs take priority
+	if s.rslintConfigPath != "" {
+		t.Errorf("expected empty config path (skipped), got %q", s.rslintConfigPath)
+	}
+}
+
+func TestReloadConfigAndRelint_ClearsTypeInfoFiles(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+	s.cwd = "/project"
+	s.rslintConfigPath = "/project/rslint.json"
+	// Set stale tsConfigPaths
+	s.tsConfigPaths = []string{"/project/old-tsconfig.json"}
+
+	s.reloadConfigAndRelint()
+
+	// Config deleted → tsConfigPaths should be cleared
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths cleared, got %v", s.tsConfigPaths)
+	}
+}
+
 // ======== handleDidChangeWatchedFiles tests ========
 
 func TestHandleDidChangeWatchedFiles_NilParams(t *testing.T) {
@@ -131,6 +191,51 @@ func TestHandleDidChangeWatchedFiles_DetectsConfigFiles(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHandleDidChangeWatchedFiles_TsConfigChangeRebuildsTypeInfoFiles(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+	s.cwd = "/project"
+	// Set stale tsConfigPaths
+	s.tsConfigPaths = []string{"/project/old-tsconfig.json"}
+
+	ctx := context.Background()
+	err := s.handleDidChangeWatchedFiles(ctx, &lsproto.DidChangeWatchedFilesParams{
+		Changes: []*lsproto.FileEvent{
+			{Uri: "file:///project/tsconfig.json", Type: lsproto.FileChangeTypeChanged},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// rebuildTsConfigPaths should have run → no config → tsConfigPaths cleared
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths cleared after tsconfig change, got %v", s.tsConfigPaths)
+	}
+}
+
+func TestHandleDidChangeWatchedFiles_TsConfigVariantDetected(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+	s.cwd = "/project"
+	s.tsConfigPaths = []string{"/project/old-tsconfig.json"}
+
+	ctx := context.Background()
+	// tsconfig.build.json should also trigger rebuild
+	err := s.handleDidChangeWatchedFiles(ctx, &lsproto.DidChangeWatchedFilesParams{
+		Changes: []*lsproto.FileEvent{
+			{Uri: "file:///project/tsconfig.build.json", Type: lsproto.FileChangeTypeChanged},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths cleared after tsconfig.build.json change")
 	}
 }
 

--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -163,6 +163,7 @@ type Server struct {
 	jsConfigs        map[string]config.RslintConfig                // configDirectory -> config entries (from JS/TS configs)
 	jsonConfig       config.RslintConfig                           // fallback JSON config (rslint.json/rslint.jsonc)
 	rslintConfigPath string                                        // path to rslint.json/rslint.jsonc, empty if not found
+	tsConfigPaths    []string                                       // resolved parserOptions.project tsconfig paths
 	documents        map[lsproto.DocumentUri]string                // URI -> content
 	diagnostics      map[lsproto.DocumentUri][]rule.RuleDiagnostic // URI -> diagnostics
 

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/project"
 	"github.com/microsoft/typescript-go/shim/project/logging"
 	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tspath"
 	"github.com/microsoft/typescript-go/shim/vfs"
 
 	"github.com/web-infra-dev/rslint/internal/config"
@@ -139,8 +140,10 @@ func (s *Server) handleInitialized(ctx context.Context, params *lsproto.Initiali
 }
 
 // reloadConfig loads (or reloads) the rslint JSON configuration from s.rslintConfigPath.
-// Unlike the CLI, the LSP does not need tsConfigs here — the session discovers
-// tsconfig files on its own via projectService.
+// The LSP session discovers tsconfig files on its own via projectService for
+// providing type information. However, we still need to know which files are
+// covered by parserOptions.project so that type-aware rules (e.g. require-await)
+// are only enabled for files in the configured tsconfigs — matching CLI behavior.
 func (s *Server) reloadConfig() error {
 	loader := config.NewConfigLoader(s.fs, s.cwd)
 	rslintConfig, _, err := loader.LoadRslintConfig(s.rslintConfigPath)
@@ -148,6 +151,7 @@ func (s *Server) reloadConfig() error {
 		return fmt.Errorf("could not load rslint config: %w", err)
 	}
 	s.jsonConfig = rslintConfig
+	s.rebuildTsConfigPaths()
 	return nil
 }
 
@@ -188,6 +192,8 @@ func (s *Server) handleConfigUpdate(ctx context.Context, params any) error {
 	s.rslintConfigPath = ""
 	log.Printf("[rslint] Config updated from JS/TS configs (%d config files)", len(payload.Configs))
 
+	s.rebuildTsConfigPaths()
+
 	// Ask the client to re-pull diagnostics with the updated config.
 	if err := s.RefreshDiagnostics(ctx); err != nil {
 		log.Printf("[rslint] Failed to refresh diagnostics after config update: %v", err)
@@ -209,13 +215,24 @@ func (s *Server) handleDidChangeWatchedFiles(ctx context.Context, params *lsprot
 		s.session.DidChangeWatchedFiles(ctx, params.Changes)
 	}
 
-	// Check for rslint config changes — these need immediate handling
-	// because Session doesn't know about rslint.json.
+	// Check for config file changes that affect rslint.
+	needsTypeInfoRebuild := false
 	for _, change := range params.Changes {
-		if isRslintConfigURI(string(change.Uri)) {
+		uri := string(change.Uri)
+		if isRslintConfigURI(uri) {
+			// rslint config changed — reload config + typeInfoFiles + relint all.
 			s.reloadConfigAndRelint()
 			return nil
 		}
+		if isTsConfigURI(uri) {
+			needsTypeInfoRebuild = true
+		}
+	}
+	if needsTypeInfoRebuild {
+		// tsconfig changed — rebuild tsConfigPaths so type-aware rule filtering
+		// stays in sync. Session already handles the project state update and
+		// triggers RefreshDiagnostics for relinting.
+		s.rebuildTsConfigPaths()
 	}
 
 	return nil
@@ -226,9 +243,68 @@ func isRslintConfigURI(uri string) bool {
 	return strings.HasSuffix(uri, "/rslint.json") || strings.HasSuffix(uri, "/rslint.jsonc")
 }
 
-// reloadConfigAndRelint re-discovers and reloads the rslint config, then
-// re-lints all open documents.
+// isTsConfigURI returns true if the URI points to a tsconfig/jsconfig file,
+// including variants like tsconfig.build.json, tsconfig.app.json, etc.
+func isTsConfigURI(uri string) bool {
+	idx := strings.LastIndex(uri, "/")
+	if idx < 0 {
+		return false
+	}
+	name := uri[idx+1:]
+	return (strings.HasPrefix(name, "tsconfig") || strings.HasPrefix(name, "jsconfig")) &&
+		strings.HasSuffix(name, ".json")
+}
+
+// resolveTsConfigPaths resolves parserOptions.project from a config and
+// normalizes paths with realpath for cross-platform consistency.
+func (s *Server) resolveTsConfigPaths(cfg config.RslintConfig, cwd string) []string {
+	paths, _ := config.ResolveTsConfigPaths(cfg, cwd, s.fs)
+	for i, p := range paths {
+		paths[i] = tspath.NormalizePath(s.fs.Realpath(p))
+	}
+	return paths
+}
+
+// rebuildTsConfigPaths resolves parserOptions.project from the current config.
+// Called when a tsconfig or rslint config changes so that type-aware rule
+// filtering stays in sync.
+func (s *Server) rebuildTsConfigPaths() {
+	if len(s.jsConfigs) > 0 {
+		var merged []string
+		seen := make(map[string]struct{})
+		for dir, entries := range s.jsConfigs {
+			configDir := uriToPath(lsproto.DocumentUri(dir))
+			paths := s.resolveTsConfigPaths(entries, configDir)
+			if paths == nil {
+				// At least one config has no parserOptions.project and no
+				// auto-detected tsconfig. Cannot determine which files should
+				// have type-aware rules without per-file config resolution.
+				// Disable filtering entirely (conservative: allow all).
+				s.tsConfigPaths = nil
+				return
+			}
+			for _, p := range paths {
+				if _, ok := seen[p]; !ok {
+					seen[p] = struct{}{}
+					merged = append(merged, p)
+				}
+			}
+		}
+		s.tsConfigPaths = merged
+	} else if s.rslintConfigPath != "" {
+		s.tsConfigPaths = s.resolveTsConfigPaths(s.jsonConfig, s.cwd)
+	} else {
+		s.tsConfigPaths = nil
+	}
+}
+
+// reloadConfigAndRelint re-discovers and reloads the rslint JSON config, then
+// re-lints all open documents. Skips when JS/TS configs are active — those
+// take priority and are managed by handleConfigUpdate.
 func (s *Server) reloadConfigAndRelint() {
+	if len(s.jsConfigs) > 0 {
+		return
+	}
 	log.Printf("Reloading rslint config...")
 
 	configPath, found := findRslintConfig(s.fs, s.cwd)
@@ -236,6 +312,7 @@ func (s *Server) reloadConfigAndRelint() {
 		log.Printf("rslint config file no longer exists, clearing config")
 		s.jsonConfig = config.RslintConfig{}
 		s.rslintConfigPath = ""
+		s.tsConfigPaths = nil
 	} else {
 		s.rslintConfigPath = configPath
 		if err := s.reloadConfig(); err != nil {
@@ -459,7 +536,7 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 			})
 		}
 
-		ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig)
+		ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, s.tsConfigPaths, s.fs)
 		if err != nil {
 			log.Printf("Error running lint for fixAll pass %d: %v", pass, err)
 			break
@@ -598,7 +675,7 @@ type LintResponse struct {
 	RuleCount   int                  `json:"ruleCount"`
 }
 
-func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool) ([]rule.RuleDiagnostic, error) {
+func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool, tsConfigPaths []string, fs vfs.FS) ([]rule.RuleDiagnostic, error) {
 	filename := uriToPath(uri)
 
 	// GetLanguageService flushes any pending changes (from DidChangeFile) and
@@ -608,6 +685,27 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 		return nil, fmt.Errorf("failed to get language service: %w", err)
 	}
 	program := languageService.GetProgram()
+
+	// Determine if this file has type information from the configured tsconfigs.
+	// The session's program has a ConfigFilePath (the tsconfig it was created from).
+	// If that tsconfig is NOT in parserOptions.project, type-aware rules should
+	// be filtered out — matching CLI behavior.
+	hasTypeInfo := true
+	if tsConfigPaths != nil {
+		configFilePath := program.Options().ConfigFilePath
+		if configFilePath != "" {
+			configFilePath = fs.Realpath(configFilePath)
+		}
+		programConfig := tspath.NormalizePath(configFilePath)
+		hasTypeInfo = false
+		for _, tc := range tsConfigPaths {
+			if tc == programConfig {
+				hasTypeInfo = true
+				break
+			}
+		}
+	}
+
 	// Collect diagnostics
 	var diagnostics []rule.RuleDiagnostic
 	var diagnosticsLock sync.Mutex
@@ -622,6 +720,9 @@ func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx c
 	linter.RunLinterInProgram(program, []string{filename}, nil, util.ExcludePaths,
 		func(sourceFile *ast.SourceFile) []linter.ConfiguredRule {
 			activeRules, _ := config.GlobalRuleRegistry.GetEnabledRules(rslintConfig, sourceFile.FileName(), cwd, enforcePlugins)
+			if !hasTypeInfo {
+				activeRules = linter.FilterNonTypeAwareRules(activeRules)
+			}
 			return activeRules
 		}, false, diagnosticCollector, nil, nil)
 
@@ -849,7 +950,7 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 	}
 
 	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
-	ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig)
+	ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, s.tsConfigPaths, s.fs)
 	if err != nil {
 		log.Printf("Error running lint for push diagnostics: %v", err)
 		return

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -1293,3 +1293,148 @@ func TestCloseAndReopen(t *testing.T) {
 	}
 }
 
+
+// ======== tsConfigPaths lifecycle tests ========
+
+func TestHandleConfigUpdate_RebuildsTsConfigPaths(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+	ctx := context.Background()
+
+	// Set stale tsConfigPaths
+	s.tsConfigPaths = []string{"/old/tsconfig.json"}
+
+	// Config update with no parserOptions.project and no tsconfig.json (mockFS has no files)
+	// → ResolveTsConfigPaths returns nil → rebuildTsConfigPaths clears tsConfigPaths
+	err := s.handleConfigUpdate(ctx, map[string]any{
+		"configs": []any{
+			map[string]any{
+				"configDirectory": "file:///project",
+				"entries": []any{
+					map[string]any{
+						"rules": map[string]any{"no-console": "error"},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+
+	// tsConfigPaths should be nil (mockFS has no tsconfig.json to auto-detect)
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths nil after config update with no project, got %v", s.tsConfigPaths)
+	}
+}
+
+func TestHandleConfigUpdate_EmptyConfigs_ClearsTsConfigPaths(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+	ctx := context.Background()
+
+	s.tsConfigPaths = []string{"/project/tsconfig.json"}
+
+	err := s.handleConfigUpdate(ctx, map[string]any{
+		"configs": []any{},
+	})
+	if err != nil {
+		t.Fatalf("handleConfigUpdate failed: %v", err)
+	}
+
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths nil after empty config update, got %v", s.tsConfigPaths)
+	}
+}
+
+func TestRebuildTsConfigPaths_MixedConfigsWithAndWithoutProject(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+
+	// Config A has project, Config B doesn't (and no tsconfig.json to auto-detect)
+	// → ResolveTsConfigPaths returns nil for B → rebuildTsConfigPaths should set nil (allow all)
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///project-a": {
+			{
+				LanguageOptions: &config.LanguageOptions{
+					ParserOptions: &config.ParserOptions{
+						Project: []string{"./tsconfig.json"},
+					},
+				},
+			},
+		},
+		"file:///project-b": {
+			{
+				Rules: config.Rules{"no-console": "error"},
+			},
+		},
+	}
+
+	s.rebuildTsConfigPaths()
+
+	// Should be nil because config B has no project and no auto-detected tsconfig
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths nil for mixed configs (some without project), got %v", s.tsConfigPaths)
+	}
+}
+
+func TestRebuildTsConfigPaths_AllConfigsHaveProject(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{
+		"/project-a/tsconfig.json": true,
+		"/project-b/tsconfig.json": true,
+	}}
+
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///project-a": {
+			{
+				LanguageOptions: &config.LanguageOptions{
+					ParserOptions: &config.ParserOptions{
+						Project: []string{"./tsconfig.json"},
+					},
+				},
+			},
+		},
+		"file:///project-b": {
+			{
+				LanguageOptions: &config.LanguageOptions{
+					ParserOptions: &config.ParserOptions{
+						Project: []string{"./tsconfig.json"},
+					},
+				},
+			},
+		},
+	}
+
+	s.rebuildTsConfigPaths()
+
+	if s.tsConfigPaths == nil {
+		t.Fatal("expected tsConfigPaths non-nil when all configs have project")
+	}
+	if len(s.tsConfigPaths) != 2 {
+		t.Fatalf("expected 2 tsconfig paths, got %d: %v", len(s.tsConfigPaths), s.tsConfigPaths)
+	}
+	// Verify actual paths contain the expected tsconfig locations
+	pathSet := make(map[string]bool)
+	for _, p := range s.tsConfigPaths {
+		pathSet[p] = true
+	}
+	if !pathSet["/project-a/tsconfig.json"] {
+		t.Errorf("expected /project-a/tsconfig.json in paths, got %v", s.tsConfigPaths)
+	}
+	if !pathSet["/project-b/tsconfig.json"] {
+		t.Errorf("expected /project-b/tsconfig.json in paths, got %v", s.tsConfigPaths)
+	}
+}
+
+func TestRebuildTsConfigPaths_NoConfig(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{}}
+
+	// No jsConfigs, no rslintConfigPath
+	s.rebuildTsConfigPaths()
+
+	if s.tsConfigPaths != nil {
+		t.Errorf("expected tsConfigPaths nil when no config, got %v", s.tsConfigPaths)
+	}
+}

--- a/internal/utils/create_program.go
+++ b/internal/utils/create_program.go
@@ -118,3 +118,24 @@ func createProgramFromConfig(singleThreaded bool, config *tsoptions.ParsedComman
 
 	return program, nil
 }
+
+// CollectProgramFiles collects all source file paths from the given programs
+// into a set for fast lookup. Also stores symlink-resolved paths to handle
+// platform differences (e.g. macOS /tmp → /private/tmp).
+func CollectProgramFiles(programs []*compiler.Program, fs vfs.FS) map[string]struct{} {
+	fileSet := make(map[string]struct{})
+	for _, prog := range programs {
+		for _, sf := range prog.GetSourceFiles() {
+			name := sf.FileName()
+			if _, ok := fileSet[name]; ok {
+				continue
+			}
+			fileSet[name] = struct{}{}
+			if resolved := fs.Realpath(name); resolved != name {
+				fileSet[resolved] = struct{}{}
+			}
+		}
+	}
+	return fileSet
+}
+

--- a/packages/vscode-extension/__tests__/fixtures-type-aware-scope/packages/cli/src/preview.ts
+++ b/packages/vscode-extension/__tests__/fixtures-type-aware-scope/packages/cli/src/preview.ts
@@ -1,0 +1,3 @@
+export async function previewCommand(): Promise<void> {
+  console.log('preview');
+}

--- a/packages/vscode-extension/__tests__/fixtures-type-aware-scope/packages/core/src/index.ts
+++ b/packages/vscode-extension/__tests__/fixtures-type-aware-scope/packages/core/src/index.ts
@@ -1,0 +1,3 @@
+export async function coreFunction(): Promise<void> {
+  console.log('hello');
+}

--- a/packages/vscode-extension/__tests__/fixtures-type-aware-scope/packages/core/tsconfig.json
+++ b/packages/vscode-extension/__tests__/fixtures-type-aware-scope/packages/core/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": { "strict": true, "noEmit": true },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/vscode-extension/__tests__/fixtures-type-aware-scope/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-type-aware-scope/rslint.config.js
@@ -1,0 +1,16 @@
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./packages/core/tsconfig.json'],
+      },
+    },
+    rules: {
+      '@typescript-eslint/require-await': 'error',
+      'no-console': 'error',
+    },
+    plugins: ['@typescript-eslint'],
+  },
+];

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -87,6 +87,28 @@ async function main() {
     failed = true;
   }
 
+  // --- Type-aware rule scope tests ---
+  const typeAwareScopeWorkspace = path.resolve(
+    testsSourceDir,
+    'fixtures-type-aware-scope',
+  );
+  const typeAwareScopeTestsPath = path.resolve(
+    __dirname,
+    './suite-type-aware-scope',
+  );
+
+  try {
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath: typeAwareScopeTestsPath,
+      launchArgs: ['--disable-extensions', typeAwareScopeWorkspace],
+      version: 'stable',
+    });
+  } catch (err) {
+    console.error('Type-aware scope tests failed:', err);
+    failed = true;
+  }
+
   if (failed) {
     console.error('Some test suites failed');
     process.exit(1);

--- a/packages/vscode-extension/__tests__/suite-type-aware-scope/index.ts
+++ b/packages/vscode-extension/__tests__/suite-type-aware-scope/index.ts
@@ -1,0 +1,27 @@
+import fastGlob from 'fast-glob';
+import path from 'node:path';
+import Mocha from 'mocha';
+
+export function run(
+  testPath: string,
+  callback: (error: unknown, failures?: number) => void,
+) {
+  const files = fastGlob.sync('**/*.test.js', {
+    cwd: testPath,
+  });
+  const mocha = new Mocha({
+    ui: 'tdd',
+  });
+
+  files.forEach((file) => {
+    mocha.addFile(path.join(testPath, file));
+  });
+
+  try {
+    mocha.run((failures) => {
+      callback(null, failures);
+    });
+  } catch (error) {
+    callback(error);
+  }
+}

--- a/packages/vscode-extension/__tests__/suite-type-aware-scope/type-aware-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-type-aware-scope/type-aware-scope.test.ts
@@ -1,0 +1,96 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import path from 'node:path';
+
+// Tests that type-aware rules (e.g. require-await) only run on files covered
+// by parserOptions.project, matching CLI behavior.
+//
+// Fixture: rslint.config.js has project: ['./packages/core/tsconfig.json']
+// - packages/core/src/index.ts: IN tsconfig, require-await SHOULD fire
+// - packages/cli/src/preview.ts: NOT in tsconfig, require-await should NOT fire
+suite('rslint type-aware rule scope', function () {
+  this.timeout(60000);
+
+  function getWorkspaceRoot(): string {
+    return vscode.workspace.workspaceFolders![0].uri.fsPath;
+  }
+
+  async function waitForDiagnostics(
+    doc: vscode.TextDocument,
+    predicate?: (diags: vscode.Diagnostic[]) => boolean,
+  ): Promise<vscode.Diagnostic[]> {
+    for (let i = 0; i < 20; i++) {
+      const diagnostics = vscode.languages.getDiagnostics(doc.uri);
+      if (predicate ? predicate(diagnostics) : diagnostics.length > 0) {
+        return diagnostics;
+      }
+      await new Promise((resolve) => {
+        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
+          for (const uri of e.uris) {
+            if (uri.toString() === doc.uri.toString()) {
+              disposable.dispose();
+              resolve(void 0);
+              return;
+            }
+          }
+        });
+        setTimeout(() => {
+          disposable.dispose();
+          resolve(void 0);
+        }, 1500);
+      });
+    }
+    return vscode.languages.getDiagnostics(doc.uri);
+  }
+
+  test('file IN parserOptions.project tsconfig should get type-aware rules', async () => {
+    const filePath = path.join(
+      getWorkspaceRoot(),
+      'packages/core/src/index.ts',
+    );
+    const doc = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(doc);
+
+    const diagnostics = await waitForDiagnostics(doc, (diags) =>
+      diags.some((d) => d.message.includes('require-await')),
+    );
+
+    // require-await should fire (type-aware, file IS in tsconfig)
+    assert.ok(
+      diagnostics.some((d) => d.message.includes('require-await')),
+      `Expected require-await for file in tsconfig. Got: ${diagnostics.map((d) => d.message).join(', ')}`,
+    );
+
+    // no-console should also fire (non-type-aware, always runs)
+    assert.ok(
+      diagnostics.some((d) => d.message.includes('no-console')),
+      'Expected no-console for file in tsconfig',
+    );
+  });
+
+  test('file NOT in parserOptions.project tsconfig should NOT get type-aware rules', async () => {
+    const filePath = path.join(
+      getWorkspaceRoot(),
+      'packages/cli/src/preview.ts',
+    );
+    const doc = await vscode.workspace.openTextDocument(filePath);
+    await vscode.window.showTextDocument(doc);
+
+    // Wait for no-console (non-type-aware) to appear — proves rslint IS linting the file
+    const diagnostics = await waitForDiagnostics(doc, (diags) =>
+      diags.some((d) => d.message.includes('no-console')),
+    );
+
+    // no-console SHOULD fire (non-type-aware, always runs)
+    assert.ok(
+      diagnostics.some((d) => d.message.includes('no-console')),
+      `Expected no-console for file outside tsconfig. Got: ${diagnostics.map((d) => d.message).join(', ')}`,
+    );
+
+    // require-await should NOT fire (type-aware, file is NOT in configured tsconfig)
+    assert.ok(
+      !diagnostics.some((d) => d.message.includes('require-await')),
+      'require-await should NOT fire for file outside parserOptions.project tsconfig',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Type-aware lint rules (e.g. `@typescript-eslint/require-await`) were running on files outside the configured `parserOptions.project` tsconfigs in the LSP, causing false positives that the CLI did not produce.

**Root cause**: The LSP's session auto-discovers tsconfigs for all files (providing TypeChecker), but the CLI only enables type-aware rules for files covered by `parserOptions.project`. The LSP was missing this filtering.

**Fix**: At lint time, compare the session program's `ConfigFilePath` against the resolved `parserOptions.project` paths. Filter type-aware rules for files whose tsconfig is not in the configured set.

**Shared utilities extracted** (CLI and LSP reuse):
- `config.ResolveTsConfigPaths` — resolve tsconfig paths from rslint config with auto-detection fallback
- `config.GetActiveRulesForFile` — rule selection + type-aware filtering
- `utils.CollectProgramFiles` — collect source file paths from programs

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).