### PR TITLE
test: close editor tab before deleting temp files in VSCode E2E tests

### DIFF
--- a/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
@@ -146,6 +146,11 @@ export async function withTmpFile(
     const editor = await vscode.window.showTextDocument(doc);
     await testFn(doc, editor);
   } finally {
+    // Close the editor tab so VSCode sends a synchronous didClose to the LSP,
+    // which cleans up the session overlay. Without this, the file deletion
+    // triggers an async didClose via the file watcher, which can race with
+    // the next test's LSP requests (all blocking methods are serialized).
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     if (fs.existsSync(tmpFile)) {
       fs.unlinkSync(tmpFile);
     }
@@ -200,6 +205,11 @@ export async function withOnSaveFixAll(
       );
     }
   } finally {
+    // Close the editor tab so VSCode sends a synchronous didClose to the LSP,
+    // which cleans up the session overlay. Without this, the file deletion
+    // triggers an async didClose via the file watcher, which can race with
+    // the next test's LSP requests (all blocking methods are serialized).
+    await vscode.commands.executeCommand('workbench.action.closeActiveEditor');
     if (fs.existsSync(tmpFile)) {
       fs.unlinkSync(tmpFile);
     }


### PR DESCRIPTION
## Summary

Fix intermittent flaky test `cascade on-save - single save fixes both passes` in VSCode extension E2E tests.

**Root cause**: `withTmpFile` and `withOnSaveFixAll` delete temp files without closing the editor tab first. This causes VSCode's file watcher to send an async `didClose` to the LSP, which can race with the next test's `codeAction` request (both are blocking methods processed on the same goroutine). When the race hits, `handleFixAllCodeAction` encounters an unstable session state and returns empty edits.

**Fix**: Call `closeActiveEditor` before `fs.unlinkSync` in both helpers, so `didClose` is sent synchronously to the LSP and the session overlay is cleaned up before the next test starts.

## Related Links

- CI failure: https://github.com/web-infra-dev/rslint/actions/runs/24280384125/job/70901458100

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).