### PR TITLE
feat: port rule no-multi-str

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
+	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
@@ -523,6 +524,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
+	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)

--- a/internal/rules/no_multi_str/no_multi_str.go
+++ b/internal/rules/no_multi_str/no_multi_str.go
@@ -1,0 +1,39 @@
+package no_multi_str
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-multi-str
+var NoMultiStrRule = rule.Rule{
+	Name: "no-multi-str",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindStringLiteral: func(node *ast.Node) {
+				// Skip string literals inside JSX contexts.
+				// Possible JSX parents for a StringLiteral:
+				//   - JsxAttribute:  <div attr="value">
+				//   - JsxExpression: <div>{'value'}</div> or <div attr={'value'}>
+				if node.Parent != nil &&
+					(ast.IsJsxAttributeLike(node.Parent) || ast.IsJsxExpression(node.Parent)) {
+					return
+				}
+
+				raw := utils.TrimmedNodeText(ctx.SourceFile, node)
+
+				// A line break in the raw source of a string literal means it uses
+				// the backslash-newline continuation syntax (e.g. 'line1 \<LF> line2').
+				if strings.ContainsAny(raw, "\n\r\u2028\u2029") {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "multilineString",
+						Description: "Multiline support is limited to browsers supporting ES5 only.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_multi_str/no_multi_str.md
+++ b/internal/rules/no_multi_str/no_multi_str.md
@@ -1,0 +1,26 @@
+# no-multi-str
+
+## Rule Details
+
+Disallows multiline strings created using a trailing backslash before a line break. This syntax was historically an undocumented feature of JavaScript and should be avoided.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x =
+  'Line 1 \
+         Line 2';
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var x = 'Line 1 ' + 'Line 2';
+
+var x = `Line 1
+         Line 2`;
+```
+
+## Original Documentation
+
+- [ESLint no-multi-str](https://eslint.org/docs/latest/rules/no-multi-str)

--- a/internal/rules/no_multi_str/no_multi_str_test.go
+++ b/internal/rules/no_multi_str/no_multi_str_test.go
@@ -1,0 +1,333 @@
+package no_multi_str
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMultiStrRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoMultiStrRule,
+		// ================================================================
+		// Valid cases — should NOT trigger
+		// ================================================================
+		[]rule_tester.ValidTestCase{
+			// ---- Single-line strings ----
+			{Code: `var a = 'Line 1 Line 2';`},
+			{Code: `var a = "double quoted";`},
+			{Code: `var a = '';`},
+			{Code: `var a = "";`},
+
+			// ---- Escape sequences that look like newlines but are NOT real ----
+			// \n escape → produces newline in value, but raw source stays single-line
+			{Code: `var a = 'hello\nworld';`},
+			{Code: `var a = "hello\nworld";`},
+			// \r escape
+			{Code: `var a = 'hello\rworld';`},
+			// \u2028 / \u2029 escape
+			{Code: `var a = 'hello\u2028world';`},
+			{Code: `var a = 'hello\u2029world';`},
+
+			// ---- Template literals — allowed to span multiple lines ----
+			{Code: "var a = `Line 1\nLine 2`;"},
+			{Code: "var a = `\n`;"},
+
+			// ---- String concatenation across lines (each string is single-line) ----
+			{Code: "var a = 'Line 1' +\n'Line 2';"},
+
+			// ---- JSX contexts — string literals in JSX are exempt ----
+			// JSX attribute (direct string): parent = JsxAttribute
+			{Code: `var a = <div attr="hello"></div>;`, Tsx: true},
+			// JSX attribute (expression): parent = JsxExpression
+			{Code: `var a = <div attr={'hello'}></div>;`, Tsx: true},
+			// JSX child expression: parent = JsxExpression
+			{Code: `var a = <div>{'hello'}</div>;`, Tsx: true},
+			// Multiline string inside JSX expression — exempt because parent is JsxExpression
+			{Code: "<div attr={'foo\\\nbar'}></div>;", Tsx: true},
+			{Code: "<div>{'foo\\\nbar'}</div>;", Tsx: true},
+
+			// ---- Non-string expressions ----
+			{Code: `var a = 42;`},
+			{Code: `var a = true;`},
+		},
+		// ================================================================
+		// Invalid cases — should trigger
+		// ================================================================
+		[]rule_tester.InvalidTestCase{
+			// ================================================================
+			// Dimension 1: Line break types
+			// ================================================================
+
+			// LF (\n)
+			{
+				Code: "var x = 'Line 1 \\\n Line 2'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 9},
+				},
+			},
+			// CR (\r)
+			{
+				Code: "'foo\\\rbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+			// CRLF (\r\n)
+			{
+				Code: "'foo\\\r\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+			// LS (U+2028)
+			{
+				Code: "'foo\\\u2028bar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+			// PS (U+2029)
+			{
+				Code: "'foo\\\u2029ar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 2: Quote types
+			// ================================================================
+
+			// Single quote
+			{
+				Code: "'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+			// Double quote
+			{
+				Code: "\"foo\\\nbar\";",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Dimension 3: Nesting contexts
+			// ================================================================
+
+			// Function call argument
+			{
+				Code: "test('Line 1 \\\n Line 2');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 6},
+				},
+			},
+			// Object property value
+			{
+				Code: "var obj = { key: 'foo\\\nbar' };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 18},
+				},
+			},
+			// Computed property key
+			{
+				Code: "var obj = { ['foo\\\nbar']: 1 };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 14},
+				},
+			},
+			// Array element
+			{
+				Code: "var arr = ['foo\\\nbar'];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 12},
+				},
+			},
+			// Return statement
+			{
+				Code: "function f() { return 'foo\\\nbar'; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 23},
+				},
+			},
+			// Conditional / ternary
+			{
+				Code: "var a = x ? 'foo\\\nbar' : 'safe';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 13},
+				},
+			},
+			// Default parameter
+			{
+				Code: "function f(x = 'foo\\\nbar') {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 16},
+				},
+			},
+			// Class property
+			{
+				Code: "class A { prop = 'foo\\\nbar' }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 18},
+				},
+			},
+			// Arrow function implicit return
+			{
+				Code: "const f = () => 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 17},
+				},
+			},
+			// Binary expression (+ concatenation)
+			{
+				Code: "var a = 'foo\\\nbar' + x;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 9},
+				},
+			},
+			// Logical OR
+			{
+				Code: "var a = x || 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 14},
+				},
+			},
+			// Nullish coalescing
+			{
+				Code: "var a = x ?? 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 14},
+				},
+			},
+			// Assignment
+			{
+				Code: "x = 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 5},
+				},
+			},
+			// Throw statement
+			{
+				Code: "throw 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 7},
+				},
+			},
+			// Switch case
+			{
+				Code: "switch (x) { case 'foo\\\nbar': break; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 19},
+				},
+			},
+			// Computed member access
+			{
+				Code: "var a = obj['foo\\\nbar'];",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 13},
+				},
+			},
+			// Parenthesized expression
+			{
+				Code: "var a = ('foo\\\nbar');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 10},
+				},
+			},
+			// Nested function call
+			{
+				Code: "fn1(fn2('foo\\\nbar'));",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 9},
+				},
+			},
+			// Nested object
+			{
+				Code: "var obj = { a: { b: 'foo\\\nbar' } };",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 21},
+				},
+			},
+			// Template literal expression (string inside template)
+			{
+				Code: "var a = `${'foo\\\nbar'}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 12},
+				},
+			},
+
+			// ================================================================
+			// Dimension 4: TypeScript-specific contexts
+			// ================================================================
+
+			// Enum initializer
+			{
+				Code: "enum E { A = 'foo\\\nbar' }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 14},
+				},
+			},
+			// Type position (string literal type)
+			{
+				Code: "type T = 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 10},
+				},
+			},
+
+			// ================================================================
+			// Dimension 5: Edge cases
+			// ================================================================
+
+			// String spanning 3+ lines
+			{
+				Code: "'line1\\\nline2\\\nline3';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+			// Empty continuation (backslash + newline + closing quote)
+			{
+				Code: "'\\\n';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+				},
+			},
+			// String not at beginning of file (later line)
+			{
+				Code: "var x;\nvar y = 'foo\\\nbar';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 2, Column: 9},
+				},
+			},
+
+			// ================================================================
+			// Dimension 6: Multiple errors in one file
+			// ================================================================
+
+			// Two multiline strings in separate statements
+			{
+				Code: "'foo\\\nbar';\n'baz\\\nqux';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 1},
+					{MessageId: "multilineString", Line: 3, Column: 1},
+				},
+			},
+			// Two multiline strings as function arguments
+			{
+				Code: "fn('one\\\ntwo', 'three\\\nfour');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multilineString", Line: 1, Column: 4},
+					{MessageId: "multilineString", Line: 2, Column: 7},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -251,6 +251,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
+    './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-proto.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-multi-str.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-multi-str.test.ts.snap
@@ -1,0 +1,952 @@
+// Rstest Snapshot v1
+
+exports[`no-multi-str > invalid 1`] = `
+{
+  "code": "var x = 'Line 1 \\
+ Line 2'",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 2`] = `
+{
+  "code": "'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 3`] = `
+{
+  "code": "'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 4`] = `
+{
+  "code": "'foo\\ bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 5`] = `
+{
+  "code": "'foo\\ ar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 6`] = `
+{
+  "code": "'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 7`] = `
+{
+  "code": ""foo\\
+bar";",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 8`] = `
+{
+  "code": "test('Line 1 \\
+ Line 2');",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 2,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 9`] = `
+{
+  "code": "var obj = { key: 'foo\\
+bar' };",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 10`] = `
+{
+  "code": "var obj = { ['foo\\
+bar']: 1 };",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 11`] = `
+{
+  "code": "var arr = ['foo\\
+bar'];",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 12`] = `
+{
+  "code": "function f() { return 'foo\\
+bar'; }",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 13`] = `
+{
+  "code": "var a = x ? 'foo\\
+bar' : 'safe';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 14`] = `
+{
+  "code": "function f(x = 'foo\\
+bar') {}",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 15`] = `
+{
+  "code": "class A { prop = 'foo\\
+bar' }",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 16`] = `
+{
+  "code": "const f = () => 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 17`] = `
+{
+  "code": "var a = 'foo\\
+bar' + x;",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 18`] = `
+{
+  "code": "var a = x || 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 19`] = `
+{
+  "code": "var a = x ?? 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 20`] = `
+{
+  "code": "x = 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 21`] = `
+{
+  "code": "throw 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 22`] = `
+{
+  "code": "switch (x) { case 'foo\\
+bar': break; }",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 23`] = `
+{
+  "code": "var a = obj['foo\\
+bar'];",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 24`] = `
+{
+  "code": "var a = ('foo\\
+bar');",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 25`] = `
+{
+  "code": "fn1(fn2('foo\\
+bar'));",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 26`] = `
+{
+  "code": "var obj = { a: { b: 'foo\\
+bar' } };",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 27`] = `
+{
+  "code": "var a = \`\${'foo\\
+bar'}\`;",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 28`] = `
+{
+  "code": "enum E { A = 'foo\\
+bar' }",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 29`] = `
+{
+  "code": "type T = 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 30`] = `
+{
+  "code": "'line1\\
+line2\\
+line3';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 31`] = `
+{
+  "code": "'\\
+';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 32`] = `
+{
+  "code": "var x;
+var y = 'foo\\
+bar';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 33`] = `
+{
+  "code": "'foo\\
+bar';
+'baz\\
+qux';",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-multi-str > invalid 34`] = `
+{
+  "code": "fn('one\\
+two', 'three\\
+four');",
+  "diagnostics": [
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 2,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+    {
+      "message": "Multiline support is limited to browsers supporting ES5 only.",
+      "messageId": "multilineString",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-multi-str",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-multi-str.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-multi-str.test.ts
@@ -1,0 +1,201 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-multi-str', {
+  valid: [
+    // ---- Single-line strings ----
+    "var a = 'Line 1 Line 2';",
+    'var a = "double quoted";',
+    "var a = '';",
+    'var a = "";',
+
+    // ---- Escape sequences (not real newlines in raw source) ----
+    "var a = 'hello\\nworld';",
+    'var a = "hello\\nworld";',
+    "var a = 'hello\\rworld';",
+    "var a = 'hello\\u2028world';",
+    "var a = 'hello\\u2029world';",
+
+    // ---- Template literals can span multiple lines ----
+    'var a = `Line 1\nLine 2`;',
+    'var a = `\n`;',
+
+    // ---- String concatenation across lines ----
+    "var a = 'Line 1' +\n'Line 2';",
+
+    // ---- Non-string expressions ----
+    'var a = 42;',
+    'var a = true;',
+  ],
+  invalid: [
+    // ================================================================
+    // Line break types
+    // ================================================================
+    {
+      code: "var x = 'Line 1 \\\n Line 2'",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "'foo\\\rbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "'foo\\\r\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "'foo\\\u2028bar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "'foo\\\u2029ar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+
+    // ================================================================
+    // Quote types
+    // ================================================================
+    {
+      code: "'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: '"foo\\\nbar";',
+      errors: [{ messageId: 'multilineString' }],
+    },
+
+    // ================================================================
+    // Nesting contexts
+    // ================================================================
+    {
+      code: "test('Line 1 \\\n Line 2');",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var obj = { key: 'foo\\\nbar' };",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var obj = { ['foo\\\nbar']: 1 };",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var arr = ['foo\\\nbar'];",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "function f() { return 'foo\\\nbar'; }",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = x ? 'foo\\\nbar' : 'safe';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "function f(x = 'foo\\\nbar') {}",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "class A { prop = 'foo\\\nbar' }",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "const f = () => 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = 'foo\\\nbar' + x;",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = x || 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = x ?? 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "x = 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "throw 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "switch (x) { case 'foo\\\nbar': break; }",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = obj['foo\\\nbar'];",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = ('foo\\\nbar');",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "fn1(fn2('foo\\\nbar'));",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var obj = { a: { b: 'foo\\\nbar' } };",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "var a = `${'foo\\\nbar'}`;",
+      errors: [{ messageId: 'multilineString' }],
+    },
+
+    // ================================================================
+    // TypeScript-specific contexts
+    // ================================================================
+    {
+      code: "enum E { A = 'foo\\\nbar' }",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    {
+      code: "type T = 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+
+    // ================================================================
+    // Edge cases
+    // ================================================================
+    // 3+ lines
+    {
+      code: "'line1\\\nline2\\\nline3';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    // Empty continuation
+    {
+      code: "'\\\n';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+    // String on a later line
+    {
+      code: "var x;\nvar y = 'foo\\\nbar';",
+      errors: [{ messageId: 'multilineString' }],
+    },
+
+    // ================================================================
+    // Multiple errors
+    // ================================================================
+    {
+      code: "'foo\\\nbar';\n'baz\\\nqux';",
+      errors: [
+        { messageId: 'multilineString' },
+        { messageId: 'multilineString' },
+      ],
+    },
+    {
+      code: "fn('one\\\ntwo', 'three\\\nfour');",
+      errors: [
+        { messageId: 'multilineString' },
+        { messageId: 'multilineString' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-multi-str` rule from ESLint to rslint.

Disallows multiline strings created using a trailing backslash before a line break (`\` followed by a newline). This syntax was historically an undocumented feature of JavaScript.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-multi-str
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-multi-str.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).