### PR TITLE
feat: port rule @typescript-eslint/explicit-function-return-type

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/consistent_type_imports"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/default_param_last"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/dot_notation"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/explicit_function_return_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/naming_convention"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_delete"
@@ -401,6 +402,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/consistent-type-imports", consistent_type_imports.ConsistentTypeImportsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/default-param-last", default_param_last.DefaultParamLastRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/dot-notation", dot_notation.DotNotationRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/explicit-function-return-type", explicit_function_return_type.ExplicitFunctionReturnTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/naming-convention", naming_convention.NamingConventionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-constructor", no_array_constructor.NoArrayConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-delete", no_array_delete.NoArrayDeleteRule)

--- a/internal/plugins/typescript/rules/explicit_function_return_type/allow_expr_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/allow_expr_test.go
@@ -1,0 +1,54 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestAllowExpressionsObjectMethods tests that allowExpressions correctly handles
+// object method shorthand and object getters.
+// In ESLint's AST: { foo() {} } → Property > FunctionExpression.
+// Property is NOT in allowExpressions exclusion list, so it should be valid.
+// In tsgo: { foo() {} } → ObjectLiteralExpression > MethodDeclaration.
+func TestAllowExpressionsObjectMethods(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// Object method shorthand with allowExpressions: true
+		{
+			Code:    `const obj = { foo() { return 1; } };`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// Object getter with allowExpressions: true
+		{
+			Code:    `const obj = { get foo() { return 1; } };`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// Object method with function value — already works (PropertyAssignment parent)
+		{
+			Code:    `const obj = { foo: function() { return 1; } };`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Class method — NOT valid with allowExpressions (MethodDefinition is excluded in ESLint)
+		{
+			Code: `
+class Foo {
+  method() { return 1; }
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// Class getter — NOT valid with allowExpressions
+		{
+			Code: `
+class Foo {
+  get prop() { return 1; }
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/bodyless_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/bodyless_test.go
@@ -1,0 +1,122 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestBodyless(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// declare function — no body, skip (ESLint treats as TSDeclareFunction)
+		{Code: `declare function foo(): void;`},
+		{Code: `declare function foo();`},
+		// Abstract methods — no body, skip (ESLint treats as TSAbstractMethodDefinition)
+		{Code: `
+abstract class Foo {
+  abstract method(): void;
+}
+		`},
+		{Code: `
+abstract class Foo {
+  abstract method();
+}
+		`},
+		// Overload signatures — no body, skip. Only the implementation body matters.
+		{Code: `
+function foo(x: number): void;
+function foo(x: string): void;
+function foo(x: any): void {}
+		`},
+		{Code: `
+class Foo {
+  method(x: number): void;
+  method(x: string): void;
+  method(x: any): void {}
+}
+		`},
+		// declare class method
+		{Code: `
+declare class Foo {
+  method(): void;
+}
+		`},
+		{Code: `
+declare class Foo {
+  method();
+}
+		`},
+	}, []rule_tester.InvalidTestCase{
+		// Overload: the implementation body still needs a return type
+		{
+			Code: `
+function foo(x: number): void;
+function foo(x: any) { return x; }
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 1}},
+		},
+	})
+}
+
+func TestGetFunctionHeadLocEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+		// async function — head starts at `async`, not `function`
+		{
+			Code:   `async function foo() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 1}},
+		},
+		// export default function — head starts at `function`
+		{
+			Code:   `export default function() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+		// export async function — head starts at `async`
+		{
+			Code:   `export async function foo() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 8}},
+		},
+		// export default async function — head starts at `async`
+		{
+			Code:   `export default async function foo() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+		// class static async method — head includes all modifiers
+		{
+			Code: `
+class A {
+  static async method() {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// class private method — head includes `private`
+		{
+			Code: `
+class A {
+  private method() {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// class property with function expression — head includes property name
+		{
+			Code: `
+class A {
+  static foo = function() {};
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// arrow in object property — head includes property key
+		{
+			Code: `
+const x = {
+  foo: () => {},
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/edge_cases_test.go
@@ -1,0 +1,157 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestMethodHOF(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// MethodDeclaration returning function — HOF allows outer
+		{
+			Code: `
+class Foo {
+  method() {
+    return (): void => {};
+  }
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// Object method shorthand returning function
+		{
+			Code: `
+const obj = {
+  method() {
+    return (): void => {};
+  },
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// Getter with return type — inner arrow typed by ancestor
+		{
+			Code: `class A { get prop(): () => void { return () => {}; } }`,
+		},
+		// Method with return type — inner arrow typed by ancestor
+		{
+			Code: `
+class A {
+  method(): () => void {
+    return () => {};
+  }
+}
+			`,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// MethodDeclaration returning function — inner still needs type
+		{
+			Code: `
+class Foo {
+  method() {
+    return () => {};
+  }
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 15}},
+		},
+		// Object method NOT HOF — not all returns are functions
+		{
+			Code: `
+const obj = {
+  method(x: boolean) {
+    if (x) return 'string';
+    return (): void => {};
+  },
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// Getter without return type
+		{
+			Code: `
+class A {
+  get prop() { return 1; }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+	})
+}
+
+func TestAncestorReturnType(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// Arrow with expression body inside property of returned object — ancestor has return type
+		{
+			Code: `
+interface Foo { bar: () => string; }
+function foo(): Foo {
+  return { bar: () => 'test' };
+}
+			`,
+		},
+		{
+			Code: `
+interface Foo { bar: () => string; }
+const foo = (): Foo => ({ bar: () => 'test' });
+			`,
+		},
+		// Method/Getter with return type — inner arrow typed by ancestor
+		{
+			Code: `
+interface Foo { bar: () => string; }
+class A {
+  method(): Foo {
+    return { bar: () => 'test' };
+  }
+}
+			`,
+		},
+		{
+			Code: `
+interface Foo { bar: () => string; }
+class A {
+  get prop(): Foo {
+    return { bar: () => 'test' };
+  }
+}
+			`,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Arrow with BLOCK body — ancestorHasReturnType returns false
+		// (the PropertyAssignment.Initializer is the arrow, but it has block body so isBodylessArrow=false)
+		{
+			Code: `
+interface Foo { bar: () => string; }
+function foo(): Foo {
+  return { bar: () => { return 'test'; } };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 12}},
+		},
+		// Function expression in property — not a bodyless arrow
+		{
+			Code: `
+interface Foo { bar: () => string; }
+function foo(): Foo {
+  return { bar: function() { return 'test'; } };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 12}},
+		},
+		// Method shorthand in returned object — always needs return type
+		{
+			Code: `
+interface Foo { bar(): string; }
+function foo(): Foo {
+  return { bar() { return 'test'; } };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 12}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.go
@@ -1,0 +1,580 @@
+package explicit_function_return_type
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type options struct {
+	allowConciseArrowFunctionExpressionsStartingWithVoid bool
+	allowDirectConstAssertionInArrowFunctions            bool
+	allowedNames                                         []string
+	allowExpressions                                     bool
+	allowFunctionsWithoutTypeParameters                  bool
+	allowHigherOrderFunctions                            bool
+	allowIIFEs                                           bool
+	allowTypedFunctionExpressions                        bool
+}
+
+func parseOptions(rawOpts any) options {
+	opts := options{
+		allowConciseArrowFunctionExpressionsStartingWithVoid: false,
+		allowDirectConstAssertionInArrowFunctions:            true,
+		allowedNames:                        nil,
+		allowExpressions:                    false,
+		allowFunctionsWithoutTypeParameters: false,
+		allowHigherOrderFunctions:           true,
+		allowIIFEs:                          false,
+		allowTypedFunctionExpressions:       true,
+	}
+
+	optsMap := utils.GetOptionsMap(rawOpts)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowConciseArrowFunctionExpressionsStartingWithVoid"].(bool); ok {
+		opts.allowConciseArrowFunctionExpressionsStartingWithVoid = v
+	}
+	if v, ok := optsMap["allowDirectConstAssertionInArrowFunctions"].(bool); ok {
+		opts.allowDirectConstAssertionInArrowFunctions = v
+	}
+	if v, ok := optsMap["allowedNames"].([]interface{}); ok {
+		for _, name := range v {
+			if s, ok := name.(string); ok {
+				opts.allowedNames = append(opts.allowedNames, s)
+			}
+		}
+	}
+	if v, ok := optsMap["allowExpressions"].(bool); ok {
+		opts.allowExpressions = v
+	}
+	if v, ok := optsMap["allowFunctionsWithoutTypeParameters"].(bool); ok {
+		opts.allowFunctionsWithoutTypeParameters = v
+	}
+	if v, ok := optsMap["allowHigherOrderFunctions"].(bool); ok {
+		opts.allowHigherOrderFunctions = v
+	}
+	if v, ok := optsMap["allowIIFEs"].(bool); ok {
+		opts.allowIIFEs = v
+	}
+	if v, ok := optsMap["allowTypedFunctionExpressions"].(bool); ok {
+		opts.allowTypedFunctionExpressions = v
+	}
+	return opts
+}
+
+type functionInfo struct {
+	node    *ast.Node
+	returns []*ast.Node
+}
+
+var ExplicitFunctionReturnTypeRule = rule.CreateRule(rule.Rule{
+	Name: "explicit-function-return-type",
+	Run:  run,
+})
+
+func run(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+	opts := parseOptions(rawOptions)
+	functionStack := make([]*functionInfo, 0)
+
+	enterFunction := func(node *ast.Node) {
+		functionStack = append(functionStack, &functionInfo{node: node})
+	}
+
+	popFunctionInfo := func() *functionInfo {
+		if len(functionStack) == 0 {
+			return nil
+		}
+		info := functionStack[len(functionStack)-1]
+		functionStack = functionStack[:len(functionStack)-1]
+		return info
+	}
+
+	report := func(node *ast.Node) {
+		loc := utils.GetFunctionHeadLoc(ctx.SourceFile, node)
+		ctx.ReportRange(loc, rule.RuleMessage{
+			Id:          "missingReturnType",
+			Description: "Missing return type on function.",
+		})
+	}
+
+	// checkFunctionReturnType checks the common validity conditions:
+	// - allowHigherOrderFunctions + doesImmediatelyReturnFunctionExpression
+	// - has explicit return type
+	// - is constructor or setter
+	// Returns true if the function is valid (no error should be reported).
+	checkFunctionReturnType := func(info *functionInfo) bool {
+		node := info.node
+		// Skip bodyless functions: declare functions, abstract methods, overload signatures.
+		// ESLint models these as TSDeclareFunction / TSAbstractMethodDefinition which are
+		// separate node types not visited by the rule. In tsgo they share the same Kind.
+		if node.Body() == nil {
+			return true
+		}
+		if opts.allowHigherOrderFunctions && doesImmediatelyReturnFunctionExpression(info) {
+			return true
+		}
+		if node.Type() != nil {
+			return true
+		}
+		if node.Kind == ast.KindConstructor || node.Kind == ast.KindSetAccessor {
+			return true
+		}
+		return false
+	}
+
+	isAllowedFunction := func(node *ast.Node) bool {
+		if opts.allowFunctionsWithoutTypeParameters && node.TypeParameters() == nil {
+			return true
+		}
+		if opts.allowIIFEs && isIIFE(node) {
+			return true
+		}
+		if len(opts.allowedNames) == 0 {
+			return false
+		}
+		return isNameAllowed(ctx.SourceFile, node, opts.allowedNames)
+	}
+
+	// exitFunctionExpression handles ArrowFunction and FunctionExpression exit
+	exitFunctionExpression := func(node *ast.Node) {
+		info := popFunctionInfo()
+		if info == nil {
+			return
+		}
+
+		// allowConciseArrowFunctionExpressionsStartingWithVoid
+		if opts.allowConciseArrowFunctionExpressionsStartingWithVoid &&
+			node.Kind == ast.KindArrowFunction {
+			af := node.AsArrowFunction()
+			if af.Body != nil && af.Body.Kind != ast.KindBlock {
+				if ast.SkipParentheses(af.Body).Kind == ast.KindVoidExpression {
+					return
+				}
+			}
+		}
+
+		if isAllowedFunction(node) {
+			return
+		}
+
+		if opts.allowTypedFunctionExpressions &&
+			(isValidFunctionExpressionReturnType(node, opts) ||
+				ancestorHasReturnType(node)) {
+			return
+		}
+
+		if !checkFunctionReturnType(info) {
+			report(node)
+		}
+	}
+
+	// exitFunctionDeclaration handles FunctionDeclaration exit
+	exitFunctionDeclaration := func(node *ast.Node) {
+		info := popFunctionInfo()
+		if info == nil {
+			return
+		}
+		if isAllowedFunction(node) {
+			return
+		}
+		if opts.allowTypedFunctionExpressions && node.Type() != nil {
+			return
+		}
+		if !checkFunctionReturnType(info) {
+			report(node)
+		}
+	}
+
+	// exitMethodOrAccessor handles MethodDeclaration and GetAccessor exit
+	exitMethodOrAccessor := func(node *ast.Node) {
+		info := popFunctionInfo()
+		if info == nil {
+			return
+		}
+		if isAllowedFunction(node) {
+			return
+		}
+
+		// In ESLint, object methods/getters are Property > FunctionExpression, so they go
+		// through exitFunctionExpression. In tsgo they are MethodDeclaration/GetAccessor
+		// directly inside ObjectLiteralExpression. Apply the same expression-path checks.
+		if node.Parent != nil && node.Parent.Kind == ast.KindObjectLiteralExpression {
+			if opts.allowTypedFunctionExpressions &&
+				(isObjectMethodTyped(node, opts) || ancestorHasReturnType(node) || opts.allowExpressions) {
+				return
+			}
+		}
+
+		if !checkFunctionReturnType(info) {
+			report(node)
+		}
+	}
+
+	// Constructors and setters never need return types — just pop the stack.
+	exitConstructorOrSetter := func(_ *ast.Node) {
+		popFunctionInfo()
+	}
+
+	return rule.RuleListeners{
+		// Enter listeners - push to stack
+		ast.KindFunctionDeclaration: enterFunction,
+		ast.KindFunctionExpression:  enterFunction,
+		ast.KindArrowFunction:       enterFunction,
+		ast.KindMethodDeclaration:   enterFunction,
+		ast.KindGetAccessor:         enterFunction,
+		ast.KindConstructor:         enterFunction,
+		ast.KindSetAccessor:         enterFunction,
+
+		// Exit listeners
+		rule.ListenerOnExit(ast.KindFunctionDeclaration): exitFunctionDeclaration,
+		rule.ListenerOnExit(ast.KindFunctionExpression):  exitFunctionExpression,
+		rule.ListenerOnExit(ast.KindArrowFunction):       exitFunctionExpression,
+		rule.ListenerOnExit(ast.KindMethodDeclaration):   exitMethodOrAccessor,
+		rule.ListenerOnExit(ast.KindGetAccessor):         exitMethodOrAccessor,
+		rule.ListenerOnExit(ast.KindConstructor):         exitConstructorOrSetter,
+		rule.ListenerOnExit(ast.KindSetAccessor):         exitConstructorOrSetter,
+
+		// Return statement listener
+		ast.KindReturnStatement: func(node *ast.Node) {
+			if len(functionStack) > 0 {
+				info := functionStack[len(functionStack)-1]
+				info.returns = append(info.returns, node)
+			}
+		},
+	}
+}
+
+// isIIFE checks if a function node is the callee of an immediately invoked call expression.
+func isIIFE(node *ast.Node) bool {
+	parent := node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(parent.AsCallExpression().Expression)
+	return callee == node
+}
+
+// isFunction checks if a node is a FunctionDeclaration, FunctionExpression, or ArrowFunction.
+// Matches ESLint's ASTUtils.isFunction — excludes methods, getters, setters, and constructors.
+func isFunction(node *ast.Node) bool {
+	return ast.IsFunctionDeclaration(node) || ast.IsFunctionExpressionOrArrowFunction(node)
+}
+
+// doesImmediatelyReturnFunctionExpression checks if a function immediately returns another function.
+// tsgo preserves ParenthesizedExpression (ESLint strips them), so we must unwrap with SkipParentheses.
+func doesImmediatelyReturnFunctionExpression(info *functionInfo) bool {
+	node := info.node
+	// Arrow function with expression body that is a function
+	if node.Kind == ast.KindArrowFunction {
+		af := node.AsArrowFunction()
+		if af.Body != nil && af.Body.Kind != ast.KindBlock {
+			return isFunction(ast.SkipParentheses(af.Body))
+		}
+	}
+
+	if len(info.returns) == 0 {
+		return false
+	}
+
+	for _, ret := range info.returns {
+		arg := ret.Expression()
+		if arg == nil || !isFunction(ast.SkipParentheses(arg)) {
+			return false
+		}
+	}
+	return true
+}
+
+// getEffectiveParent returns the first meaningful parent, skipping ParenthesizedExpressions.
+// ESLint strips parens from the AST; tsgo preserves them, so this bridges the gap.
+func getEffectiveParent(node *ast.Node) *ast.Node {
+	if node.Parent == nil {
+		return nil
+	}
+	return ast.WalkUpParenthesizedExpressions(node.Parent)
+}
+
+// isTypeAssertion checks if a node is `x as T` or `<T>x`.
+func isTypeAssertion(node *ast.Node) bool {
+	return ast.IsAsExpression(node) || ast.IsTypeAssertionExpression(node)
+}
+
+// isVariableDeclaratorWithTypeAnnotation checks if a node is a VariableDeclaration with a type annotation.
+func isVariableDeclaratorWithTypeAnnotation(node *ast.Node) bool {
+	if node.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	decl := node.AsVariableDeclaration()
+	return decl.Type != nil
+}
+
+// isPropertyDefinitionWithTypeAnnotation checks if a node is a PropertyDeclaration with a type annotation.
+func isPropertyDefinitionWithTypeAnnotation(node *ast.Node) bool {
+	if node.Kind != ast.KindPropertyDeclaration {
+		return false
+	}
+	return node.AsPropertyDeclaration().Type != nil
+}
+
+// isDefaultFunctionParameterWithTypeAnnotation checks `(param: Type = () => {})`.
+// In tsgo, the function is the initializer of a Parameter node with a type annotation.
+func isDefaultFunctionParameterWithTypeAnnotation(node *ast.Node) bool {
+	if node.Kind != ast.KindParameter {
+		return false
+	}
+	param := node.AsParameterDeclaration()
+	return param.Type != nil && param.Initializer != nil
+}
+
+// isFunctionArgument checks if a parent is a call expression and the function is an argument (not callee).
+func isFunctionArgument(parent *ast.Node, funcNode *ast.Node) bool {
+	if parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(parent.AsCallExpression().Expression)
+	return callee != funcNode
+}
+
+// isTypedJSX checks if a node is JSXExpressionContainer or JSXSpreadAttribute.
+func isTypedJSX(node *ast.Node) bool {
+	return node.Kind == ast.KindJsxExpression || node.Kind == ast.KindJsxSpreadAttribute
+}
+
+// isConstructorArgument checks if a node is a NewExpression.
+func isConstructorArgument(node *ast.Node) bool {
+	return node.Kind == ast.KindNewExpression
+}
+
+// isTypedParent checks if the parent of a function expression provides type context.
+func isTypedParent(parent *ast.Node, funcNode *ast.Node) bool {
+	return isTypeAssertion(parent) ||
+		isVariableDeclaratorWithTypeAnnotation(parent) ||
+		isDefaultFunctionParameterWithTypeAnnotation(parent) ||
+		isPropertyDefinitionWithTypeAnnotation(parent) ||
+		isFunctionArgument(parent, funcNode) ||
+		isTypedJSX(parent)
+}
+
+// isPropertyOfObjectWithType checks if a node is a property (or nested property)
+// of a typed object expression.
+func isPropertyOfObjectWithType(property *ast.Node, funcNode *ast.Node) bool {
+	if property == nil {
+		return false
+	}
+	if property.Kind != ast.KindPropertyAssignment &&
+		property.Kind != ast.KindShorthandPropertyAssignment {
+		return false
+	}
+	objectExpr := property.Parent
+	if objectExpr == nil || objectExpr.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	parent := getEffectiveParent(objectExpr)
+	if parent == nil {
+		return false
+	}
+	return isTypedParent(parent, funcNode) || isPropertyOfObjectWithType(parent, funcNode)
+}
+
+// isTypedFunctionExpression checks if a function expression is in a typed context.
+func isTypedFunctionExpression(node *ast.Node, opts options) bool {
+	if !opts.allowTypedFunctionExpressions {
+		return false
+	}
+	parent := getEffectiveParent(node)
+	if parent == nil {
+		return false
+	}
+	return isTypedParent(parent, node) ||
+		isPropertyOfObjectWithType(parent, node) ||
+		isConstructorArgument(parent)
+}
+
+// isValidFunctionExpressionReturnType checks if a function expression's return type
+// is either typed or valid with the provided options.
+func isValidFunctionExpressionReturnType(node *ast.Node, opts options) bool {
+	if isTypedFunctionExpression(node, opts) {
+		return true
+	}
+
+	if opts.allowExpressions {
+		parent := getEffectiveParent(node)
+		if parent != nil &&
+			parent.Kind != ast.KindVariableDeclaration &&
+			parent.Kind != ast.KindMethodDeclaration &&
+			parent.Kind != ast.KindExportAssignment &&
+			parent.Kind != ast.KindPropertyDeclaration {
+			return true
+		}
+	}
+
+	if !opts.allowDirectConstAssertionInArrowFunctions ||
+		node.Kind != ast.KindArrowFunction {
+		return false
+	}
+
+	af := node.AsArrowFunction()
+	body := af.Body
+	if body == nil {
+		return false
+	}
+	// Skip through parentheses and satisfies expressions.
+	// tsgo preserves ParenthesizedExpression; ESLint strips them.
+	body = ast.SkipParentheses(body)
+	for body.Kind == ast.KindSatisfiesExpression {
+		body = ast.SkipParentheses(body.AsSatisfiesExpression().Expression)
+	}
+
+	return ast.IsConstAssertion(body)
+}
+
+// isObjectMethodTyped checks if an object method is in a typed context.
+// This handles the tsgo-specific case where object method shorthand (e.g., { foo() {} })
+// is a MethodDeclaration inside ObjectLiteralExpression.
+//
+// NOTE: isConstructorArgument is intentionally NOT checked here. In ESLint,
+// isConstructorArgument is only for direct function arguments to new expressions
+// (e.g., `new Foo(() => {})`), not for methods inside objects passed to new expressions
+// (e.g., `new Proxy(obj, { get() {} })`).
+func isObjectMethodTyped(node *ast.Node, opts options) bool {
+	if !opts.allowTypedFunctionExpressions {
+		return false
+	}
+	objectExpr := node.Parent
+	if objectExpr == nil || objectExpr.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	parent := getEffectiveParent(objectExpr)
+	if parent == nil {
+		return false
+	}
+	return isTypedParent(parent, node) ||
+		isPropertyOfObjectWithType(parent, node)
+}
+
+// ancestorHasReturnType checks if any ancestor function has a return type.
+func ancestorHasReturnType(node *ast.Node) bool {
+	ancestor := node.Parent
+	// tsgo preserves ParenthesizedExpression; ESLint strips them.
+	// Skip parens to reach the meaningful parent (e.g., PropertyAssignment or ReturnStatement).
+	for ancestor != nil && ancestor.Kind == ast.KindParenthesizedExpression {
+		ancestor = ancestor.Parent
+	}
+
+	// In ESLint's model: if (ancestor.type === Property) ancestor = ancestor.value;
+	// Property.value for `arrowFn: () => 'test'` is the ArrowFunction itself.
+	// In tsgo, PropertyAssignment.Initializer is the value expression.
+	// Skip through parens since tsgo preserves ParenthesizedExpression.
+	if ancestor != nil && ancestor.Kind == ast.KindPropertyAssignment {
+		pa := ancestor.AsPropertyAssignment()
+		if pa.Initializer != nil {
+			ancestor = ast.SkipParentheses(pa.Initializer)
+		}
+	}
+
+	// Check if the function is being returned (or is a bodyless arrow return value)
+	isReturnStatement := ancestor != nil && ancestor.Kind == ast.KindReturnStatement
+	isBodylessArrow := ancestor != nil &&
+		ancestor.Kind == ast.KindArrowFunction &&
+		ancestor.AsArrowFunction().Body != nil &&
+		ancestor.AsArrowFunction().Body.Kind != ast.KindBlock
+
+	if !isReturnStatement && !isBodylessArrow {
+		return false
+	}
+
+	for ancestor != nil {
+		switch ancestor.Kind {
+		case ast.KindArrowFunction, ast.KindFunctionExpression, ast.KindFunctionDeclaration,
+			ast.KindMethodDeclaration, ast.KindGetAccessor:
+			// In tsgo, methods and getters are their own node types (not FunctionExpression
+			// inside MethodDefinition like ESLint). Check their return type the same way.
+			if ancestor.Type() != nil {
+				return true
+			}
+		case ast.KindVariableDeclaration:
+			decl := ancestor.AsVariableDeclaration()
+			return decl.Type != nil
+		case ast.KindPropertyDeclaration:
+			return ancestor.AsPropertyDeclaration().Type != nil
+		case ast.KindExpressionStatement:
+			return false
+		}
+		ancestor = ancestor.Parent
+	}
+	return false
+}
+
+// isNameAllowed checks if a function's name is in the allowed names list.
+func isNameAllowed(sourceFile *ast.SourceFile, node *ast.Node, allowedNames []string) bool {
+	var funcName string
+
+	switch node.Kind {
+	case ast.KindArrowFunction, ast.KindFunctionExpression:
+		// Check if the function expression has a name
+		if node.Kind == ast.KindFunctionExpression {
+			fe := node.AsFunctionExpression()
+			if fe.Name() != nil && fe.Name().Kind == ast.KindIdentifier {
+				funcName = fe.Name().AsIdentifier().Text
+			}
+		}
+		if funcName == "" {
+			parent := node.Parent
+			if parent == nil {
+				return false
+			}
+			switch parent.Kind {
+			case ast.KindVariableDeclaration:
+				decl := parent.AsVariableDeclaration()
+				if decl.Name() != nil && decl.Name().Kind == ast.KindIdentifier {
+					funcName = decl.Name().AsIdentifier().Text
+				}
+			case ast.KindMethodDeclaration:
+				md := parent.AsMethodDeclaration()
+				if md.Name() != nil && md.Name().Kind == ast.KindIdentifier {
+					funcName = md.Name().AsIdentifier().Text
+				}
+			case ast.KindPropertyDeclaration:
+				pd := parent.AsPropertyDeclaration()
+				if pd.Name() != nil && pd.Name().Kind == ast.KindIdentifier {
+					funcName = pd.Name().AsIdentifier().Text
+				}
+			case ast.KindPropertyAssignment:
+				pa := parent.AsPropertyAssignment()
+				if pa.Name() != nil && pa.Name().Kind == ast.KindIdentifier {
+					funcName = pa.Name().AsIdentifier().Text
+				}
+			}
+		}
+	case ast.KindFunctionDeclaration:
+		fd := node.AsFunctionDeclaration()
+		if fd.Name() != nil && fd.Name().Kind == ast.KindIdentifier {
+			funcName = fd.Name().AsIdentifier().Text
+		}
+	case ast.KindMethodDeclaration:
+		md := node.AsMethodDeclaration()
+		if md.Name() != nil && md.Name().Kind == ast.KindIdentifier {
+			funcName = md.Name().AsIdentifier().Text
+		}
+	case ast.KindGetAccessor:
+		ga := node.AsGetAccessorDeclaration()
+		if ga.Name() != nil && ga.Name().Kind == ast.KindIdentifier {
+			funcName = ga.Name().AsIdentifier().Text
+		}
+	}
+
+	if funcName == "" {
+		return false
+	}
+	for _, name := range allowedNames {
+		if name == funcName {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.md
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type.md
@@ -1,0 +1,51 @@
+# explicit-function-return-type
+
+## Rule Details
+
+Require explicit return types on functions and class methods.
+
+Functions in TypeScript often don't need to be given an explicit return type annotation. Leaving off the return type is less code to read or write and allows the compiler to infer it from the contents of the function. However, explicit return types do make it visually more clear what type is returned by a function and can speed up TypeScript type checking performance in large codebases.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+function test() {
+  return;
+}
+
+var fn = function () {
+  return 1;
+};
+
+var arrowFn = () => 'test';
+
+class Test {
+  method() {
+    return;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+function test(): void {
+  return;
+}
+
+var fn = function (): number {
+  return 1;
+};
+
+var arrowFn = (): string => 'test';
+
+class Test {
+  method(): void {
+    return;
+  }
+}
+```
+
+## Original Documentation
+
+https://typescript-eslint.io/rules/explicit-function-return-type

--- a/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/explicit_function_return_type_test.go
@@ -1,0 +1,1569 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestExplicitFunctionReturnTypeRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// return statement at top level
+		{Code: `return;`},
+		// Functions with explicit return types
+		{Code: `
+function test(): void {
+  return;
+}
+		`},
+		{Code: `
+var fn = function(): number {
+  return 1;
+};
+		`},
+		{Code: `
+var arrowFn = (): string => 'test';
+		`},
+		// Class with constructor, getter, setter, methods with return types
+		{Code: `
+class Test {
+  constructor() {}
+  get prop(): number {
+    return 1;
+  }
+  set prop() {}
+  method(): void {
+    return;
+  }
+  arrow = (): string => 'arrow';
+}
+		`},
+		// allowExpressions: true
+		{
+			Code:    `fn(() => {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		{
+			Code:    `fn(function() {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		{
+			Code:    `[function() {}, () => {}];`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		{
+			Code:    `(function() {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		{
+			Code:    `(() => {})();`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		{
+			Code:    `export default (): void => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// allowTypedFunctionExpressions: true
+		{
+			Code:    `var arrowFn: Foo = () => 'test';`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+var funcExpr: Foo = function() {
+  return 'test';
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code:    `const x = (() => {}) as Foo;`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code:    `const x = <Foo>(() => {});`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+const x = {
+  foo: () => {},
+} as Foo;
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+const x = <Foo>{
+  foo: () => {},
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+const x: Foo = {
+  foo: () => {},
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Nested object with type assertion
+		{
+			Code: `
+const x = {
+  foo: { bar: () => {} },
+} as Foo;
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+const x = <Foo>{
+  foo: { bar: () => {} },
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+const x: Foo = {
+  foo: { bar: () => {} },
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Class property with type annotation
+		{
+			Code: `
+type MethodType = () => void;
+
+class App {
+  private method: MethodType = () => {};
+}
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Setter in object literal
+		{Code: `
+const myObj = {
+  set myProp(val) {
+    this.myProp = val;
+  },
+};
+		`},
+		// allowHigherOrderFunctions: true
+		{
+			Code:    `() => (): void => {};`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code:    `() => function(): void {};`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code: `
+() => {
+  return (): void => {};
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code: `
+() => {
+  return function(): void {};
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code: `
+function fn() {
+  return (): void => {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code: `
+function fn() {
+  return function(): void {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code: `
+function FunctionDeclaration() {
+  return function FunctionExpression_Within_FunctionDeclaration() {
+    return function FunctionExpression_Within_FunctionExpression() {
+      return () => {
+        // ArrowFunctionExpression_Within_FunctionExpression
+        return () =>
+          // ArrowFunctionExpression_Within_ArrowFunctionExpression
+          (): number =>
+            1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+      };
+    };
+  };
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		{
+			Code: `
+() => () => {
+  return (): void => {
+    return;
+  };
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// allowTypedFunctionExpressions: call expression arguments
+		{
+			Code: `
+declare function foo(arg: () => void): void;
+foo(() => 1);
+foo(() => {});
+foo(() => null);
+foo(() => true);
+foo(() => '');
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Optional chain call expression arguments
+		{
+			Code: `
+declare function foo(arg: () => void): void;
+foo?.(() => 1);
+foo?.bar(() => {});
+foo?.bar?.(() => null);
+foo.bar?.(() => true);
+foo?.(() => '');
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// New expression arguments
+		{
+			Code: `
+new Promise(resolve => {});
+new Foo(1, () => {});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Typed function expression in call
+		{
+			Code: `
+class Accumulator {
+  private count: number = 0;
+
+  public accumulate(fn: () => number): void {
+    this.count += fn();
+  }
+}
+
+new Accumulator().accumulate(() => 1);
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Object method in typed call expression
+		{
+			Code: `
+declare function foo(arg: { meth: () => number }): void;
+foo({
+  meth() {
+    return 1;
+  },
+});
+foo({
+  meth: function() {
+    return 1;
+  },
+});
+foo({
+  meth: () => {
+    return 1;
+  },
+});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// allowDirectConstAssertionInArrowFunctions: true
+		{
+			Code: `
+const func = (value: number) => ({ type: 'X', value }) as const;
+const func = (value: number) => ({ type: 'X', value }) as const;
+const func = (value: number) => x as const;
+const func = (value: number) => x as const;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": true},
+		},
+		// as const satisfies
+		{
+			Code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": true},
+		},
+		// nested satisfies
+		{
+			Code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R satisfies R;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": true},
+		},
+		{
+			Code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) =>
+  ({ type: 'X', value }) as const satisfies R satisfies R satisfies R;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": true},
+		},
+		// allowConciseArrowFunctionExpressionsStartingWithVoid: true
+		{
+			Code:    `const log = (message: string) => void console.log(message);`,
+			Options: map[string]interface{}{"allowConciseArrowFunctionExpressionsStartingWithVoid": true},
+		},
+		// allowFunctionsWithoutTypeParameters: true
+		{
+			Code:    `const log = (a: string) => a;`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		{
+			Code:    `const log = <A,>(a: A): A => a;`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		{
+			Code: `
+function log<A>(a: A): A {
+  return a;
+}
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		{
+			Code: `
+function log(a: string) {
+  return a;
+}
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		{
+			Code: `
+const log = function <A>(a: A): A {
+  return a;
+};
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		{
+			Code: `
+const log = function(a: A): string {
+  return a;
+};
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		// allowedNames
+		{
+			Code: `
+function test1() {
+  return;
+}
+
+const foo = function test2() {
+  return;
+};
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"test1", "test2"}},
+		},
+		{
+			Code: `
+const test1 = function() {
+  return;
+};
+const foo = function() {
+  return function test2() {};
+};
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"test1", "test2"}},
+		},
+		{
+			Code: `
+const test1 = () => {
+  return;
+};
+export const foo = {
+  test2() {
+    return 0;
+  },
+};
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"test1", "test2"}},
+		},
+		{
+			Code: `
+class Test {
+  constructor() {}
+  get prop() {
+    return 1;
+  }
+  set prop() {}
+  method() {
+    return;
+  }
+  arrow = () => 'arrow';
+  private method() {
+    return;
+  }
+}
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"prop", "method", "arrow"}},
+		},
+		{
+			Code: `
+const x = {
+  arrowFn: () => {
+    return;
+  },
+  fn: function() {
+    return;
+  },
+};
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"arrowFn", "fn"}},
+		},
+		// Combined higher order + typed expressions
+		{
+			Code: `
+type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+			`,
+			Options: map[string]interface{}{
+				"allowHigherOrderFunctions":     true,
+				"allowTypedFunctionExpressions": true,
+			},
+		},
+		{
+			Code: `
+type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+			`,
+			Options: map[string]interface{}{
+				"allowHigherOrderFunctions":     false,
+				"allowTypedFunctionExpressions": true,
+			},
+		},
+		// allowIIFEs: true
+		{
+			Code: `
+let foo = function(): number {
+  return 1;
+};
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		{
+			Code: `
+const foo = (function() {
+  return 1;
+})();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		{
+			Code: `
+const foo = (() => {
+  return 1;
+})();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		{
+			Code: `
+const foo = (() => (() => 'foo')())();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		{
+			Code: `
+let foo = (() => (): string => {
+  return 'foo';
+})()();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		{
+			Code: `
+let foo = (() => (): string => {
+  return 'foo';
+})();
+			`,
+			Options: map[string]interface{}{
+				"allowHigherOrderFunctions": false,
+				"allowIIFEs":                true,
+			},
+		},
+		{
+			Code: `
+let foo = (() => (): void => {})()();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		{
+			Code: `
+let foo = (() => (() => {})())();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		// Class property with typed initializer
+		{Code: `
+class Bar {
+  bar: Foo = {
+    foo: x => x + 1,
+  };
+}
+		`},
+		// Default parameter with type annotation
+		{
+			Code: `
+type CallBack = () => void;
+
+function f(gotcha: CallBack = () => {}): void {}
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+type CallBack = () => void;
+
+const f = (gotcha: CallBack = () => {}): void => {};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		{
+			Code: `
+type ObjectWithCallback = { callback: () => void };
+
+const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Basic missing return types
+		{
+			Code: `
+function test(a: number, b: number) {
+  return;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 1}},
+		},
+		{
+			Code: `
+function test() {
+  return;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 1}},
+		},
+		{
+			Code: `
+var fn = function() {
+  return 1;
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 10}},
+		},
+		{
+			Code:   `var arrowFn = () => 'test';`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 18}},
+		},
+		// Class with missing return types
+		{
+			Code: `
+class Test {
+  constructor() {}
+  get prop() {
+    return 1;
+  }
+  set prop() {}
+  method() {
+    return;
+  }
+  arrow = () => 'arrow';
+  private method() {
+    return;
+  }
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 4, Column: 3},
+				{MessageId: "missingReturnType", Line: 8, Column: 3},
+				{MessageId: "missingReturnType", Line: 11, Column: 3},
+				{MessageId: "missingReturnType", Line: 12, Column: 3},
+			},
+		},
+		// allowExpressions: true - declarations still need types
+		{
+			Code: `
+function test() {
+  return;
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 1}},
+		},
+		{
+			Code:    `const foo = () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+		{
+			Code:    `const foo = function() {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 13}},
+		},
+		{
+			Code:    `export default () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 19}},
+		},
+		{
+			Code:    `export default function() {}`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+		// Class properties with allowExpressions
+		{
+			Code: `
+class Foo {
+  public a = () => {};
+  public b = function() {};
+  public c = function test() {};
+
+  static d = () => {};
+  static e = function() {};
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 3},
+				{MessageId: "missingReturnType", Line: 4, Column: 3},
+				{MessageId: "missingReturnType", Line: 5, Column: 3},
+				{MessageId: "missingReturnType", Line: 7, Column: 3},
+				{MessageId: "missingReturnType", Line: 8, Column: 3},
+			},
+		},
+		// allowTypedFunctionExpressions: true - untyped expressions still need types
+		{
+			Code:    `var arrowFn = () => 'test';`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 18}},
+		},
+		{
+			Code: `
+var funcExpr = function() {
+  return 'test';
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 16}},
+		},
+		// allowTypedFunctionExpressions: false - type assertions don't help
+		{
+			Code:    `const x = (() => {}) as Foo;`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 15}},
+		},
+		// Higher order functions with missing inner types
+		{
+			Code:    `() => () => {};`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 10}},
+		},
+		{
+			Code:    `() => function() {};`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 7}},
+		},
+		{
+			Code: `
+() => {
+  return () => {};
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 13}},
+		},
+		{
+			Code: `
+() => {
+  return function() {};
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 10}},
+		},
+		{
+			Code: `
+function fn() {
+  return () => {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 13}},
+		},
+		{
+			Code: `
+function fn() {
+  return function() {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 10}},
+		},
+		// Higher order: not all returns are functions
+		{
+			Code: `
+function fn(arg: boolean) {
+  if (arg) return 'string';
+  return function(): void {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 1}},
+		},
+		// allowTypedFunctionExpressions: false - call args don't help
+		{
+			Code: `
+declare function foo(arg: () => void): void;
+foo(() => 1);
+foo(() => {});
+foo(() => null);
+foo(() => true);
+foo(() => '');
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 8},
+				{MessageId: "missingReturnType", Line: 4, Column: 8},
+				{MessageId: "missingReturnType", Line: 5, Column: 8},
+				{MessageId: "missingReturnType", Line: 6, Column: 8},
+				{MessageId: "missingReturnType", Line: 7, Column: 8},
+			},
+		},
+		// allowTypedFunctionExpressions: false - class accumulate
+		{
+			Code: `
+class Accumulator {
+  private count: number = 0;
+
+  public accumulate(fn: () => number): void {
+    this.count += fn();
+  }
+}
+
+new Accumulator().accumulate(() => 1);
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 10, Column: 33}},
+		},
+		// allowDirectConstAssertionInArrowFunctions: non-const assertions
+		{
+			Code: `
+const func = (value: number) => ({ type: 'X', value }) as any;
+const func = (value: number) => ({ type: 'X', value }) as Action;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 2, Column: 30},
+				{MessageId: "missingReturnType", Line: 3, Column: 30},
+			},
+		},
+		// allowDirectConstAssertionInArrowFunctions: false
+		{
+			Code: `
+const func = (value: number) => ({ type: 'X', value }) as const;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 30}},
+		},
+		// allowConciseArrowFunctionExpressionsStartingWithVoid: false
+		{
+			Code:    `const log = (message: string) => void console.log(message);`,
+			Options: map[string]interface{}{"allowConciseArrowFunctionExpressionsStartingWithVoid": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 31}},
+		},
+		// allowConciseArrowFunctionExpressionsStartingWithVoid: true - block body still needs type
+		{
+			Code: `
+        const log = (message: string) => {
+          void console.log(message);
+        };
+			`,
+			Options: map[string]interface{}{"allowConciseArrowFunctionExpressionsStartingWithVoid": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 39}},
+		},
+		// allowFunctionsWithoutTypeParameters: true - generic functions still need types
+		{
+			Code:    `const log = <A,>(a: A) => a;`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType"}},
+		},
+		{
+			Code: `
+function log<A>(a: A) {
+  return a;
+}
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType"}},
+		},
+		{
+			Code: `
+const log = function <A>(a: A) {
+  return a;
+};
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType"}},
+		},
+		// allowedNames - non-matching names still need types
+		{
+			Code: `
+function hoge() {
+  return;
+}
+const foo = () => {
+  return;
+};
+const baz = function() {
+  return;
+};
+let [test, test] = function() {
+  return;
+};
+class X {
+  [test] = function() {
+    return;
+  };
+}
+const x = {
+  1: function() {
+    reutrn; // cspell:disable-line
+  },
+};
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"test", "1"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 2, Column: 1},
+				{MessageId: "missingReturnType", Line: 5, Column: 16},
+				{MessageId: "missingReturnType", Line: 8, Column: 13},
+				{MessageId: "missingReturnType", Line: 11, Column: 20},
+				{MessageId: "missingReturnType", Line: 15, Column: 3},
+				{MessageId: "missingReturnType", Line: 20, Column: 3},
+			},
+		},
+		// allowedNames with computed property
+		{
+			Code: `
+const ignoredName = 'notIgnoredName';
+class Foo {
+  [ignoredName]() {}
+}
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"ignoredName"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 3}},
+		},
+		// Untyped class property array
+		{
+			Code: `
+class Bar {
+  bar = [
+    {
+      foo: x => x + 1,
+    },
+  ];
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 5, Column: 7}},
+		},
+		// IIFE: false
+		{
+			Code: `
+const foo = (function() {
+  return 'foo';
+})();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 14}},
+		},
+		// IIFE: inner function still needs type
+		{
+			Code: `
+const foo = (function() {
+  return () => {
+    return 1;
+  };
+})();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 13}},
+		},
+		// Non-IIFE function expression with allowIIFEs
+		{
+			Code: `
+let foo = function() {
+  return 'foo';
+};
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 11}},
+		},
+		// IIFE returning arrow
+		{
+			Code: `
+let foo = (() => () => {})()();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 21}},
+		},
+		// Default parameter with allowTypedFunctionExpressions: false
+		{
+			Code: `
+type CallBack = () => void;
+
+function f(gotcha: CallBack = () => {}): void {}
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 34}},
+		},
+		{
+			Code: `
+type CallBack = () => void;
+
+const f = (gotcha: CallBack = () => {}): void => {};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 34}},
+		},
+	})
+}
+
+// TestEdgeCases covers exhaustive edge cases across all dimensions.
+func TestEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Dimension 1: All function-like AST node types with return types
+		// ============================================================
+		{Code: `function foo(): void {}`},
+		{Code: `const foo = function(): void {}`},
+		{Code: `const foo = (): void => {}`},
+		{Code: `class A { method(): void {} }`},
+		{Code: `class A { get prop(): number { return 1; } }`},
+		{Code: `class A { set prop(v: number) {} }`},
+		{Code: `class A { constructor() {} }`},
+		{Code: `const obj = { method(): void {} }`},
+		{Code: `const obj = { get prop(): number { return 1; } }`},
+		{Code: `const obj = { set prop(v: number) {} }`},
+		// Async variants
+		{Code: `async function foo(): Promise<void> {}`},
+		{Code: `const foo = async (): Promise<void> => {}`},
+		{Code: `const foo = async function(): Promise<void> {}`},
+		{Code: `class A { async method(): Promise<void> {} }`},
+		// Generator variants
+		{Code: `function* foo(): Generator { yield 1; }`},
+
+		// ============================================================
+		// Dimension 2: allowTypedFunctionExpressions — every typed context
+		// ============================================================
+		// 2a. Type assertion: `as T`
+		{
+			Code:    `const x = (() => {}) as Foo;`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2b. Type assertion: `<T>x`
+		{
+			Code:    `const x = <Foo>(() => {});`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2c. Variable declarator with type annotation
+		{
+			Code:    `const x: Foo = () => {};`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2d. Class property with type annotation
+		{
+			Code: `
+class App {
+  handler: () => void = () => {};
+}
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2e. Call expression argument (function is typed by parameter)
+		{
+			Code: `
+declare function foo(cb: () => void): void;
+foo(() => {});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2f. New expression argument
+		{
+			Code: `
+new Promise(resolve => {});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2g. Default parameter with type annotation
+		{
+			Code: `
+type Fn = () => void;
+function f(cb: Fn = () => {}): void {}
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2h. Property of typed object — nested 1 level
+		{
+			Code: `
+const x: Foo = { bar: () => {} };
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2i. Property of typed object — nested 2 levels
+		{
+			Code: `
+const x: Foo = { a: { b: () => {} } };
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2j. Property of typed object — nested 3 levels
+		{
+			Code: `
+const x: Foo = { a: { b: { c: () => {} } } };
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2k. Object typed via `as` with nested properties
+		{
+			Code: `
+const x = { a: { b: { c: () => {} } } } as Foo;
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2l. Object in call argument with method shorthand
+		{
+			Code: `
+declare function foo(arg: { fn: () => void }): void;
+foo({ fn() {} });
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// 2m. Object in new expression argument — direct arrow arg is typed, not nested object prop
+		// NOTE: `new Foo({ callback: () => {} })` is intentionally NOT here —
+		// isConstructorArgument is only checked at the top level, not inside isPropertyOfObjectWithType.
+		// This matches ESLint behavior.
+		// 2n. Optional call expression argument
+		{
+			Code: `
+declare function foo(cb: () => void): void;
+foo?.(() => {});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+
+		// ============================================================
+		// Dimension 3: ancestorHasReturnType — function returns object with arrows
+		// ============================================================
+		// 3a. Function with return type returning object with arrow property
+		{
+			Code: `
+interface Foo { bar: () => string; }
+function foo(): Foo {
+  return { bar: () => 'test' };
+}
+			`,
+			Options: map[string]interface{}{
+				"allowTypedFunctionExpressions": true,
+				"allowHigherOrderFunctions":     true,
+			},
+		},
+		// 3b. Arrow with return type returning object with arrow property
+		{
+			Code: `
+interface Foo { bar: () => string; }
+const foo = (): Foo => ({ bar: () => 'test' });
+			`,
+			Options: map[string]interface{}{
+				"allowTypedFunctionExpressions": true,
+				"allowHigherOrderFunctions":     true,
+			},
+		},
+		// 3c. Typed variable with higher-order function returning arrow in object
+		{
+			Code: `
+interface Foo { bar: () => string; }
+const foo: () => Foo = () => ({ bar: () => 'test' });
+			`,
+			Options: map[string]interface{}{
+				"allowTypedFunctionExpressions": true,
+				"allowHigherOrderFunctions":     true,
+			},
+		},
+
+		// ============================================================
+		// Dimension 4: allowHigherOrderFunctions — deeply nested
+		// ============================================================
+		// 4a. Three levels of HOF with final typed return
+		{
+			Code: `
+function a() {
+  return function b() {
+    return (): void => {};
+  };
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// 4b. HOF: arrow with block body and multiple returns all returning functions
+		{
+			Code: `
+function fn(arg: boolean) {
+  if (arg) {
+    return () => (): number => 1;
+  } else {
+    return function(): string { return 'foo'; };
+  }
+  return function(): void {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// 4c. HOF: mixed with extra statements between returns
+		{
+			Code: `
+() => {
+  const foo = 'foo';
+  return function(): string {
+    return foo;
+  };
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+
+		// ============================================================
+		// Dimension 5: allowIIFEs — complex nesting
+		// ============================================================
+		// 5a. IIFE with explicit return type on inner
+		{
+			Code: `
+const foo = ((arg: number): number => {
+  return arg;
+})(0);
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		// 5b. Nested IIFE inside IIFE
+		{
+			Code: `
+const foo = (() => (() => 'foo')())();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		// 5c. IIFE + higher order: outer is IIFE, inner has return type
+		{
+			Code: `
+let foo = (() => (): string => {
+  return 'foo';
+})()();
+			`,
+			Options: map[string]interface{}{
+				"allowHigherOrderFunctions": true,
+				"allowIIFEs":                true,
+			},
+		},
+
+		// ============================================================
+		// Dimension 6: allowExpressions — expression contexts
+		// ============================================================
+		// 6a. Ternary expression
+		{
+			Code:    `const x = true ? () => {} : () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// 6b. Logical expression
+		{
+			Code:    `const x = false || (() => {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// 6c. Comma expression
+		{
+			Code:    `(0, () => {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+
+		// ============================================================
+		// Dimension 7: allowedNames — with class methods and object methods
+		// ============================================================
+		// 7a. Class getter with allowed name
+		{
+			Code: `
+class Foo {
+  get bar() { return 1; }
+}
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"bar"}},
+		},
+		// 7b. Object method shorthand with allowed name
+		{
+			Code: `
+const obj = { foo() { return 1; } };
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"foo"}},
+		},
+		// 7c. Named function expression matches allowed name
+		{
+			Code: `
+const x = function namedFn() { return 1; };
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"namedFn"}},
+		},
+
+		// ============================================================
+		// Dimension 8: Class property typed array with nested objects
+		// ============================================================
+		{Code: `
+class Bar {
+  bar: Foo[] = [
+    {
+      foo: x => x + 1,
+    },
+  ];
+}
+		`},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Dimension 1: Basic function types without return types
+		// ============================================================
+		// 1a. Async function without return type
+		{
+			Code:   `async function foo() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 1}},
+		},
+		// 1b. Async arrow without return type
+		{
+			Code:   `const foo = async () => {};`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 22}},
+		},
+		// 1c. Async method without return type
+		{
+			Code: `
+class A {
+  async method() {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// 1d. Object getter without return type
+		{
+			Code: `
+const obj = {
+  get foo() { return 1; },
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// 1e. Object method shorthand without return type
+		{
+			Code: `
+const obj = {
+  foo() { return 1; },
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// 1f. Generator function without return type
+		{
+			Code:   `function* foo() { yield 1; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 1}},
+		},
+
+		// ============================================================
+		// Dimension 2: allowTypedFunctionExpressions: false — every context is invalid
+		// ============================================================
+		// 2a. Object property in typed context
+		{
+			Code: `
+interface Foo {}
+const x: Foo = {
+  foo: () => {},
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 3}},
+		},
+		// 2b. Object method shorthand in typed call
+		{
+			Code: `
+declare function foo(arg: { meth: () => number }): void;
+foo({
+  meth() {
+    return 1;
+  },
+});
+foo({
+  meth: function() {
+    return 1;
+  },
+});
+foo({
+  meth: () => {
+    return 1;
+  },
+});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 4, Column: 3},
+				{MessageId: "missingReturnType", Line: 9, Column: 3},
+				{MessageId: "missingReturnType", Line: 14, Column: 3},
+			},
+		},
+		// 2c. IIFE with allowTypedFunctionExpressions: false
+		{
+			Code:    `(() => true)();`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 5}},
+		},
+
+		// ============================================================
+		// Dimension 3: allowHigherOrderFunctions — edge cases
+		// ============================================================
+		// 3a. Not all returns are function expressions
+		{
+			Code: `
+function fn() {
+  const bar = () => (): number => 1;
+  const baz = () => () => 'baz';
+  return function(): void {};
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 24}},
+		},
+		// 3b. Deeply nested HOF: innermost function still needs return type
+		{
+			Code: `
+function FunctionDeclaration() {
+  return function FunctionExpression_Within_FunctionDeclaration() {
+    return function FunctionExpression_Within_FunctionExpression() {
+      return () => {
+        return () =>
+          () =>
+            1;
+      };
+    };
+  };
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 7, Column: 14}},
+		},
+		// 3c. HOF where inner function returns non-function in some branches
+		{
+			Code: `
+() => () => {
+  return () => {
+    return;
+  };
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 13}},
+		},
+
+		// ============================================================
+		// Dimension 4: allowTypedFunctionExpressions — inner arrow in higher-order typed context
+		// ============================================================
+		// 4a. Inner arrow of higher-order typed function without return type
+		{
+			Code: `
+type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+			`,
+			Options: map[string]interface{}{
+				"allowHigherOrderFunctions":     true,
+				"allowTypedFunctionExpressions": false,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 47},
+			},
+		},
+		// 4b. All three levels invalid when both options are false.
+		// Exit listeners fire innermost-first, so errors are reported in reverse position order.
+		{
+			Code: `
+type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+			`,
+			Options: map[string]interface{}{
+				"allowHigherOrderFunctions":     false,
+				"allowTypedFunctionExpressions": false,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 47},
+				{MessageId: "missingReturnType", Line: 3, Column: 39},
+				{MessageId: "missingReturnType", Line: 3, Column: 31},
+			},
+		},
+
+		// ============================================================
+		// Dimension 5: Class property arrow in typed context that IS reportable
+		// ============================================================
+		// 5a. Class property without type annotation — arrow inside is invalid
+		{
+			Code: `
+class Foo {
+  foo = () => () => {
+    return console.log('foo');
+  };
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 18}},
+		},
+		// 5b. Nested arrow inside untyped variable assignment
+		{
+			Code: `
+function foo(): any {
+  const bar = () => () => console.log('aa');
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 24}},
+		},
+		// 5c. Nested arrow inside anyValue assignment
+		{
+			Code: `
+let anyValue: any;
+function foo(): any {
+  anyValue = () => () => console.log('aa');
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 4, Column: 23}},
+		},
+
+		// ============================================================
+		// Dimension 6: allowIIFEs edge cases
+		// ============================================================
+		// 6a. IIFE returning another function — inner needs type
+		{
+			Code: `
+let foo = (() => () => {})()();
+			`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 21}},
+		},
+
+		// ============================================================
+		// Dimension 7: allowDirectConstAssertionInArrowFunctions edge cases
+		// ============================================================
+		// 7a. as const satisfies with allowDirectConstAssertionInArrowFunctions: false
+		{
+			Code: `
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+			`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 7, Column: 30}},
+		},
+
+		// ============================================================
+		// Dimension 8: allowExpressions — declaration contexts are still invalid
+		// ============================================================
+		// 8a. export default with allowExpressions still reports on assignment arrow
+		{
+			Code:    `export default () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 19}},
+		},
+
+		// ============================================================
+		// Dimension 9: Untyped class property — nested object with arrow
+		// ============================================================
+		{
+			Code: `
+class Bar {
+  bar = [
+    {
+      foo: x => x + 1,
+    },
+  ];
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 5, Column: 7}},
+		},
+
+		// ============================================================
+		// Dimension 10: Object property with function expression — no typed context
+		// ============================================================
+		{
+			Code: `
+const x = {
+  foo: () => {},
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		{
+			Code: `
+const x = {
+  foo: function() {},
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+
+		// ============================================================
+		// Dimension 11: Multiple options interacting
+		// ============================================================
+		// 11a. allowExpressions: true — declaration (var assignment) still needs type
+		{
+			Code: `
+const foo = () => {};
+			`,
+			Options: map[string]interface{}{
+				"allowExpressions":          true,
+				"allowHigherOrderFunctions": true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 2, Column: 16},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/final_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/final_test.go
@@ -1,0 +1,104 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestFinalEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// satisfies at top level is NOT a typed context (matches ESLint)
+		// ============================================================
+		// satisfies DOES NOT exempt the function — only `as` does
+		// (The ESLint rule only treats AsExpression/TypeAssertionExpression as typed,
+		//  not SatisfiesExpression)
+
+		// ============================================================
+		// Nested method shorthand in typed context
+		// ============================================================
+		{
+			Code: `
+const x: Foo = {
+  a: {
+    method() { return 1; },
+  },
+};
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Nested arrow in new expression argument
+		{
+			Code: `
+new Foo(() => {});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// Deeply nested method in typed call expression
+		{
+			Code: `
+declare function setup(opts: { hooks: { onInit: () => void } }): void;
+setup({
+  hooks: {
+    onInit() {},
+  },
+});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+		// module.exports = arrow — with allowExpressions, BinaryExpression parent is not excluded
+		{
+			Code:    `module.exports = () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// Decorator on class method — method has return type, valid
+		{
+			Code: `
+function decorator(target: any, key: string, desc: any): void {}
+class A {
+  @decorator
+  method(): void {}
+}
+			`,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// satisfies at top level — arrow still needs return type
+		// ============================================================
+		{
+			Code:   `const fn = (() => {}) satisfies Foo;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+		// new Foo({ callback: () => {} }) — arrow in property of object in new expression
+		// isConstructorArgument is only checked at top level, not inside isPropertyOfObjectWithType
+		{
+			Code: `
+new Foo({ callback: () => {} });
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 2, Column: 11}},
+		},
+		// Decorator on method — method without return type still needs one
+		{
+			Code: `
+function decorator(target: any, key: string, desc: any): void {}
+class A {
+  @decorator
+  method() {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType"}},
+		},
+		// allowExpressions: true + allowTypedFunctionExpressions: false
+		// allowExpressions is gated behind allowTypedFunctionExpressions, so it has no effect
+		{
+			Code: `[() => {}];`,
+			Options: map[string]interface{}{
+				"allowExpressions":              true,
+				"allowTypedFunctionExpressions": false,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType"}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/misc_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/misc_test.go
@@ -1,0 +1,138 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestMiscEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// Private class members with return types
+		{Code: `
+class A {
+  #method(): void {}
+  #arrow = (): void => {};
+  private fn = (): void => {};
+}
+		`},
+		// Override method with return type
+		{Code: `
+class A { method(): void {} }
+class B extends A {
+  override method(): void {}
+}
+		`},
+		// Parenless arrow in class property with type annotation
+		{Code: `
+class A {
+  fn: (x: number) => number = x => x + 1;
+}
+		`},
+		// Abstract getter with return type (no body)
+		{Code: `
+abstract class A {
+  abstract get foo(): number;
+}
+		`},
+		// Object method with async
+		{Code: `
+const obj = {
+  async foo(): Promise<void> {},
+};
+		`},
+		// Object method with generator
+		{Code: `
+const obj = {
+  *gen(): Generator { yield 1; },
+};
+		`},
+		// Nested IIFE with typed result
+		{
+			Code:    `const x = (() => (() => 'foo')())();`,
+			Options: map[string]interface{}{"allowIIFEs": true},
+		},
+		// allowExpressions with object shorthand method
+		{
+			Code: `
+const obj = {
+  foo() {},
+  get bar() { return 1; },
+  async baz() {},
+};
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Private members without return types
+		{
+			Code: `
+class A {
+  #method() {}
+  #arrow = () => {};
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 3},
+				{MessageId: "missingReturnType", Line: 4, Column: 3},
+			},
+		},
+		// Override method without return type
+		{
+			Code: `
+class A { method(): void {} }
+class B extends A {
+  override method() {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 4, Column: 3},
+			},
+		},
+		// Object async method without return type
+		{
+			Code: `
+const obj = {
+  async foo() {},
+};
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 3},
+			},
+		},
+		// allowedNames does NOT match private identifiers (matches ESLint behavior)
+		{
+			Code: `
+class A {
+  #method() {}
+}
+			`,
+			Options: map[string]interface{}{"allowedNames": []interface{}{"#method"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// Parenless arrow in untyped class property
+		{
+			Code: `
+class A {
+  fn = x => x + 1;
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+		// allowExpressions does NOT apply to class methods/getters
+		{
+			Code: `
+class A {
+  foo() {}
+  get bar() { return 1; }
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingReturnType", Line: 3, Column: 3},
+				{MessageId: "missingReturnType", Line: 4, Column: 3},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/parens_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/parens_test.go
@@ -1,0 +1,49 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestParenthesizedExpressionEdgeCases tests that tsgo's preserved ParenthesizedExpression
+// nodes don't break the rule. ESLint strips parens from AST; tsgo keeps them.
+func TestParenthesizedExpressionEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// HOF: arrow with parenthesized function body — should recognize inner as function
+		{
+			Code:    `() => ((): void => {});`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// HOF: return parenthesized function — should recognize as HOF
+		{
+			Code: `
+function foo() {
+  return ((): void => {});
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+		// allowDirectConstAssertionInArrowFunctions: parenthesized `as const`
+		{
+			Code:    `const fn = (value: number) => (({ type: 'X', value }) as const);`,
+			Options: map[string]interface{}{"allowDirectConstAssertionInArrowFunctions": true},
+		},
+		// ancestorHasReturnType: property value wrapped in parens
+		{
+			Code: `
+interface Foo { bar: () => string; }
+function foo(): Foo {
+  return { bar: (() => 'test') };
+}
+			`,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// Parenthesized non-function body — NOT HOF
+		{
+			Code:   `() => (1);`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType"}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/remaining_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/remaining_test.go
@@ -1,0 +1,244 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRemainingEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// ============================================================
+		// Setter in object literal — always valid (no return type needed)
+		// ============================================================
+		{Code: `const obj = { set foo(v) {} };`},
+		{Code: `const obj = { set foo(v: string) {} };`},
+
+		// ============================================================
+		// Generator with return type
+		// ============================================================
+		{Code: `class Foo { *gen(): Generator { yield 1; } }`},
+
+		// ============================================================
+		// Namespace / module export function
+		// ============================================================
+		{Code: `
+namespace N {
+  export function foo(): void {}
+}
+		`},
+
+		// ============================================================
+		// allowExpressions contexts that should be valid
+		// ============================================================
+		// Ternary
+		{
+			Code:    `true ? () => {} : () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// Logical
+		{
+			Code:    `false || (() => {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// Array element
+		{
+			Code:    `[() => {}, function() {}];`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+		// Parenthesized expression
+		{
+			Code:    `(function() {});`,
+			Options: map[string]interface{}{"allowExpressions": true},
+		},
+
+		// ============================================================
+		// allowTypedFunctionExpressions with parenthesized type assertions
+		// ============================================================
+		{
+			Code:    `const x = ((() => {}) as Foo);`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+
+		// ============================================================
+		// allowHigherOrderFunctions: method returning function
+		// ============================================================
+		{
+			Code: `
+class Foo {
+  method() {
+    return function inner(): void {};
+  }
+}
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": true},
+		},
+
+		// ============================================================
+		// allowIIFEs: function expression called via .call / .apply / .bind
+		// These are NOT IIFEs — the function is an argument, not callee
+		// ============================================================
+		// (Not testing .call/.apply because they would be method calls,
+		//  the function would be accessed via property, not wrapped in CallExpression directly)
+
+		// ============================================================
+		// Optional chaining on call expression argument
+		// ============================================================
+		{
+			Code: `
+declare const foo: undefined | ((cb: () => void) => void);
+foo?.(() => {});
+			`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": true},
+		},
+
+		// ============================================================
+		// allowFunctionsWithoutTypeParameters: method / getter
+		// ============================================================
+		{
+			Code: `
+class Foo {
+  method(x: number) { return x; }
+}
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		{
+			Code: `
+const obj = {
+  get foo() { return 1; },
+};
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+		// Generic method still needs return type
+		{
+			Code: `
+class Foo {
+  method<T>(x: T): T { return x; }
+}
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+		},
+
+		// ============================================================
+		// ancestorHasReturnType through VariableDeclaration with type
+		// ============================================================
+		// Expression body: outer bodyless arrow → VariableDeclaration has type
+		{
+			Code: `
+type Fn = () => () => void;
+const foo: Fn = () => () => {};
+			`,
+		},
+		// Block body: inner arrow in return → walk up finds VariableDeclaration type
+		{
+			Code: `
+type Fn = () => () => void;
+const foo: Fn = () => {
+  return () => {};
+};
+			`,
+		},
+		// Block body inner arrow with block body — ancestor walk still finds type
+		{
+			Code: `
+type Fn = () => () => void;
+const foo: Fn = () => {
+  return () => {
+    console.log('hi');
+  };
+};
+			`,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ============================================================
+		// Generator method without return type
+		// ============================================================
+		{
+			Code:   `class Foo { *gen() { yield 1; } }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 13}},
+		},
+
+		// ============================================================
+		// Namespace export function without return type
+		// ============================================================
+		{
+			Code: `
+namespace N {
+  export function foo() {}
+}
+			`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 10}},
+		},
+
+		// ============================================================
+		// allowExpressions: declarations in various contexts still invalid
+		// ============================================================
+		// export default arrow
+		{
+			Code:    `export default () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 19}},
+		},
+		// Variable assignment
+		{
+			Code:    `const foo = () => {};`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+		// Class property assignment
+		{
+			Code: `
+class Foo {
+  foo = () => {};
+}
+			`,
+			Options: map[string]interface{}{"allowExpressions": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+
+		// ============================================================
+		// allowFunctionsWithoutTypeParameters: generic method needs type
+		// ============================================================
+		{
+			Code: `
+class Foo {
+  method<T>(x: T) { return x; }
+}
+			`,
+			Options: map[string]interface{}{"allowFunctionsWithoutTypeParameters": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 3, Column: 3}},
+		},
+
+		// ============================================================
+		// allowTypedFunctionExpressions: false — parens don't help
+		// ============================================================
+		{
+			Code:    `const x = ((() => {})) as Foo;`,
+			Options: map[string]interface{}{"allowTypedFunctionExpressions": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingReturnType", Line: 1, Column: 16}},
+		},
+
+		// ============================================================
+		// ancestorHasReturnType fails: no typed ancestor
+		// ============================================================
+		// Untyped variable — inner arrow has no ancestor with return type
+		{
+			Code: `
+const foo = () => {
+  return () => {
+    console.log('hi');
+  };
+};
+			`,
+			Options: map[string]interface{}{"allowHigherOrderFunctions": false},
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Inner arrow reported first (exit order)
+				{MessageId: "missingReturnType", Line: 3, Column: 13},
+				{MessageId: "missingReturnType", Line: 2, Column: 16},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/explicit_function_return_type/void_paren_test.go
+++ b/internal/plugins/typescript/rules/explicit_function_return_type/void_paren_test.go
@@ -1,0 +1,18 @@
+package explicit_function_return_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestVoidParenthesized(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ExplicitFunctionReturnTypeRule, []rule_tester.ValidTestCase{
+		// Parenthesized void expression — should still be valid
+		{
+			Code:    `const log = (message: string) => (void console.log(message));`,
+			Options: map[string]interface{}{"allowConciseArrowFunctionExpressionsStartingWithVoid": true},
+		},
+	}, []rule_tester.InvalidTestCase{})
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -175,6 +175,116 @@ func GetForStatementHeadLoc(
 	return TrimNodeTextRange(sourceFile, node).WithEnd(statement.Pos())
 }
 
+/**
+ * Gets the location of a function node's "head" for reporting.
+ * Matches the behavior of typescript-eslint's getFunctionHeadLoc:
+ *
+ * - `function foo() {}`         → `function foo`
+ * - `(function() {})`           → `function`
+ * - `() => {}`                  → `=>`
+ * - `class A { method() {} }`   → `method`
+ * - `class A { get foo() {} }`  → `get foo`
+ * - `class A { static async foo() {} }` → `static async foo`
+ * - `class A { foo = () => {} }` → `foo = `
+ * - `{ foo: function() {} }`    → `foo: function`
+ * - `export default function() {}` → `function`
+ */
+func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRange {
+	parent := node.Parent
+
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		start := TrimNodeTextRange(sourceFile, node)
+		if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+			return start.WithEnd(parenPos)
+		}
+		if node.Body() != nil {
+			return start.WithEnd(node.Body().Pos())
+		}
+		return start
+
+	case ast.KindArrowFunction:
+		if parent != nil && (parent.Kind == ast.KindPropertyDeclaration || parent.Kind == ast.KindPropertyAssignment) {
+			start := TrimNodeTextRange(sourceFile, parent)
+			if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+				return start.WithEnd(parenPos)
+			}
+			af := node.AsArrowFunction()
+			if af.Parameters != nil && len(af.Parameters.Nodes) > 0 {
+				paramStart := scanner.GetRangeOfTokenAtPosition(sourceFile, af.Parameters.Nodes[0].Pos())
+				return start.WithEnd(paramStart.Pos())
+			}
+			return start.WithEnd(af.EqualsGreaterThanToken.Pos())
+		}
+		af := node.AsArrowFunction()
+		arrowRange := scanner.GetRangeOfTokenAtPosition(sourceFile, af.EqualsGreaterThanToken.Pos())
+		return core.NewTextRange(arrowRange.Pos(), arrowRange.End())
+
+	case ast.KindFunctionExpression:
+		if parent != nil && (parent.Kind == ast.KindPropertyAssignment || parent.Kind == ast.KindPropertyDeclaration) {
+			start := TrimNodeTextRange(sourceFile, parent)
+			if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+				return start.WithEnd(parenPos)
+			}
+			if node.Body() != nil {
+				return start.WithEnd(node.Body().Pos())
+			}
+			return start
+		}
+		start := TrimNodeTextRange(sourceFile, node)
+		if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+			return start.WithEnd(parenPos)
+		}
+		if node.Body() != nil {
+			return start.WithEnd(node.Body().Pos())
+		}
+		return start
+
+	case ast.KindFunctionDeclaration:
+		start := findFunctionKeywordPos(sourceFile, node)
+		if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+			return core.NewTextRange(start, parenPos)
+		}
+		if node.Body() != nil {
+			return core.NewTextRange(start, node.Body().Pos())
+		}
+		return TrimNodeTextRange(sourceFile, node)
+	}
+
+	return TrimNodeTextRange(sourceFile, node)
+}
+
+// findOpenParenPos finds the position of the first '(' token in a function node.
+func findOpenParenPos(sourceFile *ast.SourceFile, node *ast.Node) int {
+	s := scanner.GetScannerForSourceFile(sourceFile, node.Pos())
+	end := node.End()
+	for s.TokenStart() < end {
+		if s.Token() == ast.KindOpenParenToken {
+			return s.TokenStart()
+		}
+		s.Scan()
+	}
+	return -1
+}
+
+// findFunctionKeywordPos returns the start position of the function head,
+// skipping only `export` and `default` keywords. Other modifiers like `async`
+// and `declare` are kept because they are part of the function signature
+// (matching ESLint's behavior where FunctionDeclaration.loc excludes export/default).
+func findFunctionKeywordPos(sourceFile *ast.SourceFile, node *ast.Node) int {
+	s := scanner.GetScannerForSourceFile(sourceFile, node.Pos())
+	end := node.End()
+	for s.TokenStart() < end {
+		tok := s.Token()
+		if tok == ast.KindExportKeyword || tok == ast.KindDefaultKeyword {
+			s.Scan()
+			continue
+		}
+		return s.TokenStart()
+	}
+	return TrimNodeTextRange(sourceFile, node).Pos()
+}
+
 var arrayPredicateFunctions = []string{"every", "filter", "find", "findIndex", "findLast", "findLastIndex", "some"}
 
 func IsArrayMethodCallWithPredicate(

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -90,7 +90,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/consistent-type-imports.test.ts',
     './tests/typescript-eslint/rules/default-param-last.test.ts',
     './tests/typescript-eslint/rules/dot-notation.test.ts',
-    // './tests/typescript-eslint/rules/explicit-function-return-type.test.ts',
+    './tests/typescript-eslint/rules/explicit-function-return-type.test.ts',
     // './tests/typescript-eslint/rules/explicit-member-accessibility.test.ts',
     // './tests/typescript-eslint/rules/explicit-module-boundary-types.test.ts',
     // './tests/typescript-eslint/rules/init-declarations.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/explicit-function-return-type.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/explicit-function-return-type.test.ts.snap
@@ -1,0 +1,2106 @@
+// Rstest Snapshot v1
+
+exports[`explicit-function-return-type > invalid 1`] = `
+{
+  "code": "
+function test(a: number, b: number) {
+  return;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 2`] = `
+{
+  "code": "
+function test() {
+  return;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 3`] = `
+{
+  "code": "
+var fn = function () {
+  return 1;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 10,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 4`] = `
+{
+  "code": "
+var arrowFn = () => 'test';
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 5`] = `
+{
+  "code": "
+class Test {
+  constructor() {}
+  get prop() {
+    return 1;
+  }
+  set prop() {}
+  method() {
+    return;
+  }
+  arrow = () => 'arrow';
+  private method() {
+    return;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 11,
+        },
+        "start": {
+          "column": 3,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 12,
+        },
+        "start": {
+          "column": 3,
+          "line": 12,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 6`] = `
+{
+  "code": "
+function test() {
+  return;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 7`] = `
+{
+  "code": "const foo = () => {};",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 8`] = `
+{
+  "code": "const foo = function () {};",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 9`] = `
+{
+  "code": "export default () => {};",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 10`] = `
+{
+  "code": "export default function () {}",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 11`] = `
+{
+  "code": "
+class Foo {
+  public a = () => {};
+  public b = function () {};
+  public c = function test() {};
+
+  static d = () => {};
+  static e = function () {};
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 7,
+        },
+        "start": {
+          "column": 3,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 12`] = `
+{
+  "code": "var arrowFn = () => 'test';",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 13`] = `
+{
+  "code": "
+function foo(): any {
+  const bar = () => () => console.log('aa');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 14`] = `
+{
+  "code": "
+let anyValue: any;
+function foo(): any {
+  anyValue = () => () => console.log('aa');
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 4,
+        },
+        "start": {
+          "column": 23,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 15`] = `
+{
+  "code": "
+class Foo {
+  foo(): any {
+    const bar = () => () => {
+      return console.log('foo');
+    };
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 4,
+        },
+        "start": {
+          "column": 26,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 16`] = `
+{
+  "code": "
+var funcExpr = function () {
+  return 'test';
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 17`] = `
+{
+  "code": "const x = (() => {}) as Foo;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 18`] = `
+{
+  "code": "
+interface Foo {}
+const x = {
+  foo: () => {},
+} as Foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 19`] = `
+{
+  "code": "
+interface Foo {}
+const x: Foo = {
+  foo: () => {},
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 20`] = `
+{
+  "code": "const foo = <button onClick={() => {}} />;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 21`] = `
+{
+  "code": "const foo = <button on={{ click: () => {} }} />;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 22`] = `
+{
+  "code": "const foo = <Bar>{() => {}}</Bar>;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 23`] = `
+{
+  "code": "const foo = <Bar>{{ on: () => {} }}</Bar>;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 24`] = `
+{
+  "code": "const foo = <button {...{ onClick: () => {} }} />;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 25`] = `
+{
+  "code": "
+function foo(): any {
+  class Foo {
+    foo = () => () => {
+      return console.log('foo');
+    };
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 4,
+        },
+        "start": {
+          "column": 20,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 26`] = `
+{
+  "code": "() => () => {};",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 27`] = `
+{
+  "code": "() => function () {};",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 28`] = `
+{
+  "code": "
+() => {
+  return () => {};
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 29`] = `
+{
+  "code": "
+() => {
+  return function () {};
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 30`] = `
+{
+  "code": "
+function fn() {
+  return () => {};
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 31`] = `
+{
+  "code": "
+function fn() {
+  return function () {};
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 32`] = `
+{
+  "code": "
+function fn() {
+  const bar = () => (): number => 1;
+  const baz = () => () => 'baz';
+  return function (): void {};
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 4,
+        },
+        "start": {
+          "column": 24,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 33`] = `
+{
+  "code": "
+function fn(arg: boolean) {
+  if (arg) return 'string';
+  return function (): void {};
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 34`] = `
+{
+  "code": "
+function FunctionDeclaration() {
+  return function FunctionExpression_Within_FunctionDeclaration() {
+    return function FunctionExpression_Within_FunctionExpression() {
+      return () => {
+        // ArrowFunctionExpression_Within_FunctionExpression
+        return () =>
+          // ArrowFunctionExpression_Within_ArrowFunctionExpression
+          () =>
+            1; // ArrowFunctionExpression_Within_ArrowFunctionExpression_WithNoBody
+      };
+    };
+  };
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 9,
+        },
+        "start": {
+          "column": 14,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 35`] = `
+{
+  "code": "
+() => () => {
+  return () => {
+    return;
+  };
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 36`] = `
+{
+  "code": "
+declare function foo(arg: () => void): void;
+foo(() => 1);
+foo(() => {});
+foo(() => null);
+foo(() => true);
+foo(() => '');
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 5,
+        },
+        "start": {
+          "column": 8,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 7,
+        },
+        "start": {
+          "column": 8,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 37`] = `
+{
+  "code": "
+class Accumulator {
+  private count: number = 0;
+
+  public accumulate(fn: () => number): void {
+    this.count += fn();
+  }
+}
+
+new Accumulator().accumulate(() => 1);
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 10,
+        },
+        "start": {
+          "column": 33,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 38`] = `
+{
+  "code": "(() => true)();",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 39`] = `
+{
+  "code": "
+declare function foo(arg: { meth: () => number }): void;
+foo({
+  meth() {
+    return 1;
+  },
+});
+foo({
+  meth: function () {
+    return 1;
+  },
+});
+foo({
+  meth: () => {
+    return 1;
+  },
+});
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 9,
+        },
+        "start": {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 14,
+        },
+        "start": {
+          "column": 3,
+          "line": 14,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 40`] = `
+{
+  "code": "
+type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 47,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 41`] = `
+{
+  "code": "
+type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 31,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 3,
+        },
+        "start": {
+          "column": 39,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 47,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 42`] = `
+{
+  "code": "
+const func = (value: number) => ({ type: 'X', value }) as any;
+const func = (value: number) => ({ type: 'X', value }) as Action;
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 30,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 43`] = `
+{
+  "code": "
+const func = (value: number) => ({ type: 'X', value }) as const;
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 44`] = `
+{
+  "code": "
+interface R {
+  type: string;
+  value: number;
+}
+
+const func = (value: number) => ({ type: 'X', value }) as const satisfies R;
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 7,
+        },
+        "start": {
+          "column": 30,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 45`] = `
+{
+  "code": "const log = (message: string) => void console.log(message);",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 46`] = `
+{
+  "code": "
+        const log = (message: string) => {
+          void console.log(message);
+        };
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 2,
+        },
+        "start": {
+          "column": 39,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 47`] = `
+{
+  "code": "const log = <A,>(a: A) => a;",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 48`] = `
+{
+  "code": "
+function log<A>(a: A) {
+  return a;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 49`] = `
+{
+  "code": "
+const log = function <A>(a: A) {
+  return a;
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 2,
+        },
+        "start": {
+          "column": 13,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 50`] = `
+{
+  "code": "
+function hoge() {
+  return;
+}
+const foo = () => {
+  return;
+};
+const baz = function () {
+  return;
+};
+let [test, test] = function () {
+  return;
+};
+class X {
+  [test] = function () {
+    return;
+  };
+}
+const x = {
+  1: function () {
+    reutrn;
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 8,
+        },
+        "start": {
+          "column": 13,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 11,
+        },
+        "start": {
+          "column": 20,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 15,
+        },
+        "start": {
+          "column": 3,
+          "line": 15,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 20,
+        },
+        "start": {
+          "column": 3,
+          "line": 20,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 6,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 51`] = `
+{
+  "code": "
+const ignoredName = 'notIgnoredName';
+class Foo {
+  [ignoredName]() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 52`] = `
+{
+  "code": "
+class Bar {
+  bar = [
+    {
+      foo: x => x + 1,
+    },
+  ];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 53`] = `
+{
+  "code": "
+const foo = (function () {
+  return 'foo';
+})();
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 54`] = `
+{
+  "code": "
+const foo = (function () {
+  return () => {
+    return 1;
+  };
+})();
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 55`] = `
+{
+  "code": "
+let foo = function () {
+  return 'foo';
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 56`] = `
+{
+  "code": "
+let foo = (() => () => {})()();
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 21,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 57`] = `
+{
+  "code": "
+type CallBack = () => void;
+
+function f(gotcha: CallBack = () => {}): void {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 4,
+        },
+        "start": {
+          "column": 34,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 58`] = `
+{
+  "code": "
+type CallBack = () => void;
+
+const f = (gotcha: CallBack = () => {}): void => {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 4,
+        },
+        "start": {
+          "column": 34,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`explicit-function-return-type > invalid 59`] = `
+{
+  "code": "
+type ObjectWithCallback = { callback: () => void };
+
+const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
+      ",
+  "diagnostics": [
+    {
+      "message": "Missing return type on function.",
+      "messageId": "missingReturnType",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 4,
+        },
+        "start": {
+          "column": 43,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/explicit-function-return-type",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -12,6 +12,7 @@ bigints
 binaryexpression
 bleh
 bmatcuk
+bodyless
 cachedvfs
 catchable
 clazz
@@ -53,7 +54,6 @@ funcw
 gcflags
 getsp
 github
-GitHub
 gnored
 GOARCH
 GOEXE
@@ -168,6 +168,7 @@ tsgolint
 tsoptions
 tspath
 tsutils
+typeparam
 unbnound
 uncast
 undefinded
@@ -189,7 +190,6 @@ visitchildren
 walltime
 wasmer
 wasmfs
-typeparam
 xdescribe
 xjavascript
 aavascript


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/explicit-function-return-type` rule from typescript-eslint to rslint.

This rule requires explicit return types on functions and class methods. Supports all 8 configuration options:
- `allowExpressions`
- `allowTypedFunctionExpressions` (default: true)
- `allowHigherOrderFunctions` (default: true)
- `allowDirectConstAssertionInArrowFunctions` (default: true)
- `allowConciseArrowFunctionExpressionsStartingWithVoid`
- `allowFunctionsWithoutTypeParameters`
- `allowedNames`
- `allowIIFEs`

Also extracts `GetFunctionHeadLoc` utility to `internal/utils/ts_eslint.go` for reuse by other rules (`promise-function-async`, `require-await`, `no-misused-promises`) that currently have TODO comments for it.

Verified 1:1 alignment with ESLint on real projects (rsbuild: 79/79, rspack: 161/161, 0 diff).

## Related Links

- Rule documentation: https://typescript-eslint.io/rules/explicit-function-return-type
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/explicit-function-return-type.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).