### PR TITLE
feat: port rule @typescript-eslint/no-use-before-define

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_unary_minus"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_vars"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_use_before_define"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_empty_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
@@ -434,6 +435,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-type-assertion", no_unsafe_type_assertion.NoUnsafeTypeAssertionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-unary-minus", no_unsafe_unary_minus.NoUnsafeUnaryMinusRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-vars", no_unused_vars.NoUnusedVarsRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-use-before-define", no_use_before_define.NoUseBeforeDefineRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", no_useless_constructor.NoUselessConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-empty-export", no_useless_empty_export.NoUselessEmptyExportRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -18,23 +18,23 @@ type EnableAutofixRemoval struct {
 }
 
 type Config struct {
-	Vars                              string `json:"vars"`
-	VarsIgnorePattern                 string `json:"varsIgnorePattern"`
-	Args                              string `json:"args"`
-	ArgsIgnorePattern                 string `json:"argsIgnorePattern"`
-	CaughtErrors                      string `json:"caughtErrors"`
-	CaughtErrorsIgnorePattern         string `json:"caughtErrorsIgnorePattern"`
-	DestructuredArrayIgnorePattern    string `json:"destructuredArrayIgnorePattern"`
-	IgnoreRestSiblings                bool   `json:"ignoreRestSiblings"`
-	IgnoreClassWithStaticInitBlock    bool   `json:"ignoreClassWithStaticInitBlock"`
-	IgnoreUsingDeclarations           bool   `json:"ignoreUsingDeclarations"`
-	ReportUsedIgnorePattern           bool   `json:"reportUsedIgnorePattern"`
-	EnableAutofixRemoval              EnableAutofixRemoval `json:"enableAutofixRemoval"`
+	Vars                           string               `json:"vars"`
+	VarsIgnorePattern              string               `json:"varsIgnorePattern"`
+	Args                           string               `json:"args"`
+	ArgsIgnorePattern              string               `json:"argsIgnorePattern"`
+	CaughtErrors                   string               `json:"caughtErrors"`
+	CaughtErrorsIgnorePattern      string               `json:"caughtErrorsIgnorePattern"`
+	DestructuredArrayIgnorePattern string               `json:"destructuredArrayIgnorePattern"`
+	IgnoreRestSiblings             bool                 `json:"ignoreRestSiblings"`
+	IgnoreClassWithStaticInitBlock bool                 `json:"ignoreClassWithStaticInitBlock"`
+	IgnoreUsingDeclarations        bool                 `json:"ignoreUsingDeclarations"`
+	ReportUsedIgnorePattern        bool                 `json:"reportUsedIgnorePattern"`
+	EnableAutofixRemoval           EnableAutofixRemoval `json:"enableAutofixRemoval"`
 
-	varsIgnoreRe                *regexp.Regexp
-	argsIgnoreRe                *regexp.Regexp
-	caughtErrorsIgnoreRe        *regexp.Regexp
-	destructuredArrayIgnoreRe   *regexp.Regexp
+	varsIgnoreRe              *regexp.Regexp
+	argsIgnoreRe              *regexp.Regexp
+	caughtErrorsIgnoreRe      *regexp.Regexp
+	destructuredArrayIgnoreRe *regexp.Regexp
 }
 
 type analysisContext struct {
@@ -144,57 +144,20 @@ func isInTypeContext(node *ast.Node) bool {
 			ast.KindTypeLiteral,
 			ast.KindMappedType:
 			return true
-		// Note: KindAsExpression, KindTypeAssertionExpression, KindSatisfiesExpression
-		// are NOT included here. Their expression operand is a value context;
-		// only the type annotation part is a type context. Since we walk up
-		// from the identifier, a value operand will pass through these nodes
-		// and continue upward without being misclassified as type-only.
+			// Note: KindAsExpression, KindTypeAssertionExpression, KindSatisfiesExpression
+			// are NOT included here. Their expression operand is a value context;
+			// only the type annotation part is a type context. Since we walk up
+			// from the identifier, a value operand will pass through these nodes
+			// and continue upward without being misclassified as type-only.
 		}
 		parent = parent.Parent
 	}
 	return false
 }
 
-// isDeclarationName checks if the node is the name of a declaration.
-// NOTE: We do NOT use ast.IsDeclarationName() here because it also returns true
-// for ShorthandPropertyAssignment names, which are both declaration names AND
-// value references. We need them to be counted as usages in collectSymbolUsages.
+// isDeclarationName delegates to utils.IsDeclarationIdentifier.
 func isDeclarationName(node *ast.Node) bool {
-	if node == nil || node.Parent == nil {
-		return false
-	}
-	parent := node.Parent
-	switch parent.Kind {
-	case ast.KindVariableDeclaration:
-		return parent.AsVariableDeclaration().Name() == node
-	case ast.KindFunctionDeclaration:
-		return parent.AsFunctionDeclaration().Name() == node
-	case ast.KindParameter:
-		return parent.AsParameterDeclaration().Name() == node
-	case ast.KindClassDeclaration:
-		return parent.AsClassDeclaration().Name() == node
-	case ast.KindInterfaceDeclaration:
-		return parent.AsInterfaceDeclaration().Name() == node
-	case ast.KindTypeAliasDeclaration:
-		return parent.AsTypeAliasDeclaration().Name() == node
-	case ast.KindEnumDeclaration:
-		return parent.AsEnumDeclaration().Name() == node
-	case ast.KindModuleDeclaration:
-		return parent.AsModuleDeclaration().Name() == node
-	case ast.KindCatchClause:
-		return parent.AsCatchClause().VariableDeclaration == node
-	case ast.KindImportSpecifier:
-		return parent.AsImportSpecifier().Name() == node
-	case ast.KindImportClause:
-		return parent.AsImportClause().Name() == node
-	case ast.KindBindingElement:
-		return parent.AsBindingElement().Name() == node
-	case ast.KindNamespaceImport:
-		return parent.AsNamespaceImport().Name() == node
-	case ast.KindImportEqualsDeclaration:
-		return parent.AsImportEqualsDeclaration().Name() == node
-	}
-	return false
+	return utils.IsDeclarationIdentifier(node)
 }
 
 // isPartOfAssignment checks if an identifier is a write-only target in an
@@ -530,8 +493,9 @@ func isMethodCallOnSameSymbol(callee *ast.Node, sym *ast.Symbol, checker *checke
 // isInsideFunctionAssignedToSelf checks if the identifier is inside a function expression
 // whose result (directly or via IIFE) is assigned to the same variable.
 // Covers: `cb = (function(a) { return cb(1+a); })()` (IIFE)
-//         `cb = (0, function(a) { cb(1+a); })` (non-IIFE, assigned directly)
-//         `cb = (function(a) { cb(1+a); }, cb)` (discarded in comma left operand)
+//
+//	`cb = (0, function(a) { cb(1+a); })` (non-IIFE, assigned directly)
+//	`cb = (function(a) { cb(1+a); }, cb)` (discarded in comma left operand)
 func isInsideFunctionAssignedToSelf(node *ast.Node, sym *ast.Symbol, checker *checker.Checker) bool {
 	current := node
 	for current != nil {

--- a/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
@@ -1,0 +1,444 @@
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestEdgeCases covers missing scenarios from the ESLint/typescript-eslint test suites
+// and systematically enumerates edge cases across class definitions, scoping, and nesting.
+func TestEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUseBeforeDefineRule,
+
+		// =====================================================================
+		// VALID cases
+		// =====================================================================
+		[]rule_tester.ValidTestCase{
+
+			// ----- Class body: method/getter/setter bodies are separate execution context -----
+			{Code: `class C { method() { C; } }`},
+			{Code: `class C { static method() { C; } }`},
+			{Code: `class C { get x() { return C; } }`},
+			{Code: `class C { set x(v: any) { C; } }`},
+
+			// ----- Class body: instance field with arrow (body not evaluated during init) -----
+			{Code: `class C { field = () => C; }`},
+			{Code: `class C { field = class extends C {}; }`},
+
+			// ----- Class body: static field / static block (runs after class binding) -----
+			{Code: `class C { static field = C; }`},
+			{Code: `class C { static { C; } }`},
+			{Code: `class C { static field = class extends C {}; }`},
+			{Code: `class C { static field = class { [C as any](){} }; }`},
+
+			// ----- let/const before class static block — same execution context -----
+			{Code: `let a = 1; class C { static { a; } }`},
+			{Code: `class C { static { let a: any; a; } }`},
+
+			// ----- Class expression: method body -----
+			{Code: `const C = class { method() { C; } };`},
+			{Code: `(class C { method() { C; } });`},
+
+			// ----- Class expression: static field referencing outer let -----
+			// Static field initializer runs during class definition, which is during
+			// the initialization of `const C = ...`, but the class binding for named
+			// class expressions is available inside the class.
+			{Code: `(class C { static field = C; });`},
+
+			// ----- Superclass method bodies referencing the derived class -----
+			{Code: `class C extends (class { method() { C; } }) {}`},
+
+			// ----- Superclass instance field referencing derived class (separate context) -----
+			{Code: `class C extends (class { field = C; }) {}`},
+
+			// ----- Class instance field arrow function -----
+			{Code: `class C { field = () => C; }`},
+
+			// ----- Cross-scope class reference with classes:false -----
+			{
+				Code:    `function foo() { new A(); } class A {}`,
+				Options: map[string]interface{}{"classes": false},
+			},
+
+			// ----- Cross-scope variable with variables:false -----
+			{
+				Code:    `function foo() { bar; } var bar: any;`,
+				Options: map[string]interface{}{"variables": false},
+			},
+			{
+				Code:    `var foo = () => bar; var bar: any;`,
+				Options: map[string]interface{}{"variables": false},
+			},
+			{
+				Code:    `class C { static { () => foo; } } let foo: any;`,
+				Options: map[string]interface{}{"variables": false},
+			},
+
+			// ----- typedefs:false + ignoreTypeReferences:false -----
+			{
+				Code:    `var x: Foo = {} as any; interface Foo {}`,
+				Options: map[string]interface{}{"typedefs": false, "ignoreTypeReferences": false},
+			},
+			{
+				Code:    `let myVar: MyString; type MyString = string;`,
+				Options: map[string]interface{}{"typedefs": false, "ignoreTypeReferences": false},
+			},
+
+			// ----- Optional chaining with declared variables -----
+			{Code: `const updatedAt = (null as any)?.updatedAt;`},
+			{Code: `function f() { return function t() {}; } f()?.();`},
+			{Code: `var a = { b: 5 }; alert(a?.b);`},
+
+			// ----- allowNamedExports with TS-specific declarations -----
+			{
+				Code:    `export { Foo, baz }; enum Foo { BAR } let baz: Enum; enum Enum {}`,
+				Options: map[string]interface{}{"allowNamedExports": true},
+			},
+
+			// ----- Decorators with classes:false -----
+			{
+				Code: `
+@Directive({
+  selector: '[test]',
+  providers: [{ useExisting: MyClass }],
+})
+export class MyClass implements Validator {}
+`,
+				Options: map[string]interface{}{"classes": false},
+			},
+
+			// ----- Constructor with default parameter using this -----
+			{Code: `
+class A {
+  printerName: string = '';
+  constructor(printName: string) {
+    this.printerName = printName;
+  }
+  openPort(printerName = this.printerName) {
+    return printerName;
+  }
+}
+`},
+
+			// ----- Class body self-references (typescript-eslint considers the class -----
+			// ----- name as defined before the body in source order)               -----
+			{Code: `class C extends C {}`},
+			{Code: `class C { [C as any]() {} }`},
+			{Code: `(class C { [C as any]() {} });`},
+			{Code: `class C { [C as any]: any; }`},
+			{Code: `class C { static [C as any]() {} }`},
+			{Code: `const C = class { static field = C; };`},
+			{Code: `const C = class { static { C; } };`},
+			{Code: `(class C extends C {});`},
+
+			// ----- Type predicate (value is Type) -----
+			{Code: `type T = (value: unknown) => value is string;`},
+
+			// ----- Global augmentation -----
+			{Code: `
+(globalThis as any).foo = true;
+declare global {
+  namespace NodeJS {
+    interface Global {
+      foo?: boolean;
+    }
+  }
+}
+`},
+		},
+
+		// =====================================================================
+		// INVALID cases
+		// =====================================================================
+		[]rule_tester.InvalidTestCase{
+
+			// ----- Class extends another class declared after -----
+			{
+				Code: `class C extends D {} class D {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 17},
+				},
+			},
+
+			// ----- Class with computed key referencing variable declared after -----
+			{
+				Code: `class C { [a as any]() {} } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 12},
+				},
+			},
+
+			// ----- Static field referencing variable declared after -----
+			{
+				Code: `class C { static field = a; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 26},
+				},
+			},
+
+			// ----- Static block referencing variable declared after -----
+			{
+				Code: `class C { static { a; } } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 20},
+				},
+			},
+
+			// ----- Static field referencing class declared after -----
+			{
+				Code: `class C { static field = D; } class D {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 26},
+				},
+			},
+
+			// ----- variables:false still catches same-scope -----
+			{
+				Code:    `foo; var foo: any;`,
+				Options: map[string]interface{}{"variables": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 1},
+				},
+			},
+
+			// ----- ignoreTypeReferences:false with type annotation -----
+			{
+				Code:    `let var1: StringOrNumber; type StringOrNumber = string | number;`,
+				Options: map[string]interface{}{"ignoreTypeReferences": false, "typedefs": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- Optional chaining before define -----
+			{
+				Code: `f()?.(); function f() { return function t() {}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `alert(a?.b); var a = { b: 5 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 7},
+				},
+			},
+
+			// ----- export const / export function still reports with allowNamedExports -----
+			{
+				Code:    `export const foo = a; const a = 1;`,
+				Options: map[string]interface{}{"allowNamedExports": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code:    `export function foo() { return a; } const a = 1;`,
+				Options: map[string]interface{}{"allowNamedExports": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- Multiple export specifiers with some before define -----
+			{
+				Code:    `export { Foo, baz }; enum Foo { BAR } let baz: Enum; enum Enum {}`,
+				Options: map[string]interface{}{"allowNamedExports": false, "ignoreTypeReferences": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- Deeply nested: function inside arrow inside class method -----
+			{
+				Code: `
+const x = (() => {
+  return function inner() {
+    return a;
+  };
+})();
+const a = 1;
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- let/const in block scope -----
+			{
+				Code: `{ a; let a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `if (true) { function foo() { a; } let a: any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- Array destructuring with earlier ref -----
+			{
+				Code: `var [b = a, a] = {} as any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 10},
+				},
+			},
+
+			// ----- nofunc: var function expression still caught -----
+			{
+				Code:    `a(); var a = function () {};`,
+				Options: map[string]interface{}{"functions": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 1},
+				},
+			},
+
+			// ----- classes:false with var = class (still caught, it's a variable) -----
+			{
+				Code:    `new A(); var A = class {};`,
+				Options: map[string]interface{}{"classes": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code:    `function foo() { new A(); } var A = class {};`,
+				Options: map[string]interface{}{"classes": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// =========== For-loop TDZ ===========
+
+			// for-loop initializer self-reference
+			{
+				Code: `for (let x = x;;) {} let y: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			// for-in referencing later let
+			{
+				Code: `for (let x in xs) {} let xs: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			// for-of referencing later let
+			{
+				Code: `for (let x of xs) {} let xs: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// =========== Cross-variable: class member referencing later declaration ===========
+			// These use DEFAULT options (not variables:false / classes:false) because
+			// the typescript-eslint rule treats computed keys as cross-scope references
+			// (inside method/property scope), so option=false would suppress them.
+
+			{
+				Code: `class C { [a as any]() {} } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static [a as any](){} } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { [a as any]: any; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { [a as any] = 1; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static [a as any]: any; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static [a as any] = 1; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// =========== Static block/field with later declarations ===========
+
+			{
+				Code: `class C { static { D; } } class D {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static { (class extends D {}); } } class D {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static { (class { [a as any](){} }); } } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static { (class { static field = a; }); } } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// =========== Superclass / nested static field with later declarations ===========
+
+			{
+				Code: `class C extends (class { [a as any](){} }) {} let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C extends (class { static field = a; }) {} let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static field = class extends D {}; } class D {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static field = class { [a as any](){} }; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `class C { static field = class { static field = a; }; } let a: any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -1,0 +1,576 @@
+package no_use_before_define
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// options mirrors the typescript-eslint rule schema.
+// See https://typescript-eslint.io/rules/no-use-before-define/#options
+type options struct {
+	functions            bool
+	classes              bool
+	variables            bool
+	enums                bool
+	typedefs             bool
+	ignoreTypeReferences bool
+	allowNamedExports    bool
+}
+
+func parseOptions(rawOptions any) options {
+	opts := options{
+		functions:            true,
+		classes:              true,
+		variables:            true,
+		enums:                true,
+		typedefs:             true,
+		ignoreTypeReferences: true,
+		allowNamedExports:    false,
+	}
+
+	// Handle "nofunc" string option.
+	if str, ok := rawOptions.(string); ok {
+		if str == "nofunc" {
+			opts.functions = false
+		}
+		return opts
+	}
+
+	// Handle array format from JS tests: ["nofunc"] or [{...}]
+	if arr, ok := rawOptions.([]interface{}); ok && len(arr) > 0 {
+		if str, ok := arr[0].(string); ok {
+			if str == "nofunc" {
+				opts.functions = false
+			}
+			return opts
+		}
+	}
+
+	optsMap := utils.GetOptionsMap(rawOptions)
+	if optsMap == nil {
+		return opts
+	}
+
+	if v, ok := optsMap["functions"].(bool); ok {
+		opts.functions = v
+	}
+	if v, ok := optsMap["classes"].(bool); ok {
+		opts.classes = v
+	}
+	if v, ok := optsMap["variables"].(bool); ok {
+		opts.variables = v
+	}
+	if v, ok := optsMap["enums"].(bool); ok {
+		opts.enums = v
+	}
+	if v, ok := optsMap["typedefs"].(bool); ok {
+		opts.typedefs = v
+	}
+	if v, ok := optsMap["ignoreTypeReferences"].(bool); ok {
+		opts.ignoreTypeReferences = v
+	}
+	if v, ok := optsMap["allowNamedExports"].(bool); ok {
+		opts.allowNamedExports = v
+	}
+
+	return opts
+}
+
+// definitionType categorizes a declaration for option-based filtering.
+// Maps to ESLint's scope-manager DefinitionType.
+type definitionType int
+
+const (
+	defUnknown definitionType = iota
+	defVariable
+	defFunctionName
+	defClassName
+	defTypeName      // interface or type alias
+	defEnumName      // enum declaration
+	defNamespaceName // module/namespace declaration
+	defImport
+	defCatchClause
+	defParameter
+)
+
+func getDefinitionType(decl *ast.Node) definitionType {
+	if decl == nil {
+		return defUnknown
+	}
+	switch decl.Kind {
+	case ast.KindVariableDeclaration, ast.KindBindingElement:
+		return defVariable
+	case ast.KindFunctionDeclaration:
+		return defFunctionName
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return defClassName
+	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+		return defTypeName
+	case ast.KindEnumDeclaration:
+		return defEnumName
+	case ast.KindModuleDeclaration:
+		return defNamespaceName
+	case ast.KindImportSpecifier, ast.KindImportClause, ast.KindNamespaceImport, ast.KindImportEqualsDeclaration:
+		return defImport
+	case ast.KindCatchClause:
+		return defCatchClause
+	case ast.KindParameter:
+		return defParameter
+	}
+	return defUnknown
+}
+
+// isNamedExport checks if the identifier is the local name in an export specifier.
+// e.g. the `a` in `export { a }` or `export { a as b }`.
+func isNamedExport(node *ast.Node) bool {
+	if node.Parent == nil || node.Parent.Kind != ast.KindExportSpecifier {
+		return false
+	}
+	spec := node.Parent.AsExportSpecifier()
+	// For `export { a as b }`: PropertyName=a (local), Name()=b (exported).
+	if spec.PropertyName != nil {
+		return spec.PropertyName == node
+	}
+	return spec.Name() == node
+}
+
+// isExportedAliasName checks if the identifier is the non-local export alias.
+// e.g. the `b` in `export { a as b }` — not a real reference.
+func isExportedAliasName(node *ast.Node) bool {
+	if node.Parent == nil || node.Parent.Kind != ast.KindExportSpecifier {
+		return false
+	}
+	spec := node.Parent.AsExportSpecifier()
+	return spec.PropertyName != nil && spec.Name() == node
+}
+
+// isTypeReference checks if the identifier is in a type-only context:
+// inside a TypeReference (e.g. `x: Foo`) or a typeof type query (e.g. `typeof Foo`).
+func isTypeReference(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	if node.Parent.Kind == ast.KindTypeReference {
+		return true
+	}
+	return ast.IsPartOfTypeQuery(node)
+}
+
+// isInFunctionTypeScope checks if the identifier is inside a function type
+// annotation (e.g. `type F = (x: Foo) => void`). References there live in a
+// separate scope and should not be checked.
+func isInFunctionTypeScope(node *ast.Node) bool {
+	found := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		switch n.Kind {
+		case ast.KindFunctionType, ast.KindConstructorType:
+			return true
+		// Stop at real scope boundaries.
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+			ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindClassDeclaration, ast.KindClassExpression,
+			ast.KindSourceFile:
+			return true
+		}
+		return false
+	})
+	if found == nil {
+		return false
+	}
+	return found.Kind == ast.KindFunctionType || found.Kind == ast.KindConstructorType
+}
+
+// getEnclosingFunctionScope returns the nearest enclosing function-like node
+// that creates a new variable scope, or nil for program-level code.
+//
+// This models ESLint's "variableScope" concept:
+//   - Static class field initializers and static blocks run synchronously during
+//     class evaluation, so they are part of the outer execution context (skipped).
+//   - Instance field initializers are conceptually separate execution contexts.
+func getEnclosingFunctionScope(node *ast.Node) *ast.Node {
+	current := node.Parent
+	for current != nil {
+		switch current.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+			ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor:
+			return current
+		case ast.KindClassStaticBlockDeclaration:
+			// Static blocks run during class definition — same execution context.
+			current = current.Parent
+			continue
+		case ast.KindPropertyDeclaration:
+			// Static field initializers: same execution context as class definition.
+			// Instance field initializers: separate execution context.
+			if ast.HasStaticModifier(current) && current.AsPropertyDeclaration().Initializer != nil {
+				current = current.Parent
+				continue
+			}
+			return current
+		}
+		current = current.Parent
+	}
+	return nil
+}
+
+// isFromSeparateExecutionContext returns true when reference and declaration
+// live in different function-level scopes.
+func isFromSeparateExecutionContext(refNode *ast.Node, declNode *ast.Node) bool {
+	return getEnclosingFunctionScope(refNode) != getEnclosingFunctionScope(declNode)
+}
+
+// isInRange checks if a source position falls within [node.Pos(), node.End()].
+func isInRange(node *ast.Node, location int) bool {
+	return node != nil && node.Pos() <= location && location <= node.End()
+}
+
+// hasScopeBoundaryBetween returns true if there is a class or function scope
+// boundary between the reference node and the declaration node. This matches
+// the typescript-eslint `variable.scope !== reference.from` check.
+func hasScopeBoundaryBetween(refNode *ast.Node, declNode *ast.Node) bool {
+	current := refNode.Parent
+	for current != nil && current != declNode {
+		switch current.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			return true
+		}
+		current = current.Parent
+	}
+	return false
+}
+
+// isInsideModuleAugmentation checks if a declaration is inside (or is)
+// a `declare module '...' { ... }` augmentation block.
+func isInsideModuleAugmentation(node *ast.Node) bool {
+	return ast.FindAncestor(node, ast.IsExternalModuleAugmentation) != nil
+}
+
+// isClassRefInClassDecorator returns true if the reference appears inside a
+// decorator of the class it refers to. Decorators are transpiled after the
+// class declaration, so such references are safe.
+func isClassRefInClassDecorator(decl *ast.Node, refNode *ast.Node) bool {
+	if decl.Kind != ast.KindClassDeclaration {
+		return false
+	}
+	decorators := decl.Decorators()
+	if len(decorators) == 0 {
+		return false
+	}
+	refStart := refNode.Pos()
+	refEnd := refNode.End()
+	for _, deco := range decorators {
+		if refStart >= deco.Pos() && refEnd <= deco.End() {
+			return true
+		}
+	}
+	return false
+}
+
+// isSentinelKind returns true for node kinds that form scope boundaries and
+// stop the isEvaluatedDuringInitialization walk (matching ESLint's SENTINEL_TYPE).
+func isSentinelKind(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+		ast.KindClassDeclaration, ast.KindClassExpression,
+		ast.KindArrowFunction, ast.KindCatchClause,
+		ast.KindImportDeclaration, ast.KindExportDeclaration,
+		// Method-like kinds create separate execution contexts and must stop
+		// the isEvaluatedDuringInitialization walk. Without this, parameters
+		// inside methods would incorrectly "escape" into enclosing variable
+		// initializers. ESLint doesn't need these because in its AST model
+		// methods are FunctionExpressions.
+		ast.KindMethodDeclaration, ast.KindConstructor,
+		ast.KindGetAccessor, ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+// isEvaluatedDuringInitialization returns true when the reference is evaluated
+// during the initialization of its own declaration. Examples:
+//
+//	var a = a         // self-referencing initializer
+//	var [a = a] = []  // destructuring default
+//	for (var a in a)  // for-in/for-of right-hand side
+//
+// NOTE: Unlike the ESLint core rule, the typescript-eslint version does NOT
+// check class body evaluation (extends clause, computed property keys, etc.).
+// It relies purely on source-position comparison for class declarations.
+// See: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-use-before-define.ts
+func isEvaluatedDuringInitialization(refNode *ast.Node, decl *ast.Node) bool {
+	if isFromSeparateExecutionContext(refNode, decl) {
+		return false
+	}
+
+	// The typescript-eslint rule's isInInitializer checks
+	// `variable.scope !== reference.from` first. If the reference crosses a
+	// scope boundary (class, block, etc.) relative to the declaration, it is
+	// NOT considered "in the initializer" even when positionally inside the
+	// initializer's range. We approximate this by checking whether any
+	// class/function/block scope exists between the reference and the decl.
+	if hasScopeBoundaryBetween(refNode, decl) {
+		return false
+	}
+
+	location := refNode.End()
+
+	// Only check variable/binding-element initializers (not class bodies).
+	declName := utils.GetDeclarationIdentifier(decl)
+	if declName == nil {
+		return false
+	}
+	for node := declName.Parent; node != nil; node = node.Parent {
+		switch node.Kind {
+		case ast.KindVariableDeclaration:
+			varDecl := node.AsVariableDeclaration()
+			if varDecl.Initializer != nil && isInRange(varDecl.Initializer, location) {
+				return true
+			}
+			// Check for-in/for-of right-hand side.
+			if varDeclList := node.Parent; varDeclList != nil && varDeclList.Parent != nil {
+				forStmt := varDeclList.Parent
+				if forStmt.Kind == ast.KindForInStatement || forStmt.Kind == ast.KindForOfStatement {
+					if isInRange(forStmt.AsForInOrOfStatement().Expression, location) {
+						return true
+					}
+				}
+			}
+			return false
+		case ast.KindBindingElement:
+			if init := node.AsBindingElement().Initializer; init != nil && isInRange(init, location) {
+				return true
+			}
+		case ast.KindParameter:
+			if init := node.AsParameterDeclaration().Initializer; init != nil && isInRange(init, location) {
+				return true
+			}
+		default:
+			if isSentinelKind(node.Kind) {
+				return false
+			}
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Rule definition
+// ---------------------------------------------------------------------------
+
+var NoUseBeforeDefineRule = rule.CreateRule(rule.Rule{
+	Name: "no-use-before-define",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		return rule.RuleListeners{
+			ast.KindIdentifier: func(node *ast.Node) {
+				if !utils.IsDeclarationIdentifier(node) {
+					checkIdentifier(ctx, opts, node)
+				}
+			},
+		}
+	},
+})
+
+func checkIdentifier(ctx rule.RuleContext, opts options, node *ast.Node) {
+	if ctx.TypeChecker == nil {
+		return
+	}
+
+	// The renamed export name in `export { a as b }` is not a reference.
+	if isExportedAliasName(node) {
+		return
+	}
+
+	sym := ctx.TypeChecker.GetSymbolAtLocation(node)
+	if sym == nil {
+		return
+	}
+
+	// For alias symbols (import/export specifiers), resolve through the alias
+	// to find the actual local declaration. Also include the alias's own
+	// declarations (import specifiers) so that imports serve as the "definition
+	// point" even when module augmentation adds later declarations.
+	declarations := sym.Declarations
+	if sym.Flags&ast.SymbolFlagsAlias != 0 {
+		if resolved := ctx.TypeChecker.SkipAlias(sym); resolved != nil && len(resolved.Declarations) > 0 {
+			declarations = append(append([]*ast.Node(nil), resolved.Declarations...), sym.Declarations...)
+		}
+	}
+	if len(declarations) == 0 {
+		return
+	}
+
+	// Find the earliest declaration in this source file, skipping export
+	// specifiers (they are the reference site, not a definition) and module
+	// augmentation declarations (they appear after the real definition).
+	var firstDecl *ast.Node
+	for _, decl := range declarations {
+		if decl.Kind == ast.KindExportSpecifier {
+			continue
+		}
+		if isInsideModuleAugmentation(decl) {
+			continue
+		}
+		if ast.GetSourceFileOfNode(decl) == ctx.SourceFile {
+			if firstDecl == nil || decl.Pos() < firstDecl.Pos() {
+				firstDecl = decl
+			}
+		}
+	}
+	if firstDecl == nil {
+		return
+	}
+
+	defType := getDefinitionType(firstDecl)
+	declName := utils.GetDeclarationIdentifier(firstDecl)
+	if declName == nil {
+		return
+	}
+
+	// In a QualifiedName chain (A.B.C), only the leftmost name is a real reference.
+	if node.Parent != nil && node.Parent.Kind == ast.KindQualifiedName {
+		topQN := node.Parent
+		for topQN.Parent != nil && topQN.Parent.Kind == ast.KindQualifiedName {
+			topQN = topQN.Parent
+		}
+		leftmost := topQN.AsQualifiedName().Left
+		for leftmost.Kind == ast.KindQualifiedName {
+			leftmost = leftmost.AsQualifiedName().Left
+		}
+		if leftmost != node {
+			return
+		}
+		// QualifiedName inside import-equals is a namespace alias, not a use.
+		if topQN.Parent != nil && topQN.Parent.Kind == ast.KindImportEqualsDeclaration {
+			return
+		}
+	}
+
+	// Named exports: always check (ignoring other options) unless allowNamedExports.
+	// For `export { X }`, we need the earliest local binding of X (the import
+	// site or variable declaration), not a resolved alias target that might
+	// include module augmentation declarations appearing later in the file.
+	if isNamedExport(node) {
+		if opts.allowNamedExports {
+			return
+		}
+		localDeclName := findLocalBindingName(ctx, sym)
+		if localDeclName != nil && isDefinedBeforeUse(localDeclName, node) {
+			return
+		}
+		if localDeclName == nil && isDefinedBeforeUse(declName, node) {
+			return
+		}
+		reportNode(ctx, node)
+		return
+	}
+
+	// Defined before use — no violation, unless evaluated during its own initialization.
+	if isDefinedBeforeUse(declName, node) &&
+		(!isEvaluatedDuringInitialization(node, firstDecl) || node.Parent.Kind == ast.KindTypeReference) {
+		return
+	}
+
+	// Option-based filtering.
+	if !isForbidden(opts, defType, node, firstDecl) {
+		return
+	}
+
+	if isClassRefInClassDecorator(firstDecl, node) {
+		return
+	}
+
+	if isInFunctionTypeScope(node) {
+		return
+	}
+
+	reportNode(ctx, node)
+}
+
+// findLocalBindingName walks the alias chain from sym back through imports
+// to find the earliest local binding (import specifier / namespace import)
+// name node in the current file. Returns nil if no local binding is found.
+func findLocalBindingName(ctx rule.RuleContext, sym *ast.Symbol) *ast.Node {
+	// Walk through the alias chain to find import-site declarations.
+	current := sym
+	for current != nil && current.Flags&ast.SymbolFlagsAlias != 0 {
+		for _, d := range current.Declarations {
+			if ast.GetSourceFileOfNode(d) != ctx.SourceFile {
+				continue
+			}
+			switch d.Kind {
+			case ast.KindImportSpecifier, ast.KindNamespaceImport, ast.KindImportClause, ast.KindImportEqualsDeclaration:
+				return utils.GetDeclarationIdentifier(d)
+			}
+		}
+		resolved := ctx.TypeChecker.SkipAlias(current)
+		if resolved == current || resolved == nil {
+			break
+		}
+		current = resolved
+	}
+	// Fallback: find any local non-augmentation declaration.
+	for _, d := range sym.Declarations {
+		if d.Kind == ast.KindExportSpecifier {
+			continue
+		}
+		if ast.GetSourceFileOfNode(d) == ctx.SourceFile {
+			return utils.GetDeclarationIdentifier(d)
+		}
+	}
+	return nil
+}
+
+// isDefinedBeforeUse compares end positions (matching ESLint behavior).
+func isDefinedBeforeUse(declName *ast.Node, refNode *ast.Node) bool {
+	return declName.End() <= refNode.End()
+}
+
+// isForbidden decides whether a use-before-define should be reported based on
+// the rule options and the declaration type.
+//
+// For classes, variables and enums the option only suppresses cross-scope
+// references (different function scope). Same-scope TDZ violations are always
+// reported regardless of the option value.
+func isForbidden(opts options, defType definitionType, refNode *ast.Node, declNode *ast.Node) bool {
+	if opts.ignoreTypeReferences && isTypeReference(refNode) {
+		return false
+	}
+
+	switch defType {
+	case defFunctionName:
+		return opts.functions
+	case defClassName:
+		if isFromSeparateExecutionContext(refNode, declNode) {
+			return opts.classes
+		}
+		return true // same scope — always report (TDZ)
+	case defVariable:
+		if isFromSeparateExecutionContext(refNode, declNode) {
+			return opts.variables
+		}
+		return true
+	case defEnumName:
+		if isFromSeparateExecutionContext(refNode, declNode) {
+			return opts.enums
+		}
+		return true
+	case defTypeName:
+		return opts.typedefs
+	}
+
+	return true
+}
+
+func reportNode(ctx rule.RuleContext, node *ast.Node) {
+	name := ""
+	if ast.IsIdentifier(node) {
+		name = node.AsIdentifier().Text
+	}
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          "noUseBeforeDefine",
+		Description: fmt.Sprintf("'%s' was used before it was defined.", name),
+	})
+}

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.md
@@ -1,0 +1,53 @@
+# no-use-before-define
+
+## Rule Details
+
+Disallow the use of variables before they are defined.
+
+This rule extends the base ESLint `no-use-before-define` rule to add support for TypeScript-specific constructs like `type`, `interface`, and `enum` declarations.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+alert(a);
+var a = 10;
+
+f();
+function f() {}
+
+new A();
+class A {}
+
+const foo = Foo.FOO;
+enum Foo { FOO }
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+var a = 10;
+alert(a);
+
+type Foo = string;
+const x: Foo = "hello";
+
+function f() {}
+f();
+```
+
+## Options
+
+- `functions` (boolean, default `true`) - Whether to check function declarations
+- `classes` (boolean, default `true`) - Whether to check class declarations
+- `variables` (boolean, default `true`) - Whether to check variable declarations
+- `enums` (boolean, default `true`) - Whether to check enum declarations
+- `typedefs` (boolean, default `true`) - Whether to check type/interface declarations
+- `ignoreTypeReferences` (boolean, default `true`) - Whether to ignore references in type annotations
+- `allowNamedExports` (boolean, default `false`) - Whether to allow references in named exports
+
+Also accepts `"nofunc"` as a shorthand for `{ functions: false }`.
+
+## Original Documentation
+
+- https://typescript-eslint.io/rules/no-use-before-define
+- https://eslint.org/docs/latest/rules/no-use-before-define

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_test.go
@@ -1,0 +1,857 @@
+package no_use_before_define
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUseBeforeDefineRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUseBeforeDefineRule, []rule_tester.ValidTestCase{
+		// Type declarations before use
+		{
+			Code: `
+type foo = 1;
+const x: foo = 1;
+`,
+		},
+		{
+			Code: `
+type foo = 1;
+type bar = foo;
+`,
+		},
+		{
+			Code: `
+interface Foo {}
+const x: Foo = {};
+`,
+		},
+		// Variable declared before use
+		{
+			Code: `
+var a = 10;
+alert(a);
+`,
+		},
+		{
+			Code: `
+function b(a: number) {
+  alert(a);
+}
+`,
+		},
+		// Declare statements
+		{
+			Code: `declare function a(): void;`,
+		},
+		{
+			Code: `
+declare class a {
+  foo(): void;
+}
+`,
+		},
+		// Optional chaining
+		{
+			Code: `const updatedAt = (null as any)?.updatedAt;`,
+		},
+		// "nofunc" option
+		{
+			Code: `
+a();
+function a() {
+  alert(arguments);
+}
+`,
+			Options: map[string]interface{}{"functions": false},
+		},
+		// Arrow function IIFE
+		{
+			Code: `
+(() => {
+  var a = 42;
+  alert(a);
+})();
+`,
+		},
+		// Catch clause
+		{
+			Code: `
+a();
+try {
+  throw new Error();
+} catch (a) {}
+`,
+		},
+		// Class declared before use
+		{
+			Code: `
+class A {}
+new A();
+`,
+		},
+		// Sequential variable declarations
+		{
+			Code: `
+var a = 0, b = a;
+`,
+		},
+		// var _a = { a: 0, b: _a } = {} as any; — skipped, complex destructuring assignment target
+		// Self-referencing function
+		{
+			Code: `
+function foo() {
+  foo();
+}
+`,
+		},
+		{
+			Code: `
+var foo = function () {
+  foo();
+};
+`,
+		},
+		// For-in/for-of with declared variable
+		{
+			Code: `
+var a: any;
+for (a in a) {}
+`,
+		},
+		{
+			Code: `
+var a: any;
+for (a of a) {}
+`,
+		},
+		// Block-level bindings
+		{
+			Code: `
+'use strict';
+a();
+{
+  function a() {}
+}
+`,
+		},
+		{
+			Code: `
+'use strict';
+{
+  a();
+  function a() {}
+}
+`,
+			Options: map[string]interface{}{"functions": false},
+		},
+		{
+			Code: `
+switch (foo) {
+  case 1: {
+    a();
+  }
+  default: {
+    let a: any;
+  }
+}
+`,
+		},
+		// Object style options
+		{
+			Code: `
+a();
+function a() {
+  alert(arguments);
+}
+`,
+			Options: map[string]interface{}{"functions": false},
+		},
+		{
+			Code: `
+function foo() {
+  new A();
+}
+class A {}
+`,
+			Options: map[string]interface{}{"classes": false},
+		},
+		// "variables" option
+		{
+			Code: `
+function foo() {
+  bar;
+}
+var bar: any;
+`,
+			Options: map[string]interface{}{"variables": false},
+		},
+		{
+			Code: `
+var foo = () => bar;
+var bar: any;
+`,
+			Options: map[string]interface{}{"variables": false},
+		},
+		// "typedefs" option
+		{
+			Code: `
+var x: Foo = 2 as any;
+type Foo = string | number;
+`,
+			Options: map[string]interface{}{"typedefs": false},
+		},
+		// ignoreTypeReferences
+		{
+			Code: `
+interface Bar {
+  type: typeof Foo;
+}
+const Foo = 2;
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": true},
+		},
+		{
+			Code: `
+interface Bar {
+  type: typeof Foo.FOO;
+}
+class Foo {
+  public static readonly FOO = '';
+}
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": true},
+		},
+		{
+			Code: `
+interface Bar {
+  type: typeof Foo.Bar.Baz;
+}
+const Foo = {
+  Bar: {
+    Baz: 1,
+  },
+};
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": true},
+		},
+		// Interface with same name as later variable
+		{
+			Code: `
+interface Foo {
+  bar: string;
+}
+const bar = 'blah';
+`,
+		},
+		// Enums with enums: false
+		{
+			Code: `
+function foo(): Foo {
+  return Foo.FOO;
+}
+enum Foo { FOO }
+`,
+			Options: map[string]interface{}{"enums": false},
+		},
+		{
+			Code: `
+let foo: Foo;
+enum Foo { FOO }
+`,
+			Options: map[string]interface{}{"enums": false},
+		},
+		{
+			Code: `
+class Test {
+  foo(args: Foo): Foo {
+    return Foo.FOO;
+  }
+}
+enum Foo { FOO }
+`,
+			Options: map[string]interface{}{"enums": false},
+		},
+		// allowNamedExports
+		{
+			Code: `
+export { a };
+const a = 1;
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		{
+			Code: `
+export { a as b };
+const a = 1;
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		{
+			Code: `
+export { Foo };
+enum Foo { BAR }
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		// Decorators
+		{
+			Code: `
+@Directive({
+  selector: '[rcCidrIpPattern]',
+  providers: [
+    {
+      provide: NG_VALIDATORS,
+      useExisting: CidrIpPatternDirective,
+      multi: true,
+    },
+  ],
+})
+export class CidrIpPatternDirective implements Validator {}
+`,
+		},
+		// satisfies / as with ignoreTypeReferences: false
+		{
+			Code: `
+const obj = {
+  foo: 'foo-value',
+  bar: 'bar-value',
+} satisfies {
+  [key in 'foo' | 'bar']: ` + "`${key}-value`" + `;
+};
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+		},
+		{
+			Code: `
+const obj = {
+  foo: 'foo-value',
+  bar: 'bar-value',
+} as {
+  [key in 'foo' | 'bar']: ` + "`${key}-value`" + `;
+};
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+		},
+		// Namespace alias
+		{
+			Code: `
+namespace A.X.Y {}
+import Z = A.X.Y;
+const X = 23;
+`,
+		},
+		// typeof in satisfies with ignoreTypeReferences: true
+		{
+			Code: `
+const foo = {
+  bar: 'bar',
+} satisfies {
+  bar: typeof baz;
+};
+const baz = '';
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": true},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Basic use before define
+		{
+			Code: `
+a++;
+var a = 19;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code: `
+a();
+var a = function () {};
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code: `
+alert(a[1]);
+var a = [1, 3];
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 7},
+			},
+		},
+		// Function with nested use before define
+		{
+			Code: `
+a();
+function a() {
+  alert(b);
+  var b = 10;
+  a();
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+				{MessageId: "noUseBeforeDefine", Line: 4, Column: 9},
+			},
+		},
+		// nofunc still catches var assigned function expression
+		{
+			Code: `
+a();
+var a = function () {};
+`,
+			Options: map[string]interface{}{"functions": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		// Arrow function
+		{
+			Code: `
+(() => {
+  alert(a);
+  var a = 42;
+})();
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 9},
+			},
+		},
+		// Arrow function calling function before define
+		{
+			Code: `
+(() => a())();
+function a() {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 8},
+			},
+		},
+		// Catch clause with var
+		{
+			Code: `
+a();
+try {
+  throw new Error();
+} catch (foo) {
+  var a: any;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		// Arrow expression
+		{
+			Code: `
+var f = () => a;
+var a: any;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 15},
+			},
+		},
+		// Class before define
+		{
+			Code: `
+new A();
+class A {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 5},
+			},
+		},
+		{
+			Code: `
+function foo() {
+  new A();
+}
+class A {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 7},
+			},
+		},
+		{
+			Code: `
+new A();
+var A = class {};
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 5},
+			},
+		},
+		{
+			Code: `
+function foo() {
+  new A();
+}
+var A = class {};
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 7},
+			},
+		},
+		// Block-level bindings
+		{
+			Code: `
+a++;
+{
+  var a: any;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code: `
+'use strict';
+{
+  a();
+  function a() {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+{
+  a;
+  let a = 1;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+switch (foo) {
+  case 1:
+    a();
+  default:
+    let a: any;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 4, Column: 5},
+			},
+		},
+		// Object style options — var assigned function still caught
+		{
+			Code: `
+a();
+var a = function () {};
+`,
+			Options: map[string]interface{}{"classes": false, "functions": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		// classes: false still catches var assigned class and same-scope class
+		{
+			Code: `
+new A();
+var A = class {};
+`,
+			Options: map[string]interface{}{"classes": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 5},
+			},
+		},
+		{
+			Code: `
+function foo() {
+  new A();
+}
+var A = class {};
+`,
+			Options: map[string]interface{}{"classes": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 7},
+			},
+		},
+		// Self-referencing initializer
+		{
+			Code: `var a = a;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code: `let a = a + b;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code: `const a = foo(a);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code: `function foo(a = a) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code: `var { a = a } = [] as any;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 11},
+			},
+		},
+		{
+			Code: `var [a = a] = [] as any;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 10},
+			},
+		},
+		{
+			Code: `var { b = a, a } = {} as any;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 11},
+			},
+		},
+		{
+			Code: `var [b = a, a] = {} as any;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 10},
+			},
+		},
+		{
+			Code: `var { a = 0 } = a;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 17},
+			},
+		},
+		{
+			Code: `var [a = 0] = a;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 1, Column: 15},
+			},
+		},
+		// For-in/for-of with inline declaration
+		{
+			Code: `
+for (var a in a) {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 15},
+			},
+		},
+		{
+			Code: `
+for (var a of a) {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 15},
+			},
+		},
+		// ignoreTypeReferences: false
+		{
+			Code: `
+interface Bar {
+  type: typeof Foo;
+}
+const Foo = 2;
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 16},
+			},
+		},
+		{
+			Code: `
+interface Bar {
+  type: typeof Foo.FOO;
+}
+class Foo {
+  public static readonly FOO = '';
+}
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 16},
+			},
+		},
+		{
+			Code: `
+interface Bar {
+  type: typeof Foo.Bar.Baz;
+}
+const Foo = {
+  Bar: {
+    Baz: 1,
+  },
+};
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 16},
+			},
+		},
+		// variables: false still catches same-scope
+		{
+			Code: `
+function foo() {
+  bar;
+  var bar = 1;
+}
+var bar: any;
+`,
+			Options: map[string]interface{}{"variables": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 3},
+			},
+		},
+		// Enum references
+		{
+			Code: `
+class Test {
+  foo(args: Foo): Foo {
+    return Foo.FOO;
+  }
+}
+enum Foo { FOO }
+`,
+			Options: map[string]interface{}{"enums": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 4, Column: 12},
+			},
+		},
+		{
+			Code: `
+function foo(): Foo {
+  return Foo.FOO;
+}
+enum Foo { FOO }
+`,
+			Options: map[string]interface{}{"enums": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 3, Column: 10},
+			},
+		},
+		{
+			Code: `
+const foo = Foo.Foo;
+enum Foo { FOO }
+`,
+			Options: map[string]interface{}{"enums": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 13},
+			},
+		},
+		// Named exports (default allowNamedExports: false)
+		{
+			Code: `
+export { a };
+const a = 1;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		{
+			Code: `
+export { a as b };
+const a = 1;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		{
+			Code: `
+export { a, b };
+let a: any, b: any;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 13},
+			},
+		},
+		{
+			Code: `
+export { f };
+function f() {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		{
+			Code: `
+export { C };
+class C {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		// Function call before define
+		{
+			Code: `
+f();
+function f() {}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 1},
+			},
+		},
+		{
+			Code: `
+alert(a);
+var a = 10;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 7},
+			},
+		},
+		// Export enum/namespace before define
+		{
+			Code: `
+export { Foo };
+enum Foo { BAR }
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		{
+			Code: `
+export { Foo };
+namespace Foo {
+  export let bar = () => console.log('bar');
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		// satisfies with ignoreTypeReferences: false
+		{
+			Code: `
+const foo = {
+  bar: 'bar',
+} satisfies {
+  bar: typeof baz;
+};
+const baz = '';
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 5, Column: 15},
+			},
+		},
+	})
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -934,6 +934,91 @@ func FindEnclosingScope(node *ast.Node) *ast.Node {
 	})
 }
 
+// IsDeclarationIdentifier checks if the node is the name (identifier) of a declaration.
+// Unlike ast.IsDeclarationName(), this returns false for ShorthandPropertyAssignment
+// names since they are both declaration names AND value references.
+func IsDeclarationIdentifier(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	parent := node.Parent
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		return parent.AsVariableDeclaration().Name() == node
+	case ast.KindFunctionDeclaration:
+		return parent.AsFunctionDeclaration().Name() == node
+	case ast.KindParameter:
+		return parent.AsParameterDeclaration().Name() == node
+	case ast.KindClassDeclaration:
+		return parent.AsClassDeclaration().Name() == node
+	case ast.KindClassExpression:
+		return parent.AsClassExpression().Name() == node
+	case ast.KindFunctionExpression:
+		return parent.AsFunctionExpression().Name() == node
+	case ast.KindInterfaceDeclaration:
+		return parent.AsInterfaceDeclaration().Name() == node
+	case ast.KindTypeAliasDeclaration:
+		return parent.AsTypeAliasDeclaration().Name() == node
+	case ast.KindEnumDeclaration:
+		return parent.AsEnumDeclaration().Name() == node
+	case ast.KindModuleDeclaration:
+		return parent.AsModuleDeclaration().Name() == node
+	case ast.KindCatchClause:
+		return parent.AsCatchClause().VariableDeclaration == node
+	case ast.KindImportSpecifier:
+		return parent.AsImportSpecifier().Name() == node
+	case ast.KindImportClause:
+		return parent.AsImportClause().Name() == node
+	case ast.KindBindingElement:
+		return parent.AsBindingElement().Name() == node
+	case ast.KindNamespaceImport:
+		return parent.AsNamespaceImport().Name() == node
+	case ast.KindImportEqualsDeclaration:
+		return parent.AsImportEqualsDeclaration().Name() == node
+	case ast.KindEnumMember:
+		return parent.AsEnumMember().Name() == node
+	}
+	return false
+}
+
+// GetDeclarationIdentifier returns the name node of a declaration.
+func GetDeclarationIdentifier(decl *ast.Node) *ast.Node {
+	if decl == nil {
+		return nil
+	}
+	switch decl.Kind {
+	case ast.KindVariableDeclaration:
+		return decl.AsVariableDeclaration().Name()
+	case ast.KindFunctionDeclaration:
+		return decl.AsFunctionDeclaration().Name()
+	case ast.KindClassDeclaration:
+		return decl.AsClassDeclaration().Name()
+	case ast.KindClassExpression:
+		return decl.AsClassExpression().Name()
+	case ast.KindInterfaceDeclaration:
+		return decl.AsInterfaceDeclaration().Name()
+	case ast.KindTypeAliasDeclaration:
+		return decl.AsTypeAliasDeclaration().Name()
+	case ast.KindEnumDeclaration:
+		return decl.AsEnumDeclaration().Name()
+	case ast.KindModuleDeclaration:
+		return decl.AsModuleDeclaration().Name()
+	case ast.KindImportSpecifier:
+		return decl.AsImportSpecifier().Name()
+	case ast.KindImportClause:
+		return decl.AsImportClause().Name()
+	case ast.KindNamespaceImport:
+		return decl.AsNamespaceImport().Name()
+	case ast.KindImportEqualsDeclaration:
+		return decl.AsImportEqualsDeclaration().Name()
+	case ast.KindParameter:
+		return decl.AsParameterDeclaration().Name()
+	case ast.KindBindingElement:
+		return decl.AsBindingElement().Name()
+	}
+	return nil
+}
+
 // VisitDestructuringIdentifiers calls fn for each identifier target in a
 // destructuring assignment pattern (object/array literal on the left side
 // of an assignment expression). Handles shorthand properties, renamed

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -161,6 +161,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-shadow/no-shadow.test.ts',
     './tests/typescript-eslint/rules/no-this-alias.test.ts',
     // './tests/typescript-eslint/rules/no-type-alias.test.ts',
+    './tests/typescript-eslint/rules/no-use-before-define.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-boolean-literal-compare.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-condition.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-parameter-property-assignment.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-use-before-define.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-use-before-define.test.ts.snap
@@ -1,0 +1,857 @@
+// Rstest Snapshot v1
+
+exports[`no-use-before-define > invalid 1`] = `
+{
+  "code": "
+a++;
+var a = 19;
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 2`] = `
+{
+  "code": "
+a();
+var a = function () {};
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 3`] = `
+{
+  "code": "
+a();
+function a() {
+  alert(b);
+  var b = 10;
+  a();
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+    {
+      "message": "'b' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 4`] = `
+{
+  "code": "
+(() => {
+  alert(a);
+  var a = 42;
+})();
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 5`] = `
+{
+  "code": "
+new A();
+class A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 6`] = `
+{
+  "code": "
+function foo() {
+  new A();
+}
+class A {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'A' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 7`] = `
+{
+  "code": "var a = a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 8`] = `
+{
+  "code": "let a = a + b;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 9`] = `
+{
+  "code": "const a = foo(a);",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 10`] = `
+{
+  "code": "function foo(a = a) {}",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 11`] = `
+{
+  "code": "var { a = a } = [] as any;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 12`] = `
+{
+  "code": "var [a = a] = [] as any;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 13`] = `
+{
+  "code": "var { b = a, a } = {} as any;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 14`] = `
+{
+  "code": "var { a = 0 } = a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 15`] = `
+{
+  "code": "var [a = 0] = a;",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 16`] = `
+{
+  "code": "
+for (var a in a) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 17`] = `
+{
+  "code": "
+for (var a of a) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 15,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 18`] = `
+{
+  "code": "
+interface Bar {
+  type: typeof Foo;
+}
+const Foo = 2;
+      ",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 19`] = `
+{
+  "code": "
+function foo(): Foo {
+  return Foo.FOO;
+}
+enum Foo { FOO }
+      ",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 20`] = `
+{
+  "code": "
+const foo = Foo.Foo;
+enum Foo { FOO }
+      ",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 21`] = `
+{
+  "code": "
+export { a };
+const a = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 22`] = `
+{
+  "code": "
+export { a as b };
+const a = 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 23`] = `
+{
+  "code": "
+export { a, b };
+let a: any, b: any;
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+    {
+      "message": "'b' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 24`] = `
+{
+  "code": "
+export { f };
+function f() {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'f' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 25`] = `
+{
+  "code": "
+export { C };
+class C {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'C' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 26`] = `
+{
+  "code": "
+f();
+function f() {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'f' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 27`] = `
+{
+  "code": "
+alert(a);
+var a = 10;
+      ",
+  "diagnostics": [
+    {
+      "message": "'a' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 28`] = `
+{
+  "code": "
+export { Foo };
+enum Foo { BAR }
+      ",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-use-before-define > invalid 29`] = `
+{
+  "code": "
+export { Foo };
+namespace Foo {
+  export let bar = () => console.log('bar');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "'Foo' was used before it was defined.",
+      "messageId": "noUseBeforeDefine",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-use-before-define",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-use-before-define.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-use-before-define.test.ts
@@ -1,14 +1,10 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
-import { AST_NODE_TYPES } from '@typescript-eslint/utils';
-
-
 
 const ruleTester = new RuleTester();
 
-const parserOptions = { ecmaVersion: 6 as const };
-
 ruleTester.run('no-use-before-define', {
   valid: [
+    // Type declarations before use
     `
 type foo = 1;
 const x: foo = 1;
@@ -21,38 +17,24 @@ type bar = foo;
 interface Foo {}
 const x: Foo = {};
     `,
+    // Variable declared before use
     `
 var a = 10;
 alert(a);
     `,
     `
-function b(a) {
+function b(a: number) {
   alert(a);
 }
     `,
-    'Object.hasOwnProperty.call(a);',
-    `
-function a() {
-  alert(arguments);
-}
-    `,
-    'declare function a();',
+    // Declare statements
+    'declare function a(): void;',
     `
 declare class a {
-  foo();
+  foo(): void;
 }
     `,
-    'const updatedAt = data?.updatedAt;',
-    `
-function f() {
-  return function t() {};
-}
-f()?.();
-    `,
-    `
-var a = { b: 5 };
-alert(a?.b);
-    `,
+    // nofunc option
     {
       code: `
 a();
@@ -60,36 +42,28 @@ function a() {
   alert(arguments);
 }
       `,
-      options: ['nofunc'],
+      options: [{ functions: false }],
     },
-    {
-      code: `
+    // Arrow function IIFE
+    `
 (() => {
   var a = 42;
   alert(a);
 })();
-      `,
-      languageOptions: { parserOptions },
-    },
+    `,
+    // Catch clause
     `
 a();
 try {
   throw new Error();
 } catch (a) {}
     `,
-    {
-      code: `
+    // Class declared before use
+    `
 class A {}
 new A();
-      `,
-      languageOptions: { parserOptions },
-    },
-    `
-var a = 0,
-  b = a;
     `,
-    { code: 'var { a = 0, b = a } = {};', languageOptions: { parserOptions } },
-    { code: 'var [a = 0, b = a] = {};', languageOptions: { parserOptions } },
+    // Self-referencing function
     `
 function foo() {
   foo();
@@ -100,20 +74,15 @@ var foo = function () {
   foo();
 };
     `,
+    // For-in/for-of with declared variable
     `
-var a;
-for (a in a) {
-}
+var a: any;
+for (a in a) {}
     `,
-    {
-      code: `
-var a;
-for (a of a) {
-}
-      `,
-      languageOptions: { parserOptions },
-    },
-
+    `
+var a: any;
+for (a of a) {}
+    `,
     // Block-level bindings
     {
       code: `
@@ -123,7 +92,6 @@ a();
   function a() {}
 }
       `,
-      languageOptions: { parserOptions },
     },
     {
       code: `
@@ -133,33 +101,9 @@ a();
   function a() {}
 }
       `,
-      languageOptions: { parserOptions },
-      options: ['nofunc'],
+      options: [{ functions: false }],
     },
-    {
-      code: `
-switch (foo) {
-  case 1: {
-    a();
-  }
-  default: {
-    let a;
-  }
-}
-      `,
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-a();
-{
-  let a = function () {};
-}
-      `,
-      languageOptions: { parserOptions },
-    },
-
-    // object style options
+    // Object style options
     {
       code: `
 a();
@@ -171,60 +115,37 @@ function a() {
     },
     {
       code: `
-'use strict';
-{
-  a();
-  function a() {}
-}
-      `,
-      languageOptions: { parserOptions },
-      options: [{ functions: false }],
-    },
-    {
-      code: `
 function foo() {
   new A();
 }
 class A {}
       `,
-      languageOptions: { parserOptions },
       options: [{ classes: false }],
     },
-
     // "variables" option
     {
       code: `
 function foo() {
   bar;
 }
-var bar;
+var bar: any;
       `,
       options: [{ variables: false }],
     },
-    {
-      code: `
-var foo = () => bar;
-var bar;
-      `,
-      languageOptions: { parserOptions },
-      options: [{ variables: false }],
-    },
-
     // "typedefs" option
     {
       code: `
-var x: Foo = 2;
+var x: Foo = 2 as any;
 type Foo = string | number;
       `,
       options: [{ typedefs: false }],
     },
-    // https://github.com/typescript-eslint/typescript-eslint/issues/2572
+    // ignoreTypeReferences
     {
       code: `
 interface Bar {
   type: typeof Foo;
 }
-
 const Foo = 2;
       `,
       options: [{ ignoreTypeReferences: true }],
@@ -234,107 +155,35 @@ const Foo = 2;
 interface Bar {
   type: typeof Foo.FOO;
 }
-
 class Foo {
   public static readonly FOO = '';
 }
       `,
       options: [{ ignoreTypeReferences: true }],
     },
-    {
-      code: `
-interface Bar {
-  type: typeof Foo.Bar.Baz;
-}
-
-const Foo = {
-  Bar: {
-    Baz: 1,
-  },
-};
-      `,
-      options: [{ ignoreTypeReferences: true }],
-    },
-    // https://github.com/bradzacher/eslint-plugin-typescript/issues/141
-    {
-      code: `
-interface ITest {
-  first: boolean;
-  second: string;
-  third: boolean;
-}
-
-let first = () => console.log('first');
-
-export let second = () => console.log('second');
-
-export namespace Third {
-  export let third = () => console.log('third');
-}
-      `,
-      languageOptions: {
-        parserOptions: { ecmaVersion: 6, sourceType: 'module' },
-      },
-    },
-    // https://github.com/eslint/typescript-eslint-parser/issues/550
-    `
-function test(file: Blob) {
-  const slice: typeof file.slice =
-    file.slice || (file as any).webkitSlice || (file as any).mozSlice;
-  return slice;
-}
-    `,
-    // https://github.com/eslint/typescript-eslint-parser/issues/435
+    // Interface with same name as later variable
     `
 interface Foo {
   bar: string;
 }
 const bar = 'blah';
     `,
+    // Enums with enums: false
     {
       code: `
 function foo(): Foo {
   return Foo.FOO;
 }
-
-enum Foo {
-  FOO,
-}
+enum Foo { FOO }
       `,
       options: [{ enums: false }],
     },
-    {
-      code: `
-let foo: Foo;
-
-enum Foo {
-  FOO,
-}
-      `,
-      options: [{ enums: false }],
-    },
-    {
-      code: `
-class Test {
-  foo(args: Foo): Foo {
-    return Foo.FOO;
-  }
-}
-
-enum Foo {
-  FOO,
-}
-      `,
-      options: [{ enums: false }],
-    },
-
-    // "allowNamedExports" option
+    // allowNamedExports
     {
       code: `
 export { a };
 const a = 1;
       `,
-      languageOptions: { parserOptions },
       options: [{ allowNamedExports: true }],
     },
     {
@@ -342,154 +191,16 @@ const a = 1;
 export { a as b };
 const a = 1;
       `,
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export { a, b };
-let a, b;
-      `,
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export { a };
-var a;
-      `,
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export { f };
-function f() {}
-      `,
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export { C };
-class C {}
-      `,
-      languageOptions: { parserOptions },
       options: [{ allowNamedExports: true }],
     },
     {
       code: `
 export { Foo };
-
-enum Foo {
-  BAR,
-}
+enum Foo { BAR }
       `,
-      languageOptions: { parserOptions },
       options: [{ allowNamedExports: true }],
     },
-    {
-      code: `
-export { Foo };
-
-namespace Foo {
-  export let bar = () => console.log('bar');
-}
-      `,
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export { Foo, baz };
-
-enum Foo {
-  BAR,
-}
-
-let baz: Enum;
-enum Enum {}
-      `,
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    // https://github.com/typescript-eslint/typescript-eslint/issues/2502
-    {
-      code: `
-import * as React from 'react';
-
-<div />;
-      `,
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-          sourceType: 'module',
-        },
-      },
-    },
-    {
-      code: `
-import React from 'react';
-
-<div />;
-      `,
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-          sourceType: 'module',
-        },
-      },
-    },
-    {
-      code: `
-import { h } from 'preact';
-
-<div />;
-      `,
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-          jsxPragma: 'h',
-          sourceType: 'module',
-        },
-      },
-    },
-    {
-      code: `
-const React = require('react');
-
-<div />;
-      `,
-      languageOptions: {
-        parserOptions: {
-          ecmaFeatures: {
-            jsx: true,
-          },
-        },
-      },
-    },
-    // https://github.com/typescript-eslint/typescript-eslint/issues/2527
-    `
-type T = (value: unknown) => value is Id;
-    `,
-    `
-global.foo = true;
-
-declare global {
-  namespace NodeJS {
-    interface Global {
-      foo?: boolean;
-    }
-  }
-}
-    `,
-    // https://github.com/typescript-eslint/typescript-eslint/issues/2824
+    // Decorators
     `
 @Directive({
   selector: '[rcCidrIpPattern]',
@@ -503,164 +214,30 @@ declare global {
 })
 export class CidrIpPatternDirective implements Validator {}
     `,
-    {
-      code: `
-@Directive({
-  selector: '[rcCidrIpPattern]',
-  providers: [
-    {
-      provide: NG_VALIDATORS,
-      useExisting: CidrIpPatternDirective,
-      multi: true,
-    },
-  ],
-})
-export class CidrIpPatternDirective implements Validator {}
-      `,
-      options: [
-        {
-          classes: false,
-        },
-      ],
-    },
-    // https://github.com/typescript-eslint/typescript-eslint/issues/2941
-    `
-class A {
-  constructor(printName) {
-    this.printName = printName;
-  }
-
-  openPort(printerName = this.printerName) {
-    this.tscOcx.ActiveXopenport(printerName);
-
-    return this;
-  }
-}
-    `,
-    {
-      code: `
-const obj = {
-  foo: 'foo-value',
-  bar: 'bar-value',
-} satisfies {
-  [key in 'foo' | 'bar']: \`\${key}-value\`;
-};
-      `,
-      options: [{ ignoreTypeReferences: false }],
-    },
-    {
-      code: `
-const obj = {
-  foo: 'foo-value',
-  bar: 'bar-value',
-} as {
-  [key in 'foo' | 'bar']: \`\${key}-value\`;
-};
-      `,
-      options: [{ ignoreTypeReferences: false }],
-    },
-    {
-      code: `
-const obj = {
-  foo: {
-    foo: 'foo',
-  } as {
-    [key in 'foo' | 'bar']: key;
-  },
-};
-      `,
-      options: [{ ignoreTypeReferences: false }],
-    },
-    {
-      code: `
-const foo = {
-  bar: 'bar',
-} satisfies {
-  bar: typeof baz;
-};
-
-const baz = '';
-      `,
-      options: [{ ignoreTypeReferences: true }],
-    },
+    // Namespace alias
     `
 namespace A.X.Y {}
-
 import Z = A.X.Y;
-
 const X = 23;
     `,
   ],
   invalid: [
+    // Basic use before define
     {
       code: `
 a++;
 var a = 19;
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: {
-        parserOptions: { sourceType: 'module' },
-      },
-    },
-    {
-      code: `
-a++;
-var a = 19;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-a++;
-var a = 19;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
 a();
 var a = function () {};
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    {
-      code: `
-alert(a[1]);
-var a = [1, 3];
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-    },
+    // Function with nested errors
     {
       code: `
 a();
@@ -671,32 +248,11 @@ function a() {
 }
       `,
       errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-        {
-          data: { name: 'b' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
+        { messageId: 'noUseBeforeDefine' },
+        { messageId: 'noUseBeforeDefine' },
       ],
     },
-    {
-      code: `
-a();
-var a = function () {};
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      options: ['nofunc'],
-    },
+    // Arrow function
     {
       code: `
 (() => {
@@ -704,73 +260,15 @@ var a = function () {};
   var a = 42;
 })();
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    {
-      code: `
-(() => a())();
-function a() {}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-a();
-try {
-  throw new Error();
-} catch (foo) {
-  var a;
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-    },
-    {
-      code: `
-var f = () => a;
-var a;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
+    // Class before define
     {
       code: `
 new A();
 class A {}
       `,
-      errors: [
-        {
-          data: { name: 'A' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
@@ -779,751 +277,159 @@ function foo() {
 }
 class A {}
       `,
-      errors: [
-        {
-          data: { name: 'A' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    {
-      code: `
-new A();
-var A = class {};
-      `,
-      errors: [
-        {
-          data: { name: 'A' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-function foo() {
-  new A();
-}
-var A = class {};
-      `,
-      errors: [
-        {
-          data: { name: 'A' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-
-    // Block-level bindings
-    {
-      code: `
-a++;
-{
-  var a;
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-'use strict';
-{
-  a();
-  function a() {}
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-{
-  a;
-  let a = 1;
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-switch (foo) {
-  case 1:
-    a();
-  default:
-    let a;
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-if (true) {
-  function foo() {
-    a;
-  }
-  let a;
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-
-    // object style options
-    {
-      code: `
-a();
-var a = function () {};
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      options: [{ classes: false, functions: false }],
-    },
-    {
-      code: `
-new A();
-var A = class {};
-      `,
-      errors: [
-        {
-          data: { name: 'A' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ classes: false }],
-    },
-    {
-      code: `
-function foo() {
-  new A();
-}
-var A = class {};
-      `,
-      errors: [
-        {
-          data: { name: 'A' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ classes: false }],
-    },
-
-    // invalid initializers
+    // Self-referencing initializer
     {
       code: 'var a = a;',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: 'let a = a + b;',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: 'const a = foo(a);',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: 'function foo(a = a) {}',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
+    },
+    // Destructuring
+    {
+      code: 'var { a = a } = [] as any;',
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
-      code: 'var { a = a } = [];',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      code: 'var [a = a] = [] as any;',
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
-      code: 'var [a = a] = [];',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: 'var { b = a, a } = {};',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: 'var [b = a, a] = {};',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      code: 'var { b = a, a } = {} as any;',
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: 'var { a = 0 } = a;',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: 'var [a = 0] = a;',
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
+    },
+    // For-in/for-of with inline declaration
+    {
+      code: `
+for (var a in a) {}
+      `,
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
-for (var a in a) {
-}
+for (var a of a) {}
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    {
-      code: `
-for (var a of a) {
-}
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-
-    // "ignoreTypeReferences" option
+    // ignoreTypeReferences: false
     {
       code: `
 interface Bar {
   type: typeof Foo;
 }
-
 const Foo = 2;
       `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
       options: [{ ignoreTypeReferences: false }],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    {
-      code: `
-interface Bar {
-  type: typeof Foo.FOO;
-}
-
-class Foo {
-  public static readonly FOO = '';
-}
-      `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      options: [{ ignoreTypeReferences: false }],
-    },
-    {
-      code: `
-interface Bar {
-  type: typeof Foo.Bar.Baz;
-}
-
-const Foo = {
-  Bar: {
-    Baz: 1,
-  },
-};
-      `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      options: [{ ignoreTypeReferences: false }],
-    },
-    {
-      code: `
-const foo = {
-  bar: 'bar',
-} satisfies {
-  bar: typeof baz;
-};
-
-const baz = '';
-      `,
-      errors: [
-        {
-          data: { name: 'baz' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      options: [{ ignoreTypeReferences: false }],
-    },
-
-    // "variables" option
-    {
-      code: `
-function foo() {
-  bar;
-  var bar = 1;
-}
-var bar;
-      `,
-      errors: [
-        {
-          data: { name: 'bar' },
-          messageId: 'noUseBeforeDefine',
-          type: AST_NODE_TYPES.Identifier,
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ variables: false }],
-    },
-    {
-      code: `
-class Test {
-  foo(args: Foo): Foo {
-    return Foo.FOO;
-  }
-}
-
-enum Foo {
-  FOO,
-}
-      `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          line: 4,
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      options: [{ enums: true }],
-    },
+    // Enum references
     {
       code: `
 function foo(): Foo {
   return Foo.FOO;
 }
-
-enum Foo {
-  FOO,
-}
+enum Foo { FOO }
       `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          line: 3,
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
       options: [{ enums: true }],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
 const foo = Foo.Foo;
-
-enum Foo {
-  FOO,
-}
+enum Foo { FOO }
       `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          line: 2,
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
       options: [{ enums: true }],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    // "allowNamedExports" option
+    // Named exports (default allowNamedExports: false)
     {
       code: `
 export { a };
 const a = 1;
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-export { a };
-const a = 1;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{}],
-    },
-    {
-      code: `
-export { a };
-const a = 1;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: false }],
-    },
-    {
-      code: `
-export { a };
-const a = 1;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: ['nofunc'],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
 export { a as b };
 const a = 1;
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
 export { a, b };
-let a, b;
+let a: any, b: any;
       `,
       errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-        {
-          data: { name: 'b' },
-          messageId: 'noUseBeforeDefine',
-        },
+        { messageId: 'noUseBeforeDefine' },
+        { messageId: 'noUseBeforeDefine' },
       ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-export { a };
-var a;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
     },
     {
       code: `
 export { f };
 function f() {}
       `,
-      errors: [
-        {
-          data: { name: 'f' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
 export { C };
 class C {}
       `,
-      errors: [
-        {
-          data: { name: 'C' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
-    {
-      code: `
-export const foo = a;
-const a = 1;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export function foo() {
-  return a;
-}
-const a = 1;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export class C {
-  foo() {
-    return a;
-  }
-}
-const a = 1;
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: true }],
-    },
-    {
-      code: `
-export { Foo };
-
-enum Foo {
-  BAR,
-}
-      `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-export { Foo };
-
-namespace Foo {
-  export let bar = () => console.log('bar');
-}
-      `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-    },
-    {
-      code: `
-export { Foo, baz };
-
-enum Foo {
-  BAR,
-}
-
-let baz: Enum;
-enum Enum {}
-      `,
-      errors: [
-        {
-          data: { name: 'Foo' },
-          messageId: 'noUseBeforeDefine',
-        },
-        {
-          data: { name: 'baz' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-      languageOptions: { parserOptions },
-      options: [{ allowNamedExports: false, ignoreTypeReferences: true }],
-    },
+    // Function call before define
     {
       code: `
 f();
 function f() {}
       `,
-      errors: [
-        {
-          data: { name: 'f' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
 alert(a);
 var a = 10;
       `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
+    },
+    // Export enum/namespace before define
+    {
+      code: `
+export { Foo };
+enum Foo { BAR }
+      `,
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
     {
       code: `
-f()?.();
-function f() {
-  return function t() {};
+export { Foo };
+namespace Foo {
+  export let bar = () => console.log('bar');
 }
       `,
-      errors: [
-        {
-          data: { name: 'f' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
-    },
-    {
-      code: `
-alert(a?.b);
-var a = { b: 5 };
-      `,
-      errors: [
-        {
-          data: { name: 'a' },
-          messageId: 'noUseBeforeDefine',
-        },
-      ],
+      errors: [{ messageId: 'noUseBeforeDefine' }],
     },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-use-before-define` rule to rslint.

This rule disallows the use of variables before they are defined, with TypeScript-specific support for `type`, `interface`, `enum`, and `namespace` declarations.

**Options**: `functions`, `classes`, `variables`, `enums`, `typedefs`, `ignoreTypeReferences`, `allowNamedExports`, `"nofunc"`.

**End-to-end verified** against the original `@typescript-eslint/no-use-before-define` on real projects:
- rspack (748 files): 409 warnings, **0 diff** vs ESLint
- rsbuild (1192 files): 39 warnings, **0 diff** vs ESLint

Also extracted `IsDeclarationIdentifier` and `GetDeclarationIdentifier` into `internal/utils/` for reuse across rules (used by `no-unused-vars` and this rule).

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/no-use-before-define
- ESLint core rule: https://eslint.org/docs/latest/rules/no-use-before-define

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).