### PR TITLE
perf: optimize gitignore scanning for large monorepos

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -666,8 +666,15 @@ func runCMD() int {
 			// ReadGitignoreAsGlobs walks UP (ancestor inheritance) and DOWN
 			// (nested .gitignore) from each configDir. Sibling configs are
 			// fully isolated — they never share gitignore patterns.
+			//
+			// Config ignores are passed so that directories which are
+			// directory-level blocked (e.g. **/tests/**) are pruned during
+			// the .gitignore scan. This is safe because isDirPathBlocked is
+			// the same function used by the linter — blocked dirs' files
+			// are never linted, so their .gitignore patterns are irrelevant.
 			for configDir, entries := range configMap {
-				gitGlobs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs)
+				configIgnores := rslintconfig.ExtractConfigIgnores(entries)
+				gitGlobs := rslintconfig.ReadGitignoreAsGlobs(configDir, fs, configIgnores)
 				if len(gitGlobs) > 0 {
 					configMap[configDir] = append(
 						rslintconfig.RslintConfig{{Ignores: gitGlobs}},
@@ -694,7 +701,8 @@ func runCMD() int {
 			currentDirectory = payload.SingleConfigDir
 
 			// Inject .gitignore patterns as global ignores.
-			gitGlobs := rslintconfig.ReadGitignoreAsGlobs(currentDirectory, fs)
+			configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
+			gitGlobs := rslintconfig.ReadGitignoreAsGlobs(currentDirectory, fs, configIgnores)
 			if len(gitGlobs) > 0 {
 				rslintConfig = append(
 					rslintconfig.RslintConfig{{Ignores: gitGlobs}},
@@ -713,7 +721,8 @@ func runCMD() int {
 		rslintConfig, _, currentDirectory = rslintconfig.LoadConfigurationWithFallback(config, currentDirectory, fs)
 
 		// Inject .gitignore patterns as global ignores.
-		gitGlobs := rslintconfig.ReadGitignoreAsGlobs(currentDirectory, fs)
+		configIgnores := rslintconfig.ExtractConfigIgnores(rslintConfig)
+		gitGlobs := rslintconfig.ReadGitignoreAsGlobs(currentDirectory, fs, configIgnores)
 		if len(gitGlobs) > 0 {
 			rslintConfig = append(
 				rslintconfig.RslintConfig{{Ignores: gitGlobs}},

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -732,12 +732,7 @@ func (config RslintConfig) GetConfigForFile(filePath string, cwd string) *Merged
 	// 1. Collect all global ignore patterns and evaluate once.
 	// This allows `!` negation patterns in separate entries to work correctly,
 	// aligned with ESLint v10 which merges all global ignores before evaluating.
-	var globalIgnorePatterns []string
-	for _, entry := range config {
-		if isGlobalIgnoreEntry(entry) {
-			globalIgnorePatterns = append(globalIgnorePatterns, entry.Ignores...)
-		}
-	}
+	globalIgnorePatterns := ExtractConfigIgnores(config)
 	if len(globalIgnorePatterns) > 0 {
 		// Phase 1: directory-level check. Patterns like `dir/**` block the
 		// directory entirely — `!` negation cannot undo this. Aligned with

--- a/internal/config/file_discovery.go
+++ b/internal/config/file_discovery.go
@@ -48,15 +48,11 @@ func DiscoverGapFiles(
 	allowDirs []string,
 ) []string {
 	// 1. Collect global ignore patterns and files patterns from config entries.
-	var globalIgnores []string
+	globalIgnores := ExtractConfigIgnores(config)
+
 	var allFilesPatterns []string
 	hasFilesField := false
-
 	for _, entry := range config {
-		if isGlobalIgnoreEntry(entry) {
-			globalIgnores = append(globalIgnores, entry.Ignores...)
-			continue
-		}
 		if len(entry.Files) > 0 {
 			hasFilesField = true
 			allFilesPatterns = append(allFilesPatterns, entry.Files...)

--- a/internal/config/file_discovery_test.go
+++ b/internal/config/file_discovery_test.go
@@ -682,3 +682,393 @@ func TestDiscoverGapFiles_EntersNonExcludedDirs(t *testing.T) {
 	assert.Equal(t, len(gapFiles), 3)
 	_ = paths
 }
+
+// =============================================================================
+// End-to-end cross-matrix tests: config ignores × .gitignore × gap files × linter
+//
+// These tests simulate the full flow:
+//   1. ReadGitignoreAsGlobs (with configIgnores for pruning)
+//   2. Inject gitignore globs into config
+//   3. DiscoverGapFiles
+//   4. Verify GetConfigForFile (linter's per-file decision) is consistent
+//
+// The structural guarantee being tested: if isDirPathBlocked(dir, configIgnores)
+// returns true in collectGitignoreGlobs (causing .gitignore skip), then
+// GetConfigForFile also returns nil for any file in that dir.
+// =============================================================================
+
+// e2eSetup creates a fixture, runs ReadGitignoreAsGlobs + config injection + DiscoverGapFiles,
+// and returns gap files + the final config (for GetConfigForFile verification).
+func e2eSetup(t *testing.T, files map[string]string, config RslintConfig, programFiles map[string]struct{}) (string, []string, RslintConfig) {
+	t.Helper()
+	dir := setupGitignoreFixture(t, files)
+
+	configIgnores := ExtractConfigIgnores(config)
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	if programFiles == nil {
+		programFiles = map[string]struct{}{}
+	}
+
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil)
+	return dir, gapFiles, config
+}
+
+// E2E case 1: Standard rspack-like scenario.
+// config ignores tests/, .gitignore ignores target/.
+// Files in src/ should be gap files. Files in tests/ and target/ should not.
+func TestE2E_StandardMonorepo(t *testing.T) {
+	files := map[string]string{
+		".gitignore":               "target/\n",
+		"src/index.ts":             "x",
+		"src/utils.ts":             "x",
+		"tests/unit/a.test.ts":     "x",
+		"tests/.gitignore":         "snapshots/\n",
+		"target/build/output.ts":   "x",
+		"packages/foo/src/main.ts": "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir, gapFiles, finalConfig := e2eSetup(t, files, config, nil)
+
+	// Exactly 3 gap files: src/index.ts, src/utils.ts, packages/foo/src/main.ts.
+	// tests/ excluded by config ignore, target/ excluded by gitignore.
+	assert.Equal(t, len(gapFiles), 3, "should have exactly 3 gap files, got %d: %v", len(gapFiles), gapFiles)
+
+	gapSet := toSet(gapFiles)
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/index.ts")])
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/utils.ts")])
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/packages/foo/src/main.ts")])
+
+	// Linter consistency: excluded files return nil from GetConfigForFile.
+	for _, excluded := range []string{"/tests/unit/a.test.ts", "/target/build/output.ts"} {
+		mc := finalConfig.GetConfigForFile(tspath.NormalizePath(dir+excluded), dir)
+		assert.Assert(t, mc == nil, "GetConfigForFile(%s) should be nil", excluded)
+	}
+
+	// Linter consistency: included files return non-nil.
+	for _, included := range []string{"/src/index.ts", "/packages/foo/src/main.ts"} {
+		mc := finalConfig.GetConfigForFile(tspath.NormalizePath(dir+included), dir)
+		assert.Assert(t, mc != nil, "GetConfigForFile(%s) should be non-nil", included)
+	}
+}
+
+// E2E case 2: Nested .gitignore in non-ignored dir affects TS Program files.
+// packages/foo/.gitignore ignores generated/. A file there is in programFiles
+// (simulating tsconfig inclusion). GetConfigForFile should return nil for it.
+func TestE2E_NestedGitignoreAffectsProgramFiles(t *testing.T) {
+	files := map[string]string{
+		".gitignore":                        "dist/\n",
+		"packages/foo/.gitignore":           "generated/\n",
+		"packages/foo/src/index.ts":         "x",
+		"packages/foo/src/generated/api.ts": "x",
+	}
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	// Build programFiles with both files (simulating tsconfig include: ["src"])
+	dir := setupGitignoreFixture(t, files)
+	indexPath := tspath.NormalizePath(dir + "/packages/foo/src/index.ts")
+	genPathFull := tspath.NormalizePath(dir + "/packages/foo/src/generated/api.ts")
+
+	configIgnores := ExtractConfigIgnores(config)
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	// generated/api.ts is in programFiles but gitignored.
+	// GetConfigForFile should return nil because gitignore patterns are in config.
+	mc := config.GetConfigForFile(genPathFull, dir)
+	assert.Assert(t, mc == nil, "GetConfigForFile should return nil for gitignored generated/ file (nested .gitignore collected)")
+
+	// index.ts is in programFiles and NOT gitignored → should get rules.
+	mc = config.GetConfigForFile(indexPath, dir)
+	assert.Assert(t, mc != nil, "GetConfigForFile should return config for non-ignored file")
+}
+
+// E2E case 3: Config ignores with file-level pattern (**/tests/**/*).
+// The negation !tests/e2e/**/* re-includes tests/e2e/ at file level.
+// tests/e2e/ files should be discoverable as gap files.
+func TestE2E_FileLevelIgnoreWithNegation(t *testing.T) {
+	files := map[string]string{
+		"src/index.ts":        "x",
+		"tests/unit/a.ts":     "x",
+		"tests/e2e/smoke.ts":  "x",
+		"tests/.gitignore":    "tmp/\n",
+		"tests/e2e/.gitignore": "screenshots/\n",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**/*", "!tests/e2e/**/*"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir, gapFiles, finalConfig := e2eSetup(t, files, config, nil)
+
+	gapSet := toSet(gapFiles)
+
+	// src/index.ts → discovered
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/index.ts")], "src/index.ts should be gap file")
+
+	// tests/unit/a.ts → file-level ignored, not negated → NOT discovered
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/tests/unit/a.ts")], "tests/unit/ should be excluded")
+
+	// tests/e2e/smoke.ts → file-level ignored BUT negated → discovered!
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/tests/e2e/smoke.ts")], "tests/e2e/ should be re-included by negation")
+
+	// Verify linter: tests/e2e/smoke.ts gets rules
+	mc := finalConfig.GetConfigForFile(tspath.NormalizePath(dir+"/tests/e2e/smoke.ts"), dir)
+	assert.Assert(t, mc != nil, "GetConfigForFile should return config for negation-included tests/e2e/ file")
+
+	// Verify linter: tests/unit/a.ts does NOT get rules
+	mc = finalConfig.GetConfigForFile(tspath.NormalizePath(dir+"/tests/unit/a.ts"), dir)
+	assert.Assert(t, mc == nil, "GetConfigForFile should return nil for ignored tests/unit/ file")
+}
+
+// E2E case 4: .gitignore + config ignores target different dirs.
+// .gitignore ignores dist/, config ignores vendor/. Both should be excluded.
+func TestE2E_GitignoreAndConfigIgnoreIndependent(t *testing.T) {
+	files := map[string]string{
+		".gitignore":         "dist/\n",
+		"src/index.ts":       "x",
+		"dist/bundle.ts":     "x",
+		"vendor/lib/util.ts": "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/vendor/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir, gapFiles, finalConfig := e2eSetup(t, files, config, nil)
+
+	gapSet := toSet(gapFiles)
+
+	// src/ → discovered
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/index.ts")], "src/index.ts should be gap file")
+	// dist/ → excluded by gitignore
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/dist/bundle.ts")], "dist/ should be excluded by gitignore")
+	// vendor/ → excluded by config ignore
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/vendor/lib/util.ts")], "vendor/ should be excluded by config ignore")
+
+	// Verify linter
+	mc := finalConfig.GetConfigForFile(tspath.NormalizePath(dir+"/dist/bundle.ts"), dir)
+	assert.Assert(t, mc == nil, "dist/ file should be nil in linter (gitignored)")
+	mc = finalConfig.GetConfigForFile(tspath.NormalizePath(dir+"/vendor/lib/util.ts"), dir)
+	assert.Assert(t, mc == nil, "vendor/ file should be nil in linter (config-ignored)")
+}
+
+// E2E case 5: No .gitignore at all + config ignores.
+// Only config ignores are active.
+func TestE2E_NoGitignoreOnlyConfigIgnores(t *testing.T) {
+	files := map[string]string{
+		"src/index.ts":         "x",
+		"tests/unit/a.test.ts": "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir, gapFiles, _ := e2eSetup(t, files, config, nil)
+
+	gapSet := toSet(gapFiles)
+
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/index.ts")], "src/index.ts should be gap file")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/tests/unit/a.test.ts")], "tests/ should be excluded")
+}
+
+// E2E case 6: programFiles interaction — file in program is not a gap file.
+func TestE2E_ProgramFilesExcluded(t *testing.T) {
+	files := map[string]string{
+		".gitignore":   "dist/\n",
+		"src/index.ts": "x",
+		"src/utils.ts": "x",
+	}
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	// Create fixture once and use the same dir for programFiles and e2e flow.
+	dir := setupGitignoreFixture(t, files)
+	indexPath := tspath.NormalizePath(dir + "/src/index.ts")
+	utilsPath := tspath.NormalizePath(dir + "/src/utils.ts")
+
+	programFiles := map[string]struct{}{
+		indexPath: {},
+	}
+
+	configIgnores := ExtractConfigIgnores(config)
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), programFiles, nil, nil)
+	gapSet := toSet(gapFiles)
+
+	// index.ts in program → NOT a gap file
+	assert.Assert(t, !gapSet[indexPath], "file in program should not be gap file")
+	// utils.ts not in program → IS a gap file
+	assert.Assert(t, gapSet[utilsPath], "file not in program should be gap file")
+}
+
+// E2E case 7: Multiple config ignore entries + gitignore — verify all patterns combine correctly.
+func TestE2E_MultipleIgnoreEntries(t *testing.T) {
+	files := map[string]string{
+		".gitignore":            "target/\n",
+		"src/index.ts":          "x",
+		"tests/a.test.ts":       "x",
+		"scripts/build.ts":      "x",
+		"target/output.ts":      "x",
+		"packages/foo/index.ts": "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**"}},
+		{Ignores: []string{"scripts/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir, gapFiles, finalConfig := e2eSetup(t, files, config, nil)
+	gapSet := toSet(gapFiles)
+
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/src/index.ts")], "src/ → discovered")
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/packages/foo/index.ts")], "packages/ → discovered")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/tests/a.test.ts")], "tests/ → config-ignored")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/scripts/build.ts")], "scripts/ → config-ignored")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/target/output.ts")], "target/ → gitignored")
+
+	// Verify linter consistency for all excluded paths
+	for _, excluded := range []string{"/tests/a.test.ts", "/scripts/build.ts", "/target/output.ts"} {
+		mc := finalConfig.GetConfigForFile(tspath.NormalizePath(dir+excluded), dir)
+		assert.Assert(t, mc == nil, "GetConfigForFile(%s) should return nil", excluded)
+	}
+}
+
+// E2E case 8: config-ignored directory's file is in TS Program → GetConfigForFile returns nil.
+// This verifies that even if tsconfig pulls in files from a config-ignored directory,
+// the linter correctly skips them (isDirBlockedByIgnores blocks the directory).
+func TestE2E_ConfigIgnoredDirInProgram(t *testing.T) {
+	files := map[string]string{
+		"src/index.ts":             "x",
+		"tests/helpers/setup.ts":   "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir := setupGitignoreFixture(t, files)
+	testFile := tspath.NormalizePath(dir + "/tests/helpers/setup.ts")
+
+	configIgnores := ExtractConfigIgnores(config)
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	// Even though setup.ts is in programFiles, GetConfigForFile should return nil
+	// because tests/ is directory-blocked by config ignores.
+	mc := config.GetConfigForFile(testFile, dir)
+	assert.Assert(t, mc == nil, "GetConfigForFile should return nil for file in config-ignored dir, even if in TS Program")
+}
+
+// E2E case 9: gitignore and config ignore both target the same directory (dist/).
+// Both mechanisms should work — the file should be excluded regardless of which one catches it.
+func TestE2E_OverlappingGitignoreAndConfigIgnore(t *testing.T) {
+	files := map[string]string{
+		".gitignore":       "dist/\n",
+		"src/index.ts":     "x",
+		"dist/bundle.ts":   "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/dist/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir, gapFiles, finalConfig := e2eSetup(t, files, config, nil)
+	gapSet := toSet(gapFiles)
+
+	distFile := tspath.NormalizePath(dir + "/dist/bundle.ts")
+	assert.Assert(t, !gapSet[distFile], "dist/ should be excluded (both gitignore and config ignore)")
+
+	mc := finalConfig.GetConfigForFile(distFile, dir)
+	assert.Assert(t, mc == nil, "GetConfigForFile should return nil for doubly-ignored dist/ file")
+}
+
+// E2E case 10: allowDirs scope combined with config ignores.
+// Only files in the allowed directory should be discovered, config ignores still apply.
+func TestE2E_AllowDirsWithConfigIgnores(t *testing.T) {
+	files := map[string]string{
+		".gitignore":              "dist/\n",
+		"packages/foo/src/a.ts":  "x",
+		"packages/foo/dist/b.ts": "x",
+		"packages/bar/src/c.ts":  "x",
+		"tests/unit/d.ts":        "x",
+	}
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir := setupGitignoreFixture(t, files)
+	configIgnores := ExtractConfigIgnores(config)
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	// Only allow packages/foo/
+	fooDir := tspath.NormalizePath(dir + "/packages/foo")
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, nil, []string{fooDir})
+	gapSet := toSet(gapFiles)
+
+	assert.Assert(t, gapSet[tspath.NormalizePath(dir+"/packages/foo/src/a.ts")], "packages/foo/src/a.ts should be discovered (in allowDirs)")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/packages/foo/dist/b.ts")], "packages/foo/dist/b.ts should be excluded (gitignored)")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/packages/bar/src/c.ts")], "packages/bar/ should be excluded (not in allowDirs)")
+	assert.Assert(t, !gapSet[tspath.NormalizePath(dir+"/tests/unit/d.ts")], "tests/ should be excluded (config-ignored)")
+}
+
+// E2E case 11: allowFiles (lint-staged fast path) combined with gitignore injection.
+// Files passed explicitly should still be filtered by gitignore patterns.
+func TestE2E_AllowFilesWithGitignore(t *testing.T) {
+	files := map[string]string{
+		".gitignore":     "dist/\n",
+		"src/index.ts":   "x",
+		"dist/bundle.ts": "x",
+	}
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"test-rule": "error"}},
+	}
+
+	dir := setupGitignoreFixture(t, files)
+	configIgnores := ExtractConfigIgnores(config)
+	gitGlobs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	if len(gitGlobs) > 0 {
+		config = append(RslintConfig{{Ignores: gitGlobs}}, config...)
+	}
+
+	srcFile := tspath.NormalizePath(dir + "/src/index.ts")
+	distFile := tspath.NormalizePath(dir + "/dist/bundle.ts")
+
+	// Simulate lint-staged passing both files explicitly.
+	gapFiles := DiscoverGapFiles(config, dir, osvfs.FS(), map[string]struct{}{}, []string{srcFile, distFile}, nil)
+	gapSet := toSet(gapFiles)
+
+	assert.Assert(t, gapSet[srcFile], "src/index.ts should be discovered (explicit allowFile)")
+	assert.Assert(t, !gapSet[distFile], "dist/bundle.ts should be excluded (gitignored even when explicitly passed)")
+}
+
+func toSet(items []string) map[string]bool {
+	m := make(map[string]bool, len(items))
+	for _, item := range items {
+		m[item] = true
+	}
+	return m
+}

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -17,8 +17,14 @@ import (
 //  2. Descendant .gitignore files: walks DOWN from configDir, collecting
 //     nested .gitignore with directory-scoped prefixes.
 //
+// configIgnores are the user-configured global ignore patterns (from config
+// entries with only ignores). Directories that are directory-level blocked by
+// these patterns are skipped during the descendant scan — their .gitignore
+// files are not collected because files in those directories will never be
+// linted (isDirPathBlocked guarantees this).
+//
 // Returns nil if no .gitignore files are found.
-func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS) []string {
+func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS, configIgnores []string) []string {
 	if fsys == nil {
 		return nil
 	}
@@ -32,12 +38,25 @@ func ReadGitignoreAsGlobs(configDir string, fsys vfs.FS) []string {
 	allGlobs = append(allGlobs, ancestorGlobs...)
 
 	// Phase 2: collect descendant .gitignore files (walk DOWN from configDir).
-	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs)
+	collectGitignoreGlobs(normalizedRoot, "", fsys, &allGlobs, configIgnores)
 
 	if len(allGlobs) == 0 {
 		return nil
 	}
 	return allGlobs
+}
+
+// ExtractConfigIgnores collects global ignore patterns from config entries.
+// These are patterns from entries that have only ignores (no files/rules/etc.),
+// which represent user-configured directories to exclude from linting.
+func ExtractConfigIgnores(config RslintConfig) []string {
+	var ignores []string
+	for _, entry := range config {
+		if isGlobalIgnoreEntry(entry) {
+			ignores = append(ignores, entry.Ignores...)
+		}
+	}
+	return ignores
 }
 
 // collectAncestorGitignoreGlobs walks UP from dir to filesystem root,
@@ -88,7 +107,14 @@ func parentDir(dir string) string {
 // their patterns to globs. Already-converted patterns from parent .gitignore
 // are used to prune directories during scanning (avoids entering e.g. target/
 // with thousands of subdirectories).
-func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string) {
+//
+// configIgnores provides additional directory-level pruning from the user's
+// lint config. If isDirPathBlocked returns true for a directory against these
+// patterns, the directory is skipped. This is safe because isDirPathBlocked
+// is the same function used by the linter's GetConfigForFile
+// (via isDirBlockedByIgnores) — if a directory is blocked here, its files
+// will never be linted, so collecting its .gitignore is unnecessary.
+func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]string, configIgnores []string) {
 	gitignorePath := absDir + "/.gitignore"
 	var localGlobs []string
 	if content, ok := fsys.ReadFile(gitignorePath); ok {
@@ -107,15 +133,25 @@ func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]
 			childRel = relDir + "/" + dir
 		}
 
-		// Prune directories already matched by collected patterns.
+		// Prune directories already matched by collected gitignore patterns.
 		// This is critical for performance: without it, scanning a repo like
 		// rspack enters target/ (6,277 Rust build dirs, 0 .ts files).
 		if isDirIgnoredByGlobs(*result, childRel) {
 			continue
 		}
 
+		// Prune directories that are directory-level blocked by config ignores.
+		// isDirPathBlocked is the same function the linter uses in
+		// GetConfigForFile → isDirBlockedByIgnores. If it returns true here,
+		// the linter will also return nil for any file in this directory,
+		// meaning files here are never linted. Therefore their .gitignore
+		// patterns are irrelevant and we can safely skip collecting them.
+		if len(configIgnores) > 0 && isDirPathBlocked(childRel, configIgnores) {
+			continue
+		}
+
 		childAbs := absDir + "/" + dir
-		collectGitignoreGlobs(childAbs, childRel, fsys, result)
+		collectGitignoreGlobs(childAbs, childRel, fsys, result, configIgnores)
 	}
 }
 

--- a/internal/config/gitignore.go
+++ b/internal/config/gitignore.go
@@ -133,20 +133,24 @@ func collectGitignoreGlobs(absDir string, relDir string, fsys vfs.FS, result *[]
 			childRel = relDir + "/" + dir
 		}
 
-		// Prune directories already matched by collected gitignore patterns.
-		// This is critical for performance: without it, scanning a repo like
-		// rspack enters target/ (6,277 Rust build dirs, 0 .ts files).
-		if isDirIgnoredByGlobs(*result, childRel) {
-			continue
-		}
-
 		// Prune directories that are directory-level blocked by config ignores.
 		// isDirPathBlocked is the same function the linter uses in
 		// GetConfigForFile → isDirBlockedByIgnores. If it returns true here,
 		// the linter will also return nil for any file in this directory,
 		// meaning files here are never linted. Therefore their .gitignore
 		// patterns are irrelevant and we can safely skip collecting them.
+		// Checked first because configIgnores is typically a short list (a few
+		// user-defined patterns), whereas *result grows as we collect more
+		// .gitignore patterns — checking configIgnores first avoids a linear
+		// scan of the longer list for directories blocked by config.
 		if len(configIgnores) > 0 && isDirPathBlocked(childRel, configIgnores) {
+			continue
+		}
+
+		// Prune directories already matched by collected gitignore patterns.
+		// This is critical for performance: without it, scanning a repo like
+		// rspack enters target/ (6,277 Rust build dirs, 0 .ts files).
+		if isDirIgnoredByGlobs(*result, childRel) {
 			continue
 		}
 

--- a/internal/config/gitignore_test.go
+++ b/internal/config/gitignore_test.go
@@ -7,9 +7,21 @@ import (
 	"testing"
 
 	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"gotest.tools/v3/assert"
 )
+
+// gitignoreSpyFS wraps a real VFS and tracks which directories GetAccessibleEntries was called on.
+type gitignoreSpyFS struct {
+	vfs.FS
+	accessedDirs []string
+}
+
+func (s *gitignoreSpyFS) GetAccessibleEntries(path string) vfs.Entries {
+	s.accessedDirs = append(s.accessedDirs, path)
+	return s.FS.GetAccessibleEntries(path)
+}
 
 func setupGitignoreFixture(t *testing.T, files map[string]string) string {
 	t.Helper()
@@ -120,7 +132,7 @@ func TestReadGitignoreAsGlobs_RootOnly(t *testing.T) {
 		".gitignore": "dist/\n*.log\n",
 		"src/a.ts":   "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 	assert.Assert(t, len(globs) >= 2)
 
 	hasDistGlob := false
@@ -141,7 +153,7 @@ func TestReadGitignoreAsGlobs_NoGitignore(t *testing.T) {
 	dir := setupGitignoreFixture(t, map[string]string{
 		"src/a.ts": "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 	assert.Assert(t, globs == nil, "should return nil when no .gitignore")
 }
 
@@ -151,7 +163,7 @@ func TestReadGitignoreAsGlobs_Nested(t *testing.T) {
 		"packages/app/.gitignore": "tmp/\n",
 		"src/a.ts":                "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 
 	hasDistGlob := false
 	hasTmpGlob := false
@@ -173,7 +185,7 @@ func TestReadGitignoreAsGlobs_NestedNegation(t *testing.T) {
 		"packages/app/.gitignore": "!dist/\n",
 		"src/a.ts":                "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 
 	hasDistGlob := false
 	hasNegation := false
@@ -197,7 +209,7 @@ func TestReadGitignoreAsGlobs_PrunesGitignoredDirs(t *testing.T) {
 		"src/a.ts":                      "x",
 		"target/deep/nested/.gitignore": "# should not be read\nfoo\n",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 
 	// Positive: root .gitignore should be read
 	assert.Assert(t, len(globs) >= 1, "should have at least root target/ glob")
@@ -216,7 +228,7 @@ func TestReadGitignoreAsGlobs_SkipsNodeModules(t *testing.T) {
 		"node_modules/pkg/.gitignore": "# should not be read\n",
 		"src/a.ts":                    "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 
 	// Only root .gitignore should be read
 	assert.Equal(t, len(globs), 1)
@@ -240,7 +252,7 @@ func TestReadGitignoreAsGlobs_ThreeLevelNested(t *testing.T) {
 		"packages/app/sub/.gitignore": "cache/\n",
 		"src/a.ts":                    "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 
 	hasRoot := false
 	hasApp := false
@@ -307,7 +319,7 @@ func TestReadGitignoreAsGlobs_AncestorInheritance(t *testing.T) {
 		"packages/app/src/a.ts": "x",
 	})
 	childDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(childDir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(childDir, osvfs.FS(), nil)
 
 	hasDistGlob := false
 	for _, g := range globs {
@@ -326,7 +338,7 @@ func TestReadGitignoreAsGlobs_AncestorPlusOwn(t *testing.T) {
 		"packages/app/src/a.ts":   "x",
 	})
 	childDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(childDir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(childDir, osvfs.FS(), nil)
 
 	hasDist := false
 	hasTmp := false
@@ -353,7 +365,7 @@ func TestReadGitignoreAsGlobs_SiblingIsolation(t *testing.T) {
 		"packages/lib/src/b.ts":   "x",
 	})
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	appGlobs := ReadGitignoreAsGlobs(appDir, osvfs.FS())
+	appGlobs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
 
 	for _, g := range appGlobs {
 		if strings.Contains(g, "cache") {
@@ -382,7 +394,7 @@ func TestReadGitignoreAsGlobs_DeepAncestor(t *testing.T) {
 		"packages/app/sub/src/a.ts": "x",
 	})
 	deepDir := tspath.NormalizePath(filepath.Join(dir, "packages/app/sub"))
-	globs := ReadGitignoreAsGlobs(deepDir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(deepDir, osvfs.FS(), nil)
 
 	hasDist := false
 	for _, g := range globs {
@@ -402,7 +414,7 @@ func TestReadGitignoreAsGlobs_MultipleAncestors(t *testing.T) {
 		"packages/app/src/a.ts": "x",
 	})
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
 
 	hasDist := false
 	hasVendor := false
@@ -427,7 +439,7 @@ func TestReadGitignoreAsGlobs_AncestorNegationOverride(t *testing.T) {
 		"packages/app/src/a.ts": "x",
 	})
 	appDir := tspath.NormalizePath(filepath.Join(dir, "packages/app"))
-	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(appDir, osvfs.FS(), nil)
 
 	hasDist := false
 	hasNegation := false
@@ -448,7 +460,7 @@ func TestReadGitignoreAsGlobs_EmptyFile(t *testing.T) {
 		".gitignore": "",
 		"src/a.ts":   "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 	assert.Assert(t, globs == nil, "empty .gitignore → no globs")
 }
 
@@ -457,6 +469,387 @@ func TestReadGitignoreAsGlobs_OnlyComments(t *testing.T) {
 		".gitignore": "# just a comment\n# another\n",
 		"src/a.ts":   "x",
 	})
-	globs := ReadGitignoreAsGlobs(dir, osvfs.FS())
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
 	assert.Assert(t, globs == nil, "comments-only .gitignore → no globs")
+}
+
+// =============================================================================
+// Cross-matrix tests: configIgnores × .gitignore interaction
+//
+// These tests verify that passing configIgnores to ReadGitignoreAsGlobs
+// correctly prunes config-ignored directories while preserving all .gitignore
+// patterns from non-ignored directories.
+// =============================================================================
+
+// Matrix case: config ignores dir-level (**/tests/**) + nested .gitignore inside tests/
+// Expected: tests/.gitignore NOT collected (pruned), root .gitignore collected.
+// --- Cross-matrix: configIgnores × .gitignore ---
+//
+// Helper: globSet converts a glob slice to a set for precise assertions.
+func globSet(globs []string) map[string]bool {
+	m := make(map[string]bool, len(globs))
+	for _, g := range globs {
+		m[g] = true
+	}
+	return m
+}
+
+// A1: dir-level config ignore (**/tests/**) prunes tests/.gitignore.
+func TestReadGitignoreAsGlobs_ConfigIgnoresPrunesDir(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":            "dist/\n",
+		"tests/.gitignore":      "snapshots/\n",
+		"tests/unit/.gitignore": "coverage/\n",
+		"tests/unit/a.test.ts":  "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**"})
+	gs := globSet(globs)
+
+	// Exactly 1 glob: root .gitignore "dist/" → "**/dist/**/*"
+	assert.Equal(t, len(globs), 1, "should have exactly 1 glob (root only), got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "should contain root dist pattern")
+}
+
+// A2: file-level config ignore (**/tests/**/*) does NOT prune tests/.gitignore.
+func TestReadGitignoreAsGlobs_FileLevelConfigIgnoreDoesNotPrune(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":       "dist/\n",
+		"tests/.gitignore": "snapshots/\n",
+		"tests/a.test.ts":  "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**/*"})
+	gs := globSet(globs)
+
+	// 2 globs: root dist + tests snapshots (file-level ignore doesn't prune dirs)
+	assert.Equal(t, len(globs), 2, "should have 2 globs, got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["tests/**/snapshots/**/*"], "tests snapshots should be collected")
+}
+
+// A3: dir-level + negation — isDirPathBlocked skips negation → still prunes.
+func TestReadGitignoreAsGlobs_NegationInConfigIgnoreStillPrunes(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":           "dist/\n",
+		"tests/e2e/.gitignore": "screenshots/\n",
+		"tests/e2e/a.ts":       "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**", "!tests/e2e/**"})
+
+	// Exactly 1 glob: root dist. tests/e2e/.gitignore NOT collected.
+	assert.Equal(t, len(globs), 1, "should have exactly 1 glob, got: %v", globs)
+	assert.Equal(t, globs[0], "**/dist/**/*")
+}
+
+// A4: sibling dirs — config ignores tests/, packages/ .gitignore preserved.
+func TestReadGitignoreAsGlobs_SiblingDirPreservesGitignore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":              "dist/\n",
+		"packages/foo/.gitignore": "tmp/\n",
+		"tests/.gitignore":        "snapshots/\n",
+		"packages/foo/a.ts":       "x",
+		"tests/a.test.ts":         "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**"})
+	gs := globSet(globs)
+
+	// Exactly 2 globs: root dist + packages/foo tmp. tests/ pruned.
+	assert.Equal(t, len(globs), 2, "should have 2 globs, got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["packages/foo/**/tmp/**/*"], "packages/foo tmp")
+}
+
+// A5: nil configIgnores — backward compat, all .gitignore collected.
+func TestReadGitignoreAsGlobs_NilConfigIgnores(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":       "dist/\n",
+		"tests/.gitignore": "snapshots/\n",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	gs := globSet(globs)
+
+	assert.Equal(t, len(globs), 2, "should have 2 globs (both collected), got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["tests/**/snapshots/**/*"], "tests snapshots")
+}
+
+// A6: deeply nested config-ignored dir — all nested .gitignore skipped.
+func TestReadGitignoreAsGlobs_DeepNestedConfigIgnore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                   "*.log\n",
+		"vendor/.gitignore":            "cache/\n",
+		"vendor/pkg/.gitignore":        "build/\n",
+		"vendor/pkg/sub/.gitignore":    "temp/\n",
+		"src/.gitignore":               "generated/\n",
+		"vendor/pkg/sub/deep/file.txt": "x",
+		"src/a.ts":                     "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/vendor/**"})
+	gs := globSet(globs)
+
+	// Exactly 2 globs: root *.log + src generated. All 3 vendor .gitignore pruned.
+	assert.Equal(t, len(globs), 2, "should have 2 globs, got: %v", globs)
+	assert.Assert(t, gs["**/*.log"], "root *.log")
+	assert.Assert(t, gs["src/**/generated/**/*"], "src generated")
+}
+
+// A7: wildcard config ignore (crates/**) — multiple nested .gitignore skipped.
+func TestReadGitignoreAsGlobs_WildcardConfigIgnoreSkipsNested(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                    "dist/\n",
+		"crates/core/.gitignore":        "artifacts/\n",
+		"crates/binding/.gitignore":     "generated/\n",
+		"packages/rspack/.gitignore":    "tmp/\n",
+		"crates/core/src/lib.rs":        "x",
+		"crates/binding/src/lib.rs":     "x",
+		"packages/rspack/src/index.ts":  "x",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"crates/**"})
+	gs := globSet(globs)
+
+	// Exactly 2: root dist + packages/rspack tmp. Both crates/ .gitignore pruned.
+	assert.Equal(t, len(globs), 2, "should have 2 globs, got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["packages/rspack/**/tmp/**/*"], "packages/rspack tmp")
+}
+
+// A8: empty configIgnores slice (non-nil) — same as nil, no pruning.
+func TestReadGitignoreAsGlobs_EmptyConfigIgnores(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":       "dist/\n",
+		"tests/.gitignore": "snapshots/\n",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{})
+	gs := globSet(globs)
+
+	assert.Equal(t, len(globs), 2, "empty slice = no pruning, got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["tests/**/snapshots/**/*"], "tests snapshots")
+}
+
+// A9: exact path config ignore — only that specific directory blocked.
+func TestReadGitignoreAsGlobs_ExactPathConfigIgnore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":              "dist/\n",
+		"build/output/.gitignore": "cache/\n",
+		"build/tools/.gitignore":  "tmp/\n",
+	})
+
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"build/output/**"})
+	gs := globSet(globs)
+
+	// 2 globs: root dist + build/tools tmp. build/output cache pruned.
+	assert.Equal(t, len(globs), 2, "should have 2 globs, got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["build/tools/**/tmp/**/*"], "build/tools tmp preserved")
+}
+
+// A10: ExtractConfigIgnores only extracts from global-ignore entries.
+// An entry is "global ignore" when it has ONLY ignores — no files, rules, plugins, etc.
+// Note: {Files: []string{}} (empty slice) still counts as len(Files)==0, so IS global.
+func TestExtractConfigIgnores_OnlyGlobalEntries(t *testing.T) {
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**"}},                                             // global ignore ✓
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},                       // has files+rules → NOT global
+		{Ignores: []string{"scripts/**"}},                                              // global ignore ✓
+		{Files: []string{}, Ignores: []string{"also-global"}},                          // empty files + only ignores → IS global (len(Files)==0)
+		{Ignores: []string{"vendor/**"}, Rules: Rules{"r": "error"}},                   // has rules → NOT global
+		{Files: []string{"**/*.js"}, Ignores: []string{"not-global"}},                  // has non-empty files → NOT global
+	}
+
+	ignores := ExtractConfigIgnores(config)
+
+	// Entries 0, 2, 3 are global ignores. Entries 1, 4, 5 are not.
+	assert.Equal(t, len(ignores), 3, "should extract exactly 3 patterns, got: %v", ignores)
+	assert.Equal(t, ignores[0], "**/tests/**")
+	assert.Equal(t, ignores[1], "scripts/**")
+	assert.Equal(t, ignores[2], "also-global")
+}
+
+// A11: multiple global ignore entries — all patterns combined.
+func TestExtractConfigIgnores_MultipleEntries(t *testing.T) {
+	config := RslintConfig{
+		{Ignores: []string{"**/tests/**", "packages/rspack/compiled/**"}},
+		{Ignores: []string{"crates/**"}},
+	}
+
+	ignores := ExtractConfigIgnores(config)
+	assert.Equal(t, len(ignores), 3, "should combine all patterns, got: %v", ignores)
+	assert.Equal(t, ignores[0], "**/tests/**")
+	assert.Equal(t, ignores[1], "packages/rspack/compiled/**")
+	assert.Equal(t, ignores[2], "crates/**")
+}
+
+// A12: bare config ignore without /** suffix (e.g., "tests" or "dist").
+// isDirPathBlocked matches the directory itself and all parents, so this
+// should still prune. Verify via exact glob count.
+func TestReadGitignoreAsGlobs_BareConfigIgnorePattern(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":       "*.log\n",
+		"tests/.gitignore": "snapshots/\n",
+		"src/.gitignore":   "generated/\n",
+		"tests/a.test.ts":  "x",
+		"src/a.ts":         "x",
+	})
+
+	// Bare "tests" — no trailing /**. isDirPathBlocked("tests", ["tests"]) should
+	// match via matchGlob("tests", "tests") → true → blocked.
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"tests"})
+	gs := globSet(globs)
+
+	// 2 globs: root *.log + src/generated. tests/ pruned by bare "tests" pattern.
+	assert.Equal(t, len(globs), 2, "bare 'tests' should prune tests/.gitignore, got: %v", globs)
+	assert.Assert(t, gs["**/*.log"], "root *.log")
+	assert.Assert(t, gs["src/**/generated/**/*"], "src generated")
+}
+
+// A13: gitignore and config ignore both target the same directory.
+// collectGitignoreGlobs checks gitignore patterns FIRST (isDirIgnoredByGlobs),
+// then config ignores (isDirPathBlocked). If both match, the directory is pruned
+// by whichever check comes first. Verify the result is identical to having only one.
+func TestReadGitignoreAsGlobs_OverlappingGitignoreAndConfigIgnore(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":       "dist/\nbuild/\n",
+		"dist/.gitignore":  "cache/\n",
+		"build/.gitignore": "tmp/\n",
+		"src/.gitignore":   "generated/\n",
+		"dist/bundle.js":   "x",
+		"build/output.js":  "x",
+		"src/a.ts":         "x",
+	})
+
+	// dist/ is in both .gitignore and config ignores.
+	// build/ is only in .gitignore.
+	configIgnores := []string{"**/dist/**"}
+	globs := ReadGitignoreAsGlobs(dir, osvfs.FS(), configIgnores)
+	gs := globSet(globs)
+
+	// dist/ pruned by GITIGNORE (isDirIgnoredByGlobs runs first → **/dist/**/* matches).
+	// build/ pruned by GITIGNORE.
+	// Neither dist/.gitignore nor build/.gitignore collected.
+	// Only root .gitignore (dist/ + build/) and src/.gitignore (generated/) remain.
+	assert.Equal(t, len(globs), 3, "should have 3 globs, got: %v", globs)
+	assert.Assert(t, gs["**/dist/**/*"], "root dist")
+	assert.Assert(t, gs["**/build/**/*"], "root build")
+	assert.Assert(t, gs["src/**/generated/**/*"], "src generated")
+
+	// Compare: without config ignores, result should be identical (gitignore already prunes both).
+	globsNoConfig := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	assert.Equal(t, len(globsNoConfig), len(globs), "overlapping config ignore should not change result vs nil configIgnores")
+}
+
+// Regression: same fixture, with vs without configIgnores.
+// Proves the EXACT effect of configIgnores — the difference must be only patterns
+// from the config-ignored directory (and nothing else changes).
+func TestReadGitignoreAsGlobs_RegressionWithVsWithout(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                "dist/\n",
+		"src/.gitignore":            "generated/\n",
+		"tests/.gitignore":          "snapshots/\n",
+		"tests/unit/.gitignore":     "coverage/\n",
+		"tests/unit/a.test.ts":      "x",
+		"src/a.ts":                  "x",
+	})
+
+	// WITHOUT configIgnores: all 4 .gitignore files collected → 4 patterns.
+	globsWithout := ReadGitignoreAsGlobs(dir, osvfs.FS(), nil)
+	gsWithout := globSet(globsWithout)
+	assert.Equal(t, len(globsWithout), 4, "without configIgnores should collect all 4 patterns, got: %v", globsWithout)
+	assert.Assert(t, gsWithout["**/dist/**/*"])
+	assert.Assert(t, gsWithout["src/**/generated/**/*"])
+	assert.Assert(t, gsWithout["tests/**/snapshots/**/*"])
+	assert.Assert(t, gsWithout["tests/unit/**/coverage/**/*"])
+
+	// WITH configIgnores: tests/ pruned → only 2 patterns (root + src).
+	globsWith := ReadGitignoreAsGlobs(dir, osvfs.FS(), []string{"**/tests/**"})
+	gsWith := globSet(globsWith)
+	assert.Equal(t, len(globsWith), 2, "with configIgnores should collect 2 patterns (tests/ pruned), got: %v", globsWith)
+	assert.Assert(t, gsWith["**/dist/**/*"])
+	assert.Assert(t, gsWith["src/**/generated/**/*"])
+
+	// The EXACT difference: the 2 missing patterns are from tests/ subtree.
+	assert.Assert(t, !gsWith["tests/**/snapshots/**/*"], "tests/ pattern should be pruned")
+	assert.Assert(t, !gsWith["tests/unit/**/coverage/**/*"], "tests/unit/ pattern should be pruned")
+}
+
+// Spy test: verify collectGitignoreGlobs does NOT call GetAccessibleEntries
+// on config-ignored directories. This proves the directory is truly skipped
+// at the walk level (not entered then filtered), which is the performance win.
+func TestReadGitignoreAsGlobs_ConfigIgnoreSkipsWalkLevel(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                    "dist/\n",
+		"src/a.ts":                      "x",
+		"src/.gitignore":                "generated/\n",
+		"tests/unit/a.test.ts":          "x",
+		"tests/.gitignore":              "snapshots/\n",
+		"tests/unit/.gitignore":         "coverage/\n",
+		"tests/unit/deep/nested/a.ts":   "x",
+	})
+
+	spy := &gitignoreSpyFS{FS: osvfs.FS()}
+	globs := ReadGitignoreAsGlobs(dir, spy, []string{"**/tests/**"})
+
+	// Output correctness: only root + src patterns.
+	assert.Equal(t, len(globs), 2, "got: %v", globs)
+
+	// Walk correctness: tests/ and its children should NOT be accessed.
+	for _, accessed := range spy.accessedDirs {
+		rel := strings.TrimPrefix(accessed, dir)
+		if strings.Contains(rel, "tests") {
+			t.Errorf("collectGitignoreGlobs entered config-ignored tests/ directory: GetAccessibleEntries(%s)", accessed)
+		}
+	}
+
+	// Positive check: root and src/ SHOULD be accessed.
+	rootAccessed := false
+	srcAccessed := false
+	for _, accessed := range spy.accessedDirs {
+		if accessed == dir {
+			rootAccessed = true
+		}
+		if strings.HasSuffix(accessed, "/src") {
+			srcAccessed = true
+		}
+	}
+	assert.Assert(t, rootAccessed, "root directory should be accessed")
+	assert.Assert(t, srcAccessed, "src/ should be accessed (not config-ignored)")
+}
+
+// Spy comparison: same fixture WITH vs WITHOUT configIgnores.
+// Proves that configIgnores reduces the number of GetAccessibleEntries calls.
+func TestReadGitignoreAsGlobs_ConfigIgnoreReducesWalkCount(t *testing.T) {
+	dir := setupGitignoreFixture(t, map[string]string{
+		".gitignore":                  "*.log\n",
+		"tests/unit/a.ts":             "x",
+		"tests/unit/sub/b.ts":         "x",
+		"tests/.gitignore":            "tmp/\n",
+		"tests/unit/.gitignore":       "output/\n",
+		"tests/unit/sub/.gitignore":   "cache/\n",
+		"src/a.ts":                    "x",
+	})
+
+	// Without configIgnores: walks everything including tests/ subtree.
+	spyWithout := &gitignoreSpyFS{FS: osvfs.FS()}
+	ReadGitignoreAsGlobs(dir, spyWithout, nil)
+	countWithout := len(spyWithout.accessedDirs)
+
+	// With configIgnores: skips tests/ subtree.
+	spyWith := &gitignoreSpyFS{FS: osvfs.FS()}
+	ReadGitignoreAsGlobs(dir, spyWith, []string{"**/tests/**"})
+	countWith := len(spyWith.accessedDirs)
+
+	// With configIgnores should access FEWER directories.
+	assert.Assert(t, countWith < countWithout,
+		"configIgnores should reduce walk count: with=%d, without=%d", countWith, countWithout)
+
+	// Specifically: tests/, tests/unit/, tests/unit/sub/ = 3 dirs skipped.
+	assert.Equal(t, countWithout-countWith, 3,
+		"should skip exactly 3 dirs (tests/, tests/unit/, tests/unit/sub/), but diff is %d", countWithout-countWith)
 }

--- a/internal/config/vfs_adapter.go
+++ b/internal/config/vfs_adapter.go
@@ -10,9 +10,10 @@ import (
 	"github.com/microsoft/typescript-go/shim/vfs"
 )
 
-// vfsAdapter adapts a vfs.FS to a standard fs.FS rooted at a given directory.
-// This allows standard library and third-party tools (like doublestar.GlobWalk)
-// to operate on the custom vfs.FS interface.
+// vfsAdapter adapts a vfs.FS to a standard fs.FS rooted at a given directory,
+// specifically for use with fs.WalkDir in DiscoverGapFiles. It is NOT a
+// general-purpose fs.FS implementation — Open() always returns a directory
+// handle (vfsDirFile) because fs.WalkDir only opens directories.
 //
 // It tracks visited symlink targets to prevent infinite recursion caused by
 // symlink cycles, since the underlying VFS follows symlinks transparently
@@ -25,22 +26,19 @@ type vfsAdapter struct {
 
 var _ fs.FS = (*vfsAdapter)(nil)
 
+// Open implements fs.FS. This adapter is ONLY used by fs.WalkDir in
+// DiscoverGapFiles, where Open() is only called on directories (via the
+// internal readDir function). Therefore we always return a vfsDirFile
+// without calling DirectoryExists — the parent's ReadDir already confirmed
+// the entry is a directory, so the stat would be redundant.
 func (a *vfsAdapter) Open(name string) (fs.File, error) {
 	fullPath := a.fullPath(name)
 
-	if a.vfs.DirectoryExists(fullPath) {
-		return &vfsDirFile{
-			adapter: a,
-			path:    fullPath,
-			name:    name,
-		}, nil
-	}
-
-	if a.vfs.FileExists(fullPath) {
-		return &vfsRegFile{name: name}, nil
-	}
-
-	return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	return &vfsDirFile{
+		adapter: a,
+		path:    fullPath,
+		name:    name,
+	}, nil
 }
 
 func (a *vfsAdapter) fullPath(name string) string {
@@ -131,19 +129,6 @@ func (f *vfsDirFile) ReadDir(n int) ([]fs.DirEntry, error) {
 	}
 	return result, nil
 }
-
-// vfsRegFile is a minimal fs.File for regular files.
-// GlobWalk only needs directory traversal; file Open is provided for completeness.
-type vfsRegFile struct {
-	name string
-}
-
-func (f *vfsRegFile) Stat() (fs.FileInfo, error) {
-	return &vfsFileInfo{name: f.name, isDir: false}, nil
-}
-
-func (f *vfsRegFile) Read([]byte) (int, error) { return 0, io.EOF }
-func (f *vfsRegFile) Close() error             { return nil }
 
 // vfsDirEntry implements fs.DirEntry.
 type vfsDirEntry struct {

--- a/internal/config/vfs_adapter.go
+++ b/internal/config/vfs_adapter.go
@@ -11,9 +11,12 @@ import (
 )
 
 // vfsAdapter adapts a vfs.FS to a standard fs.FS rooted at a given directory,
-// specifically for use with fs.WalkDir in DiscoverGapFiles. It is NOT a
-// general-purpose fs.FS implementation — Open() always returns a directory
-// handle (vfsDirFile) because fs.WalkDir only opens directories.
+// used by fs.WalkDir in DiscoverGapFiles and doublestar.GlobWalk in
+// expandProjectGlob. It is NOT a general-purpose fs.FS implementation —
+// Open() always returns a directory handle (vfsDirFile) because both
+// callers only open directories (WalkDir by design, GlobWalk because
+// expandProjectGlob is only called when the pattern contains glob
+// meta characters).
 //
 // It tracks visited symlink targets to prevent infinite recursion caused by
 // symlink cycles, since the underlying VFS follows symlinks transparently
@@ -26,11 +29,11 @@ type vfsAdapter struct {
 
 var _ fs.FS = (*vfsAdapter)(nil)
 
-// Open implements fs.FS. This adapter is ONLY used by fs.WalkDir in
-// DiscoverGapFiles, where Open() is only called on directories (via the
-// internal readDir function). Therefore we always return a vfsDirFile
-// without calling DirectoryExists — the parent's ReadDir already confirmed
-// the entry is a directory, so the stat would be redundant.
+// Open implements fs.FS. Both callers (fs.WalkDir in DiscoverGapFiles and
+// doublestar.GlobWalk in expandProjectGlob) only call Open() on directories.
+// Therefore we always return a vfsDirFile without calling DirectoryExists —
+// the parent's ReadDir already confirmed the entry is a directory, so the
+// stat would be redundant.
 func (a *vfsAdapter) Open(name string) (fs.File, error) {
 	fullPath := a.fullPath(name)
 

--- a/internal/config/vfs_adapter_test.go
+++ b/internal/config/vfs_adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/typescript-go/shim/vfs"
 	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
 	"gotest.tools/v3/assert"
 )
@@ -52,30 +53,24 @@ func TestVfsAdapter_OpenDirectory(t *testing.T) {
 	assert.Assert(t, info.IsDir())
 }
 
-func TestVfsAdapter_OpenFile(t *testing.T) {
+// Open() always returns vfsDirFile (the adapter is only used by fs.WalkDir
+// which only opens directories). Verify this contract.
+func TestVfsAdapter_OpenAlwaysReturnsDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	createTestFile(t, filepath.Join(tmpDir, "file.json"))
 
 	adapter := &vfsAdapter{vfs: osvfs.FS(), root: tmpDir}
+
+	// Open a file path — still returns vfsDirFile (no DirectoryExists check).
 	f, err := adapter.Open("file.json")
 	assert.NilError(t, err)
 	defer f.Close()
 
 	info, err := f.Stat()
 	assert.NilError(t, err)
-	assert.Assert(t, !info.IsDir())
-}
-
-func TestVfsAdapter_OpenNotExist(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	adapter := &vfsAdapter{vfs: osvfs.FS(), root: tmpDir}
-	_, err := adapter.Open("nonexistent")
-	assert.Assert(t, err != nil)
-
-	var pathErr *fs.PathError
-	assert.Assert(t, errors.As(err, &pathErr))
-	assert.Assert(t, errors.Is(pathErr.Err, fs.ErrNotExist))
+	// This returns isDir=true because Open always returns vfsDirFile.
+	// This is correct for the fs.WalkDir use case where Open is never called for files.
+	assert.Assert(t, info.IsDir(), "Open always returns vfsDirFile for fs.WalkDir usage")
 }
 
 func TestVfsDirFile_ReadDirAll(t *testing.T) {
@@ -177,10 +172,6 @@ func TestVfsAdapter_SymlinkCycleFiltered(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Inside a/loop (=tmpDir), there's "a" directory.
-	// Inside "a", the symlink "loop" points to tmpDir again.
-	// When ReadDir on a/loop lists "a", it's a regular dir (not a symlink) → included.
-	// But when we later ReadDir on a/loop/a, "loop" symlink target (tmpDir) is
-	// already in visitedSymTargets → filtered out, breaking the cycle.
 	hasA := false
 	for _, e := range entries2 {
 		if e.Name() == "a" {
@@ -219,4 +210,34 @@ func TestVfsDirEntry_TypeAndInfo(t *testing.T) {
 	fileEntry := &vfsDirEntry{name: "file.txt", isDir: false}
 	assert.Assert(t, !fileEntry.IsDir())
 	assert.Equal(t, fileEntry.Type(), fs.FileMode(0))
+}
+
+// spyVFS wraps a real VFS and counts DirectoryExists calls.
+type spyVFS struct {
+	vfs.FS
+	directoryExistsCalls int
+}
+
+func (s *spyVFS) DirectoryExists(path string) bool {
+	s.directoryExistsCalls++
+	return s.FS.DirectoryExists(path)
+}
+
+// Open() no longer calls DirectoryExists (always returns vfsDirFile).
+// Verify with a spy VFS that DirectoryExists is never called.
+func TestVfsAdapter_OpenNeverCallsDirectoryExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	createTestFile(t, filepath.Join(tmpDir, "sub/file.txt"))
+
+	spy := &spyVFS{FS: osvfs.FS()}
+	adapter := &vfsAdapter{vfs: spy, root: tmpDir}
+
+	// Open root
+	_, err := adapter.Open(".")
+	assert.NilError(t, err)
+	// Open subdirectory
+	_, err = adapter.Open("sub")
+	assert.NilError(t, err)
+
+	assert.Equal(t, spy.directoryExistsCalls, 0, "Open should never call DirectoryExists")
 }


### PR DESCRIPTION
## Summary

Optimize gitignore scanning and `vfsAdapter` to reduce lint time on large monorepos.

**Fix 1: `collectGitignoreGlobs` skips config-ignored directories**

`collectGitignoreGlobs` now accepts config ignores and uses `isDirPathBlocked` to skip directories that are directory-level blocked by the lint config (e.g., `**/tests/**`). This is safe because `isDirPathBlocked` is the same function used by the linter's `GetConfigForFile` — if a directory is blocked here, its files will never be linted, so their `.gitignore` patterns are irrelevant.

**Fix 2: `vfsAdapter.Open()` removes redundant `DirectoryExists` stat**

`vfsAdapter` is only used by `fs.WalkDir` in `DiscoverGapFiles`, where `Open()` is only called on directories (via Go's internal `readDir` function). The `DirectoryExists` stat call was redundant since the parent's `ReadDir` already confirmed the entry is a directory. Removing it eliminates one stat syscall per directory visited.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).