### PR TITLE
feat: port rule @typescript-eslint/parameter-properties

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -74,6 +74,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/non_nullable_type_assertion_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/only_throw_error"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/parameter_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_as_const"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
@@ -439,6 +440,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/non-nullable-type-assertion-style", non_nullable_type_assertion_style.NonNullableTypeAssertionStyleRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/only-throw-error", only_throw_error.OnlyThrowErrorRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/parameter-properties", parameter_properties.ParameterPropertiesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-as-const", prefer_as_const.PreferAsConstRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-includes", prefer_includes.PreferIncludesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties.go
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties.go
@@ -1,0 +1,337 @@
+package parameter_properties
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Modifier values that match the ESLint option schema:
+// "readonly", "private", "protected", "public",
+// "private readonly", "protected readonly", "public readonly"
+
+type options struct {
+	allow  map[string]bool
+	prefer string
+}
+
+func parseOptions(rawOpts any) options {
+	o := options{
+		allow:  make(map[string]bool),
+		prefer: "class-property",
+	}
+	optsMap := utils.GetOptionsMap(rawOpts)
+	if optsMap == nil {
+		return o
+	}
+	if allow, ok := optsMap["allow"].([]interface{}); ok {
+		for _, a := range allow {
+			if s, ok := a.(string); ok {
+				o.allow[s] = true
+			}
+		}
+	}
+	if prefer, ok := optsMap["prefer"].(string); ok {
+		o.prefer = prefer
+	}
+	return o
+}
+
+// getModifiers builds the ESLint-style modifier string (e.g. "public readonly") from a node's
+// accessibility and readonly flags. The result is used to match against the user's "allow" list.
+// NOTE: class_literal_property_style has a similar printNodeModifiers, but it also handles
+// "static" and serves a different purpose (generating replacement code text).
+func getModifiers(node *ast.Node) string {
+	var parts []string
+	flags := ast.GetCombinedModifierFlags(node)
+	if flags&ast.ModifierFlagsPublic != 0 {
+		parts = append(parts, "public")
+	} else if flags&ast.ModifierFlagsProtected != 0 {
+		parts = append(parts, "protected")
+	} else if flags&ast.ModifierFlagsPrivate != 0 {
+		parts = append(parts, "private")
+	}
+	if flags&ast.ModifierFlagsReadonly != 0 {
+		parts = append(parts, "readonly")
+	}
+	return strings.Join(parts, " ")
+}
+
+func buildPreferClassPropertyMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferClassProperty",
+		Description: fmt.Sprintf("Property %s should be declared as a class property.", name),
+	}
+}
+
+func buildPreferParameterPropertyMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferParameterProperty",
+		Description: fmt.Sprintf("Property %s should be declared as a parameter property.", name),
+	}
+}
+
+// propertyNodes tracks the three pieces that must all exist for a
+// "prefer parameter-property" violation: the class property declaration,
+// a matching constructor parameter, and a leading `this.X = X` assignment.
+type propertyNodes struct {
+	classProperty         *ast.Node
+	constructorParameter  *ast.Node
+	constructorAssignment bool
+}
+
+var ParameterPropertiesRule = rule.CreateRule(rule.Rule{
+	Name: "parameter-properties",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		if opts.prefer == "class-property" {
+			return rule.RuleListeners{
+				ast.KindParameter: func(node *ast.Node) {
+					if node.Parent == nil {
+						return
+					}
+					// Check if this parameter is a parameter property
+					if !ast.IsParameterPropertyDeclaration(node, node.Parent) {
+						return
+					}
+
+					param := node.AsParameterDeclaration()
+					if param == nil {
+						return
+					}
+
+					// Skip rest parameters (e.g., private ...name: string[])
+					if param.DotDotDotToken != nil {
+						return
+					}
+
+					// Skip destructured parameters (e.g., private [test]: [string])
+					nameNode := node.Name()
+					if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+						return
+					}
+
+					modifiers := getModifiers(node)
+					if opts.allow[modifiers] {
+						return
+					}
+
+					paramName := nameNode.AsIdentifier().Text
+					ctx.ReportNode(node, buildPreferClassPropertyMessage(paramName))
+				},
+			}
+		}
+
+		// "parameter-property" mode: use a stack to handle nested classes.
+		// Each map tracks {name → propertyNodes} for the current class scope.
+		var propertyNodesByNameStack []map[string]*propertyNodes
+
+		getNodesByName := func(name string) *propertyNodes {
+			m := propertyNodesByNameStack[len(propertyNodesByNameStack)-1]
+			if existing, ok := m[name]; ok {
+				return existing
+			}
+			created := &propertyNodes{}
+			m[name] = created
+			return created
+		}
+
+		// typeAnnotationsMatch checks that both nodes either lack type annotations or
+		// have identical annotation text. ESLint compares getText(TSTypeAnnotation)
+		// which includes leading trivia (whitespace after the colon). We use
+		// GetSourceTextOfNodeFromSourceFile with includeTrivia=true to preserve
+		// the same trivia-sensitive comparison — TrimmedNodeText would strip the
+		// trivia and falsely match cases like ":  string" vs ": string".
+		typeAnnotationsMatch := func(classProp *ast.Node, ctorParam *ast.Node) bool {
+			propType := classProp.AsPropertyDeclaration().Type
+			paramType := ctorParam.AsParameterDeclaration().Type
+
+			if propType == nil || paramType == nil {
+				return propType == paramType
+			}
+
+			return scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, propType, true) ==
+				scanner.GetSourceTextOfNodeFromSourceFile(ctx.SourceFile, paramType, true)
+		}
+
+		enterClass := func(node *ast.Node) {
+			propertyNodesByNameStack = append(propertyNodesByNameStack, make(map[string]*propertyNodes))
+
+			// Process class body members (equivalent to ClassBody visitor in ESLint)
+			members := node.Members()
+			for _, member := range members {
+				if member.Kind != ast.KindPropertyDeclaration {
+					continue
+				}
+				propDecl := member.AsPropertyDeclaration()
+				if propDecl == nil {
+					continue
+				}
+				nameNode := propDecl.Name()
+				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+					continue
+				}
+				// Skip properties with initializers
+				if propDecl.Initializer != nil {
+					continue
+				}
+				// Skip if modifier is in allow list
+				if opts.allow[getModifiers(member)] {
+					continue
+				}
+				getNodesByName(nameNode.AsIdentifier().Text).classProperty = member
+			}
+		}
+
+		exitClass := func(node *ast.Node) {
+			if len(propertyNodesByNameStack) == 0 {
+				return
+			}
+			m := propertyNodesByNameStack[len(propertyNodesByNameStack)-1]
+			propertyNodesByNameStack = propertyNodesByNameStack[:len(propertyNodesByNameStack)-1]
+
+			// Collect violations and sort by source position so that
+			// diagnostics are emitted in deterministic document order
+			// (Go map iteration order is not guaranteed).
+			type violation struct {
+				name string
+				node *ast.Node
+			}
+			var violations []violation
+			for name, nodes := range m {
+				if nodes.classProperty != nil &&
+					nodes.constructorAssignment &&
+					nodes.constructorParameter != nil &&
+					typeAnnotationsMatch(nodes.classProperty, nodes.constructorParameter) {
+					violations = append(violations, violation{name, nodes.classProperty})
+				}
+			}
+			sort.Slice(violations, func(i, j int) bool {
+				return violations[i].node.Pos() < violations[j].node.Pos()
+			})
+			for _, v := range violations {
+				ctx.ReportNode(v.node, buildPreferParameterPropertyMessage(v.name))
+			}
+		}
+
+		listeners := rule.RuleListeners{
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				enterClass(node)
+			},
+			rule.ListenerOnExit(ast.KindClassDeclaration): func(node *ast.Node) {
+				exitClass(node)
+			},
+			ast.KindClassExpression: func(node *ast.Node) {
+				enterClass(node)
+			},
+			rule.ListenerOnExit(ast.KindClassExpression): func(node *ast.Node) {
+				exitClass(node)
+			},
+			ast.KindConstructor: func(node *ast.Node) {
+				if len(propertyNodesByNameStack) == 0 {
+					return
+				}
+
+				constructor := node.AsConstructorDeclaration()
+				if constructor == nil {
+					return
+				}
+
+				// Record plain constructor parameters (not parameter properties).
+				// In ESLint's AST, TSParameterProperty is a separate node type that
+				// doesn't match Identifier, so parameter properties are naturally skipped.
+				// In Go's AST there is no separate kind — we must explicitly skip them.
+				var params []*ast.Node
+				if constructor.Parameters != nil {
+					params = constructor.Parameters.Nodes
+				}
+				for _, param := range params {
+					if param.Kind != ast.KindParameter {
+						continue
+					}
+					// Skip parameter properties (already have a modifier)
+					if ast.IsParameterPropertyDeclaration(param, node) {
+						continue
+					}
+					paramDecl := param.AsParameterDeclaration()
+					if paramDecl == nil {
+						continue
+					}
+					// Skip rest parameters — ESLint's RestElement !== Identifier.
+					if paramDecl.DotDotDotToken != nil {
+						continue
+					}
+					// Skip parameters with default values — ESLint's AssignmentPattern !== Identifier.
+					if paramDecl.Initializer != nil {
+						continue
+					}
+					nameNode := param.Name()
+					if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+						continue
+					}
+					getNodesByName(nameNode.AsIdentifier().Text).constructorParameter = param
+				}
+
+				// Scan leading statements of the form `this.X = Y` (where Y is an identifier).
+				// Stop at the first non-matching statement, matching ESLint's break behavior.
+				if constructor.Body == nil {
+					return
+				}
+				statements := constructor.Body.Statements()
+				for _, stmt := range statements {
+					if stmt.Kind != ast.KindExpressionStatement {
+						break
+					}
+					expr := stmt.Expression()
+					if expr == nil || expr.Kind != ast.KindBinaryExpression {
+						break
+					}
+					binExpr := expr.AsBinaryExpression()
+					// ESLint checks for AssignmentExpression which covers all assignment
+					// operators (=, +=, -=, etc.), not just plain =.
+					if !ast.IsAssignmentOperator(binExpr.OperatorToken.Kind) {
+						break
+					}
+					// Left side must be this.X — ESLint checks MemberExpression which
+					// covers both PropertyAccessExpression (this.x) and
+					// ElementAccessExpression (this[x]) with an Identifier argument.
+					left := binExpr.Left
+					if left.Kind == ast.KindPropertyAccessExpression {
+						propAccess := left.AsPropertyAccessExpression()
+						if propAccess.Expression.Kind != ast.KindThisKeyword {
+							break
+						}
+						if propAccess.Name().Kind != ast.KindIdentifier {
+							break
+						}
+					} else if left.Kind == ast.KindElementAccessExpression {
+						elemAccess := left.AsElementAccessExpression()
+						if elemAccess.Expression.Kind != ast.KindThisKeyword {
+							break
+						}
+						if elemAccess.ArgumentExpression == nil || elemAccess.ArgumentExpression.Kind != ast.KindIdentifier {
+							break
+						}
+					} else {
+						break
+					}
+					// Right side must be an identifier
+					right := binExpr.Right
+					if right.Kind != ast.KindIdentifier {
+						break
+					}
+					rightName := right.AsIdentifier().Text
+					getNodesByName(rightName).constructorAssignment = true
+				}
+			},
+		}
+
+		return listeners
+	},
+})

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties.md
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties.md
@@ -1,0 +1,59 @@
+# parameter-properties
+
+## Rule Details
+
+Require or disallow parameter properties in class constructors.
+
+TypeScript includes a shorthand for declaring and initializing class members from constructor parameters called parameter properties. This rule can be used to enforce consistent usage of this feature.
+
+## Options
+
+- `prefer` (`"class-property"` | `"parameter-property"`): Whether to prefer class properties or parameter properties. Default: `"class-property"`.
+- `allow` (array of modifiers): Which parameter property modifiers to allow. Valid values: `"readonly"`, `"private"`, `"protected"`, `"public"`, `"private readonly"`, `"protected readonly"`, `"public readonly"`. Default: `[]`.
+
+### `prefer: "class-property"` (default)
+
+Examples of **incorrect** code:
+
+```typescript
+class Foo {
+  constructor(readonly name: string) {}
+}
+
+class Bar {
+  constructor(private age: number) {}
+}
+```
+
+Examples of **correct** code:
+
+```typescript
+class Foo {
+  constructor(name: string) {}
+}
+```
+
+### `prefer: "parameter-property"`
+
+Examples of **incorrect** code:
+
+```typescript
+class Foo {
+  member: string;
+  constructor(member: string) {
+    this.member = member;
+  }
+}
+```
+
+Examples of **correct** code:
+
+```typescript
+class Foo {
+  constructor(private member: string) {}
+}
+```
+
+## Original Documentation
+
+https://typescript-eslint.io/rules/parameter-properties

--- a/internal/plugins/typescript/rules/parameter_properties/parameter_properties_test.go
+++ b/internal/plugins/typescript/rules/parameter_properties/parameter_properties_test.go
@@ -1,0 +1,983 @@
+package parameter_properties
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestParameterProperties(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ParameterPropertiesRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// prefer: "class-property" (default) — valid cases
+		// ============================================================
+
+		// --- Basic: no parameter properties ---
+		{Code: `class Foo { constructor(name: string) {} }`},
+		{Code: `class Foo { constructor(name: string) {} }`, Options: map[string]interface{}{"prefer": "class-property"}},
+		{Code: `class Foo { constructor(...name: string[]) {} }`},
+		{Code: `class Foo { constructor(name: string, age: number) {} }`},
+
+		// --- Constructor overloads without parameter properties ---
+		{Code: `
+class Foo {
+  constructor(name: string) {}
+  constructor(name: string, age?: number) {}
+}`},
+
+		// --- Allow specific modifiers (all 7 combinations) ---
+		{Code: `class Foo { constructor(readonly name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"readonly"}}},
+		{Code: `class Foo { constructor(private name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"private"}}},
+		{Code: `class Foo { constructor(protected name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"protected"}}},
+		{Code: `class Foo { constructor(public name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"public"}}},
+		{Code: `class Foo { constructor(private readonly name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"private readonly"}}},
+		{Code: `class Foo { constructor(protected readonly name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"protected readonly"}}},
+		{Code: `class Foo { constructor(public readonly name: string) {} }`, Options: map[string]interface{}{"allow": []interface{}{"public readonly"}}},
+
+		// --- Multiple allowed modifiers ---
+		{
+			Code: `
+class Foo {
+  constructor(
+    readonly name: string,
+    private age: number,
+  ) {}
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"readonly", "private"}},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(
+    public readonly name: string,
+    private age: number,
+  ) {}
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"public readonly", "private"}},
+		},
+
+		// --- Semantically invalid: rest / destructured parameter properties ---
+		{Code: `class Foo { constructor(private ...name: string[]) {} }`},
+		{Code: `class Foo { constructor(private [test]: [string]) {} }`},
+
+		// ============================================================
+		// prefer: "parameter-property" — valid cases
+		// ============================================================
+
+		// --- Parameter property already used (no class property to convert) ---
+		{Code: `class Foo { constructor(private name: string[]) {} }`, Options: map[string]interface{}{"prefer": "parameter-property"}},
+		{Code: `class Foo { constructor(...name: string[]) {} }`, Options: map[string]interface{}{"prefer": "parameter-property"}},
+		{Code: `class Foo { constructor(age: string, ...name: string[]) {} }`, Options: map[string]interface{}{"prefer": "parameter-property"}},
+		{
+			Code: `
+class Foo {
+  constructor(
+    private age: string,
+    ...name: string[]
+  ) {}
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Type mismatch (different types) ---
+		{
+			Code: `
+class Foo {
+  public age: number;
+  constructor(age: string) {
+    this.age = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Property has initializer ---
+		{
+			Code: `
+class Foo {
+  public age = '';
+  constructor(age: string) {
+    this.age = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- One has type, the other doesn't ---
+		{
+			Code: `
+class Foo {
+  public age;
+  constructor(age: string) {
+    this.age = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+		{
+			Code: `
+class Foo {
+  public age: string;
+  constructor(age) {
+    this.age = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Non-leading assignment (chain broken before this.X = X) ---
+		{
+			Code: `
+class Foo {
+  public age: string;
+  constructor(age: string) {
+    console.log('unrelated');
+    this.age = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Different property name vs parameter name ---
+		{
+			Code: `
+class Foo {
+  other: string;
+  constructor(age: string) {
+    this.other = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Assignment RHS is not the parameter identifier ---
+		{
+			Code: `
+class Foo {
+  age: string;
+  constructor(age: string) {
+    this.age = '';
+    console.log(age);
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Property is a method, not a field ---
+		{
+			Code: `
+class Foo {
+  age() {
+    return '';
+  }
+  constructor(age: string) {
+    this.age = age;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Allow specific modifiers with prefer: parameter-property (all 6 combinations) ---
+		{
+			Code: `
+class Foo {
+  public age: string;
+  constructor(age: string) { this.age = age; }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"public"}, "prefer": "parameter-property"},
+		},
+		{
+			Code: `
+class Foo {
+  public readonly age: string;
+  constructor(age: string) { this.age = age; }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"public readonly"}, "prefer": "parameter-property"},
+		},
+		{
+			Code: `
+class Foo {
+  protected age: string;
+  constructor(age: string) { this.age = age; }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"protected"}, "prefer": "parameter-property"},
+		},
+		{
+			Code: `
+class Foo {
+  protected readonly age: string;
+  constructor(age: string) { this.age = age; }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"protected readonly"}, "prefer": "parameter-property"},
+		},
+		{
+			Code: `
+class Foo {
+  private age: string;
+  constructor(age: string) { this.age = age; }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"private"}, "prefer": "parameter-property"},
+		},
+		{
+			Code: `
+class Foo {
+  private readonly age: string;
+  constructor(age: string) { this.age = age; }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"private readonly"}, "prefer": "parameter-property"},
+		},
+
+		// ============================================================
+		// Edge cases — prefer: "parameter-property" — valid
+		// ============================================================
+
+		// --- Element access with string literal: this['member'] = member ---
+		// ESLint MemberExpression check passes, but property.type is Literal (not
+		// Identifier), so it breaks. Valid (no match).
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(member: string) {
+    this['member'] = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Computed property name on class property ---
+		{
+			Code: `
+class Foo {
+  ['member']: string;
+  constructor(member: string) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Empty constructor body ---
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(member: string) {}
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Constructor without body (overload declaration) ---
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(member: string);
+  constructor(member: string, extra?: number) {
+    console.log(extra);
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Non-identifier RHS breaks chain: this.x = x + 1 ---
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(member: string) {
+    this.member = member + '!';
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Assignment chain broken — second property not tracked ---
+		{
+			Code: `
+class Foo {
+  b: string;
+  constructor(a: string, b: string) {
+    this.a = a;
+    console.log('break');
+    this.b = b;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Inner class property should NOT match outer constructor ---
+		{
+			Code: `
+class Outer {
+  constructor(member: string) {
+    this.member = member;
+  }
+}
+class Inner {
+  member: string;
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Nested: outer property + inner constructor should NOT cross-match ---
+		{
+			Code: `
+class Outer {
+  member: string;
+  method() {
+    class Inner {
+      constructor(member: string) {
+        this.member = member;
+      }
+    }
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Parameter already IS a parameter property → should NOT report ---
+		// ESLint skips TSParameterProperty in the constructor handler;
+		// in Go we must explicitly skip parameters with modifiers.
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(private member: string) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- super() before assignments breaks the chain ---
+		{
+			Code: `
+class Foo extends Bar {
+  member: string;
+  constructor(member: string) {
+    super();
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Compound assignment (+=) does NOT break the chain ---
+		// ESLint checks for AssignmentExpression which includes all assignment
+		// operators, so this.member += member is still treated as a matching
+		// assignment (same as this.member = member). This is a quirk of the
+		// original rule — it matches the syntactic pattern, not the semantics.
+		// Moved to invalid cases below.
+
+		// --- Destructured parameter → constructorParameter not set ---
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor({ member }: { member: string }) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Rest parameter → constructorParameter not set ---
+		// ESLint: RestElement !== Identifier, so rest params are skipped.
+		{
+			Code: `
+class Foo {
+  args: string[];
+  constructor(...args: string[]) {
+    this.args = args;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Default value parameter → constructorParameter not set ---
+		// ESLint: AssignmentPattern !== Identifier, so params with defaults are skipped.
+		{
+			Code: `
+class Foo {
+  x: string;
+  constructor(x: string = 'default') {
+    this.x = x;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+
+		// --- Type annotation whitespace mismatch → no match ---
+		// ESLint compares getText(TSTypeAnnotation) which includes trivia after
+		// the colon. Different whitespace means different text → types don't match.
+		{
+			Code: `
+class Foo {
+  member:  string;
+  constructor(member: string) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// prefer: "class-property" (default) — invalid cases
+		// ============================================================
+
+		// --- All 7 modifier combinations ---
+		{
+			Code:   "\nclass Foo {\n  constructor(readonly name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+		{
+			Code:   "\nclass Foo {\n  constructor(private name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+		{
+			Code:   "\nclass Foo {\n  constructor(protected name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+		{
+			Code:   "\nclass Foo {\n  constructor(public name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+		{
+			Code:   "\nclass Foo {\n  constructor(private readonly name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+		{
+			Code:   "\nclass Foo {\n  constructor(protected readonly name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+		{
+			Code:   "\nclass Foo {\n  constructor(public readonly name: string) {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+
+		// --- Mixed: one param-property + one plain ---
+		{
+			Code: `
+class Foo {
+  constructor(
+    public name: string,
+    age: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 4, Column: 5}},
+		},
+
+		// --- Multiple parameter properties ---
+		{
+			Code: `
+class Foo {
+  constructor(
+    private name: string,
+    private age: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 4, Column: 5},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(
+    protected name: string,
+    protected age: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 4, Column: 5},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(
+    public name: string,
+    public age: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 4, Column: 5},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+			},
+		},
+
+		// --- Constructor overloads ---
+		{
+			Code: `
+class Foo {
+  constructor(name: string) {}
+  constructor(
+    private name: string,
+    age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 5, Column: 5}},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    private age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+				{MessageId: "preferClassProperty", Line: 6, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(name: string) {}
+  constructor(
+    protected name: string,
+    age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 5, Column: 5}},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(protected name: string) {}
+  constructor(
+    protected name: string,
+    age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(protected name: string) {}
+  constructor(
+    protected name: string,
+    protected age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+				{MessageId: "preferClassProperty", Line: 6, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(name: string) {}
+  constructor(
+    public name: string,
+    age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 5, Column: 5}},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(public name: string) {}
+  constructor(
+    public name: string,
+    age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(public name: string) {}
+  constructor(
+    public name: string,
+    public age?: number,
+  ) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 5, Column: 5},
+				{MessageId: "preferClassProperty", Line: 6, Column: 5},
+			},
+		},
+
+		// --- Allow options ---
+		{
+			Code:    `class Foo { constructor(readonly name: string) {} }`,
+			Options: map[string]interface{}{"allow": []interface{}{"private"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+		{
+			Code:    `class Foo { constructor(private name: string) {} }`,
+			Options: map[string]interface{}{"allow": []interface{}{"readonly"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+		{
+			Code:    `class Foo { constructor(protected name: string) {} }`,
+			Options: map[string]interface{}{"allow": []interface{}{"readonly", "private", "public", "protected readonly"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+		{
+			Code:    `class Foo { constructor(public name: string) {} }`,
+			Options: map[string]interface{}{"allow": []interface{}{"readonly", "private", "protected", "protected readonly", "public readonly"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+		{
+			Code:    `class Foo { constructor(private readonly name: string) {} }`,
+			Options: map[string]interface{}{"allow": []interface{}{"readonly", "private"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+		{
+			Code:    `class Foo { constructor(protected readonly name: string) {} }`,
+			Options: map[string]interface{}{"allow": []interface{}{"readonly", "protected", "private readonly", "public readonly"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+		{
+			Code: `
+class Foo {
+  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    protected age?: number,
+  ) {}
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"private"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 6, Column: 5}},
+		},
+
+		// ============================================================
+		// prefer: "class-property" — edge case invalid
+		// ============================================================
+
+		// --- Nested class: inner class reports its own parameter property ---
+		{
+			Code: `
+class Outer {
+  method() {
+    class Inner {
+      constructor(private x: string) {}
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 5, Column: 19}},
+		},
+
+		// --- Class expression ---
+		{
+			Code:   `const A = class { constructor(private x: string) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+
+		// --- Class expression nested in class ---
+		{
+			Code: `
+class Outer {
+  foo = class {
+    constructor(private x: string) {}
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 4, Column: 17}},
+		},
+
+		// --- Decorator on parameter property (still reported) ---
+		{
+			Code: `
+class Foo {
+  constructor(@Inject private name: string) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+
+		// --- Default value on parameter property ---
+		{
+			Code:   `class Foo { constructor(private name: string = 'default') {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+
+		// --- Abstract class ---
+		{
+			Code: `
+abstract class Foo {
+  constructor(private name: string) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+
+		// --- Generic class ---
+		{
+			Code: `
+class Foo<T> {
+  constructor(private name: T) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+
+		// --- Extends class ---
+		{
+			Code: `
+class Foo extends Bar {
+  constructor(private name: string) {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty", Line: 3, Column: 15}},
+		},
+
+		// --- Optional parameter property ---
+		{
+			Code:   `class Foo { constructor(private name?: string) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferClassProperty"}},
+		},
+
+		// --- Both outer and inner classes have parameter properties ---
+		// Note: inner class is visited and exited before outer in AST traversal,
+		// so inner's error is emitted first.
+		{
+			Code: `
+class Outer {
+  constructor(private x: string) {}
+  method() {
+    class Inner {
+      constructor(private y: string) {}
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferClassProperty", Line: 3, Column: 15},
+				{MessageId: "preferClassProperty", Line: 6, Column: 19},
+			},
+		},
+
+		// ============================================================
+		// prefer: "parameter-property" — invalid cases
+		// ============================================================
+
+		// --- Basic: property before constructor ---
+		{
+			Code: `
+class Foo {
+  member: string;
+
+  constructor(member: string) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// --- Property after constructor ---
+		{
+			Code: `
+class Foo {
+  constructor(member: string) {
+    this.member = member;
+  }
+
+  member: string;
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 7, Column: 3}},
+		},
+
+		// --- Both have no type annotation ---
+		{
+			Code: `
+class Foo {
+  member;
+  constructor(member) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// --- With allow list ---
+		{
+			Code: `
+class Foo {
+  public member: string;
+  constructor(member: string) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"allow": []interface{}{"protected", "private", "readonly"}, "prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// ============================================================
+		// prefer: "parameter-property" — edge case invalid
+		// ============================================================
+
+		// --- Multiple leading assignments → all tracked ---
+		{
+			Code: `
+class Foo {
+  a: string;
+  b: string;
+  constructor(a: string, b: string) {
+    this.a = a;
+    this.b = b;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferParameterProperty", Line: 3, Column: 3},
+				{MessageId: "preferParameterProperty", Line: 4, Column: 3},
+			},
+		},
+
+		// --- Assignment chain broken → only first property tracked ---
+		{
+			Code: `
+class Foo {
+  a: string;
+  b: string;
+  constructor(a: string, b: string) {
+    this.a = a;
+    console.log('break');
+    this.b = b;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// --- Class expression ---
+		{
+			Code: `
+const A = class {
+  member: string;
+  constructor(member: string) {
+    this.member = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// --- Nested classes: both outer and inner have violations ---
+		// Inner class exits first in AST traversal, so inner's error is emitted first.
+		{
+			Code: `
+class Outer {
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  method() {
+    class Inner {
+      age: string;
+      constructor(age: string) {
+        this.age = age;
+      }
+    }
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferParameterProperty", Line: 9, Column: 7},
+				{MessageId: "preferParameterProperty", Line: 3, Column: 3},
+			},
+		},
+
+		// --- Nested: same property name in outer and inner (independent scopes) ---
+		{
+			Code: `
+class Outer {
+  member: string;
+  constructor(member: string) {
+    this.member = member;
+  }
+  method() {
+    class Inner {
+      member: string;
+      constructor(member: string) {
+        this.member = member;
+      }
+    }
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferParameterProperty", Line: 9, Column: 7},
+				{MessageId: "preferParameterProperty", Line: 3, Column: 3},
+			},
+		},
+
+		// --- Computed element access this[member] = member (Identifier arg) ---
+		// ESLint MemberExpression covers both this.x and this[x]. When the
+		// argument is an Identifier, it passes the property.type === Identifier check.
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(member: string) {
+    this[member] = member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// --- Compound assignment (+=) still matches (ESLint quirk) ---
+		{
+			Code: `
+class Foo {
+  member: string;
+  constructor(member: string) {
+    this.member += member;
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 3, Column: 3}},
+		},
+
+		// --- Nested class expression ---
+		{
+			Code: `
+class Outer {
+  bar = class {
+    member: string;
+    constructor(member: string) {
+      this.member = member;
+    }
+  }
+}`,
+			Options: map[string]interface{}{"prefer": "parameter-property"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "preferParameterProperty", Line: 4, Column: 5}},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -197,7 +197,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no_namespace.test.ts',
     './tests/typescript-eslint/rules/non-nullable-type-assertion-style.test.ts',
     './tests/typescript-eslint/rules/only-throw-error.test.ts',
-    // './tests/typescript-eslint/rules/parameter-properties.test.ts',
+    './tests/typescript-eslint/rules/parameter-properties.test.ts',
     './tests/typescript-eslint/rules/prefer-as-const.test.ts',
     // './tests/typescript-eslint/rules/prefer-destructuring.test.ts',
     // './tests/typescript-eslint/rules/prefer-enum-initializers.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/parameter-properties.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/parameter-properties.test.ts.snap
@@ -1,0 +1,1177 @@
+// Rstest Snapshot v1
+
+exports[`parameter-properties > invalid 1`] = `
+{
+  "code": "
+class Foo {
+  constructor(readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 2`] = `
+{
+  "code": "
+class Foo {
+  constructor(private name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 3`] = `
+{
+  "code": "
+class Foo {
+  constructor(protected name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 4`] = `
+{
+  "code": "
+class Foo {
+  constructor(public name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 5`] = `
+{
+  "code": "
+class Foo {
+  constructor(private readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 6`] = `
+{
+  "code": "
+class Foo {
+  constructor(protected readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 7`] = `
+{
+  "code": "
+class Foo {
+  constructor(public readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 8`] = `
+{
+  "code": "
+class Foo {
+  constructor(
+    public name: string,
+    age: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 9`] = `
+{
+  "code": "
+class Foo {
+  constructor(
+    private name: string,
+    private age: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 10`] = `
+{
+  "code": "
+class Foo {
+  constructor(
+    protected name: string,
+    protected age: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 11`] = `
+{
+  "code": "
+class Foo {
+  constructor(
+    public name: string,
+    public age: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 12`] = `
+{
+  "code": "
+class Foo {
+  constructor(name: string) {}
+  constructor(
+    private name: string,
+    age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 13`] = `
+{
+  "code": "
+class Foo {
+  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 14`] = `
+{
+  "code": "
+class Foo {
+  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    private age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 15`] = `
+{
+  "code": "
+class Foo {
+  constructor(name: string) {}
+  constructor(
+    protected name: string,
+    age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 16`] = `
+{
+  "code": "
+class Foo {
+  constructor(protected name: string) {}
+  constructor(
+    protected name: string,
+    age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 17`] = `
+{
+  "code": "
+class Foo {
+  constructor(protected name: string) {}
+  constructor(
+    protected name: string,
+    protected age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 18`] = `
+{
+  "code": "
+class Foo {
+  constructor(name: string) {}
+  constructor(
+    public name: string,
+    age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 19`] = `
+{
+  "code": "
+class Foo {
+  constructor(public name: string) {}
+  constructor(
+    public name: string,
+    age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 20`] = `
+{
+  "code": "
+class Foo {
+  constructor(public name: string) {}
+  constructor(
+    public name: string,
+    public age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 21`] = `
+{
+  "code": "
+class Foo {
+  constructor(readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 22`] = `
+{
+  "code": "
+class Foo {
+  constructor(private name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 23`] = `
+{
+  "code": "
+class Foo {
+  constructor(protected name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 24`] = `
+{
+  "code": "
+class Foo {
+  constructor(public name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 25`] = `
+{
+  "code": "
+class Foo {
+  constructor(private readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 26`] = `
+{
+  "code": "
+class Foo {
+  constructor(protected readonly name: string) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property name should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 27`] = `
+{
+  "code": "
+class Foo {
+  constructor(private name: string) {}
+  constructor(
+    private name: string,
+    protected age?: number,
+  ) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property age should be declared as a class property.",
+      "messageId": "preferClassProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 28`] = `
+{
+  "code": "
+class Foo {
+  member: string;
+
+  constructor(member: string) {
+    this.member = member;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property member should be declared as a parameter property.",
+      "messageId": "preferParameterProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 29`] = `
+{
+  "code": "
+class Foo {
+  constructor(member: string) {
+    this.member = member;
+  }
+
+  member: string;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property member should be declared as a parameter property.",
+      "messageId": "preferParameterProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 7,
+        },
+        "start": {
+          "column": 3,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 30`] = `
+{
+  "code": "
+class Foo {
+  member;
+  constructor(member) {
+    this.member = member;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property member should be declared as a parameter property.",
+      "messageId": "preferParameterProperty",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`parameter-properties > invalid 31`] = `
+{
+  "code": "
+class Foo {
+  public member: string;
+  constructor(member: string) {
+    this.member = member;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Property member should be declared as a parameter property.",
+      "messageId": "preferParameterProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/parameter-properties",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/parameter-properties` rule from typescript-eslint to rslint.

This rule requires or disallows parameter properties in class constructors. It supports two modes:

- `prefer: "class-property"` (default): Disallows parameter properties (flags `constructor(private name: string)`)
- `prefer: "parameter-property"`: Flags class properties that could be condensed into parameter properties

Supports an `allow` option to whitelist specific modifier combinations (`readonly`, `private`, `protected`, `public`, `private readonly`, `protected readonly`, `public readonly`).

## Related Links

- Rule documentation: https://typescript-eslint.io/rules/parameter-properties
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/parameter-properties.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).