### PR TITLE
test: migrate CLI tests from JSON config to JS config

### DIFF
--- a/packages/rslint-test-tools/tests/cli/basic.test.ts
+++ b/packages/rslint-test-tools/tests/cli/basic.test.ts
@@ -166,23 +166,20 @@ describe('CLI Configuration Tests', () => {
 
   test('should output in jsonline format when --format jsonline is used', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            'prefer-const': 'off',
-            '@typescript-eslint/no-unsafe-member-access': 'error',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          'prefer-const': 'off',
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': JSON.stringify({
         compilerOptions: {
           target: 'ES2020',
@@ -216,24 +213,21 @@ describe('CLI Configuration Tests', () => {
 
   test('should output in github workflow format when --format github is used', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            'prefer-const': 'off',
-            '@typescript-eslint/no-explicit-any': 'warn',
-            '@typescript-eslint/no-unsafe-member-access': 'error',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          'prefer-const': 'off',
+          '@typescript-eslint/no-explicit-any': 'warn',
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': JSON.stringify({
         compilerOptions: {
           target: 'ES2020',
@@ -270,24 +264,21 @@ describe('CLI Configuration Tests', () => {
 
   test('should only report errors when --quiet flag is used', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            'prefer-const': 'off',
-            '@typescript-eslint/no-unsafe-member-access': 'error',
-            '@typescript-eslint/return-await': 'warn',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          'prefer-const': 'off',
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+          '@typescript-eslint/return-await': 'warn',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': JSON.stringify({
         compilerOptions: {
           target: 'ES2020',
@@ -359,22 +350,19 @@ describe('CLI Configuration Tests', () => {
 
   test('should handle directory with no matching files', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            'prefer-const': 'off',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          'prefer-const': 'off',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': JSON.stringify({
         compilerOptions: {
           target: 'ES2020',
@@ -398,23 +386,20 @@ describe('CLI Configuration Tests', () => {
 
   test('should exit with non-zero code when linting errors are found', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            'prefer-const': 'off',
-            'no-unsafe-member-access': 'error',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          'prefer-const': 'off',
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': JSON.stringify({
         compilerOptions: {
           target: 'ES2020',
@@ -441,24 +426,21 @@ describe('CLI Configuration Tests', () => {
 
   test('should exit with zero code when no linting errors are found', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            'prefer-const': 'off',
-            'no-unsafe-member-access': 'error',
-            'no-console': 'off',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          'prefer-const': 'off',
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+          'no-console': 'off',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': JSON.stringify({
         compilerOptions: {
           target: 'ES2020',

--- a/packages/rslint-test-tools/tests/cli/disable-comments.test.ts
+++ b/packages/rslint-test-tools/tests/cli/disable-comments.test.ts
@@ -53,20 +53,17 @@ async function cleanupTempDir(tempDir: string): Promise<void> {
 }
 
 function makeConfig(rules: Record<string, unknown>) {
-  return JSON.stringify([
-    {
-      language: 'javascript',
-      files: ['**/*.ts'],
-      languageOptions: {
-        parserOptions: {
-          projectService: false,
-          project: ['./tsconfig.json'],
-        },
+  return `export default [${JSON.stringify({
+    files: ['**/*.ts'],
+    languageOptions: {
+      parserOptions: {
+        projectService: false,
+        project: ['./tsconfig.json'],
       },
-      rules,
-      plugins: ['@typescript-eslint'],
     },
-  ]);
+    rules,
+    plugins: ['@typescript-eslint'],
+  })}];`;
 }
 
 const TSCONFIG = JSON.stringify({
@@ -87,7 +84,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable-next-line suppresses diagnostic on next line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '// rslint-disable-next-line @typescript-eslint/no-explicit-any',
@@ -111,7 +108,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable-line suppresses diagnostic on same line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         'const x: any = 1; // rslint-disable-line @typescript-eslint/no-explicit-any',
@@ -134,7 +131,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable + rslint-enable suppresses diagnostics inside range', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* rslint-disable @typescript-eslint/no-explicit-any */',
@@ -160,7 +157,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable without enable suppresses rest of file', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* rslint-disable @typescript-eslint/no-explicit-any */',
@@ -185,7 +182,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable without rule name suppresses all rules', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* rslint-disable */',
@@ -209,7 +206,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable + eslint-enable mixed prefixes work', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* rslint-disable @typescript-eslint/no-explicit-any */',
@@ -230,7 +227,7 @@ describe('rslint-disable comment directives', () => {
 
   test('eslint-disable + rslint-enable mixed prefixes work', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable @typescript-eslint/no-explicit-any */',
@@ -255,7 +252,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable-next-line does not suppress other lines', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '// rslint-disable-next-line @typescript-eslint/no-explicit-any',
@@ -275,7 +272,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable + rslint-enable does NOT suppress diagnostics outside range', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* rslint-disable @typescript-eslint/no-explicit-any */',
@@ -300,7 +297,7 @@ describe('rslint-disable comment directives', () => {
 
   test('block comment style works for rslint-disable-next-line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* rslint-disable-next-line @typescript-eslint/no-explicit-any */',
@@ -324,7 +321,7 @@ describe('rslint-disable comment directives', () => {
 
   test('rslint-disable-next-line with -- description suppresses diagnostic', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '// rslint-disable-next-line @typescript-eslint/no-explicit-any -- needed for legacy API',
@@ -350,7 +347,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable-next-line suppresses diagnostic on next line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '// eslint-disable-next-line @typescript-eslint/no-explicit-any',
@@ -370,7 +367,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable-next-line does not suppress other lines', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '// eslint-disable-next-line @typescript-eslint/no-explicit-any',
@@ -394,7 +391,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable-line suppresses diagnostic on same line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         'const x: any = 1; // eslint-disable-line @typescript-eslint/no-explicit-any',
@@ -417,7 +414,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable + eslint-enable suppresses diagnostics inside range', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable @typescript-eslint/no-explicit-any */',
@@ -439,7 +436,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable + eslint-enable does NOT suppress diagnostics outside range', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable @typescript-eslint/no-explicit-any */',
@@ -464,7 +461,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable without enable suppresses rest of file', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable @typescript-eslint/no-explicit-any */',
@@ -490,7 +487,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable without rule name suppresses all rules', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable */',
@@ -510,7 +507,7 @@ describe('eslint-disable comment directives', () => {
 
   test('wildcard eslint-disable-next-line suppresses all rules on next line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': ['// eslint-disable-next-line', 'const x: any = 1;'].join(
         '\n',
@@ -532,7 +529,7 @@ describe('eslint-disable comment directives', () => {
 
   test('block comment style works for disable-next-line', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable-next-line @typescript-eslint/no-explicit-any */',
@@ -560,7 +557,7 @@ describe('eslint-disable comment directives', () => {
 
   test('eslint-disable-next-line with -- description suppresses diagnostic', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '// eslint-disable-next-line @typescript-eslint/no-explicit-any -- needed for legacy API',
@@ -585,7 +582,7 @@ describe('eslint-disable comment directives', () => {
   test('eslint-disable-next-line works inside function call arguments', async () => {
     const ASSERTION_RULE = '@typescript-eslint/consistent-type-assertions';
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({
+      'rslint.config.mjs': makeConfig({
         [ASSERTION_RULE]: ['error', { assertionStyle: 'never' }],
       }),
       'tsconfig.json': TSCONFIG,
@@ -614,7 +611,7 @@ describe('eslint-disable comment directives', () => {
   test('eslint-disable-next-line works inside array literals', async () => {
     const ASSERTION_RULE = '@typescript-eslint/consistent-type-assertions';
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({
+      'rslint.config.mjs': makeConfig({
         [ASSERTION_RULE]: ['error', { assertionStyle: 'never' }],
       }),
       'tsconfig.json': TSCONFIG,
@@ -643,7 +640,7 @@ describe('eslint-disable comment directives', () => {
 
   test('multiple disable/enable ranges work independently', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': makeConfig({ [RULE]: 'error' }),
+      'rslint.config.mjs': makeConfig({ [RULE]: 'error' }),
       'tsconfig.json': TSCONFIG,
       'test.ts': [
         '/* eslint-disable @typescript-eslint/no-explicit-any */',

--- a/packages/rslint-test-tools/tests/cli/file-args.test.ts
+++ b/packages/rslint-test-tools/tests/cli/file-args.test.ts
@@ -59,7 +59,21 @@ async function cleanupTempDir(tempDir: string): Promise<void> {
   await fs.rm(tempDir, { recursive: true, force: true });
 }
 
-const baseConfig = JSON.stringify([
+const baseConfig = `export default [${JSON.stringify({
+  files: ['**/*.ts'],
+  languageOptions: {
+    parserOptions: {
+      projectService: false,
+      project: ['./tsconfig.json'],
+    },
+  },
+  rules: {
+    '@typescript-eslint/no-unsafe-member-access': 'error',
+  },
+  plugins: ['@typescript-eslint'],
+})}];`;
+
+const baseJsonConfig = JSON.stringify([
   {
     language: 'javascript',
     files: ['**/*.ts'],
@@ -88,7 +102,7 @@ const baseTsConfig = JSON.stringify({
 describe('CLI File Arguments', () => {
   test('should only lint specified file', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
       'clean.ts': 'export const x = 1;\n',
@@ -106,7 +120,7 @@ describe('CLI File Arguments', () => {
 
   test('should only lint the clean file and find no errors', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
       'clean.ts': 'export const x = 1;\n',
@@ -125,7 +139,7 @@ describe('CLI File Arguments', () => {
 
   test('should lint multiple specified files', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'a.ts': 'let a: any = 10;\na.b = 20;\n',
       'b.ts': 'let b: any = 20;\nb.c = 30;\n',
@@ -145,22 +159,19 @@ describe('CLI File Arguments', () => {
 
   test('should work with --fix and file arguments', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            '@typescript-eslint/no-inferrable-types': 'error',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          '@typescript-eslint/no-inferrable-types': 'error',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': baseTsConfig,
       'fixable.ts': 'const x: number = 42;\n',
       'other.ts': 'const y: string = "hello";\n',
@@ -190,7 +201,7 @@ describe('CLI File Arguments', () => {
 
   test('should work with --format jsonline and file arguments', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
@@ -215,7 +226,7 @@ describe('CLI File Arguments', () => {
 
   test('should warn per-file when specified file is not in the project', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'existing.ts': 'export const x = 1;\n',
     });
@@ -233,7 +244,7 @@ describe('CLI File Arguments', () => {
 
   test('should warn per-file when multiple specified files are all not in the project', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'existing.ts': 'export const x = 1;\n',
     });
@@ -254,7 +265,7 @@ describe('CLI File Arguments', () => {
 
   test('should warn for non-project file while linting project files', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'clean.ts': 'export const x = 1;\n',
     });
@@ -273,7 +284,7 @@ describe('CLI File Arguments', () => {
 
   test('should exit 0 with --max-warnings 0 when files are not in project', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'existing.ts': 'export const x = 1;\n',
     });
@@ -294,7 +305,7 @@ describe('CLI File Arguments', () => {
 
   test('should lint all files when no file arguments provided', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'a.ts': 'let a: any = 10;\na.x = 1;\n',
       'b.ts': 'let b: any = 20;\nb.y = 2;\n',
@@ -348,13 +359,16 @@ describe('CLI File Arguments', () => {
 
   test('should accept absolute file paths', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
 
     try {
-      const absPath = path.join(tempDir, 'error.ts');
+      // Use realpath to normalize symlinks (e.g. /var → /private/var on macOS)
+      // so the file arg matches the config-discovered path for dedup.
+      const realTempDir = await fs.realpath(tempDir);
+      const absPath = path.join(realTempDir, 'error.ts');
       const result = await runRslint([absPath], tempDir);
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout).toContain('no-unsafe-member-access');
@@ -366,7 +380,7 @@ describe('CLI File Arguments', () => {
 
   test('should accept subdirectory file paths', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'src/error.ts': 'let a: any = 10;\na.b = 20;\n',
       'src/clean.ts': 'export const x = 1;\n',
@@ -384,7 +398,7 @@ describe('CLI File Arguments', () => {
 
   test('should handle symlink-resolved absolute paths', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
@@ -405,7 +419,7 @@ describe('CLI File Arguments', () => {
 
   test('should handle mix of existing and nonexistent file args', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
@@ -426,7 +440,7 @@ describe('CLI File Arguments', () => {
 
   test('should deduplicate when same file is passed twice', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
@@ -443,7 +457,7 @@ describe('CLI File Arguments', () => {
 
   test('should resolve ../ in relative paths', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': baseConfig,
+      'rslint.config.mjs': baseConfig,
       'tsconfig.json': baseTsConfig,
       'src/error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
@@ -461,7 +475,7 @@ describe('CLI File Arguments', () => {
 
   test('should work with --config and file arguments', async () => {
     const tempDir = await createTempDir({
-      'custom.json': baseConfig,
+      'custom.json': baseJsonConfig,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
       'clean.ts': 'export const x = 1;\n',
@@ -482,23 +496,20 @@ describe('CLI File Arguments', () => {
 
   test('should work with --quiet and file arguments', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            '@typescript-eslint/no-unsafe-member-access': 'error',
-            '@typescript-eslint/no-explicit-any': 'warn',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          '@typescript-eslint/no-unsafe-member-access': 'error',
+          '@typescript-eslint/no-explicit-any': 'warn',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': baseTsConfig,
       'error.ts': 'let a: any = 10;\na.b = 20;\n',
     });
@@ -515,22 +526,19 @@ describe('CLI File Arguments', () => {
 
   test('should respect --max-warnings with file arguments', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.ts'],
-          languageOptions: {
-            parserOptions: {
-              projectService: false,
-              project: ['./tsconfig.json'],
-            },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.ts'],
+        languageOptions: {
+          parserOptions: {
+            projectService: false,
+            project: ['./tsconfig.json'],
           },
-          rules: {
-            '@typescript-eslint/no-explicit-any': 'warn',
-          },
-          plugins: ['@typescript-eslint'],
         },
-      ]),
+        rules: {
+          '@typescript-eslint/no-explicit-any': 'warn',
+        },
+        plugins: ['@typescript-eslint'],
+      })}];`,
       'tsconfig.json': baseTsConfig,
       'warn.ts': 'let a: any = 10;\nlet b: any = 20;\n',
     });
@@ -549,15 +557,12 @@ describe('CLI File Arguments', () => {
 
   test('should work without tsconfig (pure JS project)', async () => {
     const tempDir = await createTempDir({
-      'rslint.json': JSON.stringify([
-        {
-          language: 'javascript',
-          files: ['**/*.js'],
-          rules: {
-            'no-empty': 'error',
-          },
+      'rslint.config.mjs': `export default [${JSON.stringify({
+        files: ['**/*.js'],
+        rules: {
+          'no-empty': 'error',
         },
-      ]),
+      })}];`,
       'error.js': 'if (true) {}\n',
       'clean.js': 'const x = 1;\n',
     });


### PR DESCRIPTION
## Summary

Migrate CLI test fixtures from `rslint.json` to `rslint.config.mjs` in preparation for deprecating JSON config format. JSON config auto-enables all ported rules, which is unfriendly for new rules — JS config gives explicit control.

**Migrated (config is just a vehicle, not the test target):**
- `cli/disable-comments.test.ts` — all 24 tests
- `cli/basic.test.ts` — 6 of 12 tests (--format, --quiet, exit code, no matching files)
- `cli/file-args.test.ts` — 16 of 21 tests (file args, --fix, --quiet, --max-warnings, etc.)

**Intentionally kept as JSON (tests that validate JSON config behavior):**
- `basic.test.ts`: JSON auto-discovery, `--config` with JSON path, invalid/missing JSON error handling
- `file-args.test.ts`: `--config custom.json` with file args
- `cli-integration.test.ts`: JS-over-JSON priority, JSON regression
- `files-driven-lint.test.ts`: JSON legacy behavior (tsconfig-driven)

**Not migrated (rule-tester/API configs — `lint()` API passes config path to Go binary which only reads JSON):**
- `eslint/rslint.json`, `eslint-plugin-{import,jest,react}/rslint.json`, `typescript-eslint/fixtures/rslint.json`
- `packages/rslint/fixtures/rslint.json`, `rslint.virtual.json`

**Also fixed:**
- Added missing `@typescript-eslint/` prefix to rule names in `basic.test.ts` (JSON config auto-resolves; JS config requires full name)
- Used `fs.realpath` in absolute path test to handle macOS `/var` → `/private/var` symlink dedup

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).