### PR TITLE
feat: port rule no-with

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -152,6 +152,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
+	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
@@ -518,6 +519,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("prefer-const", prefer_const.PreferConstRule)
 	GlobalRuleRegistry.Register("no-this-before-super", no_this_before_super.NoThisBeforeSuperRule)
 	GlobalRuleRegistry.Register("no-var", no_var.NoVarRule)
+	GlobalRuleRegistry.Register("no-with", no_with.NoWithRule)
 	GlobalRuleRegistry.Register("prefer-rest-params", prefer_rest_params.PreferRestParamsRule)
 	GlobalRuleRegistry.Register("no-empty-character-class", no_empty_character_class.NoEmptyCharacterClassRule)
 	GlobalRuleRegistry.Register("no-invalid-regexp", no_invalid_regexp.NoInvalidRegexpRule)

--- a/internal/rules/no_with/no_with.go
+++ b/internal/rules/no_with/no_with.go
@@ -1,0 +1,21 @@
+package no_with
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-with
+var NoWithRule = rule.Rule{
+	Name: "no-with",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindWithStatement: func(node *ast.Node) {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "unexpectedWith",
+					Description: "Unexpected use of 'with' statement.",
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_with/no_with.md
+++ b/internal/rules/no_with/no_with.md
@@ -1,0 +1,25 @@
+# no-with
+
+## Rule Details
+
+Disallow `with` statements.
+
+The `with` statement is potentially problematic because it adds members of an object to the current scope, making it impossible to tell what a variable inside the block actually refers to. In strict mode, `with` statements are not allowed at all.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+with (point) {
+  r = Math.sqrt(x * x + y * y); // is r a member of point?
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const r = Math.sqrt(point.x * point.x + point.y * point.y);
+```
+
+## Original Documentation
+
+- [ESLint no-with](https://eslint.org/docs/latest/rules/no-with)

--- a/internal/rules/no_with/no_with_test.go
+++ b/internal/rules/no_with/no_with_test.go
@@ -1,0 +1,223 @@
+package no_with
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoWithRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoWithRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// Normal code
+			{Code: `foo.bar()`},
+			// "with" as property name
+			{Code: `obj.with(1)`},
+			// "with" as method name in object literal
+			{Code: `var obj = { with: function() {} }; obj.with();`},
+			// "with" in string literal
+			{Code: `var s = "with";`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// Basic with statement
+			{
+				Code: `with(foo) { bar() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+				},
+			},
+			// Single-statement body (no block)
+			{
+				Code: `with(foo) bar();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+				},
+			},
+			// Nested with inside with — two errors
+			{
+				Code: `with(a) { with(b) { c() } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+					{MessageId: "unexpectedWith", Line: 1, Column: 11},
+				},
+			},
+			// with inside function
+			{
+				Code: `function f() { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 16},
+				},
+			},
+			// with inside arrow function
+			{
+				Code: `var f = () => { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 17},
+				},
+			},
+			// with inside if block
+			{
+				Code: `if (true) { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 13},
+				},
+			},
+			// with inside for loop
+			{
+				Code: `for (;;) { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 12},
+				},
+			},
+			// with inside while loop
+			{
+				Code: `while (true) { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 16},
+				},
+			},
+			// with inside try/catch
+			{
+				Code: `try { with(obj) { x; } } catch(e) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 7},
+				},
+			},
+			// with inside switch case
+			{
+				Code: `switch(a) { case 1: with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 21},
+				},
+			},
+			// with with member expression
+			{
+				Code: `with(a.b) { c(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+				},
+			},
+			// with with call expression
+			{
+				Code: `with(a()) { b(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+				},
+			},
+			// Multiple sequential with statements — two errors
+			{
+				Code: "with(a) { x; }\nwith(b) { y; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+					{MessageId: "unexpectedWith", Line: 2, Column: 1},
+				},
+			},
+			// Multi-line with statement
+			{
+				Code: "with (obj) {\n  foo();\n  bar();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+				},
+			},
+			// with with empty body
+			{
+				Code: `with(obj) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+				},
+			},
+			// with inside class method
+			{
+				Code: `class C { method() { with(obj) { x; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 22},
+				},
+			},
+			// with inside class constructor
+			{
+				Code: `class C { constructor() { with(obj) { x; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 27},
+				},
+			},
+			// with inside static block
+			{
+				Code: `class C { static { with(obj) { x; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 20},
+				},
+			},
+			// with inside do...while
+			{
+				Code: `do { with(obj) { x; } } while(true)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 6},
+				},
+			},
+			// with inside for...in
+			{
+				Code: `for (var k in obj) { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 22},
+				},
+			},
+			// with inside for...of
+			{
+				Code: `for (var v of arr) { with(v) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 22},
+				},
+			},
+			// with inside else branch
+			{
+				Code: `if (false) {} else { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 22},
+				},
+			},
+			// with inside finally block
+			{
+				Code: `try {} finally { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 18},
+				},
+			},
+			// with inside catch block
+			{
+				Code: `try {} catch(e) { with(obj) { x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 19},
+				},
+			},
+			// with inside labeled statement
+			{
+				Code: `label: with(obj) { x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 8},
+				},
+			},
+			// Multi-byte characters (emoji surrogate pair) to verify UTF-16 code unit counting
+			{
+				Code: "/* 🚀 */ with(obj) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 10},
+				},
+			},
+			// deeply nested: with inside if inside function inside with
+			{
+				Code: `with(a) { function f() { if (true) { with(b) { x; } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedWith", Line: 1, Column: 1},
+					{MessageId: "unexpectedWith", Line: 1, Column: 38},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -248,6 +248,7 @@ export default defineConfig({
     './tests/eslint/rules/valid-typeof.test.ts',
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
+    './tests/eslint/rules/no-with.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-with.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-with.test.ts.snap
@@ -1,0 +1,752 @@
+// Rstest Snapshot v1
+
+exports[`no-with > invalid 1`] = `
+{
+  "code": "with(foo) { bar() }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 2`] = `
+{
+  "code": "with(foo) bar();",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 3`] = `
+{
+  "code": "with(a) { with(b) { c() } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 4`] = `
+{
+  "code": "function f() { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 5`] = `
+{
+  "code": "var f = () => { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 6`] = `
+{
+  "code": "if (true) { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 7`] = `
+{
+  "code": "for (;;) { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 8`] = `
+{
+  "code": "while (true) { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 9`] = `
+{
+  "code": "try { with(obj) { x; } } catch(e) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 10`] = `
+{
+  "code": "switch(a) { case 1: with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 11`] = `
+{
+  "code": "with(a.b) { c(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 12`] = `
+{
+  "code": "with(a()) { b(); }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 13`] = `
+{
+  "code": "with(a) { x; }
+with(b) { y; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 14`] = `
+{
+  "code": "with (obj) {
+  foo();
+  bar();
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 15`] = `
+{
+  "code": "with(obj) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 16`] = `
+{
+  "code": "class C { method() { with(obj) { x; } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 17`] = `
+{
+  "code": "class C { constructor() { with(obj) { x; } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 18`] = `
+{
+  "code": "class C { static { with(obj) { x; } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 19`] = `
+{
+  "code": "do { with(obj) { x; } } while(true)",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 20`] = `
+{
+  "code": "for (var k in obj) { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 21`] = `
+{
+  "code": "for (var v of arr) { with(v) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 22`] = `
+{
+  "code": "if (false) {} else { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 23`] = `
+{
+  "code": "try {} finally { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 24`] = `
+{
+  "code": "try {} catch(e) { with(obj) { x; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 25`] = `
+{
+  "code": "label: with(obj) { x; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 26`] = `
+{
+  "code": "/* 🚀 */ with(obj) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-with > invalid 27`] = `
+{
+  "code": "with(a) { function f() { if (true) { with(b) { x; } } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+    {
+      "message": "Unexpected use of 'with' statement.",
+      "messageId": "unexpectedWith",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-with",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-with.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-with.test.ts
@@ -1,0 +1,162 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-with', {
+  valid: [
+    // Normal code
+    'foo.bar()',
+    // "with" as property name
+    'obj.with(1)',
+    // "with" as method name in object literal
+    'var obj = { with: function() {} }; obj.with();',
+    // "with" in string literal
+    'var s = "with";',
+  ],
+  invalid: [
+    // Basic with statement
+    {
+      code: 'with(foo) { bar() }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // Single-statement body (no block)
+    {
+      code: 'with(foo) bar();',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // Nested with inside with — two errors
+    {
+      code: 'with(a) { with(b) { c() } }',
+      errors: [
+        { messageId: 'unexpectedWith' },
+        { messageId: 'unexpectedWith' },
+      ],
+    },
+    // with inside function
+    {
+      code: 'function f() { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside arrow function
+    {
+      code: 'var f = () => { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside if block
+    {
+      code: 'if (true) { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside for loop
+    {
+      code: 'for (;;) { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside while loop
+    {
+      code: 'while (true) { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside try/catch
+    {
+      code: 'try { with(obj) { x; } } catch(e) {}',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside switch case
+    {
+      code: 'switch(a) { case 1: with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with with member expression
+    {
+      code: 'with(a.b) { c(); }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with with call expression
+    {
+      code: 'with(a()) { b(); }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // Multiple sequential with statements — two errors
+    {
+      code: 'with(a) { x; }\nwith(b) { y; }',
+      errors: [
+        { messageId: 'unexpectedWith' },
+        { messageId: 'unexpectedWith' },
+      ],
+    },
+    // Multi-line with statement
+    {
+      code: 'with (obj) {\n  foo();\n  bar();\n}',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with with empty body
+    {
+      code: 'with(obj) {}',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside class method
+    {
+      code: 'class C { method() { with(obj) { x; } } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside class constructor
+    {
+      code: 'class C { constructor() { with(obj) { x; } } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside static block
+    {
+      code: 'class C { static { with(obj) { x; } } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside do...while
+    {
+      code: 'do { with(obj) { x; } } while(true)',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside for...in
+    {
+      code: 'for (var k in obj) { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside for...of
+    {
+      code: 'for (var v of arr) { with(v) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside else branch
+    {
+      code: 'if (false) {} else { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside finally block
+    {
+      code: 'try {} finally { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside catch block
+    {
+      code: 'try {} catch(e) { with(obj) { x; } }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // with inside labeled statement
+    {
+      code: 'label: with(obj) { x; }',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // Multi-byte characters (emoji surrogate pair) to verify UTF-16 code unit counting
+    {
+      code: '/* 🚀 */ with(obj) {}',
+      errors: [{ messageId: 'unexpectedWith' }],
+    },
+    // deeply nested: with inside if inside function inside with
+    {
+      code: 'with(a) { function f() { if (true) { with(b) { x; } } } }',
+      errors: [
+        { messageId: 'unexpectedWith' },
+        { messageId: 'unexpectedWith' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint `no-with` rule, which disallows `with` statements.

- Go implementation: `internal/rules/no_with/`
- Rule registration in `internal/config/config.go`
- Go tests: 4 valid + 26 invalid cases covering all syntax contexts (nesting, loops, classes, try/catch/finally, labeled statements, etc.)
- JS tests synced with Go tests, snapshots generated
- Verified on rsbuild (1192 files) and rspack (748 files) with zero false positives

## Related Links

- [ESLint no-with](https://eslint.org/docs/latest/rules/no-with)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).