### PR TITLE
feat: port rule @typescript-eslint/no-unused-expressions

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_unary_minus"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_expressions"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_empty_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
@@ -432,6 +433,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-return", no_unsafe_return.NoUnsafeReturnRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-type-assertion", no_unsafe_type_assertion.NoUnsafeTypeAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-unary-minus", no_unsafe_unary_minus.NoUnsafeUnaryMinusRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-expressions", no_unused_expressions.NoUnusedExpressionsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-vars", no_unused_vars.NoUnusedVarsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-empty-export", no_useless_empty_export.NoUselessEmptyExportRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.go
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.go
@@ -1,0 +1,241 @@
+package no_unused_expressions
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type options struct {
+	allowShortCircuit   bool
+	allowTernary        bool
+	allowTaggedTemplates bool
+	enforceForJSX       bool
+	ignoreDirectives    bool
+}
+
+func parseOptions(rawOptions any) options {
+	opts := options{}
+	optsMap := utils.GetOptionsMap(rawOptions)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowShortCircuit"].(bool); ok {
+		opts.allowShortCircuit = v
+	}
+	if v, ok := optsMap["allowTernary"].(bool); ok {
+		opts.allowTernary = v
+	}
+	if v, ok := optsMap["allowTaggedTemplates"].(bool); ok {
+		opts.allowTaggedTemplates = v
+	}
+	if v, ok := optsMap["enforceForJSX"].(bool); ok {
+		opts.enforceForJSX = v
+	}
+	if v, ok := optsMap["ignoreDirectives"].(bool); ok {
+		opts.ignoreDirectives = v
+	}
+	return opts
+}
+
+func unusedExpressionMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unusedExpression",
+		Description: "Expected an assignment or function call and instead saw an expression.",
+	}
+}
+
+// isDisallowed returns true if the expression has no side effects and should be reported.
+// This mirrors ESLint's Checker pattern.
+func isDisallowed(node *ast.Node, opts *options) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	// Expressions that never have side effects
+	case ast.KindArrayLiteralExpression,
+		ast.KindObjectLiteralExpression,
+		ast.KindArrowFunction,
+		ast.KindFunctionExpression,
+		ast.KindClassExpression,
+		ast.KindIdentifier,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindMetaProperty,
+		ast.KindThisKeyword,
+		ast.KindSuperKeyword:
+		return true
+
+	// Literals
+	case ast.KindStringLiteral,
+		ast.KindNumericLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword,
+		ast.KindNullKeyword:
+		return true
+
+	// Template literals (untagged)
+	case ast.KindTemplateExpression:
+		return true
+
+	// Sequence expressions (comma-separated)
+	case ast.KindCommaListExpression:
+		return true
+
+	// Tagged template expressions
+	case ast.KindTaggedTemplateExpression:
+		return !opts.allowTaggedTemplates
+
+	// JSX
+	case ast.KindJsxElement, ast.KindJsxFragment, ast.KindJsxSelfClosingElement:
+		return opts.enforceForJSX
+
+	// Unary expressions: void and delete have side effects, others don't
+	case ast.KindPrefixUnaryExpression:
+		unary := node.AsPrefixUnaryExpression()
+		// ++/-- have side effects
+		if unary.Operator == ast.KindPlusPlusToken || unary.Operator == ast.KindMinusMinusToken {
+			return false
+		}
+		// !, +, -, ~ do not
+		return true
+
+	// typeof has no side effects
+	case ast.KindTypeOfExpression:
+		return true
+
+	// Binary expressions
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		op := binary.OperatorToken.Kind
+		// Assignment operators have side effects
+		if ast.IsAssignmentOperator(op) {
+			return false
+		}
+		// Logical operators: &&, ||, ??
+		if op == ast.KindAmpersandAmpersandToken || op == ast.KindBarBarToken || op == ast.KindQuestionQuestionToken {
+			if opts.allowShortCircuit {
+				return isDisallowed(binary.Right, opts)
+			}
+			return true
+		}
+		// All other binary operators (arithmetic, comparison, bitwise) have no side effects
+		return true
+
+	// Conditional (ternary) expression
+	case ast.KindConditionalExpression:
+		if opts.allowTernary {
+			cond := node.AsConditionalExpression()
+			return isDisallowed(cond.WhenTrue, opts) || isDisallowed(cond.WhenFalse, opts)
+		}
+		return true
+
+	// Parenthesized expression: unwrap
+	case ast.KindParenthesizedExpression:
+		return isDisallowed(node.AsParenthesizedExpression().Expression, opts)
+
+	// TypeScript-specific: unwrap type assertions and check inner expression
+	case ast.KindAsExpression:
+		return isDisallowed(node.AsAsExpression().Expression, opts)
+	case ast.KindTypeAssertionExpression:
+		return isDisallowed(node.AsTypeAssertion().Expression, opts)
+	case ast.KindNonNullExpression:
+		return isDisallowed(node.AsNonNullExpression().Expression, opts)
+	// NOTE: SatisfiesExpression is NOT unwrapped to match @typescript-eslint behavior.
+	// The original rule does not handle TSSatisfiesExpression, so it defaults to
+	// "not disallowed" (i.e., `foo satisfies T;` is NOT flagged).
+
+	// Instantiation expression: Foo<string> as a standalone expression
+	case ast.KindExpressionWithTypeArguments:
+		expr := node.AsExpressionWithTypeArguments()
+		return isDisallowed(expr.Expression, opts)
+
+	// Expressions with side effects (NOT disallowed)
+	case ast.KindCallExpression,
+		ast.KindNewExpression,
+		ast.KindDeleteExpression,
+		ast.KindVoidExpression,
+		ast.KindAwaitExpression,
+		ast.KindYieldExpression,
+		ast.KindPostfixUnaryExpression:
+		return false
+
+	default:
+		// Unknown node types default to not disallowed (safe)
+		return false
+	}
+}
+
+// isDirectiveContext returns true if the parent node is a valid context for
+// directive prologues: SourceFile, function body (Block), class static block
+// body (Block), or ModuleBlock. Arbitrary blocks (e.g., if-blocks) are NOT valid.
+// NOTE: Per spec, class static blocks do NOT have directive prologues, but the
+// @typescript-eslint parser treats leading string literals in static blocks as
+// directives, so we match that behavior for alignment.
+func isDirectiveContext(parent *ast.Node) bool {
+	switch parent.Kind {
+	case ast.KindSourceFile, ast.KindModuleBlock:
+		return true
+	case ast.KindBlock:
+		// Block is a directive context if it's the body of a function-like or class static block
+		return parent.Parent != nil && ast.IsFunctionLikeOrClassStaticBlockDeclaration(parent.Parent)
+	default:
+		return false
+	}
+}
+
+// isDirective checks if a node is a directive prologue (e.g., 'use strict').
+// Uses ast.IsPrologueDirective from tsgo to identify string literal expression
+// statements, then validates the node appears in the leading directive sequence
+// of a valid context (SourceFile, function body, or module/namespace block).
+func isDirective(node *ast.Node) bool {
+	if !ast.IsPrologueDirective(node) {
+		return false
+	}
+	parent := node.Parent
+	if parent == nil || !isDirectiveContext(parent) {
+		return false
+	}
+	// Check that this node appears in the leading sequence of directive-like statements.
+	// node.Parent.Statements() covers SourceFile, Block, and ModuleBlock.
+	for _, stmt := range parent.Statements() {
+		if stmt == node {
+			return true
+		}
+		if !ast.IsPrologueDirective(stmt) {
+			return false
+		}
+	}
+	return false
+}
+
+// https://typescript-eslint.io/rules/no-unused-expressions
+var NoUnusedExpressionsRule = rule.CreateRule(rule.Rule{
+	Name: "no-unused-expressions",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			ast.KindExpressionStatement: func(node *ast.Node) {
+				exprStmt := node.AsExpressionStatement()
+				expr := exprStmt.Expression
+
+				if !isDisallowed(expr, &opts) {
+					return
+				}
+
+				// Always allow directives (unless ignoreDirectives is irrelevant here;
+				// the base behavior always skips real directives)
+				if isDirective(node) {
+					return
+				}
+
+				ctx.ReportNode(node, unusedExpressionMessage())
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.md
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions.md
@@ -1,0 +1,45 @@
+# no-unused-expressions
+
+## Rule Details
+
+Disallow unused expressions. An unused expression is an expression that is evaluated but whose result is not used. This can indicate a mistake or a misunderstanding of the code.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+0;
+a;
+f(), {};
+a && b();
+foo.bar;
+foo as any;
+<any>foo;
+foo!;
+Foo<string>;
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+a = b;
+a();
+new Foo();
+delete foo.bar;
+void 0;
+'use strict';
+import('./foo');
+foo?.();
+```
+
+## Options
+
+- `allowShortCircuit` (default: `false`): Allow short-circuit evaluations (e.g., `a && a()`).
+- `allowTernary` (default: `false`): Allow ternary expressions (e.g., `a ? b() : c()`).
+- `allowTaggedTemplates` (default: `false`): Allow tagged template literals.
+- `enforceForJSX` (default: `false`): Enforce the rule for JSX elements.
+- `ignoreDirectives` (default: `false`): Ignore directive prologues.
+
+## Original Documentation
+
+- [typescript-eslint: no-unused-expressions](https://typescript-eslint.io/rules/no-unused-expressions)
+- [ESLint: no-unused-expressions](https://eslint.org/docs/latest/rules/no-unused-expressions)

--- a/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions_test.go
+++ b/internal/plugins/typescript/rules/no_unused_expressions/no_unused_expressions_test.go
@@ -1,0 +1,685 @@
+package no_unused_expressions
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedExpressionsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedExpressionsRule, []rule_tester.ValidTestCase{
+		// ================================================================
+		// Side-effect expressions (always valid)
+		// ================================================================
+		{Code: `function f(){}`},
+		{Code: `a = b`},
+		{Code: `new a`},
+		{Code: `{}`},
+		{Code: `f(); g()`},
+		{Code: `i++`},
+		{Code: `a()`},
+		{Code: `delete foo.bar`},
+		{Code: `void new C`},
+
+		// ================================================================
+		// Directives
+		// ================================================================
+		{Code: `"use strict";`},
+		{Code: `"directive one"; "directive two"; f();`},
+		{Code: `function foo() {"use strict"; return true; }`},
+		{Code: `var foo = () => {"use strict"; return true; }`},
+		{Code: `function foo() {"directive one"; "directive two"; f(); }`},
+
+		// ================================================================
+		// allowShortCircuit
+		// ================================================================
+		{Code: `a && a()`, Options: map[string]interface{}{"allowShortCircuit": true}},
+		{Code: `a() || (b = c)`, Options: map[string]interface{}{"allowShortCircuit": true}},
+
+		// ================================================================
+		// allowTernary
+		// ================================================================
+		{Code: `a ? b() : c()`, Options: map[string]interface{}{"allowTernary": true}},
+		{
+			Code:    `a ? b() || (c = d) : e()`,
+			Options: map[string]interface{}{"allowShortCircuit": true, "allowTernary": true},
+		},
+
+		// ================================================================
+		// yield / await
+		// ================================================================
+		{Code: `function* foo(){ yield 0; }`},
+		{Code: `async function foo() { await 5; }`},
+		{Code: `async function foo() { await foo.bar; }`},
+		{
+			Code:    `async function foo() { bar && await baz; }`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+		},
+		{
+			Code:    `async function foo() { foo ? await bar : await baz; }`,
+			Options: map[string]interface{}{"allowTernary": true},
+		},
+
+		// ================================================================
+		// Tagged template literals
+		// ================================================================
+		{Code: "tag`tagged template literal`", Options: map[string]interface{}{"allowTaggedTemplates": true}},
+		{
+			Code:    `shouldNotBeAffectedByAllowTemplateTagsOption()`,
+			Options: map[string]interface{}{"allowTaggedTemplates": true},
+		},
+
+		// ================================================================
+		// Dynamic import
+		// ================================================================
+		{Code: `import('./foo')`},
+		{Code: `import('./foo').then(() => {})`},
+
+		// ================================================================
+		// Optional chaining calls
+		// ================================================================
+		{Code: `func?.("foo")`},
+		{Code: `obj?.foo("bar")`},
+		{Code: `test.age?.toLocaleString();`},
+		{Code: `one[2]?.[3][4]?.();`},
+		{Code: `a?.['b']?.c();`},
+
+		// ================================================================
+		// Assignments (not unused)
+		// ================================================================
+		{Code: `let a = (a?.b).c;`},
+		{Code: `let b = a?.['b'];`},
+		{Code: `let c = one[2]?.[3][4];`},
+
+		// ================================================================
+		// TypeScript: module/namespace directives
+		// ================================================================
+		{Code: "module Foo {\n  'use strict';\n}"},
+		{Code: "namespace Foo {\n  'use strict';\n\n  export class Foo {}\n  export class Bar {}\n}"},
+		{Code: "function foo() {\n  'use strict';\n\n  return null;\n}"},
+
+		// ================================================================
+		// TypeScript: new with generics
+		// ================================================================
+		{Code: `class Foo<T> {} new Foo<string>();`},
+
+		// ================================================================
+		// allowShortCircuit with optional chaining
+		// ================================================================
+		{Code: `foo && foo?.();`, Options: map[string]interface{}{"allowShortCircuit": true}},
+		{Code: `foo && import('./foo');`, Options: map[string]interface{}{"allowShortCircuit": true}},
+
+		// ================================================================
+		// allowTernary with imports
+		// ================================================================
+		{Code: `foo ? import('./foo') : import('./bar');`, Options: map[string]interface{}{"allowTernary": true}},
+
+		// ================================================================
+		// Update expressions (have side effects)
+		// ================================================================
+		{Code: `i--`},
+		{Code: `--i`},
+		{Code: `++i`},
+
+		// ================================================================
+		// Compound / logical assignments (have side effects)
+		// ================================================================
+		{Code: `a += 1`},
+		{Code: `a &&= b`},
+		{Code: `a ||= b`},
+		{Code: `a ??= b`},
+
+		// ================================================================
+		// TypeScript assertions wrapping calls (inner has side effects)
+		// ================================================================
+		{Code: `foo() as any;`},
+		{Code: `foo()!;`},
+		{Code: `<any>foo();`},
+		{Code: `foo() satisfies string;`},
+
+		// ================================================================
+		// TS non-null assertion wrapping call in short-circuit
+		// ================================================================
+		{Code: `foo && foo()!;`, Options: map[string]interface{}{"allowShortCircuit": true}},
+
+		// ================================================================
+		// Instantiation expression wrapping call (has side effects)
+		// ================================================================
+		{Code: `declare function getSet(): Set<unknown>; getSet()<string>();`},
+
+		// ================================================================
+		// Satisfies (not unwrapped, defaults to not disallowed)
+		// ================================================================
+		{Code: `declare const foo: string; foo satisfies string;`},
+		{Code: `foo() satisfies string;`},
+
+		// ================================================================
+		// Combined allowShortCircuit + allowTernary
+		// ================================================================
+		{
+			Code:    `a ? b && c() : d()`,
+			Options: map[string]interface{}{"allowShortCircuit": true, "allowTernary": true},
+		},
+		{Code: `a ?? b()`, Options: map[string]interface{}{"allowShortCircuit": true}},
+		{Code: `a || b()`, Options: map[string]interface{}{"allowShortCircuit": true}},
+
+		// ================================================================
+		// Yield without expression, generator
+		// ================================================================
+		{Code: `function* foo(){ yield; }`},
+
+		// ================================================================
+		// More directive edge cases
+		// ================================================================
+		{Code: `"use strict"; "use asm"; f();`},
+		{Code: `var foo = () => {"use strict"; return true; }`},
+		{Code: `function foo() { var foo = "use strict"; return true; }`},
+
+		// ================================================================
+		// Class static block — leading string treated as directive
+		// ================================================================
+		{Code: `class C { static { 'use strict'; } }`},
+
+		// ================================================================
+		// Deep nesting: TS wrappers + options combined
+		// ================================================================
+		// type assertion > parens > short-circuit > non-null > call
+		{
+			Code:    "declare const foo: Function | undefined;\n<any>(foo && foo()!)",
+			Options: map[string]interface{}{"allowShortCircuit": true},
+		},
+		// instantiation > parens > short-circuit > call
+		{
+			Code:    `(Foo && Foo())<string, number>;`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+		},
+		// deeply nested ternary + short-circuit both valid
+		{
+			Code:    `a ? (b && c()) : (d || e())`,
+			Options: map[string]interface{}{"allowShortCircuit": true, "allowTernary": true},
+		},
+		// chained optional calls
+		{Code: `a?.()?.b();`},
+	}, []rule_tester.InvalidTestCase{
+		// ================================================================
+		// Basic unused expressions
+		// ================================================================
+		{
+			Code:   `0`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `f(), 0`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `{0}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 2}},
+		},
+		{
+			Code:   `[]`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a && b();`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a() || false`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a || (b = c)`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Template literals
+		// ================================================================
+		{
+			Code:   "`untagged template literal`",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   "tag`tagged template literal`",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Options mismatches
+		// ================================================================
+		{
+			Code:    `a && b()`,
+			Options: map[string]interface{}{"allowTernary": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:    `a ? b() : c()`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:    `a || b`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:    `a() && b`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:    `a ? b : 0`,
+			Options: map[string]interface{}{"allowTernary": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:    `a ? b : c()`,
+			Options: map[string]interface{}{"allowTernary": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Member access (no side effects)
+		// ================================================================
+		{
+			Code:   `foo.bar;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Unary (no side effects: !, +)
+		// ================================================================
+		{
+			Code:   `!a`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `+a`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Directives not at prologue
+		// ================================================================
+		{
+			Code:   `"directive one"; f(); "directive two";`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 23}},
+		},
+		{
+			Code:   `function foo() {"directive one"; f(); "directive two"; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 39}},
+		},
+		{
+			Code:   `if (0) { "not a directive"; f(); }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 10}},
+		},
+		{
+			Code:   `function foo() { var foo = true; "use strict"; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 34}},
+		},
+		{
+			Code:   `var foo = () => { var foo = true; "use strict"; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 35}},
+		},
+
+		// ================================================================
+		// Untagged template literals with options
+		// ================================================================
+		{
+			Code:    "`untagged template literal`",
+			Options: map[string]interface{}{"allowTaggedTemplates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:    "tag`tagged template literal`",
+			Options: map[string]interface{}{"allowTaggedTemplates": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Optional chaining (member access without call)
+		// ================================================================
+		{
+			Code:   `obj?.foo`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `obj?.foo.bar`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `obj?.foo().bar`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Class static block — leading string treated as directive (matches @typescript-eslint)
+		// Non-leading string IS flagged.
+		// ================================================================
+		{
+			Code:   `class C { static { const x = 1; 'use strict'; } }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 33}},
+		},
+
+		// ================================================================
+		// TypeScript-specific: optional chaining member access (from TS test file)
+		// ================================================================
+		{
+			Code:   `if (0) 0;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 8}},
+		},
+		{
+			Code:   "f(0), {};",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   "a, b();",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code: "a() &&\n  function namedFunctionInExpressionContext() {\n    f();\n  };",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a?.b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `(a?.b).c;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a?.['b'];`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `(a?.['b']).c;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a?.b()?.c;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `(a?.b()).c;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `one[2]?.[3][4];`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `one.two?.three.four;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// TypeScript: module/namespace — directive not at prologue
+		// ================================================================
+		{
+			Code:   "module Foo {\n  const foo = true;\n  'use strict';\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 3, Column: 3}},
+		},
+		{
+			Code:   "namespace Foo {\n  export class Foo {}\n  export class Bar {}\n\n  'use strict';\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 5, Column: 3}},
+		},
+		{
+			Code:   "function foo() {\n  const foo = true;\n\n  ('use strict');\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 4, Column: 3}},
+		},
+
+		// ================================================================
+		// Optional chaining with allowShortCircuit — member access still invalid
+		// ================================================================
+		{
+			Code:    `foo && foo?.bar;`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Ternary with optional member access
+		// ================================================================
+		{
+			Code:    `foo ? foo?.bar : bar.baz;`,
+			Options: map[string]interface{}{"allowTernary": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// TypeScript: instantiation expression (unused)
+		// ================================================================
+		{
+			Code:   "class Foo<T> {}\nFoo<string>;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 2, Column: 1}},
+		},
+		{
+			Code:   `Map<string, string>;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// TypeScript: plain identifier
+		// ================================================================
+		{
+			Code:   "declare const foo: number | undefined;\nfoo;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 2, Column: 1}},
+		},
+
+		// ================================================================
+		// TypeScript: assertions wrapping non-call expressions
+		// ================================================================
+		{
+			Code:   "declare const foo: number | undefined;\nfoo as any;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 2, Column: 1}},
+		},
+		{
+			Code:   "declare const foo: number | undefined;\n<any>foo;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 2, Column: 1}},
+		},
+		{
+			Code:   "declare const foo: number | undefined;\nfoo!;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 2, Column: 1}},
+		},
+
+		// ================================================================
+		// Literals: boolean, null, bigint, regex
+		// ================================================================
+		{
+			Code:   `true;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `false;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `null;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `1n;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `/regex/;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Unary without side effects: -, ~, typeof
+		// ================================================================
+		{
+			Code:   `-a;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `~a;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `typeof foo;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// this as standalone expression
+		// ================================================================
+		{
+			Code:   `function foo() { this; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 18}},
+		},
+
+		// ================================================================
+		// Nested parenthesized expressions
+		// ================================================================
+		{
+			Code:   `((a));`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Arithmetic / comparison / bitwise binary expressions
+		// ================================================================
+		{
+			Code:   `a + b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a === b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		{
+			Code:   `a & b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// TS satisfies — NOT unwrapped (matches @typescript-eslint behavior)
+		// satisfies defaults to "not disallowed", so these are NOT flagged.
+		// See valid cases above if needed.
+		// ================================================================
+
+		// ================================================================
+		// Nested TS assertions wrapping non-call
+		// ================================================================
+		{
+			Code:   `declare const foo: any; (foo as any)!;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 25}},
+		},
+		{
+			Code:   `declare const foo: any; (foo as any) as number;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 25}},
+		},
+
+		// ================================================================
+		// Comma expression (both sides are calls, but comma itself is disallowed)
+		// ================================================================
+		{
+			Code:   `f(), g();`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Ternary: one branch valid, one invalid (without allowTernary, always flagged)
+		// ================================================================
+		{
+			Code:   `a ? b() || (c = d) : e`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Class static block: multiple leading strings are all directives;
+		// non-leading strings after non-directive are flagged
+		// ================================================================
+		{
+			Code: "class C { static { const x = 1; 'foo'; 'bar'; } }",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedExpression", Line: 1, Column: 33},
+				{MessageId: "unusedExpression", Line: 1, Column: 40},
+			},
+		},
+
+		// ================================================================
+		// allowShortCircuit: nested logical — right side must be valid
+		// ================================================================
+		{
+			Code:    `a && (b ?? c);`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// allowTernary: both branches must be valid, one is identifier
+		// ================================================================
+		{
+			Code:    `a ? b() : c;`,
+			Options: map[string]interface{}{"allowTernary": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Element access (no side effects)
+		// ================================================================
+		{
+			Code:   `a['b'];`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Template literal with interpolation (still no side effects)
+		// ================================================================
+		{
+			Code:   "`hello ${world}`;",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+
+		// ================================================================
+		// Deep nesting invalid: TS wrappers around non-call
+		// ================================================================
+		// instantiation > identifier (no call)
+		{
+			Code:    `(Foo && Foo)<string, number>;`,
+			Options: map[string]interface{}{"allowShortCircuit": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		// deeply nested ternary + short-circuit: one branch invalid
+		{
+			Code:    `a ? (b && c()) : (d || e)`,
+			Options: map[string]interface{}{"allowShortCircuit": true, "allowTernary": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		// chained optional member access after call (result is member access)
+		{
+			Code:   `a?.()?.b;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		// arrow function expression as statement
+		{
+			Code:   `(() => {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		// function expression as statement
+		{
+			Code:   `(function() {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		// class expression as statement
+		{
+			Code:   `(class {});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+		// object literal as statement
+		{
+			Code:   `({a: 1});`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedExpression", Line: 1, Column: 1}},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -181,7 +181,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unsafe-return.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-type-assertion.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-unary-minus.test.ts',
-    // './tests/typescript-eslint/rules/no-unused-expressions.test.ts',
+    './tests/typescript-eslint/rules/no-unused-expressions.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-basic.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-patterns.test.ts',
     './tests/typescript-eslint/rules/no-unused-vars/no-unused-vars-eslint-catch-loops.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unused-expressions.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unused-expressions.test.ts.snap
@@ -1,0 +1,1406 @@
+// Rstest Snapshot v1
+
+exports[`no-unused-expressions > invalid 1`] = `
+{
+  "code": "if (0) 0;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 2`] = `
+{
+  "code": "f(0), {};",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 3`] = `
+{
+  "code": "a, b();",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 4`] = `
+{
+  "code": "
+a() &&
+  function namedFunctionInExpressionContext() {
+    f();
+  };
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 5`] = `
+{
+  "code": "a?.b;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 6`] = `
+{
+  "code": "(a?.b).c;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 7`] = `
+{
+  "code": "a?.['b'];",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 8`] = `
+{
+  "code": "(a?.['b']).c;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 9`] = `
+{
+  "code": "a?.b()?.c;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 10`] = `
+{
+  "code": "(a?.b()).c;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 11`] = `
+{
+  "code": "one[2]?.[3][4];",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 12`] = `
+{
+  "code": "one.two?.three.four;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 13`] = `
+{
+  "code": "
+module Foo {
+  const foo = true;
+  'use strict';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 14`] = `
+{
+  "code": "
+namespace Foo {
+  export class Foo {}
+  export class Bar {}
+
+  'use strict';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 15`] = `
+{
+  "code": "
+function foo() {
+  const foo = true;
+
+  ('use strict');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 16`] = `
+{
+  "code": "foo && foo?.bar;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 17`] = `
+{
+  "code": "foo ? foo?.bar : bar.baz;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 18`] = `
+{
+  "code": "
+class Foo<T> {}
+Foo<string>;
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 19`] = `
+{
+  "code": "Map<string, string>;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 20`] = `
+{
+  "code": "
+declare const foo: number | undefined;
+foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 21`] = `
+{
+  "code": "
+declare const foo: number | undefined;
+foo as any;
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 22`] = `
+{
+  "code": "
+declare const foo: number | undefined;
+<any>foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 23`] = `
+{
+  "code": "
+declare const foo: number | undefined;
+foo!;
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 24`] = `
+{
+  "code": "true;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 25`] = `
+{
+  "code": "false;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 26`] = `
+{
+  "code": "null;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 27`] = `
+{
+  "code": "1n;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 28`] = `
+{
+  "code": "/regex/;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 29`] = `
+{
+  "code": "-a;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 30`] = `
+{
+  "code": "~a;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 31`] = `
+{
+  "code": "typeof foo;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 32`] = `
+{
+  "code": "function foo() { this; }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 33`] = `
+{
+  "code": "((a));",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 34`] = `
+{
+  "code": "a + b;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 35`] = `
+{
+  "code": "a === b;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 36`] = `
+{
+  "code": "a & b;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 37`] = `
+{
+  "code": "declare const foo: any; (foo as any)!;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 38`] = `
+{
+  "code": "declare const foo: any; (foo as any) as number;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 39`] = `
+{
+  "code": "f(), g();",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 40`] = `
+{
+  "code": "a ? b() || (c = d) : e",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 41`] = `
+{
+  "code": "class C { static { const x = 1; 'foo'; 'bar'; } }",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 42`] = `
+{
+  "code": "a && (b ?? c);",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 43`] = `
+{
+  "code": "a ? b() : c;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 44`] = `
+{
+  "code": "a['b'];",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 45`] = `
+{
+  "code": "\`hello \${world}\`;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 46`] = `
+{
+  "code": "(Foo && Foo)<string, number>;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 47`] = `
+{
+  "code": "a ? (b && c()) : (d || e)",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 48`] = `
+{
+  "code": "a?.()?.b;",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 49`] = `
+{
+  "code": "(() => {});",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 50`] = `
+{
+  "code": "(function() {});",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 51`] = `
+{
+  "code": "(class {});",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-expressions > invalid 52`] = `
+{
+  "code": "({a: 1});",
+  "diagnostics": [
+    {
+      "message": "Expected an assignment or function call and instead saw an expression.",
+      "messageId": "unusedExpression",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-expressions",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-expressions.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-expressions.test.ts
@@ -2,13 +2,7 @@ import { RuleTester } from '@typescript-eslint/rule-tester';
 
 
 
-const ruleTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      ecmaVersion: 6,
-    },
-  },
-});
+const ruleTester = new RuleTester();
 
 ruleTester.run('no-unused-expressions', {
   valid: [
@@ -72,6 +66,83 @@ ruleTester.run('no-unused-expressions', {
       code: "foo ? import('./foo') : import('./bar');",
       options: [{ allowTernary: true }],
     },
+
+    // Side-effect expressions: assignments, update, delete, void, yield, await
+    'a = b',
+    'new a',
+    'i++',
+    'i--',
+    '--i',
+    '++i',
+    'a += 1',
+    'a &&= b',
+    'a ||= b',
+    'a ??= b',
+    'delete foo.bar',
+    'void new C',
+    'function* foo(){ yield 0; }',
+    'function* foo(){ yield; }',
+    'async function foo() { await 5; }',
+
+    // TS assertions wrapping calls (inner expression has side effects)
+    'foo() as any;',
+    'foo()!;',
+    '<any>foo();',
+    'foo() satisfies string;',
+
+    // TS non-null assertion wrapping call in short-circuit
+    { code: 'foo && foo()!;', options: [{ allowShortCircuit: true }] },
+
+    // Instantiation expression wrapping call (has side effects)
+    'declare function getSet(): Set<unknown>; getSet()<string>();',
+
+    // Combined allowShortCircuit + allowTernary
+    {
+      code: 'a ? b && c() : d()',
+      options: [{ allowShortCircuit: true, allowTernary: true }],
+    },
+    {
+      code: 'a ?? b()',
+      options: [{ allowShortCircuit: true }],
+    },
+    {
+      code: 'a || b()',
+      options: [{ allowShortCircuit: true }],
+    },
+
+    // Directives: multiple, different strings, arrow body
+    '"use strict"; "use asm"; f();',
+    'var foo = () => {"use strict"; return true; }',
+
+    // String in variable declaration is not a directive (but also not a standalone expression)
+    'function foo() { var foo = "use strict"; return true; }',
+
+    // Deep nesting: TS wrappers + options combined
+    {
+      code: `
+declare const foo: Function | undefined;
+<any>(foo && foo()!)
+      `,
+      options: [{ allowShortCircuit: true }],
+    },
+    {
+      code: '(Foo && Foo())<string, number>;',
+      options: [{ allowShortCircuit: true }],
+    },
+    {
+      code: 'a ? (b && c()) : (d || e())',
+      options: [{ allowShortCircuit: true, allowTernary: true }],
+    },
+
+    // Chained optional calls
+    'a?.()?.b();',
+
+    // satisfies is NOT unwrapped (defaults to not disallowed)
+    'declare const x: string; x satisfies string;',
+    'foo() satisfies string;',
+
+    // Class static block: leading string treated as directive
+    "class C { static { 'use strict'; } }",
   ],
   invalid: [
     {
@@ -389,6 +460,164 @@ foo!;
           messageId: 'unusedExpression',
         },
       ],
+    },
+
+    // Literals: boolean, null, bigint, regex
+    {
+      code: 'true;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'false;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'null;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '1n;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '/regex/;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Unary without side effects: -, ~, typeof
+    {
+      code: '-a;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '~a;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'typeof foo;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // this / super as standalone
+    {
+      code: 'function foo() { this; }',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Nested parenthesized expressions
+    {
+      code: '((a));',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Arithmetic / comparison / bitwise binary expressions
+    {
+      code: 'a + b;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a === b;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'a & b;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // NOTE: satisfies is NOT unwrapped (matches @typescript-eslint behavior).
+    // `foo satisfies T;` is NOT flagged — see valid cases.
+
+    // Nested TS assertions wrapping non-call
+    {
+      code: 'declare const foo: any; (foo as any)!;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: 'declare const foo: any; (foo as any) as number;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Comma expression (both sides are calls, but comma itself is disallowed)
+    {
+      code: 'f(), g();',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Ternary: one branch valid, one invalid
+    {
+      code: 'a ? b() || (c = d) : e',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Class static block: leading strings are directives, non-leading flagged
+    {
+      code: "class C { static { const x = 1; 'foo'; 'bar'; } }",
+      errors: [
+        { messageId: 'unusedExpression' },
+        { messageId: 'unusedExpression' },
+      ],
+    },
+
+    // allowShortCircuit: right side must be valid
+    {
+      code: 'a && (b ?? c);',
+      options: [{ allowShortCircuit: true }],
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // allowTernary: both branches must be valid
+    {
+      code: 'a ? b() : c;',
+      options: [{ allowTernary: true }],
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Element access (no side effects)
+    {
+      code: "a['b'];",
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Template literal with interpolation
+    {
+      code: '`hello ${world}`;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+
+    // Deep nesting invalid: instantiation > short-circuit > identifier (no call)
+    {
+      code: '(Foo && Foo)<string, number>;',
+      options: [{ allowShortCircuit: true }],
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    // Deeply nested ternary + short-circuit: one branch invalid
+    {
+      code: 'a ? (b && c()) : (d || e)',
+      options: [{ allowShortCircuit: true, allowTernary: true }],
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    // Chained optional member access after call (result is member access)
+    {
+      code: 'a?.()?.b;',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    // Arrow/function/class expression as statement
+    {
+      code: '(() => {});',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '(function() {});',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    {
+      code: '(class {});',
+      errors: [{ messageId: 'unusedExpression' }],
+    },
+    // Object literal as statement
+    {
+      code: '({a: 1});',
+      errors: [{ messageId: 'unusedExpression' }],
     },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unused-expressions` rule from typescript-eslint to rslint.

Disallows unused expressions — an expression evaluated in statement position whose result is not used (e.g., bare identifiers, literals, member access, binary operators without assignment). Supports all 5 options: `allowShortCircuit`, `allowTernary`, `allowTaggedTemplates`, `enforceForJSX`, `ignoreDirectives`. Handles TypeScript-specific unwrapping for `as`, type assertions (`<T>`), non-null assertions (`!`), and instantiation expressions (`Foo<string>`).

Verified with end-to-end comparison against the original ESLint rule on both rsbuild and rspack repos — output is identical.

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-unused-expressions
- ESLint core rule: https://eslint.org/docs/latest/rules/no-unused-expressions

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).