### PR TITLE
feat: port rule import/newline-after-import

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -1,6 +1,7 @@
 package import_plugin
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_webpack_loader_syntax"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -8,6 +9,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		newline_after_import.NewlineAfterImportRule,
 		no_self_import.NoSelfImportRule,
 		no_webpack_loader_syntax.NoWebpackLoaderSyntax,
 	}

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import.go
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import.go
@@ -95,20 +95,20 @@ func checkImportDeclarations(ctx rule.RuleContext, statements []*ast.Node, lineS
 		if !isImportStatement(stmt) {
 			continue
 		}
-		if i+1 >= len(statements) {
-			continue
-		}
 
-		nextStmt := statements[i+1]
-
-		// When considerComments is enabled, a comment close to the import
-		// (within count+1 lines) is checked instead of the next statement.
-		// For imports the window anchor is the statement itself (import node = statement).
+		// ESLint's checkImport checks considerComments before checking if nextNode
+		// exists, so a trailing comment after the last import can still trigger a report.
 		if opts.considerComments {
 			if checkCommentGap(ctx, stmt, stmt.End(), lineStarts, text, opts, "import") {
 				continue
 			}
 		}
+
+		if i+1 >= len(statements) {
+			continue
+		}
+
+		nextStmt := statements[i+1]
 
 		if isImportStatement(nextStmt) {
 			continue

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import.go
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import.go
@@ -1,0 +1,267 @@
+package newline_after_import
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type ruleOptions struct {
+	count            int
+	exactCount       bool
+	considerComments bool
+}
+
+func parseOptions(options any) ruleOptions {
+	opts := ruleOptions{count: 1}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["count"]; ok {
+			if f, ok := v.(float64); ok && f >= 1 {
+				opts.count = int(f)
+			}
+		}
+		if v, ok := optsMap["exactCount"]; ok {
+			if b, ok := v.(bool); ok {
+				opts.exactCount = b
+			}
+		}
+		if v, ok := optsMap["considerComments"]; ok {
+			if b, ok := v.(bool); ok {
+				opts.considerComments = b
+			}
+		}
+	}
+	return opts
+}
+
+func makeMessage(typ string, count int) rule.RuleMessage {
+	s := ""
+	if count > 1 {
+		s = "s"
+	}
+	id := "newlineAfterImport"
+	if typ == "require" {
+		id = "newlineAfterRequire"
+	}
+	return rule.RuleMessage{
+		Id:          id,
+		Description: fmt.Sprintf("Expected %d empty line%s after %s statement not followed by another %s.", count, s, typ, typ),
+	}
+}
+
+// NewlineAfterImportRule enforces a newline after import/require statements.
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md
+var NewlineAfterImportRule = rule.Rule{
+	Name: "import/newline-after-import",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		// The linter visits SourceFile's children (not the SourceFile node itself),
+		// so a KindSourceFile listener would never fire. Process top-level statements directly.
+		sourceFile := ctx.SourceFile
+		if sourceFile != nil && sourceFile.Statements != nil {
+			statements := sourceFile.Statements.Nodes
+			lineStarts := sourceFile.ECMALineMap()
+			text := sourceFile.Text()
+
+			checkImportDeclarations(ctx, statements, lineStarts, text, opts)
+			checkRequireCalls(ctx, statements, lineStarts, text, opts)
+		}
+
+		return rule.RuleListeners{}
+	},
+}
+
+// isImportStatement returns true for ImportDeclaration and non-export ImportEqualsDeclaration.
+// "export import x = ..." is excluded because it re-exports rather than imports.
+func isImportStatement(stmt *ast.Node) bool {
+	switch stmt.Kind {
+	case ast.KindImportDeclaration:
+		return true
+	case ast.KindImportEqualsDeclaration:
+		return !ast.HasSyntacticModifier(stmt, ast.ModifierFlagsExport)
+	}
+	return false
+}
+
+func checkImportDeclarations(ctx rule.RuleContext, statements []*ast.Node, lineStarts []core.TextPos, text string, opts ruleOptions) {
+	for i, stmt := range statements {
+		if !isImportStatement(stmt) {
+			continue
+		}
+		if i+1 >= len(statements) {
+			continue
+		}
+
+		nextStmt := statements[i+1]
+
+		// When considerComments is enabled, a comment close to the import
+		// (within count+1 lines) is checked instead of the next statement.
+		// For imports the window anchor is the statement itself (import node = statement).
+		if opts.considerComments {
+			if checkCommentGap(ctx, stmt, stmt.End(), lineStarts, text, opts, "import") {
+				continue
+			}
+		}
+
+		if isImportStatement(nextStmt) {
+			continue
+		}
+
+		checkForNewLine(ctx, stmt, nextStmt, lineStarts, text, opts, "import")
+	}
+}
+
+// findLastTopLevelRequire returns the last (in document order) top-level require() call
+// not nested inside a function, block, object literal, or decorator.
+// Returns nil if no top-level require is found.
+// This mirrors ESLint's level-tracking for require detection.
+func findLastTopLevelRequire(node *ast.Node) *ast.Node {
+	if ast.IsRequireCall(node, true /* requireStringLiteralLikeArgument */) {
+		return node
+	}
+	var result *ast.Node
+	node.ForEachChild(func(child *ast.Node) bool {
+		switch child.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+			ast.KindBlock, ast.KindObjectLiteralExpression, ast.KindDecorator:
+			return false // these create a new scope level in ESLint
+		}
+		if found := findLastTopLevelRequire(child); found != nil {
+			result = found
+			// Don't stop — keep scanning to find the last one in document order.
+		}
+		return false
+	})
+	return result
+}
+
+func checkRequireCalls(ctx rule.RuleContext, statements []*ast.Node, lineStarts []core.TextPos, text string, opts ruleOptions) {
+	for i, stmt := range statements {
+		requireCall := findLastTopLevelRequire(stmt)
+		if requireCall == nil {
+			continue
+		}
+		if i+1 >= len(statements) {
+			continue
+		}
+
+		nextStmt := statements[i+1]
+
+		// For requires, ESLint uses the require CALL's end line for the comment search
+		// window, but the containing STATEMENT's end line for the gap calculation.
+		if opts.considerComments {
+			if checkCommentGap(ctx, stmt, requireCall.End(), lineStarts, text, opts, "require") {
+				continue
+			}
+		}
+
+		if findLastTopLevelRequire(nextStmt) != nil {
+			continue
+		}
+
+		checkForNewLine(ctx, stmt, nextStmt, lineStarts, text, opts, "require")
+	}
+}
+
+// getReportPos returns the position used for diagnostic reporting, following ESLint's convention:
+//   - single-line node → trimmed start position (preserves original column)
+//   - multi-line node  → column 0 of the node's end line
+func getReportPos(node *ast.Node, text string, lineStarts []core.TextPos) int {
+	trimmedPos := scanner.SkipTrivia(text, node.Pos())
+	startLine := scanner.ComputeLineOfPosition(lineStarts, trimmedPos)
+	endLine := scanner.ComputeLineOfPosition(lineStarts, node.End())
+
+	if startLine == endLine {
+		return trimmedPos
+	}
+	return int(lineStarts[endLine])
+}
+
+// checkForNewLine reports when the gap between node and nextNode doesn't satisfy the count/exactCount options.
+func checkForNewLine(ctx rule.RuleContext, node, nextNode *ast.Node, lineStarts []core.TextPos, text string, opts ruleOptions, typ string) {
+	nodeEndLine := scanner.ComputeLineOfPosition(lineStarts, node.End())
+	nextNodeStart := scanner.SkipTrivia(text, nextNode.Pos())
+	nextNodeStartLine := scanner.ComputeLineOfPosition(lineStarts, nextNodeStart)
+
+	lineDiff := nextNodeStartLine - nodeEndLine
+	expectedDiff := opts.count + 1
+
+	if lineDiff < expectedDiff || (opts.exactCount && lineDiff != expectedDiff) {
+		pos := getReportPos(node, text, lineStarts)
+		reportRange := core.NewTextRange(pos, pos)
+		msg := makeMessage(typ, opts.count)
+
+		// When exactCount is set and there are too many blank lines, report without fix.
+		if opts.exactCount && lineDiff > expectedDiff {
+			ctx.ReportRange(reportRange, msg)
+		} else {
+			fix := rule.RuleFixInsertAfter(node, strings.Repeat("\n", expectedDiff-lineDiff))
+			ctx.ReportRangeWithFixes(reportRange, msg, fix)
+		}
+	}
+}
+
+// checkCommentGap looks for a comment within count+1 lines after windowAnchorEnd.
+// If found, reports when the gap between the statement (node) and the comment is too small.
+// (following ESLint's commentAfterImport semantics: only "too few lines" is reported,
+// not "too many" — even with exactCount).
+// Returns true if a relevant comment was found (regardless of whether an error was reported).
+//
+// windowAnchorEnd controls the search window:
+//   - For imports: stmt.End() (the import node IS the statement)
+//   - For requires: requireCall.End() (ESLint uses the require call's end line for the window,
+//     but the containing statement's end line for the gap calculation)
+//
+// It checks trailing comments first (same line as the node), then leading comments
+// (on subsequent lines), because GetLeadingCommentRanges skips same-line comments
+// (collecting starts false until a newline is encountered).
+func checkCommentGap(ctx rule.RuleContext, node *ast.Node, windowAnchorEnd int, lineStarts []core.TextPos, text string, opts ruleOptions, typ string) bool {
+	windowEndLine := scanner.ComputeLineOfPosition(lineStarts, windowAnchorEnd)
+	stmtEndLine := scanner.ComputeLineOfPosition(lineStarts, node.End())
+
+	nodeFactory := &ast.NodeFactory{}
+
+	// Check trailing comments (same line as node end).
+	for commentRange := range scanner.GetTrailingCommentRanges(nodeFactory, text, node.End()) {
+		commentLine := scanner.ComputeLineOfPosition(lineStarts, commentRange.Pos())
+		if commentLine >= windowEndLine && commentLine <= windowEndLine+opts.count+1 {
+			return handleCommentInGap(ctx, node, lineStarts, text, opts, typ, commentLine, stmtEndLine)
+		}
+	}
+
+	// Check leading comments (after the next newline).
+	for commentRange := range scanner.GetLeadingCommentRanges(nodeFactory, text, node.End()) {
+		commentLine := scanner.ComputeLineOfPosition(lineStarts, commentRange.Pos())
+		if commentLine > windowEndLine+opts.count+1 {
+			break // past the search window
+		}
+		if commentLine >= windowEndLine {
+			return handleCommentInGap(ctx, node, lineStarts, text, opts, typ, commentLine, stmtEndLine)
+		}
+	}
+
+	return false
+}
+
+// handleCommentInGap reports when the gap between the statement end and the comment is too small.
+// Always returns true to indicate a comment was found.
+func handleCommentInGap(ctx rule.RuleContext, node *ast.Node, lineStarts []core.TextPos, text string, opts ruleOptions, typ string, commentLine, stmtEndLine int) bool {
+	lineDiff := commentLine - stmtEndLine
+	expectedDiff := opts.count + 1
+
+	if lineDiff < expectedDiff {
+		pos := getReportPos(node, text, lineStarts)
+		reportRange := core.NewTextRange(pos, pos)
+		msg := makeMessage(typ, opts.count)
+		fix := rule.RuleFixInsertAfter(node, strings.Repeat("\n", expectedDiff-lineDiff))
+		ctx.ReportRangeWithFixes(reportRange, msg, fix)
+	}
+	return true
+}

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import.md
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import.md
@@ -1,0 +1,42 @@
+# newline-after-import
+
+## Rule Details
+
+Enforces having one or more empty lines after the last top-level import statement or require call.
+
+This rule supports the following options:
+
+- `count` which sets the number of newlines that are enforced after the last top-level import statement or require call. This option defaults to `1`.
+- `exactCount` which enforces the exact number of newlines mentioned in `count`. This option defaults to `false`.
+- `considerComments` which enforces the rule on comments after the last import statement as well when set to true. This option defaults to `false`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import * as foo from 'foo';
+const FOO = 'BAR';
+```
+
+```javascript
+const FOO = require('./foo');
+const BAZ = 1;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import defaultExport from './foo';
+
+const FOO = 'BAR';
+```
+
+```javascript
+const FOO = require('./foo');
+const BAR = require('./bar');
+
+const BAZ = 1;
+```
+
+## Original Documentation
+
+- [eslint-plugin-import/newline-after-import](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md)

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import_test.go
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import_test.go
@@ -1,0 +1,516 @@
+package newline_after_import_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNewlineAfterImportRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&newline_after_import.NewlineAfterImportRule,
+		[]rule_tester.ValidTestCase{
+			// ===== Import declarations =====
+
+			// Consecutive imports (no code after)
+			{Code: "import path from 'path';\nimport foo from 'foo';\n"},
+			// Inline consecutive imports
+			{Code: "import path from 'path';import foo from 'foo';\n"},
+			// Consecutive imports + blank line + code
+			{Code: "import path from 'path';import foo from 'foo';\n\nvar bar = 42;"},
+			// Single import + blank line + code
+			{Code: "import foo from 'foo';\n\nvar bar = 'bar';"},
+			// Import with no code after (end of file)
+			{Code: "import foo from 'foo';"},
+			// Empty file
+			{Code: ""},
+			// Various import forms
+			{Code: "import * as foo from 'foo';\n\nvar x = 1;"},
+			{Code: "import 'side-effect';\n\nvar x = 1;"},
+			{Code: "import type { Foo } from 'foo';\n\nvar x = 1;"},
+			// Import groups separated by code (each group has its own blank line)
+			{Code: "import foo from 'foo';\n\nvar a = 123;\n\nimport { bar } from './bar-lib';"},
+			// Import followed by export block
+			{Code: "import stub from './stub';\n\nexport { stub }"},
+
+			// ===== count option =====
+
+			{Code: "import foo from 'foo';\n\n\nvar bar = 'bar';", Options: map[string]interface{}{"count": 2.0}},
+			{Code: "import foo from 'foo';\n\n\n\n\nvar bar = 'bar';", Options: map[string]interface{}{"count": 4.0}},
+			// More lines than count is OK when exactCount is false
+			{Code: "import foo from 'foo';\n\n\nvar bar = 'bar';", Options: map[string]interface{}{"count": 1.0}},
+
+			// ===== exactCount option =====
+
+			{Code: "import foo from 'foo';\n\n\nvar bar = 'bar';", Options: map[string]interface{}{"count": 2.0, "exactCount": true}},
+			{Code: "import foo from 'foo';\n\nvar bar = 'bar';", Options: map[string]interface{}{"count": 1.0, "exactCount": true}},
+
+			// ===== considerComments option =====
+
+			// Enough blank lines before comment
+			{
+				Code:    "import foo from 'foo';\n\n// Some random comment\nvar bar = 'bar';",
+				Options: map[string]interface{}{"count": 1.0, "exactCount": true, "considerComments": true},
+			},
+			{
+				Code:    "import foo from 'foo';\n\n\n// Some random comment\nvar bar = 'bar';",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true, "considerComments": true},
+			},
+			// Without considerComments, comments don't affect gap calculation
+			{
+				Code:    "import foo from 'foo';\n\n// Some random comment\nvar bar = 'bar';",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true},
+			},
+			{
+				Code:    "import foo from 'foo';\n// Some random comment\nvar bar = 'bar';",
+				Options: map[string]interface{}{"count": 1.0, "exactCount": true},
+			},
+			// Multiline block comment between import and code (without considerComments)
+			{Code: "import path from 'path';\nimport foo from 'foo';\n/**\n * some multiline comment here\n * another line of comment\n**/\nvar bar = 42;"},
+			// Inline import + multiline comment with considerComments
+			{
+				Code:    "import path from 'path';import foo from 'foo';\n\n/**\n * some multiline comment here\n * another line of comment\n**/\nvar bar = 42;",
+				Options: map[string]interface{}{"considerComments": true},
+			},
+			// Single-line comment after consecutive imports (without considerComments)
+			{Code: "import path from 'path';\nimport foo from 'foo';\n\n// Some random single line comment\nvar bar = 42;"},
+			// Leading comment before import (should not affect)
+			{Code: "/**\n * A leading comment\n */\nimport foo from 'foo';\n\n// Some random comment\nexport {foo};", Options: map[string]interface{}{"count": 2.0, "exactCount": true}},
+
+			// ===== Require calls =====
+
+			// Consecutive requires (no code after)
+			{Code: "var path = require('path');\nvar foo = require('foo');\n"},
+			// Single require (no code after)
+			{Code: "require('foo');"},
+			// Require + blank line + code
+			{Code: "var foo = require('foo-module');\n\nvar foo = 'bar';"},
+			// Require with count
+			{Code: "var foo = require('foo-module');\n\n\nvar foo = 'bar';", Options: map[string]interface{}{"count": 2.0}},
+			{Code: "var foo = require('foo-module');\n\n\n\n\nvar foo = 'bar';", Options: map[string]interface{}{"count": 4.0}},
+			{Code: "var foo = require('foo-module');\n\n\n\n\nvar foo = 'bar';", Options: map[string]interface{}{"count": 4.0, "exactCount": true}},
+			// Bare require + code
+			{Code: "require('foo-module');\n\nvar foo = 'bar';"},
+			// Require groups separated by code
+			{Code: "var foo = require('foo-module');\n\nvar a = 123;\n\nvar bar = require('bar-lib');"},
+			// Require with considerComments
+			{
+				Code:    "var foo = require('foo-module');\n\n\n// Some random comment\nvar foo = 'bar';",
+				Options: map[string]interface{}{"count": 2.0, "considerComments": true},
+			},
+			{
+				Code:    "var foo = require('foo-module');\n\n\n/**\n * Test comment\n */\nvar foo = 'bar';",
+				Options: map[string]interface{}{"count": 2.0, "considerComments": true},
+			},
+			// exactCount + considerComments for require
+			{
+				Code:    "const foo = require('foo');\n\n\n// some random comment\nconst bar = function() {};",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true, "considerComments": true},
+			},
+			// exactCount without considerComments — comment in gap doesn't matter
+			{
+				Code:    "var foo = require('foo-module');\n\n// Some random comment\n\n\nvar foo = 'bar';",
+				Options: map[string]interface{}{"count": 4.0, "exactCount": true},
+			},
+			// exactCount + considerComments — comment in gap measured correctly
+			{
+				Code:    "var foo = require('foo-module');\n\n\n\n\n// Some random comment\nvar foo = 'bar';",
+				Options: map[string]interface{}{"count": 4.0, "exactCount": true, "considerComments": true},
+			},
+
+			// ===== Require scope boundaries (should NOT be detected as top-level) =====
+
+			// Require inside function
+			{Code: "function x() { require('baz'); }"},
+			// Require inside arrow function
+			{Code: "const x = () => require('baz');\nvar y = 1;"},
+			// Require inside nested function with logic
+			{Code: "function a() {\n  var assign = Object.assign || require('object-assign');\n  var foo = require('foo');\n  var bar = 42;\n}"},
+			// Require inside if block
+			{Code: "if (true) {\n  var foo = require('foo');\n  foo();\n}"},
+			// Require inside switch (case body is NOT a Block — require IS top-level per ESLint)
+			{Code: "switch ('foo') { case 'bar': require('baz'); }"},
+			// Require as argument inside function (arrow function scopes it)
+			{Code: "const x = () => require('baz')\n    , y = () => require('bar')"},
+			// Require in binary expression inside arrow function
+			{Code: "const x = () => require('baz') && require('bar')"},
+			// Require as standalone argument (no code after — valid)
+			{Code: "a(require('b'), require('c'), require('d'));"},
+			// Require inside object literal
+			{Code: "var x = { foo: require('foo') };\nvar y = 1;"},
+			// Complex switch inside function
+			{Code: "function foo() {\n  switch (renderData.modalViewKey) {\n    case 'value':\n      var bar = require('bar');\n      return bar(renderData, options)\n    default:\n      return renderData.mainModalContent.clone()\n  }\n}"},
+			// Arrow with block body
+			{Code: "const x = () => { return require('baz'); };\nvar y = 1;"},
+			// Nested arrow
+			{Code: "const x = () => () => require('baz');\nvar y = 1;"},
+			// Arrow in ternary (requires scoped inside arrows)
+			{Code: "var foo = condition ? () => require('a') : () => require('b');\nvar bar = 42;"},
+
+			// ===== Multi-line require + considerComments (window anchored to require call) =====
+
+			// Multi-line require stmt: require call ends line 0, stmt ends line 1.
+			// Comment on line 3 is within window [0, 2] (anchored to require call end).
+			// Gap: commentLine(3) - stmtEndLine(1) = 2 = expected(2) → valid.
+			{
+				Code:    "var x = require('foo') +\n    123;\n\n// comment\nvar bar = 42;",
+				Options: map[string]interface{}{"count": 1.0, "considerComments": true},
+			},
+			// Multi-line require stmt with count:2, enough gap before comment.
+			{
+				Code:    "var x = require('foo') +\n    123;\n\n\n// comment\nvar bar = 42;",
+				Options: map[string]interface{}{"count": 2.0, "considerComments": true},
+			},
+
+			// ===== TSImportEqualsDeclaration =====
+
+			{Code: "import { ReturnValue } from 'runner';\nimport runner = require('runner');"},
+			{Code: "import runner = require('runner');\nimport { ReturnValue } from 'runner';"},
+			// Mixed import, import=require, and another import
+			{Code: "import { ReturnValue } from 'runner';\nimport runner = require('runner');\nimport { OtherValue } from 'other';"},
+			// export import (should be skipped — it's a re-export, not an import)
+			{Code: "export import a = obj;\nf(a);"},
+			// Internal module import followed by export import
+			{Code: "import { ns } from 'namespace';\nimport Bar = ns.baz.foo.Bar;\n\nexport import Foo = ns.baz.bar.Foo;"},
+
+			// ===== Arrow + require in considerComments valid =====
+
+			{
+				Code:    "const x = () => require('baz')\n    , y = () => require('bar')\n\n// some comment here\n",
+				Options: map[string]interface{}{"considerComments": true},
+			},
+			{
+				Code:    "const x = () => require('baz') && require('bar')\n\n// Some random single line comment\nvar bar = 42;",
+				Options: map[string]interface{}{"considerComments": true},
+			},
+			{
+				Code:    "const x = () => require('baz') && require('bar')\n\n// Some random single line comment\nvar bar = 42;",
+				Options: map[string]interface{}{"considerComments": true, "count": 1.0, "exactCount": true},
+			},
+
+			// ===== Decorator class =====
+
+			// Decorated class with sufficient gap
+			{Code: "import foo from 'foo';\n\n@SomeDecorator(foo)\nclass Foo {}"},
+			// Export default decorated class with sufficient gap
+			{Code: "import foo from 'foo';\n\n@SomeDecorator(foo)\nexport default class Test {}"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ===== Basic import errors =====
+
+			// Single import → code (no blank line)
+			{
+				Code:   "import foo from 'foo';\nexport default function() {};",
+				Output: []string{"import foo from 'foo';\n\nexport default function() {};"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// count: 2 (too few lines)
+			{
+				Code:    "import foo from 'foo';\n\nexport default function() {};",
+				Output:  []string{"import foo from 'foo';\n\n\nexport default function() {};"},
+				Options: map[string]interface{}{"count": 2.0},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// Multiple imports, last one needs newline
+			{
+				Code:   "import path from 'path';\nimport foo from 'foo';\nvar bar = 42;",
+				Output: []string{"import path from 'path';\nimport foo from 'foo';\n\nvar bar = 42;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 2, Column: 1,
+				}},
+			},
+			// Inline imports on same line
+			{
+				Code:   "import path from 'path';import foo from 'foo';var bar = 42;",
+				Output: []string{"import path from 'path';import foo from 'foo';\n\nvar bar = 42;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 25,
+				}},
+			},
+			// Two import groups separated by code — both need newlines
+			{
+				Code:   "import foo from 'foo';\nvar a = 123;\n\nimport { bar } from './bar-lib';\nvar b=456;",
+				Output: []string{"import foo from 'foo';\n\nvar a = 123;\n\nimport { bar } from './bar-lib';\n\nvar b=456;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "newlineAfterImport", Line: 1, Column: 1},
+					{MessageId: "newlineAfterImport", Line: 4, Column: 1},
+				},
+			},
+			// With count: 1 option explicitly
+			{
+				Code:    "import foo from 'foo';\nexport default function() {};",
+				Output:  []string{"import foo from 'foo';\n\nexport default function() {};"},
+				Options: map[string]interface{}{"count": 1.0},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+
+			// ===== Require errors =====
+
+			// Single require → code
+			{
+				Code:   "var foo = require('foo-module');\nvar something = 123;",
+				Output: []string{"var foo = require('foo-module');\n\nvar something = 123;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 1, Column: 1,
+				}},
+			},
+			// Consecutive requires → code
+			{
+				Code:   "var path = require('path');\nvar foo = require('foo');\nvar bar = 42;",
+				Output: []string{"var path = require('path');\nvar foo = require('foo');\n\nvar bar = 42;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 2, Column: 1,
+				}},
+			},
+			// Two require groups separated by non-require code
+			{
+				Code:   "var foo = require('foo-module');\nvar a = 123;\n\nvar bar = require('bar-lib');\nvar b=456;",
+				Output: []string{"var foo = require('foo-module');\n\nvar a = 123;\n\nvar bar = require('bar-lib');\n\nvar b=456;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "newlineAfterRequire", Line: 1, Column: 1},
+					{MessageId: "newlineAfterRequire", Line: 4, Column: 1},
+				},
+			},
+			// Bare require followed by bare require followed by code
+			{
+				Code:   "var foo = require('foo-module');\nvar a = 123;\n\nrequire('bar-lib');\nvar b=456;",
+				Output: []string{"var foo = require('foo-module');\n\nvar a = 123;\n\nrequire('bar-lib');\n\nvar b=456;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "newlineAfterRequire", Line: 1, Column: 1},
+					{MessageId: "newlineAfterRequire", Line: 4, Column: 1},
+				},
+			},
+			// Require in binary expression (not inside function — IS top-level)
+			{
+				Code:   "var assign = Object.assign || require('object-assign');\nvar foo = require('foo');\nvar bar = 42;",
+				Output: []string{"var assign = Object.assign || require('object-assign');\nvar foo = require('foo');\n\nvar bar = 42;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 2, Column: 1,
+				}},
+			},
+			// Mixed: require, then foo(require, require, require), then require, then code
+			{
+				Code:   "require('a');\nfoo(require('b'), require('c'), require('d'));\nrequire('d');\nvar foo = 'bar';",
+				Output: []string{"require('a');\nfoo(require('b'), require('c'), require('d'));\nrequire('d');\n\nvar foo = 'bar';"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 3, Column: 1,
+				}},
+			},
+			// Multi-line function call containing requires
+			{
+				Code:   "require('a');\nfoo(\nrequire('b'),\nrequire('c'),\nrequire('d')\n);\nvar foo = 'bar';",
+				Output: []string{"require('a');\nfoo(\nrequire('b'),\nrequire('c'),\nrequire('d')\n);\n\nvar foo = 'bar';"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 6, Column: 1,
+				}},
+			},
+			// Ternary with direct requires (NOT inside arrow) — IS top-level
+			{
+				Code:   "var foo = condition ? require('a') : require('b');\nvar bar = 42;",
+				Output: []string{"var foo = condition ? require('a') : require('b');\n\nvar bar = 42;"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 1, Column: 1,
+				}},
+			},
+
+			// ===== exactCount =====
+
+			// Too few lines with exactCount (fixable)
+			{
+				Code:    "import foo from 'foo';\n\nexport default function() {};",
+				Output:  []string{"import foo from 'foo';\n\n\nexport default function() {};"},
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// Too many lines with exactCount (no fix)
+			{
+				Code:    "import foo from 'foo';\n\n\n\nexport default function() {};",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// Way too many lines with exactCount (no fix)
+			{
+				Code:    "import foo from 'foo';\n\n\n\n\nexport default function() {};",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// exactCount with count=1 (same line — no newline at all)
+			{
+				Code:    "import foo from 'foo';export default function() {};",
+				Output:  []string{"import foo from 'foo';\n\nexport default function() {};"},
+				Options: map[string]interface{}{"count": 1.0, "exactCount": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// exactCount too many for require (no fix)
+			{
+				Code:    "const foo = require('foo');\n\n\n\nconst bar = function() {};",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 1, Column: 1,
+				}},
+			},
+
+			// ===== considerComments =====
+
+			// Comment too close to import
+			{
+				Code:    "import path from 'path';\nimport foo from 'foo';\n// Some random single line comment\nvar bar = 42;",
+				Output:  []string{"import path from 'path';\nimport foo from 'foo';\n\n// Some random single line comment\nvar bar = 42;"},
+				Options: map[string]interface{}{"considerComments": true, "count": 1.0},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 2, Column: 1,
+				}},
+			},
+			// Multiline block comment too close to import
+			{
+				Code:    "import path from 'path';\nimport foo from 'foo';\n/**\n * some multiline comment here\n * another line of comment\n**/\nvar bar = 42;",
+				Output:  []string{"import path from 'path';\nimport foo from 'foo';\n\n/**\n * some multiline comment here\n * another line of comment\n**/\nvar bar = 42;"},
+				Options: map[string]interface{}{"considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 2, Column: 1,
+				}},
+			},
+			// considerComments with count: 2 (require + multiline comment)
+			{
+				Code:    "var foo = require('foo-module');\n\n/**\n * Test comment\n */\nvar foo = 'bar';",
+				Output:  []string{"var foo = require('foo-module');\n\n\n/**\n * Test comment\n */\nvar foo = 'bar';"},
+				Options: map[string]interface{}{"considerComments": true, "count": 2.0},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 1, Column: 1,
+				}},
+			},
+			// considerComments + exactCount: too few lines before comment
+			{
+				Code:    "import foo from 'foo';\n// some random comment\nexport default function() {};",
+				Output:  []string{"import foo from 'foo';\n\n\n// some random comment\nexport default function() {};"},
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true, "considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// considerComments + exactCount: too many lines before comment (no fix)
+			{
+				Code:    "import foo from 'foo';\n\n\n\n// some random comment\nexport default function() {};",
+				Options: map[string]interface{}{"count": 2.0, "exactCount": true, "considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// Same-line trailing comment with considerComments
+			{
+				Code:    "import foo from 'foo';// some random comment\nexport default function() {};",
+				Output:  []string{"import foo from 'foo';\n\n// some random comment\nexport default function() {};"},
+				Options: map[string]interface{}{"count": 1.0, "exactCount": true, "considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+			// Consecutive requires + comment with considerComments + count: 2
+			{
+				Code:    "var foo = require('foo-module');\nvar foo = require('foo-module');\n\n// Some random comment\nvar foo = 'bar';",
+				Output:  []string{"var foo = require('foo-module');\nvar foo = require('foo-module');\n\n\n// Some random comment\nvar foo = 'bar';"},
+				Options: map[string]interface{}{"considerComments": true, "count": 2.0},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 2, Column: 1,
+				}},
+			},
+			// exactCount + considerComments: too many blank lines before comment (no fix, fallback)
+			{
+				Code:    "import foo from 'foo';\n\n\n// Some random single line comment\nvar bar = 42;",
+				Options: map[string]interface{}{"considerComments": true, "count": 1.0, "exactCount": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+
+			// ===== Multi-line import =====
+
+			// Multi-line import, column reports at col 0 of end line
+			{
+				Code:    "\nimport { A, B, C, D } from\n'../path/to/my/module/in/very/far/directory'\n// some comment\nvar foo = 'bar';\n",
+				Output:  []string{"\nimport { A, B, C, D } from\n'../path/to/my/module/in/very/far/directory'\n\n// some comment\nvar foo = 'bar';\n"},
+				Options: map[string]interface{}{"considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 3, Column: 1,
+				}},
+			},
+
+			// ===== Mixed import and require =====
+
+			// Import followed by require (both need newlines)
+			{
+				Code:   "import foo from 'foo';\nvar bar = require('bar');\nvar baz = 42;",
+				Output: []string{"import foo from 'foo';\n\nvar bar = require('bar');\n\nvar baz = 42;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "newlineAfterImport", Line: 1, Column: 1},
+					{MessageId: "newlineAfterRequire", Line: 2, Column: 1},
+				},
+			},
+
+			// ===== Multi-line require + considerComments =====
+
+			// Multi-line require stmt: require call ends line 0, stmt ends line 1.
+			// Comment on line 2 is within window [0, 2]. Gap: 2 - 1 = 1 < 2 → error.
+			{
+				Code:    "var x = require('foo') +\n    123;\n// comment\nvar bar = 42;",
+				Output:  []string{"var x = require('foo') +\n    123;\n\n// comment\nvar bar = 42;"},
+				Options: map[string]interface{}{"count": 1.0, "considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 2, Column: 1,
+				}},
+			},
+			// Multi-line require stmt with count:2. Comment too close.
+			{
+				Code:    "var x = require('foo') +\n    123;\n\n// comment\nvar bar = 42;",
+				Output:  []string{"var x = require('foo') +\n    123;\n\n\n// comment\nvar bar = 42;"},
+				Options: map[string]interface{}{"count": 2.0, "considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterRequire", Line: 2, Column: 1,
+				}},
+			},
+
+			// ===== Decorator class =====
+
+			// Decorated class immediately after import (no blank line)
+			{
+				Code:   "import foo from 'foo';\n@SomeDecorator(foo)\nclass Foo {}",
+				Output: []string{"import foo from 'foo';\n\n@SomeDecorator(foo)\nclass Foo {}"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+
+			// ===== Comment between consecutive imports (with considerComments) =====
+
+			// Both imports report: first because comment is too close, second because no blank line before code
+			{
+				Code:    "import path from 'path';\n// comment\nimport foo from 'foo';\nvar bar = 42;",
+				Output:  []string{"import path from 'path';\n\n// comment\nimport foo from 'foo';\n\nvar bar = 42;"},
+				Options: map[string]interface{}{"considerComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "newlineAfterImport", Line: 1, Column: 1},
+					{MessageId: "newlineAfterImport", Line: 3, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/plugins/import/rules/newline_after_import/newline_after_import_test.go
+++ b/internal/plugins/import/rules/newline_after_import/newline_after_import_test.go
@@ -199,6 +199,14 @@ func TestNewlineAfterImportRule(t *testing.T) {
 			{Code: "import foo from 'foo';\n\n@SomeDecorator(foo)\nclass Foo {}"},
 			// Export default decorated class with sufficient gap
 			{Code: "import foo from 'foo';\n\n@SomeDecorator(foo)\nexport default class Test {}"},
+
+			// ===== Last import + trailing comment (considerComments) =====
+
+			// Last import with enough gap before trailing comment
+			{
+				Code:    "import foo from 'foo';\n\n// trailing comment",
+				Options: map[string]interface{}{"considerComments": true},
+			},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ===== Basic import errors =====
@@ -494,6 +502,18 @@ func TestNewlineAfterImportRule(t *testing.T) {
 			{
 				Code:   "import foo from 'foo';\n@SomeDecorator(foo)\nclass Foo {}",
 				Output: []string{"import foo from 'foo';\n\n@SomeDecorator(foo)\nclass Foo {}"},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "newlineAfterImport", Line: 1, Column: 1,
+				}},
+			},
+
+			// ===== Last import + trailing comment too close (considerComments) =====
+
+			// Last import in file, comment immediately after, no more statements
+			{
+				Code:    "import foo from 'foo';\n// trailing comment",
+				Output:  []string{"import foo from 'foo';\n\n// trailing comment"},
+				Options: map[string]interface{}{"considerComments": true},
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "newlineAfterImport", Line: 1, Column: 1,
 				}},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
     // eslint-plugin-import
+    './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/newline-after-import.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/newline-after-import.test.ts
@@ -1,0 +1,234 @@
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+const rule = null as never;
+
+const IMPORT_ERROR_MESSAGE =
+  'Expected 1 empty line after import statement not followed by another import.';
+const IMPORT_ERROR_MESSAGE_MULTIPLE = (count: number) =>
+  `Expected ${count} empty lines after import statement not followed by another import.`;
+const REQUIRE_ERROR_MESSAGE =
+  'Expected 1 empty line after require statement not followed by another require.';
+const REQUIRE_ERROR_MESSAGE_MULTIPLE = (count: number) =>
+  `Expected ${count} empty lines after require statement not followed by another require.`;
+
+ruleTester.run('newline-after-import', rule, {
+  valid: [
+    // ===== Import declarations =====
+    { code: `import path from 'path';\nimport foo from 'foo';\n` },
+    { code: `import path from 'path';import foo from 'foo';\n` },
+    { code: `import path from 'path';import foo from 'foo';\n\nvar bar = 42;` },
+    { code: `import foo from 'foo';\n\nvar bar = 'bar';` },
+    { code: `import foo from 'foo';` },
+    // Various import forms
+    { code: `import * as foo from 'foo';\n\nvar x = 1;` },
+    { code: `import 'side-effect';\n\nvar x = 1;` },
+    { code: `import type { Foo } from 'foo';\n\nvar x = 1;` },
+    // Import followed by export block
+    { code: `import stub from './stub';\n\nexport { stub }` },
+
+    // ===== count option =====
+    {
+      code: `import foo from 'foo';\n\n\nvar bar = 'bar';`,
+      options: [{ count: 2 }],
+    },
+    {
+      code: `import foo from 'foo';\n\n\nvar bar = 'bar';`,
+      options: [{ count: 2, exactCount: true }],
+    },
+    {
+      code: `import foo from 'foo';\n\nvar bar = 'bar';`,
+      options: [{ count: 1, exactCount: true }],
+    },
+    // More than required lines (no exactCount)
+    {
+      code: `import foo from 'foo';\n\n\nvar bar = 'bar';`,
+      options: [{ count: 1 }],
+    },
+    {
+      code: `import foo from 'foo';\n\n\n\n\nvar bar = 'bar';`,
+      options: [{ count: 4 }],
+    },
+    // Multiple import groups
+    { code: `import foo from 'foo';\nimport { bar } from './bar-lib';` },
+    {
+      code: `import foo from 'foo';\n\nvar a = 123;\n\nimport { bar } from './bar-lib';`,
+    },
+
+    // ===== considerComments =====
+    {
+      code: `import foo from 'foo';\n\n// Some random comment\nvar bar = 'bar';`,
+      options: [{ count: 1, exactCount: true, considerComments: true }],
+    },
+    {
+      code: `import foo from 'foo';\n\n\n// Some random comment\nvar bar = 'bar';`,
+      options: [{ count: 2, exactCount: true, considerComments: true }],
+    },
+    // Comments without considerComments don't affect gap
+    {
+      code: `import foo from 'foo';\n\n// Some random comment\nvar bar = 'bar';`,
+      options: [{ count: 2, exactCount: true }],
+    },
+    {
+      code: `import foo from 'foo';\n// Some random comment\nvar bar = 'bar';`,
+      options: [{ count: 1, exactCount: true }],
+    },
+    // Multiline block comment without considerComments
+    {
+      code: `import path from 'path';\nimport foo from 'foo';\n/**\n * some multiline comment\n**/\nvar bar = 42;`,
+    },
+
+    // ===== Require calls =====
+    { code: `var path = require('path');\nvar foo = require('foo');\n` },
+    { code: `require('foo');` },
+    { code: `var foo = require('foo-module');\n\nvar foo = 'bar';` },
+    {
+      code: `var foo = require('foo-module');\n\n\nvar foo = 'bar';`,
+      options: [{ count: 2 }],
+    },
+    {
+      code: `var foo = require('foo-module');\n\n\n\n\nvar foo = 'bar';`,
+      options: [{ count: 4, exactCount: true }],
+    },
+    { code: `require('foo-module');\n\nvar foo = 'bar';` },
+    {
+      code: `var foo = require('foo-module');\n\nvar a = 123;\n\nvar bar = require('bar-lib');`,
+    },
+    {
+      code: `var foo = require('foo-module');\n\n\n// Some random comment\nvar foo = 'bar';`,
+      options: [{ count: 2, considerComments: true }],
+    },
+
+    // ===== Require scope boundaries (NOT top-level) =====
+    { code: `function x() { require('baz'); }` },
+    { code: `a(require('b'), require('c'), require('d'));` },
+    { code: `switch ('foo') { case 'bar': require('baz'); }` },
+    { code: `if (true) {\n  var foo = require('foo');\n  foo();\n}` },
+    { code: `const x = () => require('baz') && require('bar')` },
+    { code: `var x = { foo: require('foo') };\nvar y = 1;` },
+
+    // ===== TSImportEqualsDeclaration =====
+    {
+      code: `import { ExecaReturnValue } from 'execa';\nimport execa = require('execa');`,
+    },
+    {
+      code: `import execa = require('execa');\nimport { ExecaReturnValue } from 'execa';`,
+    },
+    { code: `export import a = obj;\nf(a);` },
+
+    // ===== Decorator class =====
+    { code: `import foo from 'foo';\n\n@SomeDecorator(foo)\nclass Foo {}` },
+  ],
+  invalid: [
+    // ===== Basic import errors =====
+    {
+      code: `import foo from 'foo';\nexport default function() {};`,
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+    {
+      code: `import foo from 'foo';\n\nexport default function() {};`,
+      options: [{ count: 2 }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE_MULTIPLE(2) }],
+    },
+    {
+      code: `import path from 'path';\nimport foo from 'foo';\nvar bar = 42;`,
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+    {
+      code: `import path from 'path';import foo from 'foo';var bar = 42;`,
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+    // Two import groups
+    {
+      code: `import foo from 'foo';\nvar a = 123;\n\nimport { bar } from './bar-lib';\nvar b=456;`,
+      errors: [
+        { message: IMPORT_ERROR_MESSAGE },
+        { message: IMPORT_ERROR_MESSAGE },
+      ],
+    },
+
+    // ===== Require errors =====
+    {
+      code: `var foo = require('foo-module');\nvar something = 123;`,
+      errors: [{ message: REQUIRE_ERROR_MESSAGE }],
+    },
+    {
+      code: `var path = require('path');\nvar foo = require('foo');\nvar bar = 42;`,
+      errors: [{ message: REQUIRE_ERROR_MESSAGE }],
+    },
+    // Two require groups
+    {
+      code: `var foo = require('foo-module');\nvar a = 123;\n\nvar bar = require('bar-lib');\nvar b=456;`,
+      errors: [
+        { message: REQUIRE_ERROR_MESSAGE },
+        { message: REQUIRE_ERROR_MESSAGE },
+      ],
+    },
+    // Require in binary expression (top-level)
+    {
+      code: `var assign = Object.assign || require('object-assign');\nvar foo = require('foo');\nvar bar = 42;`,
+      errors: [{ message: REQUIRE_ERROR_MESSAGE }],
+    },
+    // Mixed require with function args
+    {
+      code: `require('a');\nfoo(require('b'), require('c'), require('d'));\nrequire('d');\nvar foo = 'bar';`,
+      errors: [{ message: REQUIRE_ERROR_MESSAGE }],
+    },
+
+    // ===== exactCount =====
+    {
+      code: `import foo from 'foo';\n\nexport default function() {};`,
+      options: [{ count: 2, exactCount: true }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE_MULTIPLE(2) }],
+    },
+    {
+      code: `import foo from 'foo';\n\n\n\nexport default function() {};`,
+      options: [{ count: 2, exactCount: true }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE_MULTIPLE(2) }],
+    },
+    {
+      code: `import foo from 'foo';export default function() {};`,
+      options: [{ count: 1, exactCount: true }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+
+    // ===== considerComments =====
+    {
+      code: `import path from 'path';\nimport foo from 'foo';\n// Some random single line comment\nvar bar = 42;`,
+      options: [{ considerComments: true, count: 1 }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+    {
+      code: `var foo = require('foo-module');\n\n/**\n * Test comment\n */\nvar foo = 'bar';`,
+      options: [{ considerComments: true, count: 2 }],
+      errors: [{ message: REQUIRE_ERROR_MESSAGE_MULTIPLE(2) }],
+    },
+    // considerComments + exactCount
+    {
+      code: `import foo from 'foo';\n// some random comment\nexport default function() {};`,
+      options: [{ count: 2, exactCount: true, considerComments: true }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE_MULTIPLE(2) }],
+    },
+    // Same-line trailing comment with considerComments
+    {
+      code: `import foo from 'foo';// some random comment\nexport default function() {};`,
+      options: [{ count: 1, exactCount: true, considerComments: true }],
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+
+    // ===== Decorator class =====
+    {
+      code: `import foo from 'foo';\n@SomeDecorator(foo)\nclass Foo {}`,
+      errors: [{ message: IMPORT_ERROR_MESSAGE }],
+    },
+
+    // ===== Mixed import + require =====
+    {
+      code: `import foo from 'foo';\nvar bar = require('bar');\nvar baz = 42;`,
+      errors: [
+        { message: IMPORT_ERROR_MESSAGE },
+        { message: REQUIRE_ERROR_MESSAGE },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `import/newline-after-import` rule from eslint-plugin-import to rslint.

Enforces having one or more empty lines after the last top-level import statement or require call. Supports `count`, `exactCount`, and `considerComments` options with autofix.

## Related Links

- Rule documentation: [import/newline-after-import](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/newline-after-import.md)
- Source code: [eslint-plugin-import/src/rules/newline-after-import.js](https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/newline-after-import.js)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).