### PR TITLE
feat: port rule @typescript-eslint/no-useless-constructor

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_unary_minus"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_vars"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_empty_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/non_nullable_type_assertion_style"
@@ -433,6 +434,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-type-assertion", no_unsafe_type_assertion.NoUnsafeTypeAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-unary-minus", no_unsafe_unary_minus.NoUnsafeUnaryMinusRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-vars", no_unused_vars.NoUnusedVarsRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", no_useless_constructor.NoUselessConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-empty-export", no_useless_empty_export.NoUselessEmptyExportRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/non-nullable-type-assertion-style", non_nullable_type_assertion_style.NonNullableTypeAssertionStyleRule)

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.go
@@ -1,0 +1,247 @@
+package no_useless_constructor
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildNoUselessConstructorMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noUselessConstructor",
+		Description: "Useless constructor.",
+	}
+}
+
+func buildRemoveConstructorMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeConstructor",
+		Description: "Remove the constructor.",
+	}
+}
+
+// checkAccessibility returns true if the constructor should be checked (accessibility
+// does not make it useful). Returns false (skip) for private/protected constructors,
+// and for public constructors in classes that extend another class.
+func checkAccessibility(node *ast.Node, classHasSuperClass bool) bool {
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) {
+		return false
+	}
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsProtected) {
+		return false
+	}
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPublic) {
+		if classHasSuperClass {
+			return false
+		}
+	}
+	return true
+}
+
+// checkParams returns true if the constructor should be checked (no parameter
+// properties or decorators that make it useful).
+func checkParams(node *ast.Node, params []*ast.Node) bool {
+	for _, param := range params {
+		if param.Kind != ast.KindParameter {
+			continue
+		}
+		if ast.IsParameterPropertyDeclaration(param, node) {
+			return false
+		}
+		if ast.HasDecorators(param) {
+			return false
+		}
+	}
+	return true
+}
+
+// isSimpleParam checks if a parameter is a simple identifier (no destructuring, no default value).
+// Rest parameters are considered simple.
+func isSimpleParam(param *ast.Node) bool {
+	if param.Kind != ast.KindParameter {
+		return false
+	}
+	pd := param.AsParameterDeclaration()
+	if pd == nil {
+		return false
+	}
+	// Must not have default value
+	if pd.Initializer != nil {
+		return false
+	}
+	// Must be a simple identifier (not destructuring)
+	name := param.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return false
+	}
+	return true
+}
+
+// isSingleSuperCall checks if the body consists of exactly one statement: super(...).
+func isSingleSuperCall(statements []*ast.Node) bool {
+	if len(statements) != 1 {
+		return false
+	}
+	stmt := statements[0]
+	if stmt.Kind != ast.KindExpressionStatement {
+		return false
+	}
+	expr := stmt.Expression()
+	if expr == nil || expr.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := expr.AsCallExpression()
+	if call == nil || call.Expression == nil {
+		return false
+	}
+	return call.Expression.Kind == ast.KindSuperKeyword
+}
+
+// isSpreadArguments checks if the arguments are exactly `...arguments`.
+func isSpreadArguments(args []*ast.Node) bool {
+	if len(args) != 1 {
+		return false
+	}
+	arg := args[0]
+	if arg.Kind != ast.KindSpreadElement {
+		return false
+	}
+	se := arg.AsSpreadElement()
+	if se == nil || se.Expression == nil {
+		return false
+	}
+	return se.Expression.Kind == ast.KindIdentifier && se.Expression.Text() == "arguments"
+}
+
+// isValidIdentifierPair checks if the constructor param and super arg are both identifiers with the same name.
+func isValidIdentifierPair(paramName *ast.Node, superArg *ast.Node) bool {
+	return paramName.Kind == ast.KindIdentifier &&
+		superArg.Kind == ast.KindIdentifier &&
+		paramName.Text() == superArg.Text()
+}
+
+// isValidRestSpreadPair checks if the constructor param is a rest param and
+// the super arg is a spread element with the same identifier.
+func isValidRestSpreadPair(param *ast.Node, superArg *ast.Node) bool {
+	pd := param.AsParameterDeclaration()
+	if pd == nil || pd.DotDotDotToken == nil {
+		return false
+	}
+	if superArg.Kind != ast.KindSpreadElement {
+		return false
+	}
+	se := superArg.AsSpreadElement()
+	if se == nil || se.Expression == nil {
+		return false
+	}
+	paramName := param.Name()
+	if paramName == nil {
+		return false
+	}
+	return isValidIdentifierPair(paramName, se.Expression)
+}
+
+// isPassingThrough checks if constructor params are passed through to super() 1:1.
+func isPassingThrough(params []*ast.Node, args []*ast.Node) bool {
+	if len(params) != len(args) {
+		return false
+	}
+	for i := range params {
+		pd := params[i].AsParameterDeclaration()
+		if pd == nil {
+			return false
+		}
+		paramName := params[i].Name()
+		if paramName == nil {
+			return false
+		}
+		if pd.DotDotDotToken != nil {
+			if !isValidRestSpreadPair(params[i], args[i]) {
+				return false
+			}
+		} else {
+			if !isValidIdentifierPair(paramName, args[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// isRedundantSuperCall checks if the constructor body is just a redundant super() call.
+func isRedundantSuperCall(statements []*ast.Node, params []*ast.Node) bool {
+	if !isSingleSuperCall(statements) {
+		return false
+	}
+	// All params must be simple (identifier or rest, no destructuring/defaults)
+	for _, p := range params {
+		if !isSimpleParam(p) {
+			return false
+		}
+	}
+	// Get the super call arguments
+	expr := statements[0].Expression()
+	call := expr.AsCallExpression()
+	var args []*ast.Node
+	if call.Arguments != nil {
+		args = call.Arguments.Nodes
+	}
+	return isSpreadArguments(args) || isPassingThrough(params, args)
+}
+
+var NoUselessConstructorRule = rule.CreateRule(rule.Rule{
+	Name: "no-useless-constructor",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindConstructor: func(node *ast.Node) {
+				constructor := node.AsConstructorDeclaration()
+				if constructor == nil {
+					return
+				}
+
+				// No body means it's a declaration (declare class, overload signature, abstract)
+				if constructor.Body == nil {
+					return
+				}
+
+				classNode := ast.GetContainingClass(node)
+				if classNode == nil {
+					return
+				}
+
+				hasSuper := ast.GetExtendsHeritageClauseElement(classNode) != nil
+
+				// TypeScript-specific: skip if accessibility makes constructor useful
+				if !checkAccessibility(node, hasSuper) {
+					return
+				}
+
+				// TypeScript-specific: skip if params have parameter properties or decorators
+				var params []*ast.Node
+				if constructor.Parameters != nil {
+					params = constructor.Parameters.Nodes
+				}
+				if !checkParams(node, params) {
+					return
+				}
+
+				body := constructor.Body.Statements()
+
+				isUseless := false
+				if hasSuper {
+					isUseless = isRedundantSuperCall(body, params)
+				} else {
+					isUseless = len(body) == 0
+				}
+
+				if isUseless {
+					ctx.ReportNodeWithSuggestions(node, buildNoUselessConstructorMessage(),
+						rule.RuleSuggestion{
+							Message:  buildRemoveConstructorMessage(),
+							FixesArr: []rule.RuleFix{rule.RuleFixRemove(ctx.SourceFile, node)},
+						},
+					)
+				}
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.md
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor.md
@@ -1,0 +1,53 @@
+# no-useless-constructor
+
+## Rule Details
+
+Disallow unnecessary constructors.
+
+ES2015 provides a default class constructor if one is not specified. As such, it is unnecessary to provide an empty constructor or one that simply delegates into its parent class, as in the following examples:
+
+This rule extends ESLint's `no-useless-constructor` with TypeScript-specific support for:
+- Access modifiers (`private`, `protected`, `public`)
+- Parameter properties
+- Parameter decorators
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+class A {
+  constructor() {}
+}
+
+class B extends A {
+  constructor(foo) {
+    super(foo);
+  }
+}
+
+class C {
+  public constructor() {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+class A {
+  constructor(private name: string) {}
+}
+
+class B {
+  private constructor() {}
+}
+
+class C extends D {
+  public constructor(foo) {
+    super(foo);
+  }
+}
+```
+
+## Original Documentation
+
+- [typescript-eslint no-useless-constructor](https://typescript-eslint.io/rules/no-useless-constructor)
+- [ESLint no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)

--- a/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/plugins/typescript/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -1,0 +1,1185 @@
+package no_useless_constructor
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessConstructorRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUselessConstructorRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Basic valid cases (no constructor or constructor with logic)
+		// ============================================================
+		{Code: `class A {}`},
+		{Code: `
+class A {
+  constructor() {
+    doSomething();
+  }
+}`},
+		{Code: `
+class A {
+  dummyMethod() {
+    doSomething();
+  }
+}`},
+
+		// ============================================================
+		// Extends: constructor not just forwarding to super
+		// ============================================================
+
+		// Empty body in extended class (not calling super at all)
+		{Code: `
+class A extends B {
+  constructor() {}
+}`},
+		// Calling super with different/extra args
+		{Code: `
+class A extends B {
+  constructor() {
+    super('foo');
+  }
+}`},
+		{Code: `
+class A extends B {
+  constructor(foo, bar) {
+    super(foo, bar, 1);
+  }
+}`},
+		// Super + additional logic
+		{Code: `
+class A extends B {
+  constructor() {
+    super();
+    doSomething();
+  }
+}`},
+		{Code: `
+class A extends B {
+  constructor(...args) {
+    super(...args);
+    doSomething();
+  }
+}`},
+		// Fewer args to super
+		{Code: `
+class A extends B {
+  constructor(a, b, c) {
+    super(a, b);
+  }
+}`},
+		{Code: `
+class A extends B {
+  constructor(foo, bar) {
+    super(foo);
+  }
+}`},
+		// Params but super called with no args
+		{Code: `
+class A extends B {
+  constructor(test) {
+    super();
+  }
+}`},
+		// Body is not super call
+		{Code: `
+class A extends B {
+  constructor() {
+    foo;
+  }
+}`},
+		// Different arg order to super
+		{Code: `
+class A extends B {
+  constructor(foo, bar) {
+    super(bar);
+  }
+}`},
+
+		// ============================================================
+		// Extends with property access / complex expressions
+		// ============================================================
+		{Code: `
+class A extends B.C {
+  constructor() {
+    super(foo);
+  }
+}`},
+		// Deep property access extends
+		{Code: `
+class A extends a.b.c.D {
+  constructor() {
+    super(foo);
+  }
+}`},
+		// Extends with call expression (Mixin pattern) — not a useless constructor
+		{Code: `
+class A extends Mixin(Base) {
+  constructor() {
+    super();
+    this.init();
+  }
+}`},
+
+		// ============================================================
+		// Non-simple parameters (destructuring, defaults)
+		// ============================================================
+		{Code: `
+class A extends B.C {
+  constructor([a, b, c]) {
+    super(...arguments);
+  }
+}`},
+		{Code: `
+class A extends B.C {
+  constructor(a = f()) {
+    super(...arguments);
+  }
+}`},
+		// Object destructuring
+		{Code: `
+class A extends B {
+  constructor({ x, y }) {
+    super(...arguments);
+  }
+}`},
+		// Default value on param
+		{Code: `
+class A extends B {
+  constructor(a = 1) {
+    super(a);
+  }
+}`},
+
+		// ============================================================
+		// Declaration-only constructors (no body → skip)
+		// ============================================================
+		{Code: `
+declare class A {
+  constructor();
+}`},
+		{Code: `
+class A {
+  constructor();
+}`},
+		{Code: `
+abstract class A {
+  constructor();
+}`},
+		// Overload + implementation with body
+		{Code: `
+class A {
+  constructor(x: number);
+  constructor(x: string);
+  constructor(x: number | string) {
+    doSomething(x);
+  }
+}`},
+
+		// ============================================================
+		// TypeScript parameter properties (useful → skip)
+		// ============================================================
+		{Code: `
+class A {
+  constructor(private name: string) {}
+}`},
+		{Code: `
+class A {
+  constructor(public name: string) {}
+}`},
+		{Code: `
+class A {
+  constructor(protected name: string) {}
+}`},
+		// readonly parameter property
+		{Code: `
+class A {
+  constructor(readonly name: string) {}
+}`},
+		// Multiple param properties
+		{Code: `
+class A {
+  constructor(public x: number, public y: number) {}
+}`},
+		// Mix of param property + normal param
+		{Code: `
+class A {
+  constructor(public name: string, age: number) {}
+}`},
+		// readonly + visibility
+		{Code: `
+class A {
+  constructor(private readonly id: number) {}
+}`},
+		// Param property in extended class forwarding to super
+		{Code: `
+class A extends B {
+  constructor(public name: string) {
+    super(name);
+  }
+}`},
+
+		// ============================================================
+		// Access modifiers on constructor (useful → skip)
+		// ============================================================
+		{Code: `
+class A {
+  private constructor() {}
+}`},
+		{Code: `
+class A {
+  protected constructor() {}
+}`},
+		// Public constructor in extended class (changes parent visibility)
+		{Code: `
+class A extends B {
+  public constructor() {}
+}`},
+		// Protected constructor with different super args
+		{Code: `
+class A extends B {
+  protected constructor(foo, bar) {
+    super(bar);
+  }
+}`},
+		// Private constructor with different super args
+		{Code: `
+class A extends B {
+  private constructor(foo, bar) {
+    super(bar);
+  }
+}`},
+		// Public constructor in extended class forwarding args (visibility change)
+		{Code: `
+class A extends B {
+  public constructor(foo) {
+    super(foo);
+  }
+}`},
+		{Code: `
+class A extends B {
+  public constructor(foo) {}
+}`},
+		// Public constructor with super() in extended class
+		{Code: `
+class A extends B {
+  public constructor() {
+    super();
+  }
+}`},
+
+		// ============================================================
+		// Decorators on params (useful → skip)
+		// ============================================================
+		{Code: `
+class A extends Object {
+  constructor(@Foo foo: string) {
+    super(foo);
+  }
+}`},
+		{Code: `
+class A extends Object {
+  constructor(foo: string, @Bar() bar) {
+    super(foo, bar);
+  }
+}`},
+		// Decorator on param in non-extended class
+		{Code: `
+class A {
+  constructor(@Inject service: Service) {}
+}`},
+
+		// ============================================================
+		// Constructor with useful body logic
+		// ============================================================
+		// this.x = x assignment
+		{Code: `
+class A {
+  constructor(x) {
+    this.x = x;
+  }
+}`},
+		// Super + property assignment
+		{Code: `
+class A extends B {
+  constructor(x) {
+    super(x);
+    this.extra = true;
+  }
+}`},
+		// Super call inside try-catch
+		{Code: `
+class A extends B {
+  constructor() {
+    try { super(); } catch(e) {}
+  }
+}`},
+		// Multiple statements
+		{Code: `
+class A extends B {
+  constructor() {
+    super();
+    console.log('constructed');
+  }
+}`},
+
+		// ============================================================
+		// Class expressions (valid cases)
+		// ============================================================
+		{Code: `const A = class {}`},
+		{Code: `
+const A = class {
+  constructor() {
+    doSomething();
+  }
+}`},
+		{Code: `
+const A = class extends B {
+  constructor() {
+    super();
+    doSomething();
+  }
+}`},
+
+		// ============================================================
+		// Nested classes (inner class is valid)
+		// ============================================================
+		{Code: `
+class Outer {
+  constructor() {
+    class Inner {
+      constructor() {
+        doSomething();
+      }
+    }
+  }
+}`},
+		// Inner class with useful constructor, outer has none
+		{Code: `
+class Outer {
+  method() {
+    return class Inner extends Base {
+      constructor() {
+        super();
+        this.init();
+      }
+    }
+  }
+}`},
+
+		// ============================================================
+		// Type annotations on params (should not affect logic)
+		// ============================================================
+		// Type-annotated params forwarding — still useless, but this is valid
+		// because the type annotation doesn't change the forwarding semantics
+		// Wait — actually this SHOULD be invalid. Hmm, let me reconsider:
+		// `constructor(x: number) { super(x); }` — this is just forwarding with
+		// a type annotation. Type annotations don't make it useful. BUT we need
+		// to verify isSimpleParam handles type-annotated params.
+		// Actually this should be in INVALID. Moving it there.
+
+		// Optional param — not forwarding (different behavior)
+		{Code: `
+class A extends B {
+  constructor(x?: number) {}
+}`},
+
+		// ============================================================
+		// Class with implements (not extends, so no superClass)
+		// ============================================================
+		{Code: `
+class A implements Serializable {
+  constructor() {
+    this.init();
+  }
+}`},
+
+		// ============================================================
+		// Body content that is NOT super(): various statement types
+		// ============================================================
+		// Empty statement (semicolon) — has 1 statement, so not empty
+		{Code: `
+class A {
+  constructor() { ; }
+}`},
+		// Return statement
+		{Code: `
+class A {
+  constructor() { return; }
+}`},
+		// "use strict" directive
+		{Code: `
+class A extends B {
+  constructor() {
+    "use strict";
+    super();
+  }
+}`},
+
+		// ============================================================
+		// super.method() vs super() — must be super() call specifically
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor() {
+    super.init();
+  }
+}`},
+
+		// ============================================================
+		// Super wrapped in other expressions (not a plain super call)
+		// ============================================================
+		// void super()
+		{Code: `
+class A extends B {
+  constructor() {
+    void super();
+  }
+}`},
+		// Comma expression: super(), doSomething()
+		{Code: `
+class A extends B {
+  constructor() {
+    super(), doSomething();
+  }
+}`},
+		// Conditional super
+		{Code: `
+class A extends B {
+  constructor(x) {
+    if (x) { super(x); } else { super(); }
+  }
+}`},
+
+		// ============================================================
+		// extends null
+		// ============================================================
+		{Code: `
+class A extends null {
+  constructor() {
+    doSomething();
+  }
+}`},
+
+		// ============================================================
+		// Extends + implements combined (valid: useful body)
+		// ============================================================
+		{Code: `
+class A extends B implements I {
+  constructor() {
+    super();
+    this.init();
+  }
+}`},
+
+		// ============================================================
+		// Rest with destructuring (not simple)
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(...[x, y]) {
+    super(...arguments);
+  }
+}`},
+
+		// ============================================================
+		// new.target usage (useful body)
+		// ============================================================
+		{Code: `
+class A {
+  constructor() {
+    if (new.target === A) throw new Error();
+  }
+}`},
+
+		// ============================================================
+		// Nested: outer useless, but inner has logic (only outer flagged)
+		// Both classes handled independently
+		// ============================================================
+		// (tested via invalid cases below — outer is useless)
+
+		// Nested: outer has logic, inner is valid
+		{Code: `
+class Outer {
+  constructor() {
+    this.inner = class Inner {
+      constructor() {
+        doSomething();
+      }
+    }
+  }
+}`},
+
+		// ============================================================
+		// TypeScript `this` parameter (not simple → blocks forwarding check)
+		// ============================================================
+		// `this` param in extended class prevents forwarding match
+		{Code: `
+class A extends B {
+  constructor(this: Foo) {
+    super();
+  }
+}`},
+
+		// ============================================================
+		// Generic class (generics don't affect uselessness logic)
+		// ============================================================
+		// Generic class with useful constructor body
+		{Code: `
+class A<T> extends B<T> {
+  constructor(x: T) {
+    super(x);
+    this.data = x;
+  }
+}`},
+
+		// ============================================================
+		// export default class (useful)
+		// ============================================================
+		{Code: `
+export default class extends B {
+  constructor() {
+    super();
+    this.init();
+  }
+}`},
+
+		// ============================================================
+		// Decorator + parameter property on same param
+		// ============================================================
+		{Code: `
+class A {
+  constructor(@Inject public name: string) {}
+}`},
+
+		// ============================================================
+		// readonly param in extended class (param property → skip)
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(readonly x: number) {
+    super(x);
+  }
+}`},
+
+		// ============================================================
+		// Type assertion in super arg (not a plain identifier → not forwarding)
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(x) {
+    super(x as any);
+  }
+}`},
+
+		// ============================================================
+		// Spread of non-identifier expression in super (not forwarding)
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(...args) {
+    super(...args.slice(0));
+  }
+}`},
+
+		// ============================================================
+		// Regular param but super arg is spread (mismatch types)
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(a, b) {
+    super(a, ...b);
+  }
+}`},
+
+		// ============================================================
+		// Rest param but super arg is NOT spread (length matches, type mismatch)
+		// Exercises isValidRestSpreadPair: superArg.Kind != KindSpreadElement
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(...args) {
+    super(args);
+  }
+}`},
+
+		// ============================================================
+		// Mixed: params forwarded but extra super args
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(x) {
+    super(x, 'extra');
+  }
+}`},
+
+		// ============================================================
+		// Params reordered in super call
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(a, b, c) {
+    super(c, b, a);
+  }
+}`},
+
+		// ============================================================
+		// Rest param not at last position would be syntax error,
+		// but rest param + extra normal param forwarding: not 1:1
+		// ============================================================
+		{Code: `
+class A extends B {
+  constructor(a, ...rest) {
+    super(a);
+  }
+}`},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Basic invalid: empty constructor in non-extended class
+		// ============================================================
+		{
+			Code: `
+class A {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Extended class: just forwarding to super
+		// ============================================================
+		{
+			Code: `
+class A extends B {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// Single param forwarding
+		{
+			Code: `
+class A extends B {
+  constructor(foo) {
+    super(foo);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// Multiple params forwarding
+		{
+			Code: `
+class A extends B {
+  constructor(foo, bar) {
+    super(foo, bar);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// Spread args forwarding
+		{
+			Code: `
+class A extends B {
+  constructor(...args) {
+    super(...args);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// ...arguments forwarding
+		{
+			Code: `
+class A extends B.C {
+  constructor() {
+    super(...arguments);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B.C {\n  \n}"},
+				}},
+			},
+		},
+		// Rest params with ...arguments
+		{
+			Code: `
+class A extends B {
+  constructor(a, b, ...c) {
+    super(...arguments);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// Rest params matching forward
+		{
+			Code: `
+class A extends B {
+  constructor(a, b, ...c) {
+    super(a, b, ...c);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Public constructor without superClass (useless)
+		// ============================================================
+		{
+			Code: `
+class A {
+  public constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Class expressions (invalid)
+		// ============================================================
+		// Class expression with empty constructor
+		{
+			Code: `const A = class { constructor() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 19, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "const A = class {  }"},
+				}},
+			},
+		},
+		// Named class expression with empty constructor
+		{
+			Code: `const A = class MyClass { constructor() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 27, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "const A = class MyClass {  }"},
+				}},
+			},
+		},
+		// Class expression extends with just super forwarding
+		{
+			Code: `const A = class extends B { constructor() { super(); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 29, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "const A = class extends B {  }"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Nested classes: inner class with useless constructor
+		// ============================================================
+		{
+			Code: `
+class Outer {
+  method() {
+    class Inner {
+      constructor() {}
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 5, Column: 7, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  method() {\n    class Inner {\n      \n    }\n  }\n}"},
+				}},
+			},
+		},
+		// Inner class expression with useless constructor
+		{
+			Code: `
+class Outer {
+  method() {
+    return class extends Base {
+      constructor(x) {
+        super(x);
+      }
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 5, Column: 7, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  method() {\n    return class extends Base {\n      \n    }\n  }\n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Complex extends expressions
+		// ============================================================
+		// Deep property access extends
+		{
+			Code: `
+class A extends a.b.c.D {
+  constructor() {
+    super(...arguments);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends a.b.c.D {\n  \n}"},
+				}},
+			},
+		},
+		// Extends with call expression (mixin pattern)
+		{
+			Code: `
+class A extends Mixin(Base) {
+  constructor(...args) {
+    super(...args);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends Mixin(Base) {\n  \n}"},
+				}},
+			},
+		},
+		// Extends with generic
+		{
+			Code: `
+class A extends Base<string> {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends Base<string> {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Type-annotated params: annotations don't make it useful
+		// ============================================================
+		{
+			Code: `
+class A extends B {
+  constructor(x: number) {
+    super(x);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// Multiple type-annotated params
+		{
+			Code: `
+class A extends B {
+  constructor(x: string, y: number) {
+    super(x, y);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		// Rest param with type annotation
+		{
+			Code: `
+class A extends B {
+  constructor(...args: any[]) {
+    super(...args);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Abstract class with empty constructor body
+		// ============================================================
+		{
+			Code: `
+abstract class A {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nabstract class A {\n  \n}"},
+				}},
+			},
+		},
+		// Abstract class extends with super forwarding
+		{
+			Code: `
+abstract class A extends B {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nabstract class A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Class with implements (not extends → no superClass)
+		// ============================================================
+		{
+			Code: `
+class A implements Serializable {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A implements Serializable {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Optional param forwarding to super (still useless)
+		// ============================================================
+		{
+			Code: `
+class A extends B {
+  constructor(x?: number) {
+    super(x);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// extends + implements combo (super forwarding is useless)
+		// ============================================================
+		{
+			Code: `
+class A extends B implements I {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B implements I {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// extends null (extends clause exists → hasSuper = true)
+		// ============================================================
+		{
+			Code: `
+class A extends null {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends null {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Single-line format (position reporting)
+		// ============================================================
+		{
+			Code: `class A { constructor() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Nested: both outer and inner are useless → two errors
+		// ============================================================
+		{
+			Code: `
+class Outer {
+  constructor() {}
+  method() {
+    class Inner {
+      constructor() {}
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  \n  method() {\n    class Inner {\n      constructor() {}\n    }\n  }\n}"},
+				}},
+				{MessageId: "noUselessConstructor", Line: 6, Column: 7, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  constructor() {}\n  method() {\n    class Inner {\n      \n    }\n  }\n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Many params forwarding to super (stress test)
+		// ============================================================
+		{
+			Code: `
+class A extends B {
+  constructor(a, b, c, d, e) {
+    super(a, b, c, d, e);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Only rest param forwarding (single rest → single spread)
+		// ============================================================
+		{
+			Code: `
+class A extends B {
+  constructor(...rest) {
+    super(...rest);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// Generic class (generics don't prevent detection)
+		// ============================================================
+		{
+			Code: `
+class A<T> extends B<T> {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A<T> extends B<T> {\n  \n}"},
+				}},
+			},
+		},
+		// Generic param forwarding
+		{
+			Code: `
+class A<T> extends B<T> {
+  constructor(x: T) {
+    super(x);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A<T> extends B<T> {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// export default class (anonymous)
+		// ============================================================
+		{
+			Code: `
+export default class extends B {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nexport default class extends B {\n  \n}"},
+				}},
+			},
+		},
+		// export default class with name
+		{
+			Code: `
+export default class Foo {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nexport default class Foo {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// `this` parameter in non-extended class: empty body → useless
+		// (this param is not a param property, so checkParams passes)
+		// ============================================================
+		{
+			Code: `
+class A {
+  constructor(this: Foo) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+
+		// ============================================================
+		// String literal constructor name: 'constructor'() {}
+		// Parsed as the actual constructor
+		// ============================================================
+		{
+			Code: `
+class A {
+  'constructor'() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -190,7 +190,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-declare.test.ts',
     // './tests/typescript-eslint/rules/no-use-before-define.test.ts',
-    // './tests/typescript-eslint/rules/no-useless-constructor.test.ts',
+    './tests/typescript-eslint/rules/no-useless-constructor.test.ts',
     // './tests/typescript-eslint/rules/no-useless-empty-export.test.ts',
     // './tests/typescript-eslint/rules/no-var-requires.test.ts',
     // './tests/typescript-eslint/rules/no-wrapper-object-types.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-useless-constructor.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-useless-constructor.test.ts.snap
@@ -1,0 +1,285 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-constructor > invalid 1`] = `
+{
+  "code": "
+class A {
+  constructor() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 2`] = `
+{
+  "code": "
+class A extends B {
+  constructor() {
+    super();
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 3`] = `
+{
+  "code": "
+class A extends B {
+  constructor(foo) {
+    super(foo);
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 4`] = `
+{
+  "code": "
+class A extends B {
+  constructor(foo, bar) {
+    super(foo, bar);
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 5`] = `
+{
+  "code": "
+class A extends B {
+  constructor(...args) {
+    super(...args);
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 6`] = `
+{
+  "code": "
+class A extends B.C {
+  constructor() {
+    super(...arguments);
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 7`] = `
+{
+  "code": "
+class A extends B {
+  constructor(a, b, ...c) {
+    super(...arguments);
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 8`] = `
+{
+  "code": "
+class A extends B {
+  constructor(a, b, ...c) {
+    super(a, b, ...c);
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 9`] = `
+{
+  "code": "
+class A {
+  public constructor() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-useless-constructor` rule from typescript-eslint to rslint.

This rule disallows unnecessary constructors — empty constructors in non-extended classes and constructors that only forward parameters to `super()` in extended classes. It extends the ESLint core rule with TypeScript-specific support for access modifiers (`private`, `protected`, `public`), parameter properties, and parameter decorators.

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-useless-constructor
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-useless-constructor.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).