### PR TITLE
feat: port rule no-alert

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,6 +104,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/default_case_last"
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
+	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
 	"github.com/web-infra-dev/rslint/internal/rules/no_caller"
@@ -477,6 +478,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("default-case-last", default_case_last.DefaultCaseLastRule)
 	GlobalRuleRegistry.Register("for-direction", for_direction.ForDirectionRule)
 	GlobalRuleRegistry.Register("getter-return", getter_return.GetterReturnRule)
+	GlobalRuleRegistry.Register("no-alert", no_alert.NoAlertRule)
 	GlobalRuleRegistry.Register("no-async-promise-executor", no_async_promise_executor.NoAsyncPromiseExecutorRule)
 	GlobalRuleRegistry.Register("no-await-in-loop", no_await_in_loop.NoAwaitInLoopRule)
 	GlobalRuleRegistry.Register("no-caller", no_caller.NoCallerRule)

--- a/internal/rules/no_alert/no_alert.go
+++ b/internal/rules/no_alert/no_alert.go
@@ -1,0 +1,96 @@
+package no_alert
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// isProhibitedIdentifier checks if the name is alert, confirm, or prompt.
+func isProhibitedIdentifier(name string) bool {
+	return name == "alert" || name == "confirm" || name == "prompt"
+}
+
+// outerExpressionKinds covers parentheses, type assertions (as / angle-bracket),
+// non-null assertions (!), and satisfies — all of which are transparent at runtime.
+const outerExpressionKinds = ast.OEKParentheses | ast.OEKAssertions
+
+// isGlobalThisOrWindow checks if the node is a reference to the global object:
+// - `this` at global scope (not inside any function-like declaration or class)
+// - non-shadowed `window`
+// - non-shadowed `globalThis`
+//
+// Skips outer expression wrappers (parentheses, type assertions, non-null assertions)
+// so that `(window).alert()` and `window!.alert()` are handled correctly.
+func isGlobalThisOrWindow(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, outerExpressionKinds)
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindThisKeyword {
+		// `this` is at the global scope only when not enclosed by any
+		// function-like declaration or class body. Class fields, static blocks,
+		// and computed property names all live inside a class scope where `this`
+		// refers to the class or instance, not globalThis.
+		return ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+			return ast.IsFunctionLikeDeclaration(n) || ast.IsClassLike(n)
+		}) == nil
+	}
+	if node.Kind == ast.KindIdentifier {
+		name := node.Text()
+		if name == "window" || name == "globalThis" {
+			return !utils.IsShadowed(node, name)
+		}
+	}
+	return false
+}
+
+// https://eslint.org/docs/latest/rules/no-alert
+var NoAlertRule = rule.Rule{
+	Name: "no-alert",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				callee := ast.SkipOuterExpressions(node.Expression(), outerExpressionKinds)
+				if callee == nil {
+					return
+				}
+
+				var name string
+
+				switch callee.Kind {
+				case ast.KindIdentifier:
+					// Direct call: alert(), confirm(), prompt()
+					name = callee.Text()
+					if !isProhibitedIdentifier(name) {
+						return
+					}
+					if utils.IsShadowed(callee, name) {
+						return
+					}
+
+				case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+					// Member access: window.alert(), window['alert'](), globalThis.alert(), this.alert()
+					var ok bool
+					name, ok = utils.AccessExpressionStaticName(callee)
+					if !ok || !isProhibitedIdentifier(name) {
+						return
+					}
+					if !isGlobalThisOrWindow(utils.AccessExpressionObject(callee)) {
+						return
+					}
+
+				default:
+					return
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "unexpected",
+					Description: fmt.Sprintf("Unexpected %s.", name),
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_alert/no_alert.md
+++ b/internal/rules/no_alert/no_alert.md
@@ -1,0 +1,36 @@
+# no-alert
+
+## Rule Details
+
+Disallow the use of `alert`, `confirm`, and `prompt`.
+
+JavaScript's `alert`, `confirm`, and `prompt` functions are widely considered to be obtrusive as UI elements and should be replaced by a more appropriate custom UI implementation. Furthermore, `alert` is often used while debugging code, which should be removed before deployment to production.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+alert('here!');
+confirm('Are you sure?');
+prompt("What's your name?", 'John Doe');
+
+window.alert('here!');
+globalThis.confirm('Are you sure?');
+this.prompt("What's your name?");
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+customAlert('Something happened!');
+customConfirm('Are you sure?');
+customPrompt('Who are you?');
+
+function foo() {
+  var alert = myCustomLib.customAlert;
+  alert();
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-alert

--- a/internal/rules/no_alert/no_alert_test.go
+++ b/internal/rules/no_alert/no_alert_test.go
@@ -1,0 +1,560 @@
+package no_alert
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAlertRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoAlertRule,
+		[]rule_tester.ValidTestCase{
+			// ================================================================
+			// Non-prohibited calls
+			// ================================================================
+			{Code: `a[o.k](1)`},
+			{Code: `foo.alert(foo)`},
+			{Code: `foo.confirm(foo)`},
+			{Code: `foo.prompt(foo)`},
+			{Code: `console.alert()`},
+			{Code: `window.scroll()`},
+			{Code: `window.focus()`},
+
+			// ================================================================
+			// Shadowing: function declaration
+			// ================================================================
+			{Code: `function alert() {} alert();`},
+			{Code: `function confirm() {} confirm();`},
+			{Code: `function prompt() {} prompt();`},
+
+			// ================================================================
+			// Shadowing: variable declaration (var / let / const)
+			// ================================================================
+			{Code: `var alert = function() {}; alert();`},
+			{Code: `let alert = 1; alert();`},
+			{Code: `const alert = () => {}; alert();`},
+
+			// ================================================================
+			// Shadowing: destructuring
+			// ================================================================
+			{Code: `const { alert } = obj; alert();`},
+			{Code: `const { a: alert } = obj; alert();`},
+			{Code: `const [alert] = arr; alert();`},
+
+			// ================================================================
+			// Shadowing: function parameter
+			// ================================================================
+			{Code: `function foo(alert) { alert(); }`},
+			{Code: `const foo = (alert) => { alert(); }`},
+			{Code: `function foo({ alert }) { alert(); }`},
+			{Code: `function foo([alert]) { alert(); }`},
+
+			// ================================================================
+			// Shadowing: inner scope (variable stays in scope for nested calls)
+			// ================================================================
+			{Code: `function foo() { var alert = bar; alert(); }`},
+			{Code: `var alert = function() {}; function test() { alert(); }`},
+			{Code: `function foo() { var alert = function() {}; function test() { alert(); } }`},
+
+			// ================================================================
+			// Shadowing: class declaration
+			// ================================================================
+			{Code: `class alert {} new alert();`},
+
+			// ================================================================
+			// Shadowing: catch clause
+			// ================================================================
+			{Code: `try {} catch(alert) { alert(); }`},
+
+			// ================================================================
+			// Shadowing: import
+			// ================================================================
+			{Code: `import alert from 'foo'; alert();`},
+			{Code: `import { alert } from 'foo'; alert();`},
+
+			// ================================================================
+			// Shadowing: for-loop / for-of / for-in
+			// ================================================================
+			{Code: `for (let alert = 0; alert < 10; alert++) {}`},
+			{Code: `for (const alert of arr) { alert(); }`},
+			{Code: `for (const alert in obj) { alert(); }`},
+
+			// ================================================================
+			// Shadowing: enum
+			// ================================================================
+			{Code: `enum alert { A, B }`},
+
+			// ================================================================
+			// Dynamic property access (no static name)
+			// ================================================================
+			{Code: `window[alert]();`},
+			{Code: `window[x + y]();`},
+
+			// ================================================================
+			// this: inside function (not global scope)
+			// ================================================================
+			{Code: `function foo() { this.alert(); }`},
+			{Code: `const foo = function() { this.alert(); }`},
+
+			// ================================================================
+			// this: inside arrow function (ESLint scope = "function", not "global")
+			// ================================================================
+			{Code: `const foo = () => this.alert();`},
+			{Code: `const foo = () => { this.alert(); }`},
+			{Code: `const f = () => { const g = () => { this.alert(); } }`},
+
+			// ================================================================
+			// this: inside class (class body creates its own this binding)
+			// ================================================================
+			{Code: `class A { foo() { this.alert(); } }`},
+			{Code: `class A { constructor() { this.alert(); } }`},
+			{Code: `class A { get x() { return this.alert(); } }`},
+			{Code: `class A { set x(v) { this.alert(); } }`},
+			// class field initializer — this = instance
+			{Code: `class A { x = this.alert(); }`},
+			// class static field initializer — this = class
+			{Code: `class A { static x = this.alert(); }`},
+			// class static block — this = class
+			{Code: `class A { static { this.alert(); } }`},
+			// computed property name in class — this = outer scope (class context)
+			{Code: `class A { [this.x]() {} }`},
+			// nested: arrow inside class method
+			{Code: `class A { foo() { const f = () => this.alert(); } }`},
+
+			// ================================================================
+			// Shadowed window / globalThis
+			// ================================================================
+			{Code: `function foo() { var window = bar; window.alert(); }`},
+			{Code: `const window = {}; window.alert();`},
+			{Code: `let window = {}; window.alert();`},
+			{Code: `var globalThis = foo; globalThis.alert();`},
+			{Code: `function foo() { var globalThis = foo; globalThis.alert(); }`},
+			{Code: `import window from 'w'; window.alert();`},
+
+			// ================================================================
+			// Callee is a chained member expression (not direct prohibited call)
+			// ================================================================
+			{Code: `alert.call(null)`},
+			{Code: `alert.apply(null, [])`},
+			{Code: `window.alert.call(null)`},
+
+			// ================================================================
+			// Not a call (no CallExpression)
+			// ================================================================
+			{Code: `var x = alert;`},
+			{Code: `var x = window.alert;`},
+			{Code: `typeof alert;`},
+			{Code: `new alert()`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ================================================================
+			// Direct calls: all three prohibited names
+			// ================================================================
+			{
+				Code: `alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `confirm(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `prompt(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// window.* dot access
+			// ================================================================
+			{
+				Code: `window.alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.confirm(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.prompt(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// window['*'] bracket access
+			// ================================================================
+			{
+				Code: `window['alert'](foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window['confirm'](foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window['prompt'](foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Template literal bracket access
+			// ================================================================
+			{
+				Code: "window[`alert`](foo)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// alert shadowed locally but window.alert still flagged
+			// ================================================================
+			{
+				Code: `function alert() {} window.alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: "var alert = function() {};\nwindow.alert(foo)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: `function foo(alert) { window.alert(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+
+			// ================================================================
+			// Direct call inside function/arrow/class (not shadowed)
+			// ================================================================
+			{
+				Code: `function foo() { alert(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `const foo = () => alert()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `const foo = () => { alert(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `class A { foo() { alert(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `class A { constructor() { alert(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+
+			// ================================================================
+			// Deeply nested (3+ levels)
+			// ================================================================
+			{
+				Code: `function a() { function b() { function c() { alert(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code: `const a = () => { const b = () => { const c = () => { alert(); }; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 55},
+				},
+			},
+
+			// ================================================================
+			// Shadowed inside function but not at call site
+			// ================================================================
+			{
+				Code: "function foo() { var alert = function() {}; }\nalert();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// this.alert at global scope
+			// ================================================================
+			{
+				Code: `this.alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `this['alert'](foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// window shadowed inside function but not at outer call site
+			// ================================================================
+			{
+				Code: "function foo() { var window = bar; window.alert(); }\nwindow.alert();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// globalThis access
+			// ================================================================
+			{
+				Code: `globalThis['alert'](foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `globalThis.alert()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "function foo() { var globalThis = bar; globalThis.alert(); }\nglobalThis.alert();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Optional chaining
+			// ================================================================
+			{
+				Code: `window?.alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(window?.alert)(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Parenthesized callee (SkipParentheses)
+			// ================================================================
+			{
+				Code: `(alert)(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `((alert))(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// window/globalThis access inside nested functions (not shadowed)
+			// ================================================================
+			{
+				Code: `function foo() { window.alert(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `const foo = () => window.confirm()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `class A { foo() { window.prompt(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+
+			// ================================================================
+			// Multiple errors in one file
+			// ================================================================
+			{
+				Code: "alert();\nconfirm();\nprompt();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 2, Column: 1},
+					{MessageId: "unexpected", Line: 3, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// IIFE
+			// ================================================================
+			{
+				Code: `(function() { alert(); })()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+
+			// ================================================================
+			// Parenthesized object expression: (window).alert()
+			// ================================================================
+			{
+				Code: `(window).alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(globalThis).alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(this).alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Non-null assertion on object: window!.alert()
+			// ================================================================
+			{
+				Code: `window!.alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Type assertion on object: (window as any).alert()
+			// ================================================================
+			{
+				Code: `(window as any).alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Optional chaining on this/globalThis
+			// ================================================================
+			{
+				Code: `this?.alert(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `globalThis?.confirm()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Direct call in class field / static block (alert is not shadowed)
+			// ================================================================
+			{
+				Code: `class A { x = alert(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `class A { static { alert(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+
+			// ================================================================
+			// window.alert in class field / static block (window not shadowed)
+			// ================================================================
+			{
+				Code: `class A { x = window.alert(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `class A { static { window.alert(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+
+			// ================================================================
+			// TypeScript outer expressions on callee
+			// ================================================================
+			// Non-null assertion on callee
+			{
+				Code: `alert!(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Type assertion (as) on callee
+			{
+				Code: `(alert as Function)(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Non-null assertion on member callee
+			{
+				Code: `(window.alert!)(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Type assertion on member callee
+			{
+				Code: `(window.alert as Function)(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -245,6 +245,7 @@ export default defineConfig({
     './tests/eslint/rules/eqeqeq.test.ts',
     './tests/eslint/rules/valid-typeof.test.ts',
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
+    './tests/eslint/rules/no-alert.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-alert.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-alert.test.ts.snap
@@ -1,0 +1,1363 @@
+// Rstest Snapshot v1
+
+exports[`no-alert > invalid 1`] = `
+{
+  "code": "alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 2`] = `
+{
+  "code": "confirm(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected confirm.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 3`] = `
+{
+  "code": "prompt(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected prompt.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 4`] = `
+{
+  "code": "window.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 5`] = `
+{
+  "code": "window.confirm(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected confirm.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 6`] = `
+{
+  "code": "window.prompt(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected prompt.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 7`] = `
+{
+  "code": "window['alert'](foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 8`] = `
+{
+  "code": "window['confirm'](foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected confirm.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 9`] = `
+{
+  "code": "window['prompt'](foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected prompt.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 10`] = `
+{
+  "code": "window[\`alert\`](foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 11`] = `
+{
+  "code": "function alert() {} window.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 12`] = `
+{
+  "code": "var alert = function() {};
+window.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 13`] = `
+{
+  "code": "function foo(alert) { window.alert(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 14`] = `
+{
+  "code": "function foo() { alert(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 15`] = `
+{
+  "code": "const foo = () => alert()",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 16`] = `
+{
+  "code": "const foo = () => { alert(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 17`] = `
+{
+  "code": "class A { foo() { alert(); } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 18`] = `
+{
+  "code": "class A { constructor() { alert(); } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 19`] = `
+{
+  "code": "function a() { function b() { function c() { alert(); } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 20`] = `
+{
+  "code": "const a = () => { const b = () => { const c = () => { alert(); }; }; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 21`] = `
+{
+  "code": "function foo() { var alert = function() {}; }
+alert();",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 22`] = `
+{
+  "code": "this.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 23`] = `
+{
+  "code": "this['alert'](foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 24`] = `
+{
+  "code": "function foo() { var window = bar; window.alert(); }
+window.alert();",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 25`] = `
+{
+  "code": "globalThis['alert'](foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 26`] = `
+{
+  "code": "globalThis.alert();",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 27`] = `
+{
+  "code": "function foo() { var globalThis = bar; globalThis.alert(); }
+globalThis.alert();",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 28`] = `
+{
+  "code": "window?.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 29`] = `
+{
+  "code": "(window?.alert)(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 30`] = `
+{
+  "code": "(alert)(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 31`] = `
+{
+  "code": "((alert))(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 32`] = `
+{
+  "code": "function foo() { window.alert(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 33`] = `
+{
+  "code": "const foo = () => window.confirm()",
+  "diagnostics": [
+    {
+      "message": "Unexpected confirm.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 34`] = `
+{
+  "code": "class A { foo() { window.prompt(); } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected prompt.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 35`] = `
+{
+  "code": "alert();
+confirm();
+prompt();",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+    {
+      "message": "Unexpected confirm.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+    {
+      "message": "Unexpected prompt.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 36`] = `
+{
+  "code": "(function() { alert(); })()",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 37`] = `
+{
+  "code": "(window).alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 38`] = `
+{
+  "code": "(globalThis).alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 39`] = `
+{
+  "code": "(this).alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 40`] = `
+{
+  "code": "window!.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 41`] = `
+{
+  "code": "(window as any).alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 42`] = `
+{
+  "code": "this?.alert(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 43`] = `
+{
+  "code": "globalThis?.confirm()",
+  "diagnostics": [
+    {
+      "message": "Unexpected confirm.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 44`] = `
+{
+  "code": "class A { x = alert(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 45`] = `
+{
+  "code": "class A { static { alert(); } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 46`] = `
+{
+  "code": "class A { x = window.alert(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 47`] = `
+{
+  "code": "class A { static { window.alert(); } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 48`] = `
+{
+  "code": "alert!(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 49`] = `
+{
+  "code": "(alert as Function)(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 50`] = `
+{
+  "code": "(window.alert!)(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-alert > invalid 51`] = `
+{
+  "code": "(window.alert as Function)(foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected alert.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-alert",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-alert.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-alert.test.ts
@@ -1,0 +1,441 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-alert', {
+  valid: [
+    // ================================================================
+    // Non-prohibited calls
+    // ================================================================
+    'a[o.k](1)',
+    'foo.alert(foo)',
+    'foo.confirm(foo)',
+    'foo.prompt(foo)',
+    'console.alert()',
+    'window.scroll()',
+    'window.focus()',
+
+    // ================================================================
+    // Shadowing: function declaration
+    // ================================================================
+    'function alert() {} alert();',
+    'function confirm() {} confirm();',
+    'function prompt() {} prompt();',
+
+    // ================================================================
+    // Shadowing: variable declaration (var / let / const)
+    // ================================================================
+    'var alert = function() {}; alert();',
+    'let alert = 1; alert();',
+    'const alert = () => {}; alert();',
+
+    // ================================================================
+    // Shadowing: destructuring
+    // ================================================================
+    'const { alert } = obj; alert();',
+    'const { a: alert } = obj; alert();',
+    'const [alert] = arr; alert();',
+
+    // ================================================================
+    // Shadowing: function parameter
+    // ================================================================
+    'function foo(alert) { alert(); }',
+    'const foo = (alert) => { alert(); }',
+    'function foo({ alert }) { alert(); }',
+    'function foo([alert]) { alert(); }',
+
+    // ================================================================
+    // Shadowing: inner scope (variable stays in scope for nested calls)
+    // ================================================================
+    'function foo() { var alert = bar; alert(); }',
+    'var alert = function() {}; function test() { alert(); }',
+    'function foo() { var alert = function() {}; function test() { alert(); } }',
+
+    // ================================================================
+    // Shadowing: class declaration
+    // ================================================================
+    'class alert {} new alert();',
+
+    // ================================================================
+    // Shadowing: catch clause
+    // ================================================================
+    'try {} catch(alert) { alert(); }',
+
+    // ================================================================
+    // Shadowing: import (Go tests only — virtual file can't resolve modules)
+    // ================================================================
+
+    // ================================================================
+    // Shadowing: for-loop / for-of / for-in
+    // ================================================================
+    'for (let alert = 0; alert < 10; alert++) {}',
+    'for (const alert of arr) { alert(); }',
+    'for (const alert in obj) { alert(); }',
+
+    // ================================================================
+    // Shadowing: enum
+    // ================================================================
+    'enum alert { A, B }',
+
+    // ================================================================
+    // Dynamic property access (no static name)
+    // ================================================================
+    'window[alert]();',
+    'window[x + y]();',
+
+    // ================================================================
+    // this: inside function (not global scope)
+    // ================================================================
+    'function foo() { this.alert(); }',
+    'const foo = function() { this.alert(); }',
+
+    // ================================================================
+    // this: inside arrow function (ESLint scope = "function", not "global")
+    // ================================================================
+    'const foo = () => this.alert();',
+    'const foo = () => { this.alert(); }',
+    'const f = () => { const g = () => { this.alert(); } }',
+
+    // ================================================================
+    // this: inside class (class body creates its own this binding)
+    // ================================================================
+    'class A { foo() { this.alert(); } }',
+    'class A { constructor() { this.alert(); } }',
+    'class A { get x() { return this.alert(); } }',
+    'class A { set x(v) { this.alert(); } }',
+    // class field initializer — this = instance
+    'class A { x = this.alert(); }',
+    // class static field initializer — this = class
+    'class A { static x = this.alert(); }',
+    // class static block — this = class
+    'class A { static { this.alert(); } }',
+    // nested: arrow inside class method
+    'class A { foo() { const f = () => this.alert(); } }',
+
+    // ================================================================
+    // Shadowed window / globalThis
+    // ================================================================
+    'function foo() { var window = bar; window.alert(); }',
+    'const window = {}; window.alert();',
+    'let window = {}; window.alert();',
+    'var globalThis = foo; globalThis.alert();',
+    'function foo() { var globalThis = foo; globalThis.alert(); }',
+    // import window from 'w'; window.alert(); — Go tests only (module resolution)
+
+    // ================================================================
+    // Callee is a chained member expression (not direct prohibited call)
+    // ================================================================
+    'alert.call(null)',
+    'alert.apply(null, [])',
+    'window.alert.call(null)',
+
+    // ================================================================
+    // Not a call (no CallExpression)
+    // ================================================================
+    'var x = alert;',
+    'var x = window.alert;',
+    'typeof alert;',
+    'new alert()',
+  ],
+  invalid: [
+    // ================================================================
+    // Direct calls: all three prohibited names
+    // ================================================================
+    {
+      code: 'alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'confirm(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'prompt(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // window.* dot access
+    // ================================================================
+    {
+      code: 'window.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'window.confirm(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'window.prompt(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // window['*'] bracket access
+    // ================================================================
+    {
+      code: "window['alert'](foo)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "window['confirm'](foo)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "window['prompt'](foo)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Template literal bracket access
+    // ================================================================
+    {
+      code: 'window[`alert`](foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // alert shadowed locally but window.alert still flagged
+    // ================================================================
+    {
+      code: 'function alert() {} window.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'var alert = function() {};\nwindow.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'function foo(alert) { window.alert(); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Direct call inside function/arrow/class (not shadowed)
+    // ================================================================
+    {
+      code: 'function foo() { alert(); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const foo = () => alert()',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const foo = () => { alert(); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { foo() { alert(); } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { constructor() { alert(); } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Deeply nested (3+ levels)
+    // ================================================================
+    {
+      code: 'function a() { function b() { function c() { alert(); } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const a = () => { const b = () => { const c = () => { alert(); }; }; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Shadowed inside function but not at call site
+    // ================================================================
+    {
+      code: 'function foo() { var alert = function() {}; }\nalert();',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // this.alert at global scope
+    // ================================================================
+    {
+      code: 'this.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "this['alert'](foo)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // window shadowed inside function but not at outer call site
+    // ================================================================
+    {
+      code: 'function foo() { var window = bar; window.alert(); }\nwindow.alert();',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // globalThis access
+    // ================================================================
+    {
+      code: "globalThis['alert'](foo)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'globalThis.alert();',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'function foo() { var globalThis = bar; globalThis.alert(); }\nglobalThis.alert();',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Optional chaining
+    // ================================================================
+    {
+      code: 'window?.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '(window?.alert)(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Parenthesized callee
+    // ================================================================
+    {
+      code: '(alert)(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '((alert))(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // window/globalThis inside nested functions (not shadowed)
+    // ================================================================
+    {
+      code: 'function foo() { window.alert(); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const foo = () => window.confirm()',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { foo() { window.prompt(); } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Multiple errors in one file
+    // ================================================================
+    {
+      code: 'alert();\nconfirm();\nprompt();',
+      errors: [
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+      ],
+    },
+
+    // ================================================================
+    // IIFE
+    // ================================================================
+    {
+      code: '(function() { alert(); })()',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Parenthesized object expression
+    // ================================================================
+    {
+      code: '(window).alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '(globalThis).alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '(this).alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Non-null assertion on object
+    // ================================================================
+    {
+      code: 'window!.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Type assertion on object
+    // ================================================================
+    {
+      code: '(window as any).alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Optional chaining on this/globalThis
+    // ================================================================
+    {
+      code: 'this?.alert(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'globalThis?.confirm()',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Direct call in class field / static block (alert not shadowed)
+    // ================================================================
+    {
+      code: 'class A { x = alert(); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static { alert(); } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // window.alert in class field / static block (window not shadowed)
+    // ================================================================
+    {
+      code: 'class A { x = window.alert(); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static { window.alert(); } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // TypeScript outer expressions on callee
+    // ================================================================
+    {
+      code: 'alert!(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '(alert as Function)(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '(window.alert!)(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '(window.alert as Function)(foo)',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-alert` rule from ESLint to rslint.

Disallows the use of `alert`, `confirm`, and `prompt`. These functions are considered obtrusive UI elements and should be replaced with custom implementations. The rule also flags calls via `window.*`, `globalThis.*`, and `this.*` (at global scope), including bracket access and optional chaining.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-alert
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-alert.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).