### PR TITLE
feat: port rule no-script-url

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
+	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
@@ -520,6 +521,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
+	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)

--- a/internal/rules/no_script_url/no_script_url.go
+++ b/internal/rules/no_script_url/no_script_url.go
@@ -1,0 +1,41 @@
+package no_script_url
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-script-url
+var NoScriptUrlRule = rule.Rule{
+	Name: "no-script-url",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		const jsScheme = "javascript:"
+
+		check := func(node *ast.Node) {
+			value := utils.GetStaticStringValue(node)
+			if len(value) >= len(jsScheme) && strings.EqualFold(value[:len(jsScheme)], jsScheme) {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "unexpectedScriptURL",
+					Description: "Script URL is a form of eval.",
+				})
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindStringLiteral: func(node *ast.Node) {
+				check(node)
+			},
+			ast.KindNoSubstitutionTemplateLiteral: func(node *ast.Node) {
+				// Skip tagged templates like foo`javascript:` — the tag function
+				// controls interpretation, so the string is not used as a URL.
+				if node.Parent != nil && node.Parent.Kind == ast.KindTaggedTemplateExpression {
+					return
+				}
+				check(node)
+			},
+		}
+	},
+}

--- a/internal/rules/no_script_url/no_script_url.md
+++ b/internal/rules/no_script_url/no_script_url.md
@@ -1,0 +1,25 @@
+# no-script-url
+
+## Rule Details
+
+Disallow `javascript:` URLs.
+
+Using `javascript:` URLs is considered by some as a form of `eval`. Code passed in `javascript:` URLs has to be parsed and evaluated by the browser in the same way that `eval` is processed.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+location.href = 'javascript:void(0)';
+
+location.href = `javascript:void(0)`;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+location.href = 'https://example.com';
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-script-url

--- a/internal/rules/no_script_url/no_script_url_test.go
+++ b/internal/rules/no_script_url/no_script_url_test.go
@@ -1,0 +1,338 @@
+package no_script_url
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoScriptUrlRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoScriptUrlRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// ================================================================
+			// Basic non-matching strings
+			// ================================================================
+			{Code: `var a = 'Hello World!';`},
+			{Code: `var a = 10;`},
+			{Code: `var a = '';`},
+
+			// ================================================================
+			// Near misses — should NOT trigger
+			// ================================================================
+			// Prefix before "javascript:"
+			{Code: `var url = 'xjavascript:'`},
+			{Code: "var url = `xjavascript:`"},
+			// No colon
+			{Code: `var a = 'javascript';`},
+			// Leading whitespace
+			{Code: `var a = ' javascript:';`},
+			// Other protocols
+			{Code: `var a = 'about:blank';`},
+			{Code: `var a = 'mailto:user@example.com';`},
+			{Code: "var a = `https://example.com`;"},
+
+			// ================================================================
+			// Template literals with substitutions (TemplateExpression, not
+			// NoSubstitutionTemplateLiteral) — static value unknown
+			// ================================================================
+			{Code: "var url = `${foo}javascript:`"},
+			{Code: "var url = `javascript:${foo}`"},
+			{Code: "var url = `${a}javascript:${b}`"},
+
+			// ================================================================
+			// Tagged templates — tag controls interpretation
+			// ================================================================
+			{Code: "var a = foo`javaScript:`;"},
+			{Code: "var a = obj.tag`javascript:`;"},
+			{Code: "var a = obj['tag']`javascript:`;"},
+			{Code: "var a = tag()`javascript:`;"},
+			// Nested tagged template — inner is also tagged, should NOT trigger
+			{Code: "tag`${foo`javascript:`}`;"},
+
+			// ================================================================
+			// String concatenation — individual parts don't start with "javascript:"
+			// ================================================================
+			{Code: `var a = 'java' + 'script:';`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// ================================================================
+			// Unicode / hex escape sequences — AST .Text is the interpreted
+			// value, so \u006a = 'j' and the string becomes "javascript:"
+			// ================================================================
+			{
+				Code: `var a = '\u006aavascript:';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var a = '\x6aavascript:';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a = `\\u006aavascript:`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+
+			// ================================================================
+			// Basic string literals
+			// ================================================================
+			{
+				Code: `var a = 'javascript:void(0);';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var a = 'javascript:';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var a = "JavaScript:void(0)";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+
+			// ================================================================
+			// Case-insensitivity
+			// ================================================================
+			{
+				Code: `var a = 'JAVASCRIPT:';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var a = 'jAvAsCrIpT:void(0)';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+
+			// ================================================================
+			// Template literals (NoSubstitutionTemplateLiteral)
+			// ================================================================
+			{
+				Code: "var a = `javascript:`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "var a = `JavaScript:`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+
+			// ================================================================
+			// Nesting contexts — assignment, property, argument, etc.
+			// ================================================================
+			{
+				Code: "location.href = 'javascript:void(0)';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: "location.href = `javascript:void(0)`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 17},
+				},
+			},
+			// Object property value
+			{
+				Code: "var obj = { href: 'javascript:void(0)' };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 19},
+				},
+			},
+			// Array element
+			{
+				Code: "var arr = ['javascript:'];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 12},
+				},
+			},
+			// Function argument
+			{
+				Code: "fn('javascript:');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 4},
+				},
+			},
+			// Return statement
+			{
+				Code: "function f() { return 'javascript:'; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 23},
+				},
+			},
+			// Conditional expression
+			{
+				Code: "var a = x ? 'javascript:' : 'safe';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 13},
+				},
+			},
+			// Default parameter
+			{
+				Code: "function f(url = 'javascript:') {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 18},
+				},
+			},
+			// Class property
+			{
+				Code: "class A { url = 'javascript:' }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 17},
+				},
+			},
+			// Enum initializer (TypeScript)
+			{
+				Code: "enum E { A = 'javascript:' }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 14},
+				},
+			},
+
+			// ================================================================
+			// Multiple errors in one statement
+			// ================================================================
+			{
+				Code: "a('javascript:', 'javascript:void(0)');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 3},
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 18},
+				},
+			},
+
+			// ================================================================
+			// String literal inside tagged template expression — the string
+			// literal itself is NOT tagged, only the outer template is
+			// ================================================================
+			{
+				Code: "tag`${'javascript:'}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 7},
+				},
+			},
+
+			// ================================================================
+			// Template literal inside tagged template — parent is TemplateSpan,
+			// NOT TaggedTemplateExpression, so it should trigger
+			// ================================================================
+			{
+				Code: "tag`${`javascript:`}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 7},
+				},
+			},
+
+			// ================================================================
+			// JSX — the most common real-world trigger
+			// ================================================================
+			{
+				Code: `var a = <a href="javascript:void(0)" />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `var a = <a href={'javascript:void(0)'} />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 18},
+				},
+			},
+
+			// ================================================================
+			// Arrow function implicit return
+			// ================================================================
+			{
+				Code: "const f = () => 'javascript:';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 17},
+				},
+			},
+
+			// ================================================================
+			// Logical / nullish operators
+			// ================================================================
+			{
+				Code: "var a = x ?? 'javascript:';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: "var a = x || 'javascript:';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 14},
+				},
+			},
+
+			// ================================================================
+			// Computed property / element access
+			// ================================================================
+			{
+				Code: "var a = obj['javascript:'];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: "var obj = { ['javascript:']: 1 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 14},
+				},
+			},
+
+			// ================================================================
+			// TypeScript type position — string literal types are also checked
+			// ================================================================
+			{
+				Code: "type T = 'javascript:';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 10},
+				},
+			},
+
+			// ================================================================
+			// Binary expression — matching side still triggers
+			// ================================================================
+			{
+				Code: "var a = 'javascript:' + path;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 1, Column: 9},
+				},
+			},
+
+			// ================================================================
+			// Multi-line
+			// ================================================================
+			{
+				Code: "var a =\n  'javascript:';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedScriptURL", Line: 2, Column: 3},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -250,6 +250,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
+    './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',
 
     // eslint-plugin-jest

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-script-url.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-script-url.test.ts.snap
@@ -1,0 +1,745 @@
+// Rstest Snapshot v1
+
+exports[`no-script-url > invalid 1`] = `
+{
+  "code": "var a = 'javascript:void(0);';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 2`] = `
+{
+  "code": "var a = 'javascript:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 3`] = `
+{
+  "code": "var a = "JavaScript:void(0)";",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 4`] = `
+{
+  "code": "var a = 'JAVASCRIPT:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 5`] = `
+{
+  "code": "var a = 'jAvAsCrIpT:void(0)';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 6`] = `
+{
+  "code": "var a = \`javascript:\`;",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 7`] = `
+{
+  "code": "var a = \`JavaScript:\`;",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 8`] = `
+{
+  "code": "location.href = 'javascript:void(0)';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 9`] = `
+{
+  "code": "location.href = \`javascript:void(0)\`;",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 10`] = `
+{
+  "code": "var obj = { href: 'javascript:void(0)' };",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 11`] = `
+{
+  "code": "var arr = ['javascript:'];",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 12`] = `
+{
+  "code": "fn('javascript:');",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 13`] = `
+{
+  "code": "function f() { return 'javascript:'; }",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 14`] = `
+{
+  "code": "var a = x ? 'javascript:' : 'safe';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 15`] = `
+{
+  "code": "function f(url = 'javascript:') {}",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 16`] = `
+{
+  "code": "class A { url = 'javascript:' }",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 17`] = `
+{
+  "code": "enum E { A = 'javascript:' }",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 18`] = `
+{
+  "code": "a('javascript:', 'javascript:void(0)');",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 19`] = `
+{
+  "code": "tag\`\${'javascript:'}\`;",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 20`] = `
+{
+  "code": "tag\`\${\`javascript:\`}\`;",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 21`] = `
+{
+  "code": "const f = () => 'javascript:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 22`] = `
+{
+  "code": "var a = x ?? 'javascript:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 23`] = `
+{
+  "code": "var a = x || 'javascript:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 24`] = `
+{
+  "code": "var a = obj['javascript:'];",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 25`] = `
+{
+  "code": "var obj = { ['javascript:']: 1 };",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 26`] = `
+{
+  "code": "type T = 'javascript:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 27`] = `
+{
+  "code": "var a = 'javascript:' + path;",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-script-url > invalid 28`] = `
+{
+  "code": "var a =
+  'javascript:';",
+  "diagnostics": [
+    {
+      "message": "Script URL is a form of eval.",
+      "messageId": "unexpectedScriptURL",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-script-url",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-script-url.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-script-url.test.ts
@@ -1,0 +1,181 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-script-url', {
+  valid: [
+    // Basic non-matching strings
+    "var a = 'Hello World!';",
+    'var a = 10;',
+    "var a = '';",
+
+    // Near misses
+    "var url = 'xjavascript:'",
+    'var url = `xjavascript:`',
+    "var a = 'javascript';",
+    "var a = ' javascript:';",
+    "var a = 'about:blank';",
+    "var a = 'mailto:user@example.com';",
+    'var a = `https://example.com`;',
+
+    // Template literals with substitutions — static value unknown
+    'var url = `${foo}javascript:`',
+    'var url = `javascript:${foo}`',
+    'var url = `${a}javascript:${b}`',
+
+    // Tagged templates — tag controls interpretation
+    'var a = foo`javaScript:`;',
+    'var a = obj.tag`javascript:`;',
+    "var a = obj['tag']`javascript:`;",
+    'var a = tag()`javascript:`;',
+    // Nested tagged template — inner is also tagged
+    'tag`${foo`javascript:`}`;',
+
+    // String concatenation — individual parts don't start with "javascript:"
+    "var a = 'java' + 'script:';",
+  ],
+  invalid: [
+    // Basic string literals
+    {
+      code: "var a = 'javascript:void(0);';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var a = 'javascript:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: 'var a = "JavaScript:void(0)";',
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Case-insensitivity
+    {
+      code: "var a = 'JAVASCRIPT:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var a = 'jAvAsCrIpT:void(0)';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Template literals
+    {
+      code: 'var a = `javascript:`;',
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: 'var a = `JavaScript:`;',
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Nesting contexts
+    {
+      code: "location.href = 'javascript:void(0)';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: 'location.href = `javascript:void(0)`;',
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var obj = { href: 'javascript:void(0)' };",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var arr = ['javascript:'];",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "fn('javascript:');",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "function f() { return 'javascript:'; }",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var a = x ? 'javascript:' : 'safe';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "function f(url = 'javascript:') {}",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "class A { url = 'javascript:' }",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "enum E { A = 'javascript:' }",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Multiple errors in one statement
+    {
+      code: "a('javascript:', 'javascript:void(0)');",
+      errors: [
+        { messageId: 'unexpectedScriptURL' },
+        { messageId: 'unexpectedScriptURL' },
+      ],
+    },
+
+    // String literal inside tagged template — only the outer template
+    // is tagged; the inner string literal is still a script URL
+    {
+      code: "tag`${'javascript:'}`;",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Template literal inside tagged template — parent is TemplateSpan,
+    // NOT TaggedTemplateExpression, so it should trigger
+    {
+      code: 'tag`${`javascript:`}`;',
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Arrow function implicit return
+    {
+      code: "const f = () => 'javascript:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Logical / nullish operators
+    {
+      code: "var a = x ?? 'javascript:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var a = x || 'javascript:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Computed property / element access
+    {
+      code: "var a = obj['javascript:'];",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+    {
+      code: "var obj = { ['javascript:']: 1 };",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // TypeScript type position — string literal types are also checked
+    {
+      code: "type T = 'javascript:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Binary expression — matching side still triggers
+    {
+      code: "var a = 'javascript:' + path;",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+
+    // Multi-line
+    {
+      code: "var a =\n  'javascript:';",
+      errors: [{ messageId: 'unexpectedScriptURL' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -191,5 +191,7 @@ wasmer
 wasmfs
 typeparam
 xdescribe
+xjavascript
+aavascript
 xitiViewMap
 xtest


### PR DESCRIPTION
## Summary

Port the `no-script-url` rule from ESLint to rslint.

Disallow `javascript:` URLs. Using `javascript:` URLs is considered a form of `eval`, as the code is parsed and evaluated by the browser the same way.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-script-url
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-script-url.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).