### PR TITLE
feat: port rule no-labels

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,8 +130,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
-	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
+	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
@@ -510,8 +510,8 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-empty-pattern", no_empty_pattern.NoEmptyPatternRule)
 	GlobalRuleRegistry.Register("no-eval", no_eval.NoEvalRule)
 	GlobalRuleRegistry.Register("no-ex-assign", no_ex_assign.NoExAssignRule)
-	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-extra-bind", no_extra_bind.NoExtraBindRule)
+	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)
 	GlobalRuleRegistry.Register("no-global-assign", no_global_assign.NoGlobalAssignRule)
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
+	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
@@ -509,6 +510,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-empty-pattern", no_empty_pattern.NoEmptyPatternRule)
 	GlobalRuleRegistry.Register("no-eval", no_eval.NoEvalRule)
 	GlobalRuleRegistry.Register("no-ex-assign", no_ex_assign.NoExAssignRule)
+	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-extra-bind", no_extra_bind.NoExtraBindRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)
 	GlobalRuleRegistry.Register("no-global-assign", no_global_assign.NoGlobalAssignRule)

--- a/internal/rules/no_labels/no_labels.go
+++ b/internal/rules/no_labels/no_labels.go
@@ -1,0 +1,107 @@
+package no_labels
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// labelScope tracks nested labeled statements as a linked list (stack).
+// Each entry records the label name and the kind of its body ("loop", "switch", or "other"),
+// used to determine whether the label is allowed by the allowLoop/allowSwitch options.
+type labelScope struct {
+	label string
+	kind  string // "loop", "switch", or "other"
+	upper *labelScope
+}
+
+// getBodyKind categorizes a labeled statement's body for option matching.
+func getBodyKind(node *ast.Node) string {
+	if ast.IsIterationStatement(node, false) {
+		return "loop"
+	}
+	if node.Kind == ast.KindSwitchStatement {
+		return "switch"
+	}
+	return "other"
+}
+
+// https://eslint.org/docs/latest/rules/no-labels
+var NoLabelsRule = rule.Rule{
+	Name: "no-labels",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		allowLoop := false
+		allowSwitch := false
+		optsMap := utils.GetOptionsMap(options)
+		if optsMap != nil {
+			if v, ok := optsMap["allowLoop"].(bool); ok {
+				allowLoop = v
+			}
+			if v, ok := optsMap["allowSwitch"].(bool); ok {
+				allowSwitch = v
+			}
+		}
+
+		isAllowed := func(kind string) bool {
+			switch kind {
+			case "loop":
+				return allowLoop
+			case "switch":
+				return allowSwitch
+			default:
+				return false
+			}
+		}
+
+		var scopeInfo *labelScope
+
+		getKind := func(label string) string {
+			info := scopeInfo
+			for info != nil {
+				if info.label == label {
+					return info.kind
+				}
+				info = info.upper
+			}
+			return "other"
+		}
+
+		return rule.RuleListeners{
+			ast.KindLabeledStatement: func(node *ast.Node) {
+				ls := node.AsLabeledStatement()
+				scopeInfo = &labelScope{
+					label: ls.Label.Text(),
+					kind:  getBodyKind(ls.Statement),
+					upper: scopeInfo,
+				}
+			},
+			rule.ListenerOnExit(ast.KindLabeledStatement): func(node *ast.Node) {
+				if !isAllowed(scopeInfo.kind) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "unexpectedLabel",
+						Description: "Unexpected labeled statement.",
+					})
+				}
+				scopeInfo = scopeInfo.upper
+			},
+			ast.KindBreakStatement: func(node *ast.Node) {
+				bs := node.AsBreakStatement()
+				if bs.Label != nil && !isAllowed(getKind(bs.Label.Text())) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "unexpectedLabelInBreak",
+						Description: "Unexpected label in break statement.",
+					})
+				}
+			},
+			ast.KindContinueStatement: func(node *ast.Node) {
+				cs := node.AsContinueStatement()
+				if cs.Label != nil && !isAllowed(getKind(cs.Label.Text())) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "unexpectedLabelInContinue",
+						Description: "Unexpected label in continue statement.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_labels/no_labels.go
+++ b/internal/rules/no_labels/no_labels.go
@@ -17,13 +17,14 @@ type labelScope struct {
 
 // getBodyKind categorizes a labeled statement's body for option matching.
 func getBodyKind(node *ast.Node) string {
-	if ast.IsIterationStatement(node, false) {
+	switch {
+	case ast.IsIterationStatement(node, false):
 		return "loop"
-	}
-	if node.Kind == ast.KindSwitchStatement {
+	case node.Kind == ast.KindSwitchStatement:
 		return "switch"
+	default:
+		return "other"
 	}
-	return "other"
 }
 
 // https://eslint.org/docs/latest/rules/no-labels

--- a/internal/rules/no_labels/no_labels.md
+++ b/internal/rules/no_labels/no_labels.md
@@ -1,0 +1,78 @@
+# no-labels
+
+## Rule Details
+
+Disallow labeled statements. Labels tend to be used only rarely and are frowned upon as a remedial form of flow control that is more error prone and harder to understand.
+
+This rule aims to eliminate the use of labeled statements in JavaScript and reports whenever a labeled statement is encountered and whenever `break` or `continue` are used with a label.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+label: while (true) {}
+
+label: while (true) {
+  break label;
+}
+
+label: while (true) {
+  continue label;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var f = { label: foo() };
+
+while (true) {}
+
+while (true) {
+  break;
+}
+
+while (true) {
+  continue;
+}
+```
+
+## Options
+
+- `allowLoop` (boolean, default `false`): When `true`, allows labels attached to loop statements.
+- `allowSwitch` (boolean, default `false`): When `true`, allows labels attached to switch statements.
+
+Examples of **correct** code with `{ "allowLoop": true }`:
+
+```javascript
+A: while (a) {
+  break A;
+}
+
+A: do {
+  if (b) {
+    break A;
+  }
+} while (a);
+
+A: for (var a in obj) {
+  for (;;) {
+    switch (a) {
+      case 0:
+        continue A;
+    }
+  }
+}
+```
+
+Examples of **correct** code with `{ "allowSwitch": true }`:
+
+```javascript
+A: switch (a) {
+  case 0:
+    break A;
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-labels

--- a/internal/rules/no_labels/no_labels_test.go
+++ b/internal/rules/no_labels/no_labels_test.go
@@ -1,0 +1,640 @@
+package no_labels
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLabelsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLabelsRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// ================================================================
+			// Non-label contexts — should never trigger
+			// ================================================================
+			{Code: `var f = { label: foo() }`},
+			{Code: `while (true) {}`},
+			{Code: `while (true) { break; }`},
+			{Code: `while (true) { continue; }`},
+			{Code: `for (;;) { break; continue; }`},
+			{Code: `do { break; } while (true)`},
+			{Code: `switch (a) { case 0: break; }`},
+
+			// ================================================================
+			// allowLoop: all iteration statement types
+			// ================================================================
+			{
+				Code:    `A: while (a) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+			{
+				Code:    `A: do { if (b) { break A; } } while (a);`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+			{
+				Code:    `A: for (;;) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+			{
+				Code:    `A: for (var x in obj) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+			{
+				Code:    `A: for (var x of arr) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+			// allowLoop: continue targeting labeled loop
+			{
+				Code:    `A: while (a) { continue A; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+			// allowLoop: labeled loop with nested switch using continue to outer loop
+			{
+				Code:    `A: for (var a in obj) { for (;;) { switch (a) { case 0: continue A; } } }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+
+			// ================================================================
+			// allowSwitch
+			// ================================================================
+			{
+				Code:    `A: switch (a) { case 0: break A; }`,
+				Options: map[string]interface{}{"allowSwitch": true},
+			},
+
+			// ================================================================
+			// Both options true
+			// ================================================================
+			{
+				Code:    `A: while (a) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+			},
+			{
+				Code:    `A: switch (a) { case 0: break A; }`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+			},
+			// Both options: nested loop + switch, break/continue targeting outer loop
+			{
+				Code:    `A: while (a) { switch (x) { case 0: break A; continue A; } }`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+			},
+			// Both options: nested loops with labels — all break/continue target loops
+			{
+				Code:    `A: for (;;) { B: while (a) { break A; continue A; break B; continue B; } }`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+			},
+			// allowLoop: multiple break/continue targeting different labels — all loops, all allowed
+			{
+				Code:    `A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }`,
+				Options: map[string]interface{}{"allowLoop": true},
+			},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// ================================================================
+			// Dimension 1: All body types — default options (only unexpectedLabel)
+			// ================================================================
+			// while
+			{
+				Code: `label: while(true) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// do-while
+			{
+				Code: `A: do {} while (true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// for
+			{
+				Code: `A: for (;;) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// for-in
+			{
+				Code: `A: for (var x in obj) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// for-of
+			{
+				Code: `A: for (var x of arr) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// switch
+			{
+				Code: `A: switch (a) { case 0: break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// block
+			{
+				Code: `A: {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// if
+			{
+				Code: `A: if (true) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// variable declaration
+			{
+				Code: `A: var foo = 0;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// expression statement
+			{
+				Code: `A: foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 2: Label + break/continue — error ordering
+			// ================================================================
+			// break fires before the labeled statement exit
+			{
+				Code: `label: while (true) { break label; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 23},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// continue fires before the labeled statement exit
+			{
+				Code: `label: while (true) { continue label; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInContinue", Line: 1, Column: 23},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// both break and continue on same label
+			{
+				Code: `A: while (true) { break A; continue A; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabelInContinue", Line: 1, Column: 28},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// label targeting itself (break in label body)
+			{
+				Code: `A: break A;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 4},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 3: Nested labels — scope chain correctness
+			// ================================================================
+			// Nested: break targets outer label through inner label
+			{
+				Code: `A: { if (foo()) { break A; } bar(); };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `A: if (a) { if (foo()) { break A; } bar(); };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 26},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Nested: labeled switch with break targeting label
+			{
+				Code: `A: switch (a) { case 0: break A; default: break; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 25},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Double-nested labels in switch
+			{
+				Code: `A: switch (a) { case 0: B: { break A; } default: break; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 30},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 25},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Two nested labels both loops — inner exits before outer
+			{
+				Code: `A: while (true) { B: for (;;) { break A; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 33},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// continue targeting outer loop from inner label block
+			{
+				Code: `A: while (true) { B: { continue A; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInContinue", Line: 1, Column: 24},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// 3 levels deep: break targets outermost
+			{
+				Code: `A: { B: { C: while (true) { break A; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 29},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 11},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 6},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 4: Chained labels — getBodyKind on LabeledStatement body
+			// A: B: while(true) {} → A's body is LabeledStatement, kind = "other"
+			// ================================================================
+			// Chained labels: only inner directly labels the loop
+			{
+				Code: `A: B: while (true) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 4},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Chained labels with break targeting each
+			{
+				Code: `A: B: while (true) { break A; break B; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 22},
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 31},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 4},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Chained labels with allowLoop: B (loop) is allowed, A (other) is not
+			{
+				Code:    `A: B: while (true) { break B; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Chained labels with allowLoop: break A still errors (A is "other")
+			{
+				Code:    `A: B: while (true) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 22},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Triple chained: A: B: C: while(true) {}
+			{
+				Code: `A: B: C: while (true) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 7},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 4},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Chained labels on switch with allowSwitch: same principle
+			{
+				Code:    `A: B: switch (a) { case 0: break B; }`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 5: Same-name label shadowing
+			// ================================================================
+			// Inner label shadows outer — break targets inner
+			{
+				Code: `A: { A: while (true) { break A; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 24},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 6},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Shadowing with allowLoop: inner A (loop) allowed, break A allowed, outer A (other) errors
+			{
+				Code:    `A: { A: while (true) { break A; } }`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 6: Option combinations
+			// ================================================================
+			// allowLoop: variable declaration label — still "other"
+			{
+				Code:    `A: var foo = 0;`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowLoop: break label on block — still "other"
+			{
+				Code:    `A: break A;`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 4},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowLoop: block label with break
+			{
+				Code:    `A: { if (foo()) { break A; } bar(); };`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowLoop: if label with break
+			{
+				Code:    `A: if (a) { if (foo()) { break A; } bar(); };`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 26},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowLoop: switch label — switch is not "loop", still errors
+			{
+				Code:    `A: switch (a) { case 0: break A; default: break; };`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 25},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: variable declaration
+			{
+				Code:    `A: var foo = 0;`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: break label on other
+			{
+				Code:    `A: break A;`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 4},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: block label with break
+			{
+				Code:    `A: { if (foo()) { break A; } bar(); };`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: if label
+			{
+				Code:    `A: if (a) { if (foo()) { break A; } bar(); };`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 26},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: while label — loop is not "switch", still errors
+			{
+				Code:    `A: while (a) { break A; }`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 16},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: do-while label
+			{
+				Code:    `A: do { if (b) { break A; } } while (a);`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 18},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// allowSwitch: for-in label with break targeting labeled loop
+			{
+				Code:    `A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 57},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Both options true: block label — "other" is never allowed
+			{
+				Code:    `A: { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 6},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Both options true: if label — still "other"
+			{
+				Code:    `A: if (true) { break A; }`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 16},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Both options true: variable declaration
+			{
+				Code:    `A: var foo = 0;`,
+				Options: map[string]interface{}{"allowLoop": true, "allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 7: Cross-label break/continue with options
+			// ================================================================
+			// allowLoop: break targets outer loop from inner block label — outer is loop, allowed
+			{
+				Code:    `A: while (true) { B: { break A; } }`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					// B (block) is not allowed
+					{MessageId: "unexpectedLabel", Line: 1, Column: 19},
+				},
+			},
+			// allowLoop: continue targets outer loop from inner block label
+			{
+				Code:    `A: while (true) { B: { continue A; } }`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 19},
+				},
+			},
+			// allowSwitch: break targets outer switch from inner block label
+			{
+				Code:    `A: switch (a) { case 0: B: { break A; } }`,
+				Options: map[string]interface{}{"allowSwitch": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 25},
+				},
+			},
+
+			// ================================================================
+			// Dimension 8: Multi-line
+			// ================================================================
+			{
+				Code: "A:\n  while (true) {\n    break A;\n  }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 3, Column: 5},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 9: Sequential labels — scope cleanup
+			// After exiting A's scope, scopeInfo must be restored to nil/previous.
+			// If scope leaks, the second label or its break would see stale data.
+			// ================================================================
+			// Two sequential labels at same level — each independent
+			{
+				Code: `A: while (true) {} B: for (;;) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 20},
+				},
+			},
+			// Sequential: first label with break, second clean
+			{
+				Code: `A: { break A; } B: while (true) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 6},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 17},
+				},
+			},
+			// Sequential with allowLoop: first (block) errors, second (loop) allowed
+			{
+				Code:    `A: { break A; } B: while (true) { break B; }`,
+				Options: map[string]interface{}{"allowLoop": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 6},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 10: Multiple break/continue targeting different labels
+			// Tests that getKind correctly distinguishes labels in the chain.
+			// ================================================================
+			{
+				Code: `A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 37},
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 46},
+					{MessageId: "unexpectedLabelInContinue", Line: 1, Column: 55},
+					{MessageId: "unexpectedLabelInContinue", Line: 1, Column: 67},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 19},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 11: Labels inside function/class bodies
+			// The rule tracks scope via enter/exit, which is per-node.
+			// Labels inside nested functions still push/pop correctly.
+			// ================================================================
+			// Label inside function body
+			{
+				Code: `function f() { A: while (true) { break A; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 34},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 16},
+				},
+			},
+			// Label inside arrow function
+			{
+				Code: `var f = () => { A: while (true) { break A; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 35},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 17},
+				},
+			},
+			// Label inside class method
+			{
+				Code: `class C { method() { A: while (true) { break A; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabelInBreak", Line: 1, Column: 40},
+					{MessageId: "unexpectedLabel", Line: 1, Column: 22},
+				},
+			},
+
+			// ================================================================
+			// Dimension 12: Rare body types
+			// ================================================================
+			// Label on function declaration — "other"
+			{
+				Code: `A: function f() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Label on class declaration — "other"
+			{
+				Code: `A: class C {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Label on empty statement — "other"
+			{
+				Code: `A: ;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+			// Label on try-catch — "other"
+			{
+				Code: `A: try {} catch (e) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedLabel", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -249,6 +249,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-with.test.ts',
+    './tests/eslint/rules/no-labels.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -248,8 +248,8 @@ export default defineConfig({
     './tests/eslint/rules/valid-typeof.test.ts',
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
-    './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
+    './tests/eslint/rules/no-with.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-labels.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-labels.test.ts.snap
@@ -1,0 +1,2303 @@
+// Rstest Snapshot v1
+
+exports[`no-labels > invalid 1`] = `
+{
+  "code": "label: while(true) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 2`] = `
+{
+  "code": "A: do {} while (true);",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 3`] = `
+{
+  "code": "A: for (;;) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 4`] = `
+{
+  "code": "A: for (var x in obj) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 5`] = `
+{
+  "code": "A: for (var x of arr) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 6`] = `
+{
+  "code": "A: switch (a) { case 0: break; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 7`] = `
+{
+  "code": "A: {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 8`] = `
+{
+  "code": "A: if (true) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 9`] = `
+{
+  "code": "A: var foo = 0;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 10`] = `
+{
+  "code": "A: foo();",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 11`] = `
+{
+  "code": "label: while (true) { break label; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 12`] = `
+{
+  "code": "label: while (true) { continue label; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in continue statement.",
+      "messageId": "unexpectedLabelInContinue",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 13`] = `
+{
+  "code": "A: while (true) { break A; continue A; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in continue statement.",
+      "messageId": "unexpectedLabelInContinue",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 14`] = `
+{
+  "code": "A: break A;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 15`] = `
+{
+  "code": "A: { if (foo()) { break A; } bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 16`] = `
+{
+  "code": "A: if (a) { if (foo()) { break A; } bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 17`] = `
+{
+  "code": "A: switch (a) { case 0: break A; default: break; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 18`] = `
+{
+  "code": "A: switch (a) { case 0: B: { break A; } default: break; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 19`] = `
+{
+  "code": "A: while (true) { B: for (;;) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 20`] = `
+{
+  "code": "A: while (true) { B: { continue A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in continue statement.",
+      "messageId": "unexpectedLabelInContinue",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 21`] = `
+{
+  "code": "A: { B: { C: while (true) { break A; } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 22`] = `
+{
+  "code": "A: B: while (true) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 23`] = `
+{
+  "code": "A: B: while (true) { break A; break B; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 24`] = `
+{
+  "code": "A: B: while (true) { break B; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 25`] = `
+{
+  "code": "A: B: while (true) { break A; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 26`] = `
+{
+  "code": "A: B: C: while (true) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 27`] = `
+{
+  "code": "A: B: switch (a) { case 0: break B; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 28`] = `
+{
+  "code": "A: { A: while (true) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 29`] = `
+{
+  "code": "A: { A: while (true) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 30`] = `
+{
+  "code": "A: var foo = 0;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 31`] = `
+{
+  "code": "A: break A;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 32`] = `
+{
+  "code": "A: { if (foo()) { break A; } bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 33`] = `
+{
+  "code": "A: if (a) { if (foo()) { break A; } bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 34`] = `
+{
+  "code": "A: switch (a) { case 0: break A; default: break; };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 35`] = `
+{
+  "code": "A: var foo = 0;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 36`] = `
+{
+  "code": "A: break A;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 37`] = `
+{
+  "code": "A: { if (foo()) { break A; } bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 38`] = `
+{
+  "code": "A: if (a) { if (foo()) { break A; } bar(); };",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 39`] = `
+{
+  "code": "A: while (a) { break A; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 40`] = `
+{
+  "code": "A: do { if (b) { break A; } } while (a);",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 41`] = `
+{
+  "code": "A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 42`] = `
+{
+  "code": "A: { break A; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 43`] = `
+{
+  "code": "A: if (true) { break A; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 44`] = `
+{
+  "code": "A: var foo = 0;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 45`] = `
+{
+  "code": "A: while (true) { B: { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 46`] = `
+{
+  "code": "A: while (true) { B: { continue A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 47`] = `
+{
+  "code": "A: switch (a) { case 0: B: { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 48`] = `
+{
+  "code": "A:
+  while (true) {
+    break A;
+  }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 49`] = `
+{
+  "code": "A: while (true) {} B: for (;;) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 50`] = `
+{
+  "code": "A: { break A; } B: while (true) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 51`] = `
+{
+  "code": "A: { break A; } B: while (true) { break B; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 52`] = `
+{
+  "code": "A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 82,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in continue statement.",
+      "messageId": "unexpectedLabelInContinue",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in continue statement.",
+      "messageId": "unexpectedLabelInContinue",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 6,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 53`] = `
+{
+  "code": "function f() { A: while (true) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 54`] = `
+{
+  "code": "var f = () => { A: while (true) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 55`] = `
+{
+  "code": "class C { method() { A: while (true) { break A; } } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+    {
+      "message": "Unexpected label in break statement.",
+      "messageId": "unexpectedLabelInBreak",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 56`] = `
+{
+  "code": "A: function f() {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 57`] = `
+{
+  "code": "A: class C {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 58`] = `
+{
+  "code": "A: ;",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-labels > invalid 59`] = `
+{
+  "code": "A: try {} catch (e) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected labeled statement.",
+      "messageId": "unexpectedLabel",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-labels",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-labels.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-labels.test.ts
@@ -1,0 +1,515 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-labels', {
+  valid: [
+    // ================================================================
+    // Non-label contexts — should never trigger
+    // ================================================================
+    'var f = { label: foo() }',
+    'while (true) {}',
+    'while (true) { break; }',
+    'while (true) { continue; }',
+    'for (;;) { break; continue; }',
+    'do { break; } while (true)',
+    'switch (a) { case 0: break; }',
+
+    // ================================================================
+    // allowLoop: all iteration statement types
+    // ================================================================
+    {
+      code: 'A: while (a) { break A; }',
+      options: { allowLoop: true },
+    },
+    {
+      code: 'A: do { if (b) { break A; } } while (a);',
+      options: { allowLoop: true },
+    },
+    {
+      code: 'A: for (;;) { break A; }',
+      options: { allowLoop: true },
+    },
+    {
+      code: 'A: for (var x in obj) { break A; }',
+      options: { allowLoop: true },
+    },
+    {
+      code: 'A: for (var x of arr) { break A; }',
+      options: { allowLoop: true },
+    },
+    {
+      code: 'A: while (a) { continue A; }',
+      options: { allowLoop: true },
+    },
+    {
+      code: 'A: for (var a in obj) { for (;;) { switch (a) { case 0: continue A; } } }',
+      options: { allowLoop: true },
+    },
+
+    // ================================================================
+    // allowSwitch
+    // ================================================================
+    {
+      code: 'A: switch (a) { case 0: break A; }',
+      options: { allowSwitch: true },
+    },
+
+    // ================================================================
+    // Both options true
+    // ================================================================
+    {
+      code: 'A: while (a) { break A; }',
+      options: { allowLoop: true, allowSwitch: true },
+    },
+    {
+      code: 'A: switch (a) { case 0: break A; }',
+      options: { allowLoop: true, allowSwitch: true },
+    },
+    {
+      code: 'A: while (a) { switch (x) { case 0: break A; continue A; } }',
+      options: { allowLoop: true, allowSwitch: true },
+    },
+    {
+      code: 'A: for (;;) { B: while (a) { break A; continue A; break B; continue B; } }',
+      options: { allowLoop: true, allowSwitch: true },
+    },
+    // allowLoop: multiple break/continue targeting different labels — all loops
+    {
+      code: 'A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }',
+      options: { allowLoop: true },
+    },
+  ],
+  invalid: [
+    // ================================================================
+    // Dimension 1: All body types — default options
+    // ================================================================
+    {
+      code: 'label: while(true) {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: do {} while (true);',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: for (;;) {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: for (var x in obj) {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: for (var x of arr) {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: switch (a) { case 0: break; }',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: if (true) {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: var foo = 0;',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: foo();',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+
+    // ================================================================
+    // Dimension 2: Label + break/continue — error ordering
+    // ================================================================
+    {
+      code: 'label: while (true) { break label; }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'label: while (true) { continue label; }',
+      errors: [
+        { messageId: 'unexpectedLabelInContinue' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: while (true) { break A; continue A; }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabelInContinue' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: break A;',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+
+    // ================================================================
+    // Dimension 3: Nested labels — scope chain correctness
+    // ================================================================
+    {
+      code: 'A: { if (foo()) { break A; } bar(); };',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: if (a) { if (foo()) { break A; } bar(); };',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: switch (a) { case 0: break A; default: break; };',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: switch (a) { case 0: B: { break A; } default: break; };',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: while (true) { B: for (;;) { break A; } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: while (true) { B: { continue A; } }',
+      errors: [
+        { messageId: 'unexpectedLabelInContinue' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: { B: { C: while (true) { break A; } } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+
+    // ================================================================
+    // Dimension 4: Chained labels — getBodyKind on LabeledStatement body
+    // ================================================================
+    {
+      code: 'A: B: while (true) {}',
+      errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: B: while (true) { break A; break B; }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: B: while (true) { break B; }',
+      options: { allowLoop: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: B: while (true) { break A; }',
+      options: { allowLoop: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: B: C: while (true) {}',
+      errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: B: switch (a) { case 0: break B; }',
+      options: { allowSwitch: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+
+    // ================================================================
+    // Dimension 5: Same-name label shadowing
+    // ================================================================
+    {
+      code: 'A: { A: while (true) { break A; } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: { A: while (true) { break A; } }',
+      options: { allowLoop: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+
+    // ================================================================
+    // Dimension 6: Option combinations
+    // ================================================================
+    {
+      code: 'A: var foo = 0;',
+      options: { allowLoop: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: break A;',
+      options: { allowLoop: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: { if (foo()) { break A; } bar(); };',
+      options: { allowLoop: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: if (a) { if (foo()) { break A; } bar(); };',
+      options: { allowLoop: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: switch (a) { case 0: break A; default: break; };',
+      options: { allowLoop: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: var foo = 0;',
+      options: { allowSwitch: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: break A;',
+      options: { allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: { if (foo()) { break A; } bar(); };',
+      options: { allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: if (a) { if (foo()) { break A; } bar(); };',
+      options: { allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: while (a) { break A; }',
+      options: { allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: do { if (b) { break A; } } while (a);',
+      options: { allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }',
+      options: { allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    // Both options true: block/if/var are "other" — never allowed
+    {
+      code: 'A: { break A; }',
+      options: { allowLoop: true, allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: if (true) { break A; }',
+      options: { allowLoop: true, allowSwitch: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: var foo = 0;',
+      options: { allowLoop: true, allowSwitch: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+
+    // ================================================================
+    // Dimension 7: Cross-label break/continue with options
+    // ================================================================
+    {
+      code: 'A: while (true) { B: { break A; } }',
+      options: { allowLoop: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: while (true) { B: { continue A; } }',
+      options: { allowLoop: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: switch (a) { case 0: B: { break A; } }',
+      options: { allowSwitch: true },
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+
+    // ================================================================
+    // Dimension 8: Multi-line
+    // ================================================================
+    {
+      code: 'A:\n  while (true) {\n    break A;\n  }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+
+    // ================================================================
+    // Dimension 9: Sequential labels — scope cleanup
+    // ================================================================
+    {
+      code: 'A: while (true) {} B: for (;;) {}',
+      errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: { break A; } B: while (true) {}',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'A: { break A; } B: while (true) { break B; }',
+      options: { allowLoop: true },
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+
+    // ================================================================
+    // Dimension 10: Multiple break/continue targeting different labels
+    // ================================================================
+    {
+      code: 'A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabelInContinue' },
+        { messageId: 'unexpectedLabelInContinue' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+
+    // ================================================================
+    // Dimension 11: Labels inside function/class bodies
+    // ================================================================
+    {
+      code: 'function f() { A: while (true) { break A; } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'var f = () => { A: while (true) { break A; } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+    {
+      code: 'class C { method() { A: while (true) { break A; } } }',
+      errors: [
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabel' },
+      ],
+    },
+
+    // ================================================================
+    // Dimension 12: Rare body types
+    // ================================================================
+    {
+      code: 'A: function f() {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: class C {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: ;',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+    {
+      code: 'A: try {} catch (e) {}',
+      errors: [{ messageId: 'unexpectedLabel' }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/no-labels.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-labels.test.ts
@@ -2,11 +2,12 @@ import { RuleTester } from '../rule-tester';
 
 const ruleTester = new RuleTester();
 
+// NOTE: JS diagnostics are sorted by position (line, column ascending),
+// which differs from Go tests where errors follow AST traversal order.
+
 ruleTester.run('no-labels', {
   valid: [
-    // ================================================================
-    // Non-label contexts — should never trigger
-    // ================================================================
+    // Non-label contexts
     'var f = { label: foo() }',
     'while (true) {}',
     'while (true) { break; }',
@@ -15,9 +16,7 @@ ruleTester.run('no-labels', {
     'do { break; } while (true)',
     'switch (a) { case 0: break; }',
 
-    // ================================================================
-    // allowLoop: all iteration statement types
-    // ================================================================
+    // allowLoop: all iteration types
     {
       code: 'A: while (a) { break A; }',
       options: { allowLoop: true },
@@ -47,17 +46,13 @@ ruleTester.run('no-labels', {
       options: { allowLoop: true },
     },
 
-    // ================================================================
     // allowSwitch
-    // ================================================================
     {
       code: 'A: switch (a) { case 0: break A; }',
       options: { allowSwitch: true },
     },
 
-    // ================================================================
     // Both options true
-    // ================================================================
     {
       code: 'A: while (a) { break A; }',
       options: { allowLoop: true, allowSwitch: true },
@@ -74,7 +69,6 @@ ruleTester.run('no-labels', {
       code: 'A: for (;;) { B: while (a) { break A; continue A; break B; continue B; } }',
       options: { allowLoop: true, allowSwitch: true },
     },
-    // allowLoop: multiple break/continue targeting different labels — all loops
     {
       code: 'A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }',
       options: { allowLoop: true },
@@ -126,98 +120,98 @@ ruleTester.run('no-labels', {
     },
 
     // ================================================================
-    // Dimension 2: Label + break/continue — error ordering
+    // Dimension 2: Label + break/continue — position-sorted order
     // ================================================================
     {
       code: 'label: while (true) { break label; }',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'label: while (true) { continue label; }',
       errors: [
-        { messageId: 'unexpectedLabelInContinue' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInContinue' },
       ],
     },
     {
       code: 'A: while (true) { break A; continue A; }',
       errors: [
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabelInContinue' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
     {
       code: 'A: break A;',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
 
     // ================================================================
-    // Dimension 3: Nested labels — scope chain correctness
+    // Dimension 3: Nested labels
     // ================================================================
     {
       code: 'A: { if (foo()) { break A; } bar(); };',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: if (a) { if (foo()) { break A; } bar(); };',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: switch (a) { case 0: break A; default: break; };',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: switch (a) { case 0: B: { break A; } default: break; };',
       errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInBreak' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
     {
       code: 'A: while (true) { B: for (;;) { break A; } }',
       errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInBreak' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
     {
       code: 'A: while (true) { B: { continue A; } }',
       errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInContinue' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
     {
       code: 'A: { B: { C: while (true) { break A; } } }',
       errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInBreak' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
 
     // ================================================================
-    // Dimension 4: Chained labels — getBodyKind on LabeledStatement body
+    // Dimension 4: Chained labels
     // ================================================================
     {
       code: 'A: B: while (true) {}',
@@ -229,10 +223,10 @@ ruleTester.run('no-labels', {
     {
       code: 'A: B: while (true) { break A; break B; }',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
@@ -244,8 +238,8 @@ ruleTester.run('no-labels', {
       code: 'A: B: while (true) { break A; }',
       options: { allowLoop: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
@@ -268,9 +262,9 @@ ruleTester.run('no-labels', {
     {
       code: 'A: { A: while (true) { break A; } }',
       errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInBreak' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
     {
@@ -291,32 +285,32 @@ ruleTester.run('no-labels', {
       code: 'A: break A;',
       options: { allowLoop: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: { if (foo()) { break A; } bar(); };',
       options: { allowLoop: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: if (a) { if (foo()) { break A; } bar(); };',
       options: { allowLoop: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: switch (a) { case 0: break A; default: break; };',
       options: { allowLoop: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
@@ -328,48 +322,48 @@ ruleTester.run('no-labels', {
       code: 'A: break A;',
       options: { allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: { if (foo()) { break A; } bar(); };',
       options: { allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: if (a) { if (foo()) { break A; } bar(); };',
       options: { allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: while (a) { break A; }',
       options: { allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: do { if (b) { break A; } } while (a);',
       options: { allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: for (var a in obj) { for (;;) { switch (a) { case 0: break A; } } }',
       options: { allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     // Both options true: block/if/var are "other" — never allowed
@@ -377,16 +371,16 @@ ruleTester.run('no-labels', {
       code: 'A: { break A; }',
       options: { allowLoop: true, allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'A: if (true) { break A; }',
       options: { allowLoop: true, allowSwitch: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
@@ -420,8 +414,8 @@ ruleTester.run('no-labels', {
     {
       code: 'A:\n  while (true) {\n    break A;\n  }',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
 
@@ -438,8 +432,8 @@ ruleTester.run('no-labels', {
     {
       code: 'A: { break A; } B: while (true) {}',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
       ],
     },
@@ -447,8 +441,8 @@ ruleTester.run('no-labels', {
       code: 'A: { break A; } B: while (true) { break B; }',
       options: { allowLoop: true },
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
 
@@ -458,12 +452,12 @@ ruleTester.run('no-labels', {
     {
       code: 'A: while (true) { B: while (true) { break A; break B; continue A; continue B; } }',
       errors: [
+        { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabel' },
         { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabelInContinue' },
         { messageId: 'unexpectedLabelInContinue' },
-        { messageId: 'unexpectedLabel' },
-        { messageId: 'unexpectedLabel' },
       ],
     },
 
@@ -473,22 +467,22 @@ ruleTester.run('no-labels', {
     {
       code: 'function f() { A: while (true) { break A; } }',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'var f = () => { A: while (true) { break A; } }',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
     {
       code: 'class C { method() { A: while (true) { break A; } } }',
       errors: [
-        { messageId: 'unexpectedLabelInBreak' },
         { messageId: 'unexpectedLabel' },
+        { messageId: 'unexpectedLabelInBreak' },
       ],
     },
 


### PR DESCRIPTION
## Summary

Port the `no-labels` rule from ESLint to rslint.

This rule disallows labeled statements in JavaScript. It reports whenever a labeled statement is encountered and whenever `break` or `continue` are used with a label. Supports `allowLoop` and `allowSwitch` options.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-labels
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-labels.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).