### PR TITLE
feat: port rule no-proto

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
+	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
@@ -522,6 +523,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
+	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)

--- a/internal/rules/no_proto/no_proto.go
+++ b/internal/rules/no_proto/no_proto.go
@@ -1,0 +1,33 @@
+package no_proto
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-proto
+var NoProtoRule = rule.Rule{
+	Name: "no-proto",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		msg := rule.RuleMessage{
+			Id:          "unexpectedProto",
+			Description: "The '__proto__' property is deprecated.",
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				propAccess := node.AsPropertyAccessExpression()
+				if propAccess.Name().Text() == "__proto__" {
+					ctx.ReportNode(node, msg)
+				}
+			},
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				elemAccess := node.AsElementAccessExpression()
+				if utils.GetStaticStringValue(elemAccess.ArgumentExpression) == "__proto__" {
+					ctx.ReportNode(node, msg)
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_proto/no_proto.md
+++ b/internal/rules/no_proto/no_proto.md
@@ -1,0 +1,33 @@
+# no-proto
+
+## Rule Details
+
+Disallow the use of the `__proto__` property.
+
+When an object is created with the `new` operator, `__proto__` is set to the original "prototype" property of the object's constructor function. `Object.getPrototypeOf` is the preferred method of getting the object's prototype. To change an object's prototype, use `Object.setPrototypeOf`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = obj.__proto__;
+
+var a = obj['__proto__'];
+
+obj.__proto__ = b;
+
+obj['__proto__'] = b;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = Object.getPrototypeOf(obj);
+
+Object.setPrototypeOf(obj, b);
+
+var c = { __proto__: a };
+```
+
+## Original Documentation
+
+- [ESLint no-proto](https://eslint.org/docs/latest/rules/no-proto)

--- a/internal/rules/no_proto/no_proto_test.go
+++ b/internal/rules/no_proto/no_proto_test.go
@@ -1,0 +1,668 @@
+package no_proto
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoProtoRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoProtoRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// --- Object literal contexts (not member access) ---
+			{Code: `var a = { __proto__: [] }`},
+			{Code: `var a = { __proto__ }`},
+			{Code: `var a = { ["__proto__"]: [] }`},
+			{Code: `var a = { __proto__() {} }`},
+			{Code: `var a = { get __proto__() { return 1; } }`},
+			{Code: `var a = { set __proto__(v) {} }`},
+
+			// --- __proto__ as declaration name ---
+			{Code: `var __proto__ = 1;`},
+			{Code: `let __proto__ = 2;`},
+			{Code: `const __proto__ = 3;`},
+			{Code: `function __proto__() {}`},
+			{Code: `function foo(__proto__) {}`},
+
+			// --- Destructuring (binding pattern, not property access) ---
+			{Code: `var { __proto__ } = obj;`},
+			{Code: `var { __proto__: proto } = obj;`},
+			{Code: `var { a: { __proto__ } } = obj;`},
+			{Code: `function foo({ __proto__ }) {}`},
+			// Array destructuring binding
+			{Code: `var [__proto__] = arr;`},
+			// Rest element in destructuring
+			{Code: `var { a, ...__proto__ } = obj;`},
+			{Code: `var [a, ...__proto__] = arr;`},
+
+			// --- Catch clause binding ---
+			{Code: `try {} catch (__proto__) {}`},
+
+			// --- For-in / for-of declarations ---
+			{Code: `for (var __proto__ in obj) {}`},
+			{Code: `for (var __proto__ of arr) {}`},
+
+			// --- Import / Export ---
+			{Code: `import { __proto__ } from 'mod';`},
+			{Code: `var __proto__ = 1; export { __proto__ };`},
+
+			// --- TypeScript type-level constructs ---
+			{Code: `interface I { __proto__: string }`},
+			{Code: `type T = { __proto__: string }`},
+			{Code: `declare class C { __proto__: string }`},
+
+			// --- Class member declarations ---
+			{Code: `class C { __proto__ = 1 }`},
+			{Code: `class C { __proto__() {} }`},
+			{Code: `class C { get __proto__() { return 1; } }`},
+			{Code: `class C { static __proto__ = 1 }`},
+
+			// --- Enum member ---
+			{Code: `enum E { __proto__ = 1 }`},
+
+			// --- __proto__ as type-level names ---
+			{Code: `class __proto__ {}`},
+			{Code: `type __proto__ = string;`},
+			{Code: `namespace __proto__ {}`},
+			{Code: `function foo<__proto__>() {}`},
+			{Code: `declare function __proto__(): void;`},
+			{Code: `abstract class C { abstract __proto__(): void }`},
+
+			// --- Label ---
+			{Code: `__proto__: for (;;) { break __proto__; }`},
+
+			// --- String / non-member-access usage ---
+			{Code: `var s = "__proto__";`},
+			{Code: "var s = `__proto__`;"},
+
+			// --- Different property name ---
+			{Code: `obj.prototype`},
+			{Code: `obj.__proto`},
+			{Code: `obj.proto__`},
+			{Code: `obj.__PROTO__`},
+
+			// --- Recommended alternatives ---
+			{Code: `var a = Object.getPrototypeOf(obj);`},
+			{Code: `Object.setPrototypeOf(obj, b);`},
+
+			// --- Dynamic / non-static property access ---
+			{Code: `var x = "__proto__"; obj[x];`},
+			{Code: "obj[`__${'proto'}__`]"},
+			{Code: `var k = "__proto__"; obj[k] = 1;`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// === Dot notation ===
+			{
+				Code: `var a = obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `obj.__proto__ = b;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === Bracket notation ===
+			{
+				Code: `var a = obj["__proto__"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `obj["__proto__"] = b;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `var a = obj['__proto__'];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			// Template literal (no substitution)
+			{
+				Code: "var a = obj[`__proto__`];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+
+			// === Optional chaining ===
+			{
+				Code: `obj?.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj?.["__proto__"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === Chained / nested access ===
+			{
+				Code: `var a = foo.bar.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `obj.__proto__.hasOwnProperty("foo");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Double __proto__ — two errors
+			{
+				Code: `obj.__proto__.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Deeply chained
+			{
+				Code: `a.b.c.d.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Optional chain continuing after __proto__
+			{
+				Code: `obj?.__proto__?.toString();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === Calling __proto__ as function ===
+			{
+				Code: `obj.__proto__();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj["__proto__"]();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === this ===
+			{
+				Code: `var a = this.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `this["__proto__"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === Parenthesized expression ===
+			{
+				Code: `(obj).__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(obj)["__proto__"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === TypeScript expressions ===
+			// as assertion
+			{
+				Code: `(obj as any).__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Angle-bracket assertion
+			{
+				Code: `(<any>obj).__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Non-null assertion
+			{
+				Code: `obj!.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Satisfies expression
+			{
+				Code: `(obj satisfies any).__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === As function argument ===
+			{
+				Code: `foo(obj.__proto__);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `console.log(obj["__proto__"]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 13},
+				},
+			},
+
+			// === new / await / yield ===
+			{
+				Code: `new (obj.__proto__)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `async function f() { await obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: `function* g() { yield obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 23},
+				},
+			},
+
+			// === Tagged template ===
+			{
+				Code: "obj.__proto__`tagged`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === Update expressions (++/--) ===
+			{
+				Code: `++obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `obj.__proto__++;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === In expressions ===
+			// Template literal expression
+			{
+				Code: "var s = `${obj.__proto__}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 12},
+				},
+			},
+			// Ternary
+			{
+				Code: `var a = x ? obj.__proto__ : null;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 13},
+				},
+			},
+			// Logical OR / AND
+			{
+				Code: `var a = obj.__proto__ || default_;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var a = x && obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 14},
+				},
+			},
+			// Nullish coalescing
+			{
+				Code: `var a = obj.__proto__ ?? default_;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			// Comma operator
+			{
+				Code: `(0, obj.__proto__);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 5},
+				},
+			},
+			// in expression
+			{
+				Code: `"x" in obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 8},
+				},
+			},
+			// instanceof
+			{
+				Code: `obj.__proto__ instanceof Object;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+
+			// === Unary operators ===
+			{
+				Code: `typeof obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `void obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `delete obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 8},
+				},
+			},
+
+			// === Spread ===
+			{
+				Code: `var a = { ...obj.__proto__ };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: `var a = [...obj.__proto__];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 13},
+				},
+			},
+
+			// === Assignment patterns ===
+			// Compound assignment
+			{
+				Code: `obj.__proto__ += "";`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Logical assignment operators
+			{
+				Code: `obj.__proto__ ||= x;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.__proto__ &&= x;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.__proto__ ??= x;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+				},
+			},
+			// Destructuring default value
+			{
+				Code: `var { a = obj.__proto__ } = b;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 11},
+				},
+			},
+			// Array destructuring assignment target
+			{
+				Code: `[obj.__proto__] = [1];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 2},
+				},
+			},
+
+			// === As value in object / array literal ===
+			// Object property value
+			{
+				Code: `var a = { key: obj.__proto__ };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 16},
+				},
+			},
+			// Array element
+			{
+				Code: `var a = [obj.__proto__];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 10},
+				},
+			},
+			// Computed property key
+			{
+				Code: `var a = { [obj.__proto__]: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 12},
+				},
+			},
+
+			// === for-in / for-of with member expression as target ===
+			{
+				Code: `for (obj.__proto__ in x) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `for (obj.__proto__ of x) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 6},
+				},
+			},
+
+			// === Function / class contexts ===
+			{
+				Code: `function f() { return obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `var f = () => obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `async function f() { return obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `class C { method() { return this.__proto__; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `class C { constructor() { this.__proto__ = null; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class C { get p() { return obj.__proto__; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: `class C { static { obj.__proto__; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 20},
+				},
+			},
+			// Class field initializer value
+			{
+				Code: `class C { x = obj.__proto__ }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 15},
+				},
+			},
+			// IIFE
+			{
+				Code: `(function() { return obj.__proto__; })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 22},
+				},
+			},
+			// Arrow returning object
+			{
+				Code: `var f = () => ({ a: obj.__proto__ });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 21},
+				},
+			},
+
+			// === Namespace / module scope ===
+			{
+				Code: `namespace N { var a = obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 23},
+				},
+			},
+
+			// === Export ===
+			{
+				Code: `export default obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 16},
+				},
+			},
+
+			// === Control flow ===
+			{
+				Code: `if (obj.__proto__) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `for (var x in obj.__proto__) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `for (var x of obj.__proto__) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `while (obj.__proto__) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `switch (obj.__proto__) { case 0: break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `throw obj.__proto__;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 7},
+				},
+			},
+			// do-while
+			{
+				Code: `do {} while (obj.__proto__);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 14},
+				},
+			},
+			// try / catch / finally
+			{
+				Code: `try { obj.__proto__; } catch(e) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code: `try {} catch(e) { obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `try {} finally { obj.__proto__; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 18},
+				},
+			},
+			// For init / update
+			{
+				Code: `for (obj.__proto__ = 0;;) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 6},
+				},
+			},
+
+			// === Multiple occurrences ===
+			{
+				Code: "a.__proto__;\nb.__proto__;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+					{MessageId: "unexpectedProto", Line: 2, Column: 1},
+				},
+			},
+			// Mixed dot and bracket
+			{
+				Code: `obj.__proto__; obj["__proto__"];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 1},
+					{MessageId: "unexpectedProto", Line: 1, Column: 16},
+				},
+			},
+
+			// === Multi-byte characters ===
+			{
+				Code: "/* 🚀 */ obj.__proto__",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedProto", Line: 1, Column: 10},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -253,6 +253,7 @@ export default defineConfig({
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',
+    './tests/eslint/rules/no-proto.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-proto.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-proto.test.ts.snap
@@ -1,0 +1,2153 @@
+// Rstest Snapshot v1
+
+exports[`no-proto > invalid 1`] = `
+{
+  "code": "var a = obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 2`] = `
+{
+  "code": "obj.__proto__ = b;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 3`] = `
+{
+  "code": "var a = obj["__proto__"];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 4`] = `
+{
+  "code": "obj["__proto__"] = b;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 5`] = `
+{
+  "code": "var a = obj['__proto__'];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 6`] = `
+{
+  "code": "var a = obj[\`__proto__\`];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 7`] = `
+{
+  "code": "obj?.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 8`] = `
+{
+  "code": "obj?.["__proto__"];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 9`] = `
+{
+  "code": "var a = foo.bar.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 10`] = `
+{
+  "code": "obj.__proto__.hasOwnProperty("foo");",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 11`] = `
+{
+  "code": "obj.__proto__.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 12`] = `
+{
+  "code": "a.b.c.d.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 13`] = `
+{
+  "code": "obj?.__proto__?.toString();",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 14`] = `
+{
+  "code": "obj.__proto__();",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 15`] = `
+{
+  "code": "obj["__proto__"]();",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 16`] = `
+{
+  "code": "var a = this.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 17`] = `
+{
+  "code": "this["__proto__"];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 18`] = `
+{
+  "code": "(obj).__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 19`] = `
+{
+  "code": "(obj)["__proto__"];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 20`] = `
+{
+  "code": "(obj as any).__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 21`] = `
+{
+  "code": "(<any>obj).__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 22`] = `
+{
+  "code": "obj!.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 23`] = `
+{
+  "code": "(obj satisfies any).__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 24`] = `
+{
+  "code": "foo(obj.__proto__);",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 25`] = `
+{
+  "code": "console.log(obj["__proto__"]);",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 26`] = `
+{
+  "code": "new (obj.__proto__)();",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 27`] = `
+{
+  "code": "async function f() { await obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 28`] = `
+{
+  "code": "function* g() { yield obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 29`] = `
+{
+  "code": "obj.__proto__\`tagged\`;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 30`] = `
+{
+  "code": "++obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 31`] = `
+{
+  "code": "obj.__proto__++;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 32`] = `
+{
+  "code": "var s = \`\${obj.__proto__}\`;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 33`] = `
+{
+  "code": "var a = x ? obj.__proto__ : null;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 34`] = `
+{
+  "code": "var a = obj.__proto__ || default_;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 35`] = `
+{
+  "code": "var a = x && obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 36`] = `
+{
+  "code": "var a = obj.__proto__ ?? default_;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 37`] = `
+{
+  "code": "(0, obj.__proto__);",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 38`] = `
+{
+  "code": ""x" in obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 39`] = `
+{
+  "code": "obj.__proto__ instanceof Object;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 40`] = `
+{
+  "code": "typeof obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 41`] = `
+{
+  "code": "void obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 42`] = `
+{
+  "code": "delete obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 43`] = `
+{
+  "code": "var a = { ...obj.__proto__ };",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 44`] = `
+{
+  "code": "var a = [...obj.__proto__];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 45`] = `
+{
+  "code": "obj.__proto__ += "";",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 46`] = `
+{
+  "code": "obj.__proto__ ||= x;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 47`] = `
+{
+  "code": "obj.__proto__ &&= x;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 48`] = `
+{
+  "code": "obj.__proto__ ??= x;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 49`] = `
+{
+  "code": "var { a = obj.__proto__ } = b;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 50`] = `
+{
+  "code": "[obj.__proto__] = [1];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 51`] = `
+{
+  "code": "var a = { key: obj.__proto__ };",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 52`] = `
+{
+  "code": "var a = [obj.__proto__];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 53`] = `
+{
+  "code": "var a = { [obj.__proto__]: 1 };",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 54`] = `
+{
+  "code": "for (obj.__proto__ in x) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 55`] = `
+{
+  "code": "for (obj.__proto__ of x) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 56`] = `
+{
+  "code": "function f() { return obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 57`] = `
+{
+  "code": "var f = () => obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 58`] = `
+{
+  "code": "async function f() { return obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 59`] = `
+{
+  "code": "class C { method() { return this.__proto__; } }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 60`] = `
+{
+  "code": "class C { constructor() { this.__proto__ = null; } }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 61`] = `
+{
+  "code": "class C { get p() { return obj.__proto__; } }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 62`] = `
+{
+  "code": "class C { static { obj.__proto__; } }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 63`] = `
+{
+  "code": "class C { x = obj.__proto__ }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 64`] = `
+{
+  "code": "(function() { return obj.__proto__; })();",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 65`] = `
+{
+  "code": "var f = () => ({ a: obj.__proto__ });",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 66`] = `
+{
+  "code": "namespace N { var a = obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 67`] = `
+{
+  "code": "export default obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 68`] = `
+{
+  "code": "if (obj.__proto__) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 69`] = `
+{
+  "code": "for (var x in obj.__proto__) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 70`] = `
+{
+  "code": "for (var x of obj.__proto__) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 71`] = `
+{
+  "code": "while (obj.__proto__) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 72`] = `
+{
+  "code": "switch (obj.__proto__) { case 0: break; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 73`] = `
+{
+  "code": "throw obj.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 74`] = `
+{
+  "code": "do {} while (obj.__proto__);",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 75`] = `
+{
+  "code": "try { obj.__proto__; } catch(e) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 76`] = `
+{
+  "code": "try {} catch(e) { obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 77`] = `
+{
+  "code": "try {} finally { obj.__proto__; }",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 78`] = `
+{
+  "code": "for (obj.__proto__ = 0;;) {}",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 79`] = `
+{
+  "code": "a.__proto__;
+b.__proto__;",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 80`] = `
+{
+  "code": "obj.__proto__; obj["__proto__"];",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-proto > invalid 81`] = `
+{
+  "code": "/* 🚀 */ obj.__proto__",
+  "diagnostics": [
+    {
+      "message": "The '__proto__' property is deprecated.",
+      "messageId": "unexpectedProto",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-proto",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-proto.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-proto.test.ts
@@ -1,0 +1,499 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-proto', {
+  valid: [
+    // --- Object literal contexts (not member access) ---
+    'var a = { __proto__: [] }',
+    'var a = { __proto__ }',
+    'var a = { ["__proto__"]: [] }',
+    'var a = { __proto__() {} }',
+    'var a = { get __proto__() { return 1; } }',
+    'var a = { set __proto__(v) {} }',
+
+    // --- __proto__ as declaration name ---
+    'var __proto__ = 1;',
+    'let __proto__ = 2;',
+    'const __proto__ = 3;',
+    'function __proto__() {}',
+    'function foo(__proto__) {}',
+
+    // --- Destructuring (binding pattern, not property access) ---
+    'var { __proto__ } = obj;',
+    'var { __proto__: proto } = obj;',
+    'var { a: { __proto__ } } = obj;',
+    'function foo({ __proto__ }) {}',
+    // Array destructuring binding
+    'var [__proto__] = arr;',
+    // Rest element in destructuring
+    'var { a, ...__proto__ } = obj;',
+    'var [a, ...__proto__] = arr;',
+
+    // --- Catch clause binding ---
+    'try {} catch (__proto__) {}',
+
+    // --- For-in / for-of declarations ---
+    'for (var __proto__ in obj) {}',
+    'for (var __proto__ of arr) {}',
+
+    // --- Import / Export ---
+    "import { __proto__ } from 'mod';",
+    'var __proto__ = 1; export { __proto__ };',
+
+    // --- TypeScript type-level constructs ---
+    'interface I { __proto__: string }',
+    'type T = { __proto__: string }',
+    'declare class C { __proto__: string }',
+
+    // --- Class member declarations ---
+    'class C { __proto__ = 1 }',
+    'class C { __proto__() {} }',
+    'class C { get __proto__() { return 1; } }',
+    'class C { static __proto__ = 1 }',
+
+    // --- Enum member ---
+    'enum E { __proto__ = 1 }',
+
+    // --- __proto__ as type-level names ---
+    'class __proto__ {}',
+    'type __proto__ = string;',
+    'namespace __proto__ {}',
+    'function foo<__proto__>() {}',
+    'declare function __proto__(): void;',
+    'abstract class C { abstract __proto__(): void }',
+
+    // --- Label ---
+    '__proto__: for (;;) { break __proto__; }',
+
+    // --- String / non-member-access usage ---
+    'var s = "__proto__";',
+    'var s = `__proto__`;',
+
+    // --- Different property name ---
+    'obj.prototype',
+    'obj.__proto',
+    'obj.proto__',
+    'obj.__PROTO__',
+
+    // --- Recommended alternatives ---
+    'var a = Object.getPrototypeOf(obj);',
+    'Object.setPrototypeOf(obj, b);',
+
+    // --- Dynamic / non-static property access ---
+    'var x = "__proto__"; obj[x];',
+    "obj[`__${'proto'}__`]",
+    'var k = "__proto__"; obj[k] = 1;',
+  ],
+  invalid: [
+    // === Dot notation ===
+    {
+      code: 'var a = obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj.__proto__ = b;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Bracket notation ===
+    {
+      code: 'var a = obj["__proto__"];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj["__proto__"] = b;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: "var a = obj['__proto__'];",
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Template literal (no substitution)
+    {
+      code: 'var a = obj[`__proto__`];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Optional chaining ===
+    {
+      code: 'obj?.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj?.["__proto__"];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Chained / nested access ===
+    {
+      code: 'var a = foo.bar.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj.__proto__.hasOwnProperty("foo");',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Double __proto__ — two errors
+    {
+      code: 'obj.__proto__.__proto__;',
+      errors: [
+        { messageId: 'unexpectedProto' },
+        { messageId: 'unexpectedProto' },
+      ],
+    },
+    // Deeply chained
+    {
+      code: 'a.b.c.d.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Optional chain continuing after __proto__
+    {
+      code: 'obj?.__proto__?.toString();',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Calling __proto__ as function ===
+    {
+      code: 'obj.__proto__();',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj["__proto__"]();',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === this ===
+    {
+      code: 'var a = this.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'this["__proto__"];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Parenthesized expression ===
+    {
+      code: '(obj).__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: '(obj)["__proto__"];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === TypeScript expressions ===
+    // as assertion
+    {
+      code: '(obj as any).__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Angle-bracket assertion
+    {
+      code: '(<any>obj).__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Non-null assertion
+    {
+      code: 'obj!.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Satisfies expression
+    {
+      code: '(obj satisfies any).__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === As function argument ===
+    {
+      code: 'foo(obj.__proto__);',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'console.log(obj["__proto__"]);',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === new / await / yield ===
+    {
+      code: 'new (obj.__proto__)();',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'async function f() { await obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'function* g() { yield obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Tagged template ===
+    {
+      code: 'obj.__proto__`tagged`;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Update expressions (++/--) ===
+    {
+      code: '++obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj.__proto__++;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === In expressions ===
+    // Template literal expression
+    {
+      code: 'var s = `${obj.__proto__}`;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Ternary
+    {
+      code: 'var a = x ? obj.__proto__ : null;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Logical OR / AND
+    {
+      code: 'var a = obj.__proto__ || default_;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'var a = x && obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Nullish coalescing
+    {
+      code: 'var a = obj.__proto__ ?? default_;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Comma operator
+    {
+      code: '(0, obj.__proto__);',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // in expression
+    {
+      code: '"x" in obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // instanceof
+    {
+      code: 'obj.__proto__ instanceof Object;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Unary operators ===
+    {
+      code: 'typeof obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'void obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'delete obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Spread ===
+    {
+      code: 'var a = { ...obj.__proto__ };',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'var a = [...obj.__proto__];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Assignment patterns ===
+    // Compound assignment
+    {
+      code: 'obj.__proto__ += "";',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Logical assignment operators
+    {
+      code: 'obj.__proto__ ||= x;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj.__proto__ &&= x;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'obj.__proto__ ??= x;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Destructuring default value
+    {
+      code: 'var { a = obj.__proto__ } = b;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Array destructuring assignment target
+    {
+      code: '[obj.__proto__] = [1];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === As value in object / array literal ===
+    // Object property value
+    {
+      code: 'var a = { key: obj.__proto__ };',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Array element
+    {
+      code: 'var a = [obj.__proto__];',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Computed property key
+    {
+      code: 'var a = { [obj.__proto__]: 1 };',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === for-in / for-of with member expression as target ===
+    {
+      code: 'for (obj.__proto__ in x) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'for (obj.__proto__ of x) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Function / class contexts ===
+    {
+      code: 'function f() { return obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'var f = () => obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'async function f() { return obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'class C { method() { return this.__proto__; } }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'class C { constructor() { this.__proto__ = null; } }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'class C { get p() { return obj.__proto__; } }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'class C { static { obj.__proto__; } }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Class field initializer value
+    {
+      code: 'class C { x = obj.__proto__ }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // IIFE
+    {
+      code: '(function() { return obj.__proto__; })();',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // Arrow returning object
+    {
+      code: 'var f = () => ({ a: obj.__proto__ });',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Namespace / module scope ===
+    {
+      code: 'namespace N { var a = obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Export ===
+    {
+      code: 'export default obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Control flow ===
+    {
+      code: 'if (obj.__proto__) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'for (var x in obj.__proto__) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'for (var x of obj.__proto__) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'while (obj.__proto__) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'switch (obj.__proto__) { case 0: break; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'throw obj.__proto__;',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // do-while
+    {
+      code: 'do {} while (obj.__proto__);',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // try / catch / finally
+    {
+      code: 'try { obj.__proto__; } catch(e) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'try {} catch(e) { obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    {
+      code: 'try {} finally { obj.__proto__; }',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+    // For init
+    {
+      code: 'for (obj.__proto__ = 0;;) {}',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+
+    // === Multiple occurrences ===
+    {
+      code: 'a.__proto__;\nb.__proto__;',
+      errors: [
+        { messageId: 'unexpectedProto' },
+        { messageId: 'unexpectedProto' },
+      ],
+    },
+    // Mixed dot and bracket
+    {
+      code: 'obj.__proto__; obj["__proto__"];',
+      errors: [
+        { messageId: 'unexpectedProto' },
+        { messageId: 'unexpectedProto' },
+      ],
+    },
+
+    // === Multi-byte characters ===
+    {
+      code: '/* 🚀 */ obj.__proto__',
+      errors: [{ messageId: 'unexpectedProto' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint core rule [`no-proto`](https://eslint.org/docs/latest/rules/no-proto) which disallows the use of the deprecated `__proto__` property.

- Detects both dot notation (`obj.__proto__`) and bracket notation (`obj["__proto__"]`, `` obj[`__proto__`] ``)
- Verified end-to-end alignment with ESLint: identical output (line/column) on the same test file
- Tested on rsbuild (1192 files) and rspack (748 files) with no false positives

### Files added/modified
- `internal/rules/no_proto/` — Go implementation, tests (59 valid + 80 invalid cases), and documentation
- `internal/config/config.go` — Rule registration
- `packages/rslint-test-tools/tests/eslint/rules/no-proto.test.ts` — JS E2E tests (synced with Go tests)
- `packages/rslint-test-tools/rstest.config.mts` — Test registration

## Related Links

- [ESLint no-proto rule](https://eslint.org/docs/latest/rules/no-proto)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).