### PR TITLE
fix: prevent panic in class-literal-property-style on object literal getters

### DIFF
--- a/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.go
+++ b/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style.go
@@ -212,6 +212,12 @@ var ClassLiteralPropertyStyleRule = rule.CreateRule(rule.Rule{
 		// Only add the getter check when style is "fields"
 		if style == "fields" {
 			listeners[ast.KindGetAccessor] = func(node *ast.Node) {
+				// Only check getters inside class bodies — object literal getters use the
+				// same KindGetAccessor but are not class members and must be skipped.
+				if node.Parent == nil || !ast.IsClassLike(node.Parent) {
+					return
+				}
+
 				getter := node.AsGetAccessorDeclaration()
 
 				// Skip if getter has override modifier

--- a/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style_test.go
+++ b/internal/plugins/typescript/rules/class_literal_property_style/class_literal_property_style_test.go
@@ -247,6 +247,24 @@ class ChildClass extends BaseClass {
 			`,
 			Options: []interface{}{"getters"},
 		},
+		// Object literal getters should not trigger the rule (regression: panic on ObjectLiteralExpression)
+		{Code: `
+const obj = {
+  get foo() {
+    return 'bar';
+  }
+};
+		`},
+		{
+			Code: `
+const obj = {
+  get foo() {
+    return 'bar';
+  }
+};
+			`,
+			Options: []interface{}{"getters"},
+		},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `


### PR DESCRIPTION
## Summary

The `class-literal-property-style` rule panics when encountering a getter inside an object literal (`ObjectLiteralExpression`). This happens because `node.Parent.Members()` calls `MemberList()`, which doesn't handle `KindObjectLiteralExpression` and panics.

- Add an `ast.IsClassLike(node.Parent)` guard at the top of the getter listener to skip non-class getters (aligned with the original ESLint rule's `ClassBody > MethodDefinition[kind='get']` selector)
- Add test cases for object literal getters under both `fields` and `getters` modes

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).