### PR TITLE
feat: port rule no-eval

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
+	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
@@ -494,6 +495,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-duplicate-case", no_duplicate_case.NoDuplicateCaseRule)
 	GlobalRuleRegistry.Register("no-empty", no_empty.NoEmptyRule)
 	GlobalRuleRegistry.Register("no-empty-pattern", no_empty_pattern.NoEmptyPatternRule)
+	GlobalRuleRegistry.Register("no-eval", no_eval.NoEvalRule)
 	GlobalRuleRegistry.Register("no-ex-assign", no_ex_assign.NoExAssignRule)
 	GlobalRuleRegistry.Register("no-extra-bind", no_extra_bind.NoExtraBindRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)

--- a/internal/rules/no_eval/no_eval.go
+++ b/internal/rules/no_eval/no_eval.go
@@ -1,0 +1,224 @@
+package no_eval
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var globalObjects = []string{"window", "global", "globalThis"}
+
+// https://eslint.org/docs/latest/rules/no-eval
+var NoEvalRule = rule.Rule{
+	Name: "no-eval",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		allowIndirect := false
+		optsMap := utils.GetOptionsMap(options)
+		if optsMap != nil {
+			if v, ok := optsMap["allowIndirect"].(bool); ok {
+				allowIndirect = v
+			}
+		}
+
+		msg := rule.RuleMessage{
+			Id:          "unexpected",
+			Description: "`eval` can be harmful.",
+		}
+
+		if allowIndirect {
+			// Only flag direct eval() calls
+			return rule.RuleListeners{
+				ast.KindCallExpression: func(node *ast.Node) {
+					call := node.AsCallExpression()
+					// Optional calls eval?.() are not direct eval
+					if call.QuestionDotToken != nil {
+						return
+					}
+					callee := call.Expression
+					if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "eval" {
+						ctx.ReportNode(callee, msg)
+					}
+				},
+			}
+		}
+
+		// Default mode: flag all eval usage
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				callee := call.Expression
+				if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "eval" {
+					ctx.ReportNode(callee, msg)
+				}
+			},
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				propAccess := node.AsPropertyAccessExpression()
+				name := propAccess.Name()
+				if name == nil || name.Text() != "eval" {
+					return
+				}
+
+				obj := ast.SkipParentheses(propAccess.Expression)
+				if obj == nil {
+					return
+				}
+
+				// Check for this.eval
+				if obj.Kind == ast.KindThisKeyword {
+					if isThisReferringToGlobal(obj, ctx.SourceFile) {
+						ctx.ReportNode(name, msg)
+					}
+					return
+				}
+
+				// Check for window.eval, global.eval, globalThis.eval
+				// and chained forms like window.window.eval
+				if isGlobalObjectChain(obj, ctx.TypeChecker) {
+					ctx.ReportNode(name, msg)
+				}
+			},
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				elemAccess := node.AsElementAccessExpression()
+				argExpr := elemAccess.ArgumentExpression
+				if argExpr == nil {
+					return
+				}
+
+				// Check if accessing ['eval'] or [`eval`]
+				if utils.GetStaticStringValue(argExpr) != "eval" {
+					return
+				}
+
+				obj := ast.SkipParentheses(elemAccess.Expression)
+				if obj == nil {
+					return
+				}
+
+				// Check for this['eval']
+				if obj.Kind == ast.KindThisKeyword {
+					if isThisReferringToGlobal(obj, ctx.SourceFile) {
+						ctx.ReportNode(argExpr, msg)
+					}
+					return
+				}
+
+				if isGlobalObjectChain(obj, ctx.TypeChecker) {
+					ctx.ReportNode(argExpr, msg)
+				}
+			},
+			ast.KindIdentifier: func(node *ast.Node) {
+				if node.AsIdentifier().Text != "eval" {
+					return
+				}
+
+				parent := node.Parent
+				if parent == nil {
+					return
+				}
+
+				// Skip if this is a direct call callee (handled by KindCallExpression)
+				if ast.IsCallExpression(parent) && parent.AsCallExpression().Expression == node {
+					return
+				}
+
+				// Skip if this is a property name in property access (handled above)
+				if ast.IsPropertyAccessExpression(parent) && parent.AsPropertyAccessExpression().Name() == node {
+					return
+				}
+
+				// Skip non-reference identifiers.
+				if utils.IsNonReferenceIdentifier(node) {
+					return
+				}
+
+				// Skip if eval is shadowed by a local variable/parameter
+				if utils.IsShadowed(node, "eval") {
+					return
+				}
+
+				// Non-call reference to eval (e.g., var x = eval, func(eval))
+				ctx.ReportNode(node, msg)
+			},
+		}
+	},
+}
+
+// isGlobalObjectChain checks if a node represents a reference to a global object,
+// potentially through chaining (e.g., window.window).
+// When TypeChecker is available, it verifies the root identifier actually resolves
+// to a known global (e.g., window from lib.dom.d.ts) rather than a local variable.
+func isGlobalObjectChain(node *ast.Node, tc *checker.Checker) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+
+	if ast.IsIdentifier(node) {
+		if !slices.Contains(globalObjects, node.AsIdentifier().Text) {
+			return false
+		}
+		// When TypeChecker is available, verify the identifier is actually declared
+		// (from lib.dom.d.ts, @types/node, etc.). If it doesn't resolve, it's an
+		// unknown variable — not a known global object.
+		if tc != nil {
+			if tc.GetSymbolAtLocation(node) == nil {
+				return false
+			}
+		}
+		return true
+	}
+
+	// Handle window.window, global.global, globalThis.globalThis, etc.
+	if ast.IsPropertyAccessExpression(node) {
+		prop := node.AsPropertyAccessExpression()
+		name := prop.Name()
+		if name != nil && slices.Contains(globalObjects, name.Text()) {
+			return isGlobalObjectChain(prop.Expression, tc)
+		}
+	}
+
+	// Handle window['window'], global['global'], etc.
+	if ast.IsElementAccessExpression(node) {
+		elem := node.AsElementAccessExpression()
+		argText := utils.GetStaticStringValue(elem.ArgumentExpression)
+		if slices.Contains(globalObjects, argText) {
+			return isGlobalObjectChain(ast.SkipParentheses(elem.Expression), tc)
+		}
+	}
+
+	return false
+}
+
+// isThisReferringToGlobal checks if 'this' at the given position refers to the global object.
+// It uses ast.GetThisContainer to find the enclosing "this scope" (skipping arrow functions
+// and class computed property names) and then determines whether 'this' is the global object.
+func isThisReferringToGlobal(thisNode *ast.Node, sourceFile *ast.SourceFile) bool {
+	// GetThisContainer with includeArrowFunctions=false skips arrow functions.
+	// With includeClassComputedPropertyName=false, computed property names in
+	// classes are transparent — the walker jumps past them to the outer scope.
+	container := ast.GetThisContainer(thisNode, false /*includeArrowFunctions*/, false /*includeClassComputedPropertyName*/)
+
+	switch container.Kind {
+	case ast.KindSourceFile:
+		// Top level of script — 'this' is always global (even in strict mode).
+		// In modules, 'this' is undefined.
+		return !ast.IsExternalModule(sourceFile)
+
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression:
+		// In strict mode, 'this' is undefined — not global.
+		if utils.IsInStrictMode(thisNode, sourceFile) {
+			return false
+		}
+		// Check how the function is used to determine if 'this' defaults to global.
+		return utils.IsDefaultThisBinding(container)
+
+	default:
+		// MethodDeclaration, Constructor, GetAccessor, SetAccessor,
+		// PropertyDeclaration (field value), ClassStaticBlockDeclaration, etc.
+		// In all these cases 'this' refers to the instance/class, not global.
+		return false
+	}
+}

--- a/internal/rules/no_eval/no_eval.md
+++ b/internal/rules/no_eval/no_eval.md
@@ -1,0 +1,58 @@
+# no-eval
+
+## Rule Details
+
+Disallow the use of `eval()`. JavaScript's `eval()` function is potentially dangerous and is often misused. Using `eval()` on untrusted code can open a program up to several different injection attacks. The use of `eval()` in most contexts can be substituted for a better, alternative approach to a problem.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+eval('var a = 0');
+
+var foo = eval;
+
+this.eval('var a = 0');
+
+window.eval('var a = 0');
+
+global.eval('var a = 0');
+
+globalThis.eval('var a = 0');
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var obj = { eval: function () {} };
+obj.eval('var a = 0');
+
+class A {
+  eval() {}
+}
+new A().eval('var a = 0');
+```
+
+### Options
+
+This rule has an option to allow indirect calls to `eval`. Indirect calls to `eval` are less dangerous than direct calls because they cannot dynamically change the scope.
+
+```json
+{
+  "no-eval": ["error", { "allowIndirect": true }]
+}
+```
+
+With `{ "allowIndirect": true }`, the following patterns are **correct**:
+
+```javascript
+(0, eval)('var a = 0');
+
+var EVAL = eval;
+EVAL('var a = 0');
+
+window.eval('var a = 0');
+```
+
+## Original Documentation
+
+- [ESLint no-eval](https://eslint.org/docs/latest/rules/no-eval)

--- a/internal/rules/no_eval/no_eval_test.go
+++ b/internal/rules/no_eval/no_eval_test.go
@@ -1,0 +1,817 @@
+package no_eval
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoEvalRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoEvalRule,
+		[]rule_tester.ValidTestCase{
+			// ================================================================
+			// Basic: not eval
+			// ================================================================
+			{Code: `Eval(foo)`},
+			{Code: `setTimeout('foo')`},
+			{Code: `setInterval('foo')`},
+			{Code: `window.noeval('foo')`},
+			// global is not declared in test env (no @types/node) → treated as unknown
+			{Code: `global.eval('foo')`},
+			{Code: `global.noeval('foo')`},
+			{Code: `globalThis.noeval('foo')`},
+			{Code: `this.noeval('foo');`},
+
+			// ================================================================
+			// Property / member names — NOT references to global eval
+			// ================================================================
+			// Object literal property name
+			{Code: `var obj = { eval: 42 }`},
+			{Code: `var obj = { eval: function() {} }`},
+			// Object method shorthand
+			{Code: `var obj = { eval() { return 1; } }`},
+			// Class member names
+			{Code: `class A { eval = 42 }`},
+			{Code: `class A { eval() { return 1; } }`},
+			{Code: `class A { get eval() { return 1; } }`},
+			{Code: `class A { set eval(v) {} }`},
+			{Code: `class A { static eval() {} }`},
+			{Code: `class A { static eval = 42 }`},
+			// Destructuring property name (not a reference)
+			{Code: `var { eval: e } = obj`},
+			{Code: `var { eval: e } = obj; e()`},
+			{Code: `function foo({ eval: e }) { e() }`},
+			// TypeScript interface / type property name
+			{Code: `interface I { eval: string }`},
+			{Code: `type T = { eval: string }`},
+			// Enum member name
+			{Code: `enum E { eval }`},
+			// Label name
+			{Code: `eval: while(true) { break eval; }`},
+			// Import property name: import { eval as foo } — eval is just a source name
+			{Code: `import { eval as foo } from 'mod'; foo()`},
+			// Export rename target: export { foo as eval } — eval is just the exported alias
+			{Code: `var foo = 1; export { foo as eval }`},
+			// Re-export: export { eval } from 'mod' — eval is source module name, not local ref
+			{Code: `export { eval } from 'mod'`},
+			{Code: `export { eval as foo } from 'mod'`},
+			{Code: `export { foo as eval } from 'mod'`},
+
+			// ================================================================
+			// this.eval — safe contexts (this is NOT global)
+			// ================================================================
+			// Strict mode: function body directive
+			{Code: `function foo() { 'use strict'; this.eval('foo'); }`},
+			// Strict mode: source file directive
+			{Code: `'use strict'; function foo() { this.eval('foo'); }`},
+			// Module: always strict
+			{Code: `import x from 'y'; this.eval('foo');`},
+			{Code: `import x from 'y'; function foo() { this.eval('foo'); }`},
+			{Code: `export {}; () => { this.eval('foo') }`},
+			// Object method: this is the object
+			{Code: `var obj = {foo: function() { this.eval('foo'); }}`},
+			{Code: `var obj = {}; obj.foo = function() { this.eval('foo'); }`},
+			// Object getter/setter: this is the object
+			{Code: `var obj = { get foo() { return this.eval(); } }`},
+			{Code: `var obj = { set foo(v) { this.eval(v); } }`},
+			// Arrow inside strict function: inherits strict this
+			{Code: `function f() { 'use strict'; () => { this.eval('foo') } }`},
+			{Code: `(function f() { 'use strict'; () => { this.eval('foo') } })`},
+			{Code: `function f() { 'use strict'; () => () => this.eval('foo') }`},
+			// Class methods: this is the instance
+			{Code: `class A { foo() { this.eval(); } }`},
+			{Code: `class A { static foo() { this.eval(); } }`},
+			{Code: `class A { constructor() { this.eval(); } }`},
+			// Class method + nested arrow: still instance
+			{Code: `class A { foo() { () => this.eval(); } }`},
+			{Code: `class A { foo() { () => () => this.eval(); } }`},
+			// Class field initializer: this is the instance
+			{Code: `class A { field = this.eval(); }`},
+			{Code: `class A { field = () => this.eval(); }`},
+			// Static block: this is the class
+			{Code: `class A { static { this.eval(); } }`},
+			// Class extends: function is in strict context due to class
+			{Code: `class C extends function () { this.eval('foo'); } {}`},
+			// Uppercase variable name → constructor convention, this is instance
+			{Code: `var Foo = function() { this.eval('foo') }`},
+			{Code: `var MyClass = function() { this.eval('bar') }`},
+			// Lowercase → NOT constructor, should still flag (tested in invalid)
+
+			// IIFE — callee of call, this is caller-determined
+			{Code: `(function() { this.eval('foo') })()`},
+			// .call()/.apply()/.bind() with non-null first arg
+			{Code: `(function() { this.eval('foo') }).call(obj)`},
+			{Code: `(function() { this.eval('foo') }).apply(obj, [])`},
+			{Code: `var f = function() { this.eval('foo') }.bind(obj); f()`},
+			// Transparent expressions reaching member-assignment
+			{Code: `obj.method = true ? function() { this.eval('foo') } : null`},
+			{Code: `obj.method = null || function() { this.eval('foo') }`},
+			// IIFE with return — return inside IIFE is transparent
+			{Code: `obj.foo = (function() { return function() { this.eval('foo') } })()`},
+			// Callback with thisArg: arr.method(callback, thisArg)
+			{Code: `arr.forEach(function() { this.eval('foo') }, obj)`},
+			{Code: `arr.map(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.filter(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.find(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.findIndex(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.findLast(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.findLastIndex(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.flatMap(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.some(function(x) { return this.eval(x) }, obj)`},
+			{Code: `arr.every(function(x) { return this.eval(x) }, obj)`},
+			// Reflect.apply(callback, thisArg, args)
+			{Code: `Reflect.apply(function() { this.eval('foo') }, obj, [])`},
+			// Array.from(iter, callback, thisArg)
+			{Code: `Array.from(iter, function(x) { return this.eval(x) }, obj)`},
+			// TS type assertion wrappers with IIFE
+			{Code: `(function() { this.eval('foo') } as any)()`},
+			{Code: `(<any>function() { this.eval('foo') })()`},
+
+			// ================================================================
+			// Shadowing — eval is a local variable, not the global
+			// ================================================================
+			{Code: `function foo() { var eval = 'foo'; window[eval]('foo') }`},
+			{Code: `function foo(eval) { var x = eval }`},
+			{Code: `function foo() { let eval = 1; eval }`},
+			{Code: `function foo() { const eval = 1; eval }`},
+			// Catch clause shadowing (non-call reference — call always flags)
+			{Code: `try {} catch(eval) { var x = eval }`},
+			// Function declaration shadowing
+			{Code: `function eval() {} var x = eval`},
+			// Destructuring binding creates local eval
+			{Code: `var { a: eval } = obj; var x = eval`},
+			// Import creates local eval binding
+			{Code: `import { eval } from 'mod'; var x = eval`},
+
+			// ================================================================
+			// allowIndirect: true — all indirect forms allowed
+			// ================================================================
+			{Code: `(0, eval)('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(0, window.eval)('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(0, window['eval'])('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `var EVAL = eval; EVAL('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `var EVAL = this.eval; EVAL('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(function(exe){ exe('foo') })(eval);`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `window.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `window.window.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `window.window['eval']('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `global.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `global.global.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `this.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `function foo() { this.eval('foo') }`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(0, globalThis.eval)('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(0, globalThis['eval'])('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `var EVAL = globalThis.eval; EVAL('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `function foo() { globalThis.eval('foo') }`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `globalThis.globalThis.eval('foo');`, Options: map[string]interface{}{"allowIndirect": true}},
+			// Optional call is not direct eval
+			{Code: `eval?.('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `window?.eval('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+			{Code: `(window?.eval)('foo')`, Options: map[string]interface{}{"allowIndirect": true}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ================================================================
+			// Direct eval calls — always flagged regardless of scope
+			// ================================================================
+			{
+				Code: `eval(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// eval as parameter name — still flagged as direct call
+			{
+				Code: `function foo(eval) { eval('foo') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+			// eval in nested function
+			{
+				Code: `function foo() { function bar() { eval('x') } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			// eval in arrow function
+			{
+				Code: `var fn = () => eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			// eval in IIFE
+			{
+				Code: `(function() { eval('foo') })()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// eval in async function
+			{
+				Code: `async function foo() { eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			// eval in generator function
+			{
+				Code: `function* gen() { eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			// eval in class method
+			{
+				Code: `class A { foo() { eval('bar') } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			// eval in class field initializer
+			{
+				Code: `class A { field = eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			// eval in class static block
+			{
+				Code: `class A { static { eval('bar') } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			// eval in default parameter value
+			{
+				Code: `function foo(x = eval('bar')) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+
+			// ================================================================
+			// Direct eval with allowIndirect: true
+			// ================================================================
+			{
+				Code:    `eval(foo)`,
+				Options: map[string]interface{}{"allowIndirect": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `eval('foo')`,
+				Options: map[string]interface{}{"allowIndirect": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `function foo(eval) { eval('foo') }`,
+				Options: map[string]interface{}{"allowIndirect": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+
+			// ================================================================
+			// Indirect eval — flagged in default mode
+			// ================================================================
+			{
+				Code: `(0, eval)('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5},
+				},
+			},
+
+			// ================================================================
+			// Global object property access: dot notation
+			// ================================================================
+			{
+				Code: `window.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `window.window.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// global.eval — global is not declared in test env (no @types/node)
+			// so these are valid. Tested via window/globalThis which ARE declared.
+			{
+				Code: `globalThis.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `globalThis.globalThis.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+
+			// ================================================================
+			// Global object property access: bracket notation
+			// ================================================================
+			{
+				Code: `window.window['eval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `globalThis.globalThis['eval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			// Template literal in element access (use window since global is undeclared in test env)
+			{
+				Code: "window.window[`eval`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// Bracket notation chain: window['window']['eval']
+			{
+				Code: `window['window']['eval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			// Mixed chain: bracket then dot
+			{
+				Code: `window['window'].eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+
+			// ================================================================
+			// Indirect eval via global object (in comma expression)
+			// ================================================================
+			{
+				Code: `(0, window.eval)('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `(0, window['eval'])('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `(0, globalThis.eval)('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `(0, globalThis['eval'])('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+
+			// ================================================================
+			// Non-call eval references (various expression positions)
+			// ================================================================
+			// Variable assignment
+			{
+				Code: `var EVAL = eval; EVAL('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			// Passed as argument
+			{
+				Code: `(function(exe){ exe('foo') })(eval);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			// Global object property reference
+			{
+				Code: `var EVAL = globalThis.eval; EVAL('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			// Array literal
+			{
+				Code: `var arr = [eval]`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			// Logical expression
+			{
+				Code: `var fn = eval || function() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+			// Ternary expression
+			{
+				Code: `var fn = true ? eval : null`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			// Shorthand property — eval IS a reference to the variable
+			{
+				Code: `var obj = { eval }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			// Spread element
+			{
+				Code: `var arr = [...eval]`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// Template expression
+			{
+				Code: "var s = `${eval}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			// Computed property key — eval IS a reference
+			{
+				Code: `var obj = { [eval]: 42 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+				},
+			},
+			// Tagged template — eval IS a reference
+			{
+				Code: "eval`template`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// typeof eval — eval IS a reference
+			{
+				Code: `typeof eval`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			// Assignment target
+			{
+				Code: `eval = function() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// for-in target — eval IS a reference
+			{
+				Code: `for (eval in obj) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+			// export { eval } without rename — eval IS a reference
+			{
+				Code: `export { eval }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+			// export { eval as foo } — eval is the local reference
+			{
+				Code: `export { eval as foo }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+
+			// ================================================================
+			// this.eval — top level of script (this IS global)
+			// ================================================================
+			// Dot notation
+			{
+				Code: `this.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+			// Top-level strict — this is still global in scripts
+			{
+				Code: `'use strict'; this.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			// Bracket notation (was missing!)
+			{
+				Code: `this['eval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+			// Template literal bracket notation
+			{
+				Code: "this[`eval`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+
+			// ================================================================
+			// this.eval — non-strict function (this defaults to global)
+			// ================================================================
+			{
+				Code: `function foo() { this.eval('foo') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			// Expression statement is not a directive
+			{
+				Code: `function foo() { ('use strict'); this.eval; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 39},
+				},
+			},
+			// Lowercase variable name → NOT constructor, this IS default
+			{
+				Code: `var foo = function() { this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+			// Named function → NOT anonymous, constructor heuristic doesn't apply
+			{
+				Code: `var Foo = function foo() { this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 33},
+				},
+			},
+			// .call()/.apply() with null/undefined/void/no args → this IS default
+			{
+				Code: `(function() { this.eval('foo') }).call(null)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `(function() { this.eval('foo') }).call(undefined)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `(function() { this.eval('foo') }).call()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			// Returned function from non-IIFE → this IS default
+			{
+				Code: `function foo() { return function() { this.eval('bar') } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 43},
+				},
+			},
+			// Callback without thisArg → this IS default
+			{
+				Code: `arr.forEach(function() { this.eval('foo') })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `arr.flatMap(function(x) { return this.eval(x) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 39},
+				},
+			},
+			// Callback with null thisArg → this IS default
+			{
+				Code: `arr.forEach(function() { this.eval('foo') }, null)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			// reduce is NOT a thisArg method — second arg is initialValue
+			{
+				Code: `arr.reduce(function(a, b) { return this.eval(a) ? a : b }, '0')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 41},
+				},
+			},
+			// Async function — same as regular function
+			{
+				Code: `async function foo() { this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+			// Generator function — same as regular function
+			{
+				Code: `function* gen() { this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+
+			// ================================================================
+			// Arrow functions — this inherits from enclosing scope
+			// ================================================================
+			// Arrow at top level (script) — this is global
+			{
+				Code: `() => { this.eval('foo'); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: `() => { 'use strict'; this.eval('foo'); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: `'use strict'; () => { this.eval('foo'); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			// Nested arrows at top level
+			{
+				Code: `() => { 'use strict'; () => { this.eval('foo'); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			// Arrow inside non-strict function — this inherits function's global this
+			{
+				Code: `function foo() { () => this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+			// Deeply nested arrows in non-strict function
+			{
+				Code: `function foo() { () => () => this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			// Arrow in object literal — arrow has NO own this, inherits from outer scope
+			{
+				Code: `var obj = { foo: () => this.eval('bar') }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+
+			// ================================================================
+			// this.eval in reference context (not as call)
+			// ================================================================
+			{
+				Code: `var EVAL = this.eval; EVAL('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `'use strict'; var EVAL = this.eval; EVAL('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+
+			// ================================================================
+			// Optional chaining — flagged in default mode
+			// ================================================================
+			{
+				Code: `window?.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `(window?.eval)('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `(window?.window).eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+
+			// ================================================================
+			// Computed property name in class — this is outer scope
+			// ================================================================
+			{
+				Code: `class C { [this.eval('foo')] = 0 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `'use strict'; class C { [this.eval('foo')] = 0 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+
+			// ================================================================
+			// Optional chaining on this
+			// ================================================================
+			{
+				Code: `this?.eval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 7},
+				},
+			},
+
+			// ================================================================
+			// new eval() — NewExpression, caught by KindIdentifier
+			// ================================================================
+			{
+				Code: `new eval()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5},
+				},
+			},
+
+			// ================================================================
+			// eval as expression in various non-call contexts
+			// ================================================================
+			// export default
+			{
+				Code: `export default eval`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			// Property value (non-shorthand) — eval IS a reference
+			{
+				Code: `var obj = { key: eval }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			// eval as element access expression (eval['foo'])
+			{
+				Code: `eval['foo']`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// eval as property access expression (eval.foo)
+			{
+				Code: `eval.foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Multiple violations
+			// ================================================================
+			{
+				Code: `eval('foo'); window.eval('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `eval('a'); eval('b'); eval('c')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 12},
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -1,0 +1,115 @@
+package utils
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+// skipTransparentKinds matches parentheses + TS type assertions.
+const skipTransparentKinds = ast.OEKParentheses | ast.OEKAssertions
+
+// IsCallee checks if a node is the callee of a CallExpression or NewExpression,
+// skipping parentheses and TS type assertions between the node and the call.
+func IsCallee(node *ast.Node) bool {
+	current := node
+	parent := current.Parent
+	for parent != nil && ast.IsOuterExpression(parent, skipTransparentKinds) {
+		current = parent
+		parent = current.Parent
+	}
+	if parent == nil {
+		return false
+	}
+	if ast.IsCallExpression(parent) && parent.AsCallExpression().Expression == current {
+		return true
+	}
+	if parent.Kind == ast.KindNewExpression && parent.AsNewExpression().Expression == current {
+		return true
+	}
+	return false
+}
+
+// GetStaticStringValue returns the string value if the node is a string literal
+// or a no-substitution template literal. Returns "" if the value cannot be
+// statically determined.
+func GetStaticStringValue(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	}
+	return ""
+}
+
+// IsNonReferenceIdentifier checks if an identifier is NOT a value reference
+// (i.e., it's a declaration name, property key, label, or module specifier name
+// rather than a reference to a variable).
+func IsNonReferenceIdentifier(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+
+	// Re-export specifiers: export { x } from 'mod'
+	// All identifiers are source module names, not local references.
+	if parent.Kind == ast.KindExportSpecifier && isReExportSpecifier(parent) {
+		return true
+	}
+
+	// ast.IsDeclarationName covers: variable, function, class, parameter,
+	// property assignment, method, accessor, enum member, etc.
+	if ast.IsDeclarationName(node) {
+		// ShorthandPropertyAssignment { x } — x IS a reference to the variable.
+		if parent.Kind == ast.KindShorthandPropertyAssignment {
+			return false
+		}
+		// export { x } (no rename, local) — x IS a reference to the local/global variable.
+		if parent.Kind == ast.KindExportSpecifier && parent.AsExportSpecifier().PropertyName == nil {
+			return false
+		}
+		return true
+	}
+
+	// Property name in destructuring: { x: y } — x is just a key.
+	if parent.Kind == ast.KindBindingElement {
+		be := parent.AsBindingElement()
+		if be.PropertyName != nil && be.PropertyName == node {
+			return true
+		}
+	}
+
+	// Import source name: import { x as y } — x is the source module's export name.
+	if parent.Kind == ast.KindImportSpecifier {
+		importSpec := parent.AsImportSpecifier()
+		if importSpec.PropertyName != nil && importSpec.PropertyName == node {
+			return true
+		}
+	}
+
+	// Label names: label: while(true) { break label; continue label; }
+	if parent.Kind == ast.KindLabeledStatement ||
+		parent.Kind == ast.KindBreakStatement ||
+		parent.Kind == ast.KindContinueStatement {
+		return true
+	}
+
+	return false
+}
+
+// isReExportSpecifier checks if an ExportSpecifier is part of a re-export
+// declaration (export { ... } from 'mod').
+func isReExportSpecifier(exportSpec *ast.Node) bool {
+	// ExportSpecifier → NamedExports → ExportDeclaration
+	namedExports := exportSpec.Parent
+	if namedExports == nil {
+		return false
+	}
+	exportDecl := namedExports.Parent
+	if exportDecl == nil || exportDecl.Kind != ast.KindExportDeclaration {
+		return false
+	}
+	return exportDecl.AsExportDeclaration().ModuleSpecifier != nil
+}

--- a/internal/utils/this_binding.go
+++ b/internal/utils/this_binding.go
@@ -1,0 +1,212 @@
+package utils
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+)
+
+
+// IsDefaultThisBinding checks whether a function's 'this' binding defaults to the
+// global object. This mirrors ESLint's astUtils.isDefaultThisBinding.
+// Returns true when 'this' defaults to global; false when explicitly bound.
+func IsDefaultThisBinding(node *ast.Node) bool {
+	current := node
+	for {
+		// Walk current → parent, skipping transparent wrappers (parens, TS assertions).
+		// After this, current is the outermost wrapper and parent is the real consumer.
+		parent := current.Parent
+		for parent != nil && ast.IsOuterExpression(parent, skipTransparentKinds) {
+			current = parent
+			parent = current.Parent
+		}
+		if parent == nil {
+			return true
+		}
+
+		switch parent.Kind {
+		// { foo: function() {} } → this is the object
+		case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment:
+			return false
+
+		// obj.foo = function() {} → this is the object
+		case ast.KindBinaryExpression:
+			bin := parent.AsBinaryExpression()
+			opKind := bin.OperatorToken.Kind
+			if opKind == ast.KindEqualsToken && bin.Right == current {
+				left := ast.SkipParentheses(bin.Left)
+				if left != nil && (ast.IsPropertyAccessExpression(left) || ast.IsElementAccessExpression(left)) {
+					return false
+				}
+				return true
+			}
+			// Logical (||, &&, ??) → transparent
+			if opKind == ast.KindBarBarToken || opKind == ast.KindAmpersandAmpersandToken ||
+				opKind == ast.KindQuestionQuestionToken {
+				current = parent
+				continue
+			}
+			// Comma → last element transparent
+			if opKind == ast.KindCommaToken && bin.Right == current {
+				current = parent
+				continue
+			}
+			return true
+
+		case ast.KindConditionalExpression:
+			current = parent
+			continue
+
+			// return function() {} — only transparent if inside an IIFE
+		case ast.KindReturnStatement:
+			fn := ast.GetContainingFunction(parent)
+			if fn != nil && IsCallee(fn) {
+				current = fn
+				continue
+			}
+			return true
+
+		// (function(){})() — callee of call → not default
+		case ast.KindCallExpression:
+			call := parent.AsCallExpression()
+			if call.Expression == current {
+				return false
+			}
+			// Check for known methods with thisArg: arr.forEach(cb, thisArg)
+			return !isCallbackWithThisArg(call, current)
+
+		case ast.KindNewExpression:
+			if parent.AsNewExpression().Expression == current {
+				return false
+			}
+			return true
+
+		// (function(){}).call(obj) / .apply(obj) / .bind(obj)
+		case ast.KindPropertyAccessExpression:
+			prop := parent.AsPropertyAccessExpression()
+			if prop.Expression == current {
+				name := prop.Name()
+				if name != nil && isCallApplyBind(name.Text()) {
+					// Check if the member expression is actually called: func.call(obj)
+					callGrandparent := parent.Parent
+					for callGrandparent != nil && ast.IsOuterExpression(callGrandparent, skipTransparentKinds) {
+						callGrandparent = callGrandparent.Parent
+					}
+					if callGrandparent != nil && ast.IsCallExpression(callGrandparent) {
+						call := callGrandparent.AsCallExpression()
+						if call.Arguments != nil && len(call.Arguments.Nodes) >= 1 &&
+							!IsNullOrUndefined(call.Arguments.Nodes[0]) {
+							return false
+						}
+					}
+				}
+			}
+			return true
+
+		// var Foo = function() {} — uppercase name convention → constructor
+		case ast.KindVariableDeclaration:
+			varDecl := parent.AsVariableDeclaration()
+			if varDecl.Initializer == current {
+				varName := varDecl.Name()
+				if varName != nil && ast.IsIdentifier(varName) && startsWithUpperCase(varName.AsIdentifier().Text) {
+					// Anonymous function assigned to uppercase variable → likely constructor
+					if isFuncAnonymous(node) {
+						return false
+					}
+				}
+			}
+			return true
+
+		default:
+			return true
+		}
+	}
+}
+
+// startsWithUpperCase checks if a string starts with an uppercase ASCII letter.
+func startsWithUpperCase(s string) bool {
+	return len(s) > 0 && s[0] >= 'A' && s[0] <= 'Z'
+}
+
+// isFuncAnonymous checks if a function expression has no name.
+func isFuncAnonymous(node *ast.Node) bool {
+	if node.Kind == ast.KindFunctionExpression {
+		return node.AsFunctionExpression().Name() == nil
+	}
+	return false
+}
+
+func isCallApplyBind(name string) bool {
+	return name == "call" || name == "apply" || name == "bind"
+}
+
+// IsNullOrUndefined checks if a node is a null literal, undefined identifier,
+// or void expression, unwrapping parentheses.
+func IsNullOrUndefined(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	if node.Kind == ast.KindNullKeyword {
+		return true
+	}
+	if ast.IsIdentifier(node) && node.AsIdentifier().Text == "undefined" {
+		return true
+	}
+	if node.Kind == ast.KindVoidExpression {
+		return true
+	}
+	return false
+}
+
+// Methods known to accept a thisArg parameter: method(callback, thisArg).
+var thisArgMethods = []string{
+	"every", "filter", "find", "findIndex", "findLast", "findLastIndex",
+	"flatMap", "forEach", "map", "some",
+}
+
+// isCallbackWithThisArg checks if the callback is passed to a known method
+// with a non-null thisArg: arr.forEach(callback, thisArg).
+func isCallbackWithThisArg(call *ast.CallExpression, callback *ast.Node) bool {
+	if call.Arguments == nil {
+		return false
+	}
+	args := call.Arguments.Nodes
+
+	// Reflect.apply(callback, thisArg, args)
+	if isSpecificMemberAccess(call.Expression, "Reflect", "apply") {
+		return len(args) >= 3 && args[0] == callback && !IsNullOrUndefined(args[1])
+	}
+
+	// Array.from(iterable, callback, thisArg) / Array.fromAsync(...)
+	if isSpecificMemberAccess(call.Expression, "Array", "from") ||
+		isSpecificMemberAccess(call.Expression, "Array", "fromAsync") {
+		return len(args) >= 3 && args[1] == callback && !IsNullOrUndefined(args[2])
+	}
+
+	// arr.forEach(callback, thisArg), arr.map(callback, thisArg), etc.
+	callee := call.Expression
+	if ast.IsPropertyAccessExpression(callee) {
+		prop := callee.AsPropertyAccessExpression()
+		name := prop.Name()
+		if name != nil && slices.Contains(thisArgMethods, name.Text()) {
+			return len(args) == 2 && args[0] == callback && !IsNullOrUndefined(args[1])
+		}
+	}
+
+	return false
+}
+
+// isSpecificMemberAccess checks if node is Object.method pattern.
+func isSpecificMemberAccess(node *ast.Node, objectName, methodName string) bool {
+	if node == nil || !ast.IsPropertyAccessExpression(node) {
+		return false
+	}
+	prop := node.AsPropertyAccessExpression()
+	name := prop.Name()
+	if name == nil || name.Text() != methodName {
+		return false
+	}
+	obj := ast.SkipParentheses(prop.Expression)
+	return obj != nil && ast.IsIdentifier(obj) && obj.AsIdentifier().Text == objectName
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -33,6 +33,7 @@ export default defineConfig({
     './tests/eslint/rules/no-duplicate-case.test.ts',
     './tests/eslint/rules/no-empty.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
+    './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
     './tests/eslint/rules/no-loss-of-precision.test.ts',
     './tests/eslint/rules/no-ex-assign.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-eval.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-eval.test.ts.snap
@@ -1,0 +1,1996 @@
+// Rstest Snapshot v1
+
+exports[`no-eval > invalid 1`] = `
+{
+  "code": "eval(foo)",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 2`] = `
+{
+  "code": "eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 3`] = `
+{
+  "code": "function foo(eval) { eval('foo') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 4`] = `
+{
+  "code": "function foo() { function bar() { eval('x') } }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 5`] = `
+{
+  "code": "var fn = () => eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 6`] = `
+{
+  "code": "(function() { eval('foo') })()",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 7`] = `
+{
+  "code": "async function foo() { eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 8`] = `
+{
+  "code": "function* gen() { eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 9`] = `
+{
+  "code": "class A { foo() { eval('bar') } }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 10`] = `
+{
+  "code": "class A { field = eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 11`] = `
+{
+  "code": "class A { static { eval('bar') } }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 12`] = `
+{
+  "code": "function foo(x = eval('bar')) {}",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 13`] = `
+{
+  "code": "eval(foo)",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 14`] = `
+{
+  "code": "eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 15`] = `
+{
+  "code": "function foo(eval) { eval('foo') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 16`] = `
+{
+  "code": "(0, eval)('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 17`] = `
+{
+  "code": "globalThis.eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 18`] = `
+{
+  "code": "globalThis.globalThis.eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 19`] = `
+{
+  "code": "globalThis.globalThis['eval']('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 20`] = `
+{
+  "code": "(0, globalThis.eval)('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 21`] = `
+{
+  "code": "(0, globalThis['eval'])('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 22`] = `
+{
+  "code": "var EVAL = eval; EVAL('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 23`] = `
+{
+  "code": "(function(exe){ exe('foo') })(eval);",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 24`] = `
+{
+  "code": "var EVAL = globalThis.eval; EVAL('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 25`] = `
+{
+  "code": "var arr = [eval]",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 26`] = `
+{
+  "code": "var fn = eval || function() {}",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 27`] = `
+{
+  "code": "var fn = true ? eval : null",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 28`] = `
+{
+  "code": "var obj = { eval }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 29`] = `
+{
+  "code": "var arr = [...eval]",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 30`] = `
+{
+  "code": "var s = \`\${eval}\`",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 31`] = `
+{
+  "code": "var obj = { [eval]: 42 }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 32`] = `
+{
+  "code": "eval\`template\`",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 33`] = `
+{
+  "code": "typeof eval",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 34`] = `
+{
+  "code": "eval = function() {}",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 35`] = `
+{
+  "code": "for (eval in obj) {}",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 36`] = `
+{
+  "code": "export { eval }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 37`] = `
+{
+  "code": "export { eval as foo }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 38`] = `
+{
+  "code": "export default eval",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 39`] = `
+{
+  "code": "eval['foo']",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 40`] = `
+{
+  "code": "eval.foo",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 41`] = `
+{
+  "code": "var obj = { key: eval }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 42`] = `
+{
+  "code": "new eval()",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 43`] = `
+{
+  "code": "this.eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 44`] = `
+{
+  "code": "'use strict'; this.eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 45`] = `
+{
+  "code": "this['eval']('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 46`] = `
+{
+  "code": "this[\`eval\`]('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 47`] = `
+{
+  "code": "function foo() { this.eval('foo') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 48`] = `
+{
+  "code": "function foo() { ('use strict'); this.eval; }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 49`] = `
+{
+  "code": "async function foo() { this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 50`] = `
+{
+  "code": "function* gen() { this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 51`] = `
+{
+  "code": "var foo = function() { this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 52`] = `
+{
+  "code": "var Foo = function foo() { this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 53`] = `
+{
+  "code": "(function() { this.eval('foo') }).call(null)",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 54`] = `
+{
+  "code": "(function() { this.eval('foo') }).call(undefined)",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 55`] = `
+{
+  "code": "(function() { this.eval('foo') }).call()",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 56`] = `
+{
+  "code": "function foo() { return function() { this.eval('bar') } }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 57`] = `
+{
+  "code": "arr.forEach(function() { this.eval('foo') })",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 58`] = `
+{
+  "code": "arr.flatMap(function(x) { return this.eval(x) })",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 59`] = `
+{
+  "code": "arr.forEach(function() { this.eval('foo') }, null)",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 60`] = `
+{
+  "code": "arr.reduce(function(a, b) { return this.eval(a) ? a : b }, '0')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 61`] = `
+{
+  "code": "() => { this.eval('foo'); }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 62`] = `
+{
+  "code": "() => { 'use strict'; this.eval('foo'); }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 63`] = `
+{
+  "code": "'use strict'; () => { this.eval('foo'); }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 64`] = `
+{
+  "code": "() => { 'use strict'; () => { this.eval('foo'); } }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 65`] = `
+{
+  "code": "function foo() { () => this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 66`] = `
+{
+  "code": "function foo() { () => () => this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 67`] = `
+{
+  "code": "var obj = { foo: () => this.eval('bar') }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 68`] = `
+{
+  "code": "var EVAL = this.eval; EVAL('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 69`] = `
+{
+  "code": "'use strict'; var EVAL = this.eval; EVAL('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 70`] = `
+{
+  "code": "globalThis?.eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 71`] = `
+{
+  "code": "this?.eval('foo')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 72`] = `
+{
+  "code": "class C { [this.eval('foo')] = 0 }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 73`] = `
+{
+  "code": "'use strict'; class C { [this.eval('foo')] = 0 }",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 74`] = `
+{
+  "code": "eval('foo'); globalThis.eval('bar')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-eval > invalid 75`] = `
+{
+  "code": "eval('a'); eval('b'); eval('c')",
+  "diagnostics": [
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+    {
+      "message": "\`eval\` can be harmful.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-eval",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-eval.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-eval.test.ts
@@ -1,0 +1,496 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-eval', {
+  valid: [
+    // ================================================================
+    // Basic: not eval
+    // ================================================================
+    'Eval(foo)',
+    "setTimeout('foo')",
+    "setInterval('foo')",
+    "window.noeval('foo')",
+    // global not declared in test env (no @types/node) → treated as unknown
+    "global.eval('foo')",
+    "global.noeval('foo')",
+    "globalThis.noeval('foo')",
+    "this.noeval('foo');",
+
+    // ================================================================
+    // Property / member names — NOT references to global eval
+    // ================================================================
+    'var obj = { eval: 42 }',
+    'var obj = { eval: function() {} }',
+    'var obj = { eval() { return 1; } }',
+    'class A { eval = 42 }',
+    'class A { eval() { return 1; } }',
+    'class A { get eval() { return 1; } }',
+    'class A { set eval(v) {} }',
+    'class A { static eval() {} }',
+    'class A { static eval = 42 }',
+    'var { eval: e } = obj',
+    'function foo({ eval: e }) { e() }',
+    'interface I { eval: string }',
+    'type T = { eval: string }',
+    'enum E { eval }',
+    'eval: while(true) { break eval; }',
+    "import { eval as foo } from 'mod'; foo()",
+    'var foo = 1; export { foo as eval }',
+    // Re-export: eval is source module name, not local ref
+    "export { eval } from 'mod'",
+    "export { eval as foo } from 'mod'",
+    "export { foo as eval } from 'mod'",
+
+    // ================================================================
+    // this.eval — safe contexts (this is NOT global)
+    // ================================================================
+    "function foo() { 'use strict'; this.eval('foo'); }",
+    "'use strict'; function foo() { this.eval('foo'); }",
+    "import x from 'y'; this.eval('foo');",
+    "import x from 'y'; function foo() { this.eval('foo'); }",
+    "export {}; () => { this.eval('foo') }",
+    "var obj = {foo: function() { this.eval('foo'); }}",
+    "var obj = {}; obj.foo = function() { this.eval('foo'); }",
+    'var obj = { get foo() { return this.eval(); } }',
+    'var obj = { set foo(v) { this.eval(v); } }',
+    "function f() { 'use strict'; () => { this.eval('foo') } }",
+    "(function f() { 'use strict'; () => { this.eval('foo') } })",
+    "function f() { 'use strict'; () => () => this.eval('foo') }",
+    'class A { foo() { this.eval(); } }',
+    'class A { static foo() { this.eval(); } }',
+    'class A { constructor() { this.eval(); } }',
+    'class A { foo() { () => this.eval(); } }',
+    'class A { foo() { () => () => this.eval(); } }',
+    'class A { field = this.eval(); }',
+    'class A { field = () => this.eval(); }',
+    'class A { static { this.eval(); } }',
+    "class C extends function () { this.eval('foo'); } {}",
+
+    // ================================================================
+    // Shadowing — eval is a local variable, not the global
+    // ================================================================
+    "function foo() { var eval = 'foo'; window[eval]('foo') }",
+    'function foo(eval) { var x = eval }',
+    'function foo() { let eval = 1; eval }',
+    'function foo() { const eval = 1; eval }',
+    'try {} catch(eval) { var x = eval }',
+    'function eval() {} var x = eval',
+    'var { a: eval } = obj; var x = eval',
+    "import { eval } from 'mod'; var x = eval",
+
+    // ================================================================
+    // Uppercase constructor convention
+    // ================================================================
+    "var Foo = function() { this.eval('foo') }",
+    "var MyClass = function() { this.eval('bar') }",
+
+    // ================================================================
+    // isDefaultThisBinding — not default
+    // ================================================================
+    "(function() { this.eval('foo') })()",
+    "(function() { this.eval('foo') }).call(obj)",
+    "(function() { this.eval('foo') }).apply(obj, [])",
+    "var f = function() { this.eval('foo') }.bind(obj); f()",
+    "obj.method = true ? function() { this.eval('foo') } : null",
+    "obj.method = null || function() { this.eval('foo') }",
+    "obj.foo = (function() { return function() { this.eval('foo') } })()",
+    // Callback with thisArg
+    "arr.forEach(function() { this.eval('foo') }, obj)",
+    'arr.map(function(x) { return this.eval(x) }, obj)',
+    'arr.filter(function(x) { return this.eval(x) }, obj)',
+    'arr.find(function(x) { return this.eval(x) }, obj)',
+    'arr.findIndex(function(x) { return this.eval(x) }, obj)',
+    'arr.findLast(function(x) { return this.eval(x) }, obj)',
+    'arr.findLastIndex(function(x) { return this.eval(x) }, obj)',
+    'arr.flatMap(function(x) { return this.eval(x) }, obj)',
+    'arr.some(function(x) { return this.eval(x) }, obj)',
+    'arr.every(function(x) { return this.eval(x) }, obj)',
+    "Reflect.apply(function() { this.eval('foo') }, obj, [])",
+    'Array.from(iter, function(x) { return this.eval(x) }, obj)',
+    // TS type assertion wrappers with IIFE
+    "(function() { this.eval('foo') } as any)()",
+    "(<any>function() { this.eval('foo') })()",
+
+    // ================================================================
+    // allowIndirect: true
+    // ================================================================
+    { code: "(0, eval)('foo')", options: [{ allowIndirect: true }] as any },
+    {
+      code: "(0, window.eval)('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "(0, window['eval'])('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "var EVAL = eval; EVAL('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "var EVAL = this.eval; EVAL('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "(function(exe){ exe('foo') })(eval);",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "window.eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "window.window.eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "window.window['eval']('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "global.eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "global.global.eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "this.eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "function foo() { this.eval('foo') }",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "(0, globalThis.eval)('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "(0, globalThis['eval'])('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "var EVAL = globalThis.eval; EVAL('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "function foo() { globalThis.eval('foo') }",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "globalThis.globalThis.eval('foo');",
+      options: [{ allowIndirect: true }] as any,
+    },
+    { code: "eval?.('foo')", options: [{ allowIndirect: true }] as any },
+    {
+      code: "window?.eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+    {
+      code: "(window?.eval)('foo')",
+      options: [{ allowIndirect: true }] as any,
+    },
+  ],
+  invalid: [
+    // ================================================================
+    // Direct eval calls
+    // ================================================================
+    { code: 'eval(foo)', errors: [{ messageId: 'unexpected' }] },
+    { code: "eval('foo')", errors: [{ messageId: 'unexpected' }] },
+    {
+      code: "function foo(eval) { eval('foo') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo() { function bar() { eval('x') } }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "var fn = () => eval('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "(function() { eval('foo') })()",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "async function foo() { eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function* gen() { eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { foo() { eval('bar') } }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { field = eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { static { eval('bar') } }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo(x = eval('bar')) {}",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Direct eval with allowIndirect: true
+    // ================================================================
+    {
+      code: 'eval(foo)',
+      options: [{ allowIndirect: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "eval('foo')",
+      options: [{ allowIndirect: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo(eval) { eval('foo') }",
+      options: [{ allowIndirect: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Indirect eval — flagged in default mode
+    // ================================================================
+    { code: "(0, eval)('foo')", errors: [{ messageId: 'unexpected' }] },
+
+    // ================================================================
+    // Global object access: globalThis (declared via esnext lib)
+    // Note: window tests omitted here — JS test env has no DOM lib.
+    // Window tests are covered in Go tests (which use a tsconfig with DOM).
+    // ================================================================
+    { code: "globalThis.eval('foo')", errors: [{ messageId: 'unexpected' }] },
+    {
+      code: "globalThis.globalThis.eval('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "globalThis.globalThis['eval']('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Indirect eval via global object
+    // ================================================================
+    {
+      code: "(0, globalThis.eval)('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "(0, globalThis['eval'])('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Non-call eval references
+    // ================================================================
+    {
+      code: "var EVAL = eval; EVAL('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "(function(exe){ exe('foo') })(eval);",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "var EVAL = globalThis.eval; EVAL('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    { code: 'var arr = [eval]', errors: [{ messageId: 'unexpected' }] },
+    {
+      code: 'var fn = eval || function() {}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'var fn = true ? eval : null',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    { code: 'var obj = { eval }', errors: [{ messageId: 'unexpected' }] },
+    { code: 'var arr = [...eval]', errors: [{ messageId: 'unexpected' }] },
+    { code: 'var s = `${eval}`', errors: [{ messageId: 'unexpected' }] },
+    { code: 'var obj = { [eval]: 42 }', errors: [{ messageId: 'unexpected' }] },
+    { code: 'eval`template`', errors: [{ messageId: 'unexpected' }] },
+    { code: 'typeof eval', errors: [{ messageId: 'unexpected' }] },
+    { code: 'eval = function() {}', errors: [{ messageId: 'unexpected' }] },
+    { code: 'for (eval in obj) {}', errors: [{ messageId: 'unexpected' }] },
+    { code: 'export { eval }', errors: [{ messageId: 'unexpected' }] },
+    { code: 'export { eval as foo }', errors: [{ messageId: 'unexpected' }] },
+    { code: 'export default eval', errors: [{ messageId: 'unexpected' }] },
+    { code: "eval['foo']", errors: [{ messageId: 'unexpected' }] },
+    { code: 'eval.foo', errors: [{ messageId: 'unexpected' }] },
+    { code: 'var obj = { key: eval }', errors: [{ messageId: 'unexpected' }] },
+    { code: 'new eval()', errors: [{ messageId: 'unexpected' }] },
+
+    // ================================================================
+    // this.eval — top level of script (this IS global)
+    // ================================================================
+    { code: "this.eval('foo')", errors: [{ messageId: 'unexpected' }] },
+    {
+      code: "'use strict'; this.eval('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Bracket notation
+    { code: "this['eval']('foo')", errors: [{ messageId: 'unexpected' }] },
+    { code: "this[`eval`]('foo')", errors: [{ messageId: 'unexpected' }] },
+
+    // ================================================================
+    // this.eval — non-strict function (this defaults to global)
+    // ================================================================
+    {
+      code: "function foo() { this.eval('foo') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo() { ('use strict'); this.eval; }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "async function foo() { this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function* gen() { this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // isDefaultThisBinding — this IS default
+    // ================================================================
+    // Lowercase variable → not constructor
+    {
+      code: "var foo = function() { this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Named function → constructor heuristic doesn't apply
+    {
+      code: "var Foo = function foo() { this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // .call/.apply with null/undefined/no args
+    {
+      code: "(function() { this.eval('foo') }).call(null)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "(function() { this.eval('foo') }).call(undefined)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "(function() { this.eval('foo') }).call()",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Returned function from non-IIFE
+    {
+      code: "function foo() { return function() { this.eval('bar') } }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Callback without thisArg
+    {
+      code: "arr.forEach(function() { this.eval('foo') })",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'arr.flatMap(function(x) { return this.eval(x) })',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Callback with null thisArg
+    {
+      code: "arr.forEach(function() { this.eval('foo') }, null)",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // reduce not a thisArg method
+    {
+      code: "arr.reduce(function(a, b) { return this.eval(a) ? a : b }, '0')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Arrow functions — this inherits from enclosing scope
+    // ================================================================
+    {
+      code: "() => { this.eval('foo'); }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "() => { 'use strict'; this.eval('foo'); }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "'use strict'; () => { this.eval('foo'); }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "() => { 'use strict'; () => { this.eval('foo'); } }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo() { () => this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "function foo() { () => () => this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "var obj = { foo: () => this.eval('bar') }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // this.eval in reference context
+    // ================================================================
+    {
+      code: "var EVAL = this.eval; EVAL('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "'use strict'; var EVAL = this.eval; EVAL('foo')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Optional chaining (using globalThis — window not in JS test env)
+    // ================================================================
+    { code: "globalThis?.eval('foo')", errors: [{ messageId: 'unexpected' }] },
+    { code: "this?.eval('foo')", errors: [{ messageId: 'unexpected' }] },
+
+    // ================================================================
+    // Computed property name in class — this is outer scope
+    // ================================================================
+    {
+      code: "class C { [this.eval('foo')] = 0 }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "'use strict'; class C { [this.eval('foo')] = 0 }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // ================================================================
+    // Multiple violations
+    // ================================================================
+    {
+      code: "eval('foo'); globalThis.eval('bar')",
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: "eval('a'); eval('b'); eval('c')",
+      errors: [
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-eval` rule from ESLint to rslint.

Disallows the use of `eval()`. The rule flags direct `eval()` calls, indirect references to `eval`, access via global objects (`window.eval`, `global.eval`, `globalThis.eval`), and `this.eval` when `this` refers to the global object. Supports the `allowIndirect` option.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-eval
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-eval.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).