### PR TITLE
feat: port rule no-iterator

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,6 +136,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_import_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
+	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
@@ -525,6 +526,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("prefer-rest-params", prefer_rest_params.PreferRestParamsRule)
 	GlobalRuleRegistry.Register("no-empty-character-class", no_empty_character_class.NoEmptyCharacterClassRule)
 	GlobalRuleRegistry.Register("no-invalid-regexp", no_invalid_regexp.NoInvalidRegexpRule)
+	GlobalRuleRegistry.Register("no-iterator", no_iterator.NoIteratorRule)
 	GlobalRuleRegistry.Register("no-setter-return", no_setter_return.NoSetterReturnRule)
 	GlobalRuleRegistry.Register("no-unsafe-negation", no_unsafe_negation.NoUnsafeNegationRule)
 	GlobalRuleRegistry.Register("no-obj-calls", no_obj_calls.NoObjCallsRule)

--- a/internal/rules/no_iterator/no_iterator.go
+++ b/internal/rules/no_iterator/no_iterator.go
@@ -1,0 +1,38 @@
+package no_iterator
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-iterator
+var NoIteratorRule = rule.Rule{
+	Name: "no-iterator",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		report := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noIterator",
+				Description: "Reserved name '__iterator__'.",
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				name := node.Name()
+				if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "__iterator__" {
+					report(node)
+				}
+			},
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				argExpr := node.AsElementAccessExpression().ArgumentExpression
+				if argExpr != nil {
+					val, ok := utils.GetStaticExpressionValue(argExpr)
+					if ok && val == "__iterator__" {
+						report(node)
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_iterator/no_iterator.md
+++ b/internal/rules/no_iterator/no_iterator.md
@@ -1,0 +1,31 @@
+# no-iterator
+
+## Rule Details
+
+Disallow the use of the `__iterator__` property.
+
+The `__iterator__` property was a SpiderMonkey extension to JavaScript that could be used to create custom iterators compatible with `for...in` and `for each...in` loops. However, this property is now obsolete, so it should not be used. The standard `Symbol.iterator` property should be used instead to define the iteration protocol.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Foo.prototype.__iterator__ = function () {};
+
+var a = test.__iterator__;
+
+var a = test['__iterator__'];
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var __iterator__ = null;
+
+var a = test[__iterator__];
+
+Foo.prototype[Symbol.iterator] = function () {};
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-iterator

--- a/internal/rules/no_iterator/no_iterator_test.go
+++ b/internal/rules/no_iterator/no_iterator_test.go
@@ -1,0 +1,489 @@
+package no_iterator
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoIteratorRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoIteratorRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// Computed property with identifier (not a string literal)
+			{Code: `var a = test[__iterator__];`},
+			// Variable declaration, not member access
+			{Code: `var __iterator__ = null;`},
+			// Template literal missing trailing __
+			{Code: "foo[`__iterator`] = null;"},
+			// Template literal with newline (not exact match)
+			{Code: "foo[`__iterator__\n`] = null;"},
+			// Template literal with expression (TemplateExpression, not NoSubstitutionTemplateLiteral)
+			{Code: "foo[`__iterator__${x}`] = null;"},
+			// Object property key (not a member access)
+			{Code: `var obj = { __iterator__: 1 };`},
+			// Object shorthand
+			{Code: `var obj = { __iterator__ };`},
+			// Destructuring (not a member access)
+			{Code: `const { __iterator__ } = obj;`},
+			{Code: `const { __iterator__: alias } = obj;`},
+			// Function declaration
+			{Code: `function __iterator__() {}`},
+			// Class method declaration
+			{Code: `class Foo { __iterator__() {} }`},
+			// TypeScript interface property
+			{Code: `interface Foo { __iterator__: any; }`},
+			// TypeScript type alias
+			{Code: `type Foo = { __iterator__: any };`},
+			// Parameter name
+			{Code: `function foo(__iterator__: any) {}`},
+			// Enum member
+			{Code: `enum Foo { __iterator__ }`},
+			// Private identifier (KindPrivateIdentifier, not KindIdentifier)
+			{Code: `class Foo { #__iterator__ = 1; m() { this.#__iterator__; } }`},
+			// TypeScript QualifiedName in type position (not PropertyAccessExpression)
+			{Code: `declare namespace A { var __iterator__: number; } type X = typeof A.__iterator__;`},
+			// Import/export specifier
+			{Code: `export { __iterator__ } from 'mod';`},
+			// Label (not a member access)
+			{Code: `__iterator__: for (;;) { break __iterator__; }`},
+			// Computed with string concatenation (not a static literal)
+			{Code: `obj['__iterator' + '__'];`},
+			// Computed with variable
+			{Code: `const key = '__iterator__'; obj[key];`},
+			// Getter/setter declaration in object
+			{Code: `var obj = { get __iterator__() { return 1; } };`},
+			// JSX attribute (not a member access)
+			{Code: `var x = <Component __iterator__={value} />;`, Tsx: true},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// ========================================
+			// Basic access patterns
+			// ========================================
+			// Dot notation
+			{
+				Code: `var a = test.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 9},
+				},
+			},
+			// Bracket with single-quoted string
+			{
+				Code: `var a = test['__iterator__'];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 9},
+				},
+			},
+			// Bracket with double-quoted string
+			{
+				Code: `var a = test["__iterator__"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 9},
+				},
+			},
+			// Bracket with template literal (no substitution)
+			{
+				Code: "var a = test[`__iterator__`];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 9},
+				},
+			},
+
+			// ========================================
+			// Assignment targets
+			// ========================================
+			{
+				Code: `Foo.prototype.__iterator__ = function() {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "test[`__iterator__`] = function () {};",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.__iterator__ = 42;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Chained member access
+			// ========================================
+			{
+				Code: `a.b.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b.c.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Access on result of __iterator__ (2 errors: a.__iterator__ and a.__iterator__.__iterator__)
+			{
+				Code: `a.__iterator__.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Optional chaining
+			// ========================================
+			{
+				Code: `obj?.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj?.['__iterator__'];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a?.b?.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Parenthesized / TypeScript outer expressions
+			// ========================================
+			{
+				Code: `(obj).__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `((obj)).__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Non-null assertion on object
+			{
+				Code: `obj!.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Type assertion on object
+			{
+				Code: `(obj as any).__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Angle-bracket type assertion
+			{
+				Code: `(<any>obj).__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// this / class contexts
+			// ========================================
+			{
+				Code: `this.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `class A { m() { this.__iterator__; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `class A { x = this.__iterator__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `class A { static { this.__iterator__; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 20},
+				},
+			},
+
+			// ========================================
+			// Nested in functions / arrows
+			// ========================================
+			{
+				Code: `function foo() { obj.__iterator__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `const f = () => obj.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `const f = () => { return obj.__iterator__; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 26},
+				},
+			},
+
+			// ========================================
+			// In expressions
+			// ========================================
+			// Conditional expression
+			{
+				Code: `var x = cond ? obj.__iterator__ : null;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 16},
+				},
+			},
+			// As function argument
+			{
+				Code: `foo(obj.__iterator__);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 5},
+				},
+			},
+			// In template literal expression
+			{
+				Code: "var x = `${obj.__iterator__}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 12},
+				},
+			},
+
+			// ========================================
+			// Multiple violations in one file
+			// ========================================
+			{
+				Code: "a.__iterator__;\nb['__iterator__'];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+					{MessageId: "noIterator", Line: 2, Column: 1},
+				},
+			},
+
+			// ========================================
+			// In loops
+			// ========================================
+			{
+				Code: `for (var x in obj.__iterator__) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `while (obj.__iterator__) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 8},
+				},
+			},
+
+			// ========================================
+			// Unary / delete / typeof / void
+			// ========================================
+			{
+				Code: `delete obj.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `typeof obj.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `void obj.__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 6},
+				},
+			},
+
+			// ========================================
+			// Call / new / tagged template
+			// ========================================
+			{
+				Code: `obj.__iterator__();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new obj.__iterator__();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 5},
+				},
+			},
+
+			// ========================================
+			// super
+			// ========================================
+			{
+				Code: `class A extends B { m() { super.__iterator__; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class A extends B { m() { super['__iterator__']; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 27},
+				},
+			},
+
+			// ========================================
+			// Spread / array / object value
+			// ========================================
+			{
+				Code: `var a = [obj.__iterator__];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `var a = { x: obj.__iterator__ };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: `var a = { ...obj.__iterator__ };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 14},
+				},
+			},
+
+			// ========================================
+			// Logical / nullish / assignment operators
+			// ========================================
+			{
+				Code: `obj.__iterator__ || fallback;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.__iterator__ ?? fallback;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.__iterator__ ??= fallback;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Async / generator
+			// ========================================
+			{
+				Code: `async function f() { await obj.__iterator__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: `function* g() { yield obj.__iterator__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 23},
+				},
+			},
+
+			// ========================================
+			// Mixed bracket + dot chaining
+			// ========================================
+			{
+				Code: `obj['__iterator__'].__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Satisfies (TS 4.9+)
+			// ========================================
+			{
+				Code: `(obj satisfies any).__iterator__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Escape sequences in string/template literals
+			// ========================================
+			// Hex escape in string literal → cooked value is __iterator__
+			{
+				Code: `obj['\x5F\x5Fiterator\x5F\x5F'];`, // cspell:disable-line
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Unicode escape in string literal
+			{
+				Code: `obj['\u005F\u005Fiterator\u005F\u005F'];`, // cspell:disable-line
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Hex escape in template literal
+			{
+				Code: "obj[`\\x5F\\x5Fiterator\\x5F\\x5F`];", // cspell:disable-line
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			// Unicode escape in dot notation identifier
+			{
+				Code: `obj.\u005F\u005Fiterator\u005F\u005F;`, // cspell:disable-line
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+
+			// ========================================
+			// Multiline
+			// ========================================
+			{
+				Code: "obj\n  .__iterator__;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "obj\n  ['__iterator__'];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIterator", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -35,6 +35,7 @@ export default defineConfig({
     './tests/eslint/rules/no-empty.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
     './tests/eslint/rules/no-eval.test.ts',
+    './tests/eslint/rules/no-iterator.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
     './tests/eslint/rules/no-loss-of-precision.test.ts',
     './tests/eslint/rules/no-ex-assign.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-iterator.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-iterator.test.ts.snap
@@ -1,0 +1,1453 @@
+// Rstest Snapshot v1
+
+exports[`no-iterator > invalid 1`] = `
+{
+  "code": "var a = test.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 2`] = `
+{
+  "code": "var a = test['__iterator__'];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 3`] = `
+{
+  "code": "var a = test["__iterator__"];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 4`] = `
+{
+  "code": "var a = test[\`__iterator__\`];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 5`] = `
+{
+  "code": "Foo.prototype.__iterator__ = function() {};",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 6`] = `
+{
+  "code": "test[\`__iterator__\`] = function () {};",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 7`] = `
+{
+  "code": "obj.__iterator__ = 42;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 8`] = `
+{
+  "code": "a.b.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 9`] = `
+{
+  "code": "a.b.c.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 10`] = `
+{
+  "code": "a.__iterator__.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 11`] = `
+{
+  "code": "obj?.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 12`] = `
+{
+  "code": "obj?.['__iterator__'];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 13`] = `
+{
+  "code": "a?.b?.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 14`] = `
+{
+  "code": "(obj).__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 15`] = `
+{
+  "code": "((obj)).__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 16`] = `
+{
+  "code": "obj!.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 17`] = `
+{
+  "code": "(obj as any).__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 18`] = `
+{
+  "code": "(<any>obj).__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 19`] = `
+{
+  "code": "this.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 20`] = `
+{
+  "code": "class A { m() { this.__iterator__; } }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 21`] = `
+{
+  "code": "class A { x = this.__iterator__; }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 22`] = `
+{
+  "code": "class A { static { this.__iterator__; } }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 23`] = `
+{
+  "code": "function foo() { obj.__iterator__; }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 24`] = `
+{
+  "code": "const f = () => obj.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 25`] = `
+{
+  "code": "const f = () => { return obj.__iterator__; };",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 26`] = `
+{
+  "code": "var x = cond ? obj.__iterator__ : null;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 27`] = `
+{
+  "code": "foo(obj.__iterator__);",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 28`] = `
+{
+  "code": "var x = \`\${obj.__iterator__}\`;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 29`] = `
+{
+  "code": "a.__iterator__;
+b['__iterator__'];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 30`] = `
+{
+  "code": "for (var x in obj.__iterator__) {}",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 31`] = `
+{
+  "code": "while (obj.__iterator__) {}",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 32`] = `
+{
+  "code": "delete obj.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 33`] = `
+{
+  "code": "typeof obj.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 34`] = `
+{
+  "code": "void obj.__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 35`] = `
+{
+  "code": "obj.__iterator__();",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 36`] = `
+{
+  "code": "new obj.__iterator__();",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 37`] = `
+{
+  "code": "class A extends B { m() { super.__iterator__; } }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 38`] = `
+{
+  "code": "class A extends B { m() { super['__iterator__']; } }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 39`] = `
+{
+  "code": "var a = [obj.__iterator__];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 40`] = `
+{
+  "code": "var a = { x: obj.__iterator__ };",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 41`] = `
+{
+  "code": "var a = { ...obj.__iterator__ };",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 42`] = `
+{
+  "code": "obj.__iterator__ || fallback;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 43`] = `
+{
+  "code": "obj.__iterator__ ?? fallback;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 44`] = `
+{
+  "code": "obj.__iterator__ ??= fallback;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 45`] = `
+{
+  "code": "async function f() { await obj.__iterator__; }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 46`] = `
+{
+  "code": "function* g() { yield obj.__iterator__; }",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 47`] = `
+{
+  "code": "obj['__iterator__'].__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 48`] = `
+{
+  "code": "obj['\\x5F\\x5Fiterator\\x5F\\x5F'];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 49`] = `
+{
+  "code": "obj['\\u005F\\u005Fiterator\\u005F\\u005F'];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 50`] = `
+{
+  "code": "obj[\`\\x5F\\x5Fiterator\\x5F\\x5F\`];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 51`] = `
+{
+  "code": "obj.\\u005F\\u005Fiterator\\u005F\\u005F;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 52`] = `
+{
+  "code": "(obj satisfies any).__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 53`] = `
+{
+  "code": "obj
+  .__iterator__;",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-iterator > invalid 54`] = `
+{
+  "code": "obj
+  ['__iterator__'];",
+  "diagnostics": [
+    {
+      "message": "Reserved name '__iterator__'.",
+      "messageId": "noIterator",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-iterator",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-iterator.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-iterator.test.ts
@@ -1,0 +1,354 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-iterator', {
+  valid: [
+    // Computed property with identifier (not a string literal)
+    'var a = test[__iterator__];',
+    // Variable declaration, not member access
+    'var __iterator__ = null;',
+    // Template literal missing trailing __
+    'foo[`__iterator`] = null;',
+    // Template literal with newline (not exact match)
+    'foo[`__iterator__\n`] = null;',
+    // Template literal with expression
+    'foo[`__iterator__${x}`] = null;',
+    // Object property key (not a member access)
+    'var obj = { __iterator__: 1 };',
+    // Object shorthand
+    'var obj = { __iterator__ };',
+    // Destructuring
+    'const { __iterator__ } = obj;',
+    'const { __iterator__: alias } = obj;',
+    // Function declaration
+    'function __iterator__() {}',
+    // Class method declaration
+    'class Foo { __iterator__() {} }',
+    // TypeScript interface property
+    'interface Foo { __iterator__: any; }',
+    // TypeScript type alias
+    'type Foo = { __iterator__: any };',
+    // Parameter name
+    'function foo(__iterator__: any) {}',
+    // Enum member
+    'enum Foo { __iterator__ }',
+    // Private identifier (PrivateIdentifier, not Identifier)
+    'class Foo { #__iterator__ = 1; m() { this.#__iterator__; } }',
+    // TypeScript QualifiedName in type position (not PropertyAccessExpression)
+    'declare namespace A { var __iterator__: number; } type X = typeof A.__iterator__;',
+    // Import/export specifier
+    "export { __iterator__ } from 'mod';",
+    // Label
+    '__iterator__: for (;;) { break __iterator__; }',
+    // Computed with string concatenation (not a static literal)
+    "obj['__iterator' + '__'];",
+    // Computed with variable
+    "const key = '__iterator__'; obj[key];",
+    // Getter/setter declaration in object
+    'var obj = { get __iterator__() { return 1; } };',
+    // JSX attribute — only tested in Go (needs Tsx: true flag)
+
+    // Unicode escape in identifier resolves to __iterator__ but
+    // this is testing valid Go-side only since JS test tooling handles
+    // identifiers differently
+  ],
+  invalid: [
+    // ========================================
+    // Basic access patterns
+    // ========================================
+    {
+      code: 'var a = test.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: "var a = test['__iterator__'];",
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'var a = test["__iterator__"];',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'var a = test[`__iterator__`];',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Assignment targets
+    // ========================================
+    {
+      code: 'Foo.prototype.__iterator__ = function() {};',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'test[`__iterator__`] = function () {};',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'obj.__iterator__ = 42;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Chained member access
+    // ========================================
+    {
+      code: 'a.b.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'a.b.c.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    // 2 errors: a.__iterator__ and a.__iterator__.__iterator__
+    {
+      code: 'a.__iterator__.__iterator__;',
+      errors: [{ messageId: 'noIterator' }, { messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Optional chaining
+    // ========================================
+    {
+      code: 'obj?.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: "obj?.['__iterator__'];",
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'a?.b?.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Parenthesized / TypeScript outer expressions
+    // ========================================
+    {
+      code: '(obj).__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: '((obj)).__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'obj!.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: '(obj as any).__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: '(<any>obj).__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // this / class contexts
+    // ========================================
+    {
+      code: 'this.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'class A { m() { this.__iterator__; } }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'class A { x = this.__iterator__; }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'class A { static { this.__iterator__; } }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Nested in functions / arrows
+    // ========================================
+    {
+      code: 'function foo() { obj.__iterator__; }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'const f = () => obj.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'const f = () => { return obj.__iterator__; };',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // In expressions
+    // ========================================
+    {
+      code: 'var x = cond ? obj.__iterator__ : null;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'foo(obj.__iterator__);',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'var x = `${obj.__iterator__}`;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Multiple violations in one file
+    // ========================================
+    {
+      code: "a.__iterator__;\nb['__iterator__'];",
+      errors: [{ messageId: 'noIterator' }, { messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // In loops
+    // ========================================
+    {
+      code: 'for (var x in obj.__iterator__) {}',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'while (obj.__iterator__) {}',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Unary / delete / typeof / void
+    // ========================================
+    {
+      code: 'delete obj.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'typeof obj.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'void obj.__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Call / new
+    // ========================================
+    {
+      code: 'obj.__iterator__();',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'new obj.__iterator__();',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // super
+    // ========================================
+    {
+      code: 'class A extends B { m() { super.__iterator__; } }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: "class A extends B { m() { super['__iterator__']; } }",
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Spread / array / object value
+    // ========================================
+    {
+      code: 'var a = [obj.__iterator__];',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'var a = { x: obj.__iterator__ };',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'var a = { ...obj.__iterator__ };',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Logical / nullish / assignment operators
+    // ========================================
+    {
+      code: 'obj.__iterator__ || fallback;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'obj.__iterator__ ?? fallback;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'obj.__iterator__ ??= fallback;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Async / generator
+    // ========================================
+    {
+      code: 'async function f() { await obj.__iterator__; }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'function* g() { yield obj.__iterator__; }',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Mixed bracket + dot chaining
+    // ========================================
+    {
+      code: "obj['__iterator__'].__iterator__;",
+      errors: [{ messageId: 'noIterator' }, { messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Escape sequences in string/template literals
+    // ========================================
+    {
+      code: "obj['\\x5F\\x5Fiterator\\x5F\\x5F'];",
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: "obj['\\u005F\\u005Fiterator\\u005F\\u005F'];",
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'obj[`\\x5F\\x5Fiterator\\x5F\\x5F`];',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: 'obj.\\u005F\\u005Fiterator\\u005F\\u005F;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Satisfies (TS 4.9+)
+    // ========================================
+    {
+      code: '(obj satisfies any).__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+
+    // ========================================
+    // Multiline
+    // ========================================
+    {
+      code: 'obj\n  .__iterator__;',
+      errors: [{ messageId: 'noIterator' }],
+    },
+    {
+      code: "obj\n  ['__iterator__'];",
+      errors: [{ messageId: 'noIterator' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-iterator` rule from ESLint to rslint.

Disallows the use of the `__iterator__` property, which was a SpiderMonkey extension and is now obsolete. The standard `Symbol.iterator` should be used instead.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-iterator
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-iterator.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).