### PR TITLE
feat: port rule import/first

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -1,6 +1,7 @@
 package import_plugin
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_webpack_loader_syntax"
@@ -9,6 +10,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		first.FirstRule,
 		newline_after_import.NewlineAfterImportRule,
 		no_self_import.NoSelfImportRule,
 		no_webpack_loader_syntax.NoWebpackLoaderSyntax,

--- a/internal/plugins/import/rules/first/first.go
+++ b/internal/plugins/import/rules/first/first.go
@@ -1,0 +1,367 @@
+package first
+
+import (
+	"slices"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/first.js
+var FirstRule = rule.Rule{
+	Name: "import/first",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// The linter visits SourceFile's children but never fires a KindSourceFile
+		// listener, so run the check eagerly before returning listeners.
+		checkFirst(ctx, options)
+		return rule.RuleListeners{}
+	},
+}
+
+// getImportValue returns the module specifier string for an import node.
+// For ImportDeclaration: the string literal in `from '...'`.
+// For ImportEqualsDeclaration with external module: the string in `require('...')`.
+func getImportValue(node *ast.Node) string {
+	switch node.Kind {
+	case ast.KindImportDeclaration:
+		spec := node.AsImportDeclaration().ModuleSpecifier
+		if spec != nil && spec.Kind == ast.KindStringLiteral {
+			return spec.AsStringLiteral().Text
+		}
+	case ast.KindImportEqualsDeclaration:
+		if ast.IsExternalModuleImportEqualsDeclaration(node) {
+			expr := ast.GetExternalModuleImportEqualsDeclarationExpression(node)
+			if expr.Kind == ast.KindStringLiteral {
+				return expr.AsStringLiteral().Text
+			}
+		}
+	}
+	return ""
+}
+
+// hasReferenceBeforeImport checks whether any binding declared by the import
+// node is referenced in a body statement that precedes the import.  This
+// mirrors ESLint's shouldSort / getDeclaredVariables logic.
+//
+// When TypeChecker is available it uses symbol-based matching (accurate: skips
+// type annotations, declaration names, and shadowed identifiers).  Otherwise
+// it falls back to name-based matching (conservative).
+func hasReferenceBeforeImport(ctx rule.RuleContext, body []*ast.Node, importBodyIndex int, importNode *ast.Node) bool {
+	bindingNodes := utils.GetImportBindingNodes(importNode)
+	if len(bindingNodes) == 0 {
+		return false
+	}
+
+	importEnd := importNode.End()
+
+	if ctx.TypeChecker != nil {
+		return hasReferenceBeforeImportSymbol(ctx, body, importBodyIndex, importEnd, bindingNodes)
+	}
+	return hasReferenceBeforeImportName(body, importBodyIndex, bindingNodes)
+}
+
+// hasReferenceBeforeImportSymbol uses TypeChecker.GetSymbolAtLocation for
+// precise symbol matching — only true value/expression references count.
+func hasReferenceBeforeImportSymbol(ctx rule.RuleContext, body []*ast.Node, importBodyIndex int, importEnd int, bindingNodes []*ast.Node) bool {
+	// Resolve symbols for all import bindings.
+	symbolSet := make(map[*ast.Symbol]bool, len(bindingNodes))
+	for _, bn := range bindingNodes {
+		sym := ctx.TypeChecker.GetSymbolAtLocation(bn)
+		if sym != nil {
+			symbolSet[sym] = true
+			if resolved := ctx.TypeChecker.SkipAlias(sym); resolved != nil && resolved != sym {
+				symbolSet[resolved] = true
+			}
+		}
+	}
+	if len(symbolSet) == 0 {
+		return false
+	}
+
+	found := false
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil || found {
+			return
+		}
+		// Only check non-declaration identifier references.
+		if ast.IsIdentifier(node) && !utils.IsDeclarationIdentifier(node) {
+			sym := ctx.TypeChecker.GetSymbolAtLocation(node)
+			if sym != nil && symbolSet[sym] {
+				// Position check: reference must appear before the import's end,
+				// matching ESLint's `reference.identifier.range[0] < node.range[1]`.
+				if node.Pos() < importEnd {
+					found = true
+					return
+				}
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return found // stop early if found
+		})
+	}
+
+	for j := range importBodyIndex {
+		walk(body[j])
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+// hasReferenceBeforeImportName is the fallback when TypeChecker is unavailable.
+// It matches by identifier text — conservative (may suppress fix when ESLint
+// would not, e.g. for type annotations or shadowed names).
+func hasReferenceBeforeImportName(body []*ast.Node, importBodyIndex int, bindingNodes []*ast.Node) bool {
+	nameSet := make(map[string]bool, len(bindingNodes))
+	for _, bn := range bindingNodes {
+		nameSet[bn.Text()] = true
+	}
+
+	var contains func(*ast.Node) bool
+	contains = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		if ast.IsIdentifier(node) && !utils.IsDeclarationIdentifier(node) && nameSet[node.AsIdentifier().Text] {
+			return true
+		}
+		result := false
+		node.ForEachChild(func(child *ast.Node) bool {
+			if contains(child) {
+				result = true
+				return true
+			}
+			return false
+		})
+		return result
+	}
+
+	for j := range importBodyIndex {
+		if contains(body[j]) {
+			return true
+		}
+	}
+	return false
+}
+
+func messageFirst() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "first",
+		Description: "Import in body of module; reorder to top.",
+	}
+}
+
+func messageAbsolute() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "absolute",
+		Description: "Absolute imports should come before relative imports.",
+	}
+}
+
+// errorInfo tracks a misplaced import and the source range to extract when
+// building the autofix (from the end of the previous statement to the end of
+// this import).
+type errorInfo struct {
+	node      *ast.Node
+	rangeFrom int
+	rangeTo   int
+}
+
+func checkFirst(ctx rule.RuleContext, options any) {
+	statements := ctx.SourceFile.Statements
+	if statements == nil || len(statements.Nodes) == 0 {
+		return
+	}
+
+	absoluteFirst := utils.GetOptionsString(options) == "absolute-first"
+	body := statements.Nodes
+	sourceText := ctx.SourceFile.Text()
+
+	nonImportCount := 0
+	anyExpressions := false
+	anyRelative := false
+	var lastLegalImp *ast.Node
+	var errorInfos []errorInfo
+	shouldSort := true
+	lastSortNodesIndex := 0
+
+	for i, node := range body {
+		// Skip directives ('use strict', etc.) that precede any real expression.
+		if !anyExpressions && ast.IsPrologueDirective(node) {
+			continue
+		}
+		anyExpressions = true
+
+		if ast.IsImportOrImportEqualsDeclaration(node) {
+			// absolute-first: report absolute imports that follow a relative import.
+			if absoluteFirst {
+				value := getImportValue(node)
+				if strings.HasPrefix(value, ".") {
+					anyRelative = true
+				} else if anyRelative {
+					// Report on the specifier/reference, not the whole statement.
+					var reportNode *ast.Node
+					if node.Kind == ast.KindImportDeclaration {
+						reportNode = node.AsImportDeclaration().ModuleSpecifier
+					} else {
+						reportNode = node.AsImportEqualsDeclaration().ModuleReference
+					}
+					ctx.ReportNode(reportNode, messageAbsolute())
+				}
+			}
+
+			if nonImportCount > 0 {
+				// This import appears after non-import code.
+				// Check if any of its declared names are referenced before it;
+				// if so, moving the import could change evaluation order, so
+				// disable autofix from this point on.
+				if shouldSort {
+					if hasReferenceBeforeImport(ctx, body, i, node) {
+						shouldSort = false
+					}
+				}
+				if shouldSort {
+					lastSortNodesIndex = len(errorInfos)
+				}
+
+				rangeFrom := 0
+				if i > 0 {
+					rangeFrom = body[i-1].End()
+				}
+
+				errorInfos = append(errorInfos, errorInfo{
+					node:      node,
+					rangeFrom: rangeFrom,
+					rangeTo:   node.End(),
+				})
+			} else {
+				lastLegalImp = node
+			}
+		} else {
+			nonImportCount++
+		}
+	}
+
+	if len(errorInfos) == 0 {
+		return
+	}
+
+	for i, ei := range errorInfos {
+		if i == lastSortNodesIndex {
+			// The last sortable error carries the combined fix that moves all
+			// sortable imports to the top.
+			sortNodes := errorInfos[:lastSortNodesIndex+1]
+			fixes := buildFix(sourceText, body, lastLegalImp, sortNodes)
+			ctx.ReportNodeWithFixes(ei.node, messageFirst(), fixes...)
+		} else if i < lastSortNodesIndex {
+			// Earlier sortable errors get a no-op fix so the fixer treats them
+			// as already handled (avoids overlapping fix conflicts).
+			ctx.ReportNodeWithFixes(ei.node, messageFirst(), rule.RuleFix{
+				Range: core.NewTextRange(ei.node.End(), ei.node.End()),
+				Text:  "",
+			})
+		} else {
+			ctx.ReportNode(ei.node, messageFirst())
+		}
+	}
+}
+
+// buildFix creates a single RuleFix that moves all sortable imports to just
+// after lastLegalImp (or to the very beginning of the file when there is no
+// legal import).  It mirrors ESLint's approach of combining insert + remove
+// operations into one contiguous range replacement.
+func buildFix(sourceText string, body []*ast.Node, lastLegalImp *ast.Node, sortNodes []errorInfo) []rule.RuleFix {
+	// Collect the source text for each misplaced import (including the
+	// whitespace between it and the previous statement).
+	var insertParts []string
+	for _, sn := range sortNodes {
+		nodeText := sourceText[sn.rangeFrom:sn.rangeTo]
+		// If the extracted text starts with a non-whitespace character (e.g.
+		// the import immediately follows a `}` with no line break), prepend a
+		// newline so the moved import appears on its own line.
+		if r, _ := utf8.DecodeRuneInString(nodeText); r != utf8.RuneError && !utils.IsStrWhiteSpace(r) {
+			nodeText = "\n" + nodeText
+		}
+		insertParts = append(insertParts, nodeText)
+	}
+	insertSourceCode := strings.Join(insertParts, "")
+
+	if lastLegalImp == nil {
+		// No preceding legal import: place the imports at the very top and
+		// preserve the original leading whitespace pattern after them.
+		trimmed := strings.TrimSpace(insertSourceCode)
+		leadingWSEnd := strings.IndexFunc(insertSourceCode, func(r rune) bool {
+			return !utils.IsStrWhiteSpace(r)
+		})
+		if leadingWSEnd < 0 {
+			leadingWSEnd = len(insertSourceCode)
+		}
+		insertSourceCode = trimmed + insertSourceCode[:leadingWSEnd]
+	}
+
+	// Combine all operations (one insert + N removes) into a single text
+	// replacement covering [0, lastRemoveEnd).
+	type fixer struct {
+		rangeStart int
+		rangeEnd   int
+		text       string
+	}
+
+	var fixers []fixer
+
+	if lastLegalImp != nil {
+		fixers = append(fixers, fixer{
+			rangeStart: lastLegalImp.End(),
+			rangeEnd:   lastLegalImp.End(),
+			text:       insertSourceCode,
+		})
+	} else {
+		pos := body[0].Pos()
+		fixers = append(fixers, fixer{
+			rangeStart: pos,
+			rangeEnd:   pos,
+			text:       insertSourceCode,
+		})
+	}
+
+	for _, sn := range sortNodes {
+		fixers = append(fixers, fixer{
+			rangeStart: sn.rangeFrom,
+			rangeEnd:   sn.rangeTo,
+			text:       "",
+		})
+	}
+
+	slices.SortFunc(fixers, func(a, b fixer) int {
+		if a.rangeStart != b.rangeStart {
+			return a.rangeStart - b.rangeStart
+		}
+		return a.rangeEnd - b.rangeEnd
+	})
+
+	var builder strings.Builder
+	lastEnd := 0
+	overallEnd := 0
+	for _, f := range fixers {
+		builder.WriteString(sourceText[lastEnd:f.rangeStart])
+		builder.WriteString(f.text)
+		lastEnd = f.rangeEnd
+		if f.rangeEnd > overallEnd {
+			overallEnd = f.rangeEnd
+		}
+	}
+
+	return []rule.RuleFix{
+		{
+			Range: core.NewTextRange(0, overallEnd),
+			Text:  builder.String(),
+		},
+	}
+}

--- a/internal/plugins/import/rules/first/first.md
+++ b/internal/plugins/import/rules/first/first.md
@@ -1,0 +1,50 @@
+# import/first
+
+## Rule Details
+
+Ensures all import statements appear before other statements in a module. Since imports are hoisted, interleaving them with other code can be confusing.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import { x } from './foo';
+export { x };
+import { y } from './bar';
+```
+
+```javascript
+var a = 1;
+import { y } from './bar';
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import { x } from './foo';
+import { y } from './bar';
+export { x, y };
+```
+
+## Options
+
+### `absolute-first`
+
+When set to `"absolute-first"`, this rule enforces that absolute (package) imports appear before relative imports.
+
+Examples of **incorrect** code with `"absolute-first"`:
+
+```javascript
+import { x } from './foo';
+import { y } from 'bar';
+```
+
+Examples of **correct** code with `"absolute-first"`:
+
+```javascript
+import { y } from 'bar';
+import { x } from './foo';
+```
+
+## Original Documentation
+
+https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md

--- a/internal/plugins/import/rules/first/first_ref_test.go
+++ b/internal/plugins/import/rules/first/first_ref_test.go
@@ -1,0 +1,205 @@
+package first
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// parseStatements parses code and returns the top-level statement nodes.
+func parseStatements(t *testing.T, code string) []*ast.Node {
+	t.Helper()
+	rootDir := fixtures.GetRootDir()
+	fileName := "file.ts"
+	fs := utils.NewOverlayVFSForFile(tspath.ResolvePath(rootDir, fileName), code)
+	host := utils.CreateCompilerHost(rootDir, fs)
+	program, err := utils.CreateProgram(true, fs, rootDir, "tsconfig.json", host)
+	if err != nil {
+		t.Fatalf("failed to create program: %v", err)
+	}
+	sf := program.GetSourceFile(fileName)
+	if sf == nil || sf.Statements == nil {
+		t.Fatal("source file has no statements")
+	}
+	return sf.Statements.Nodes
+}
+
+// TestHasReferenceBeforeImportName tests the name-based fallback path
+// (used when TypeChecker is unavailable).
+func TestHasReferenceBeforeImportName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		code     string
+		impIndex int // index of the import in body to check
+		want     bool
+	}{
+		{
+			name:     "value reference before import — detected",
+			code:     "console.log(x);\nimport { x } from './foo';",
+			impIndex: 1,
+			want:     true,
+		},
+		{
+			name:     "no reference before import — not detected",
+			code:     "var a = 1;\nimport { x } from './foo';",
+			impIndex: 1,
+			want:     false,
+		},
+		{
+			name:     "declaration name same as import — NOT a reference (IsDeclarationIdentifier)",
+			code:     "function foo() {}\nimport { foo } from './mod';",
+			impIndex: 1,
+			want:     false,
+		},
+		{
+			name:     "variable declaration name same as import — NOT a reference",
+			code:     "var x = 1;\nimport { x } from './foo';",
+			impIndex: 1,
+			want:     false,
+		},
+		{
+			name:     "class declaration name same as import — NOT a reference",
+			code:     "class Foo {}\nimport { Foo } from './mod';",
+			impIndex: 1,
+			want:     false,
+		},
+		{
+			name:     "reference in nested expression — detected",
+			code:     "var a = foo();\nimport { foo } from './mod';",
+			impIndex: 1,
+			want:     true,
+		},
+		{
+			name:     "reference in nested function body — detected",
+			code:     "function setup() { x(); }\nimport { x } from './foo';",
+			impIndex: 1,
+			want:     true,
+		},
+		{
+			name:     "side-effect import (no bindings) — not detected",
+			code:     "var a = 1;\nimport './side-effect';",
+			impIndex: 1,
+			want:     false,
+		},
+		{
+			name:     "parameter with same name as import — IS a reference (name-based is conservative)",
+			code:     "function bar(x: number) { return x; }\nimport { x } from './foo';",
+			impIndex: 1,
+			// Name-based: `x` as parameter declaration is skipped by IsDeclarationIdentifier,
+			// but `return x` is a value reference with matching name → true (conservative).
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			body := parseStatements(t, tt.code)
+			if tt.impIndex >= len(body) {
+				t.Fatalf("impIndex %d out of range (body has %d statements)", tt.impIndex, len(body))
+			}
+			importNode := body[tt.impIndex]
+			bindingNodes := utils.GetImportBindingNodes(importNode)
+			got := hasReferenceBeforeImportName(body, tt.impIndex, bindingNodes)
+			if got != tt.want {
+				t.Errorf("hasReferenceBeforeImportName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildFixWithNonASCII verifies that buildFix handles source text
+// containing non-ASCII characters (e.g. in comments) without panicking
+// or producing incorrect output.
+func TestBuildFixWithNonASCII(t *testing.T) {
+	t.Parallel()
+
+	code := "import a from 'a';\nvar x = 1; // 中文注释\nimport b from 'b';"
+	body := parseStatements(t, code)
+
+	// body[0] = import a (legal)
+	// body[1] = var x = 1 (non-import)
+	// body[2] = import b (misplaced)
+	if len(body) != 3 {
+		t.Fatalf("expected 3 statements, got %d", len(body))
+	}
+
+	lastLegalImp := body[0]
+	sortNodes := []errorInfo{
+		{
+			node:      body[2],
+			rangeFrom: body[1].End(),
+			rangeTo:   body[2].End(),
+		},
+	}
+
+	fixes := buildFix(code, body, lastLegalImp, sortNodes)
+	if len(fixes) != 1 {
+		t.Fatalf("expected 1 fix, got %d", len(fixes))
+	}
+
+	// Apply the fix manually: replace [0, overallEnd) with fix text
+	result := fixes[0].Text + code[fixes[0].Range.End():]
+
+	// The comment with Chinese characters should be preserved
+	if !contains(result, "中文注释") {
+		t.Errorf("non-ASCII comment lost in fix output: %s", result)
+	}
+	// import b should come after import a
+	if !contains(result, "import a from 'a';") || !contains(result, "import b from 'b';") {
+		t.Errorf("imports missing in fix output: %s", result)
+	}
+}
+
+// TestBuildFixWithEmoji verifies that emoji in comments are preserved
+// through the fix and don't interfere with the whitespace detection logic.
+func TestBuildFixWithEmoji(t *testing.T) {
+	t.Parallel()
+
+	code := "import a from 'a';\nvar x = 1; // 🚀 rocket\nimport b from 'b';"
+	body := parseStatements(t, code)
+	if len(body) != 3 {
+		t.Fatalf("expected 3 statements, got %d", len(body))
+	}
+
+	lastLegalImp := body[0]
+	sortNodes := []errorInfo{
+		{
+			node:      body[2],
+			rangeFrom: body[1].End(),
+			rangeTo:   body[2].End(),
+		},
+	}
+
+	fixes := buildFix(code, body, lastLegalImp, sortNodes)
+	if len(fixes) != 1 {
+		t.Fatalf("expected 1 fix, got %d", len(fixes))
+	}
+
+	result := fixes[0].Text + code[fixes[0].Range.End():]
+
+	if !contains(result, "🚀 rocket") {
+		t.Errorf("emoji comment lost in fix output: %s", result)
+	}
+	if !contains(result, "import b from 'b';") {
+		t.Errorf("import missing in fix output: %s", result)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && indexSubstring(s, substr) >= 0
+}
+
+func indexSubstring(s, substr string) int {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/plugins/import/rules/first/first_test.go
+++ b/internal/plugins/import/rules/first/first_test.go
@@ -1,0 +1,679 @@
+package first_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestFirstRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&first.FirstRule,
+		[]rule_tester.ValidTestCase{
+			// ── Import statement variants ───────────────────────────────────
+			// Named imports
+			{Code: `import { x } from './foo'; import { y } from './bar'; export { x, y }`},
+			// Default import
+			{Code: "import a from 'a';\nimport b from 'b';"},
+			// Namespace import
+			{Code: "import * as ns from 'foo';\nimport { x } from 'bar';"},
+			// Side-effect import (no bindings)
+			{Code: "import 'foo';\nimport 'bar';"},
+			// Mixed import styles
+			{Code: "import a from 'a';\nimport { b } from 'b';\nimport * as c from 'c';\nimport 'd';"},
+			// Type-only import (TypeScript)
+			{Code: "import type { Foo } from './foo';\nimport { bar } from './bar';"},
+			// ImportEqualsDeclaration (external module)
+			{Code: "import y = require('bar');\nimport { x } from 'foo';"},
+			// ImportEqualsDeclaration with multiple imports
+			{Code: "import a = require('a');\nimport b = require('b');\nimport { c } from 'c';"},
+
+			// ── Directive handling ──────────────────────────────────────────
+			// Single directive before imports
+			{Code: "'use strict';\nimport { x } from 'foo';"},
+			// Double-quoted directive before imports
+			{Code: "\"use strict\";\nimport { x } from 'foo';"},
+			// Multiple directives before imports
+			{Code: "'use strict';\n'use asm';\nimport { x } from 'foo';"},
+			// Directive only, no imports
+			{Code: "'use strict';"},
+
+			// ── absolute-first option ──────────────────────────────────────
+			// Absolute then relative — ok
+			{Code: `import { x } from 'foo'; import { y } from './bar'`},
+			// Relative then absolute without option — ok
+			{Code: `import { x } from './foo'; import { y } from 'bar'`},
+			// disable-absolute-first explicitly
+			{Code: `import { x } from './foo'; import { y } from 'bar'`, Options: []interface{}{"disable-absolute-first"}},
+			// Only absolutes — ok with absolute-first
+			{Code: "import a from 'a';\nimport b from 'b';", Options: []interface{}{"absolute-first"}},
+			// Only relatives — ok with absolute-first
+			{Code: "import a from './a';\nimport b from './b';", Options: []interface{}{"absolute-first"}},
+			// Absolute then relative — ok with absolute-first
+			{Code: "import a from 'a';\nimport b from './b';", Options: []interface{}{"absolute-first"}},
+			// Scoped package — treated as absolute
+			{Code: "import a from '@scope/pkg';\nimport b from './b';", Options: []interface{}{"absolute-first"}},
+			// Parent relative import (../) — also relative
+			{Code: "import a from 'a';\nimport b from '../b';", Options: []interface{}{"absolute-first"}},
+
+			// ── Edge cases ─────────────────────────────────────────────────
+			// Empty file
+			{Code: ""},
+			// Single import only
+			{Code: "import a from 'a';"},
+			// Single non-import only (no imports = no error)
+			{Code: "var a = 1;"},
+			// Dynamic import expression in a var declaration is NOT an import statement
+			{Code: "import { x } from 'bar';\nconst a = import('foo');"},
+			// Re-export followed by more imports is fine (re-export is non-import code
+			// but there is no import AFTER it in this case)
+			{Code: "import { x } from 'foo';\nexport { y } from 'bar';"},
+			// Import with import attributes
+			{Code: "import data from './data.json' with { type: 'json' };\nimport { x } from 'foo';"},
+			// absolute-first: rel → abs → rel — second relative doesn't re-trigger
+			{Code: "import a from 'abs';\nimport b from './rel1';\nimport c from './rel2';", Options: []interface{}{"absolute-first"}},
+			// Internal module reference (import x = Namespace.Y) at top is valid
+			{Code: "import x = require('foo');\nimport y from 'bar';"},
+			// Empty import bindings
+			{Code: "import {} from 'foo';\nimport a from 'bar';"},
+			// Multiple legal imports — lastLegalImp tracks the last one
+			{Code: "import a from 'a';\nimport b from 'b';\nimport c from 'c';\nvar x = 1;"},
+			// Directives then code, no imports — no errors
+			{Code: "'use strict';\nvar a = 1;"},
+			// export * from is non-import, but no import follows — valid
+			{Code: "import a from 'a';\nexport * from 'b';"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ── Basic misplaced import detection ───────────────────────────
+			// 0: Single misplaced import after export
+			{
+				Code: "import { x } from './foo';\nexport { x };\nimport { y } from './bar';",
+				Output: []string{
+					"import { x } from './foo';\nimport { y } from './bar';\nexport { x };",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+			// 1: Two misplaced imports after export
+			{
+				Code: "import { x } from './foo';\nexport { x };\nimport { y } from './bar';\nimport { z } from './baz';",
+				Output: []string{
+					"import { x } from './foo';\nimport { y } from './bar';\nimport { z } from './baz';\nexport { x };",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+			// 2: Import after variable declaration, no previous legal import
+			{
+				Code: "var a = 1;\nimport { y } from './bar';",
+				Output: []string{
+					"import { y } from './bar';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 3: Import immediately after non-import with no whitespace
+			{
+				Code: "if (true) { console.log(1) }import a from 'b'",
+				Output: []string{
+					"import a from 'b'\nif (true) { console.log(1) }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 1, Column: 29},
+				},
+			},
+
+			// ── Directive handling ──────────────────────────────────────────
+			// 4: Directive after first import is NOT special — treated as non-import
+			{
+				Code: "import { x } from 'foo';\n'use directive';\nimport { y } from 'bar';",
+				Output: []string{
+					"import { x } from 'foo';\nimport { y } from 'bar';\n'use directive';",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+
+			// ── Import statement variants (misplaced) ──────────────────────
+			// 5: Default import after code
+			{
+				Code: "var a = 1;\nimport x from './foo';",
+				Output: []string{
+					"import x from './foo';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 6: Namespace import after code
+			{
+				Code: "var a = 1;\nimport * as ns from './foo';",
+				Output: []string{
+					"import * as ns from './foo';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 7: Side-effect import after code
+			{
+				Code: "var a = 1;\nimport './foo';",
+				Output: []string{
+					"import './foo';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 8: Type-only import after code
+			{
+				Code: "var a = 1;\nimport type { Foo } from './foo';",
+				Output: []string{
+					"import type { Foo } from './foo';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 9: ImportEqualsDeclaration after code
+			{
+				Code: "var a = 1;\nimport x = require('./foo');",
+				Output: []string{
+					"import x = require('./foo');\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+
+			// ── Interleaved imports and code ───────────────────────────────
+			// 10: Multiple non-import statements between imports
+			{
+				Code: "import a from 'a';\nvar x = 1;\nvar y = 2;\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nvar x = 1;\nvar y = 2;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+			// 11: Import after function declaration
+			{
+				Code: "import a from 'a';\nfunction foo() {}\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nfunction foo() {}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+			// 12: Import after class declaration
+			{
+				Code: "import a from 'a';\nclass Foo {}\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nclass Foo {}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+			// 13: Import after if statement
+			{
+				Code: "import a from 'a';\nif (true) { a(); }\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nif (true) { a(); }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+			// 14: Alternating import/code/import/code/import
+			{
+				Code: "import a from 'a';\nvar x = 1;\nimport b from 'b';\nvar y = 2;\nimport c from 'c';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nimport c from 'c';\nvar x = 1;\nvar y = 2;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+					{MessageId: "first", Line: 5, Column: 1},
+				},
+			},
+			// 15: Multiple misplaced imports, no legal import at top
+			{
+				Code: "var x = 1;\nimport a from 'a';\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nvar x = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+
+			// ── absolute-first option ──────────────────────────────────────
+			// 16: Relative then absolute with absolute-first
+			{
+				Code:    "import { x } from './foo'; import { y } from 'bar'",
+				Options: []interface{}{"absolute-first"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 1, Column: 46},
+				},
+			},
+			// 17: absolute-first with ImportEqualsDeclaration
+			{
+				Code:    "import { x } from './foo';\nimport y = require('bar');",
+				Options: []interface{}{"absolute-first"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 2, Column: 12},
+				},
+			},
+			// 18: absolute-first — multiple absolute imports after relative
+			{
+				Code:    "import a from './a';\nimport b from 'b';\nimport c from 'c';",
+				Options: []interface{}{"absolute-first"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 2, Column: 15},
+					{MessageId: "absolute", Line: 3, Column: 15},
+				},
+			},
+			// 19: absolute-first — relative then scoped package
+			{
+				Code:    "import a from './a';\nimport b from '@scope/pkg';",
+				Options: []interface{}{"absolute-first"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 2, Column: 15},
+				},
+			},
+			// 20: absolute-first — parent relative (..) is still relative
+			{
+				Code:    "import a from '../a';\nimport b from 'b';\nimport c from './c';",
+				Options: []interface{}{"absolute-first"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 2, Column: 15},
+				},
+			},
+
+			// ── Combined: misplaced + absolute-first ───────────────────────
+			// 21: Both absolute-first and misplaced errors fire simultaneously
+			{
+				Code:    "import a from './a';\nvar x = 1;\nimport b from 'b';",
+				Options: []interface{}{"absolute-first"},
+				Output: []string{
+					"import a from './a';\nimport b from 'b';\nvar x = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 3, Column: 15},
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+
+			// ── Non-obvious non-import statements ──────────────────────────
+			// 22: Dynamic import() in variable declaration is NOT an import statement
+			{
+				Code: "const a = import('foo');\nimport { x } from 'bar';",
+				Output: []string{
+					"import { x } from 'bar';\nconst a = import('foo');",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 23: Re-export (export...from) is NOT an import — import after it is misplaced
+			{
+				Code: "import { x } from 'foo';\nexport { y } from 'bar';\nimport { z } from 'baz';",
+				Output: []string{
+					"import { x } from 'foo';\nimport { z } from 'baz';\nexport { y } from 'bar';",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+
+			// ── First-expression edge cases ────────────────────────────────
+			// 24: Template literal as first expression is NOT a directive
+			{
+				Code: "`use strict`;\nimport a from 'a';",
+				Output: []string{
+					"import a from 'a';\n`use strict`;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 25: Empty statement (;) is NOT a directive — counts as non-import
+			{
+				Code: ";\nimport a from 'a';",
+				Output: []string{
+					"import a from 'a';\n;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 26: export default before import
+			{
+				Code: "export default 42;\nimport a from 'a';",
+				Output: []string{
+					"import a from 'a';\nexport default 42;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+
+			// ── Directive + misplaced import interaction ───────────────────
+			// 27: Directive at top, code, then import — import moves before body[0] (the directive)
+			// because there is no lastLegalImp, fix inserts before body[0].
+			{
+				Code: "'use strict';\nvar a = 1;\nimport b from 'b';",
+				Output: []string{
+					"import b from 'b';\n'use strict';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+
+			// ── absolute-first edge cases ──────────────────────────────────
+			// 28: absolute-first: rel → abs → rel — abs reported, second rel not
+			{
+				Code:    "import a from './a';\nimport b from 'b';\nimport c from './c';",
+				Options: []interface{}{"absolute-first"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "absolute", Line: 2, Column: 15},
+				},
+			},
+
+			// ── Autofix edge cases ─────────────────────────────────────────
+			// ── export * from as non-import ────────────────────────────────
+			// 29: export * re-export is non-import — import after it is misplaced
+			{
+				Code: "import a from 'a';\nexport * from 'b';\nimport c from 'c';",
+				Output: []string{
+					"import a from 'a';\nimport c from 'c';\nexport * from 'b';",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+
+			// ── Empty import bindings ──────────────────────────────────────
+			// 30: Empty import {} after code
+			{
+				Code: "var a = 1;\nimport {} from 'foo';",
+				Output: []string{
+					"import {} from 'foo';\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+
+			// ── Import attributes ──────────────────────────────────────────
+			// 31: Misplaced import with `with` clause — fix must move entire statement
+			{
+				Code: "var a = 1;\nimport data from './data.json' with { type: 'json' };",
+				Output: []string{
+					"import data from './data.json' with { type: 'json' };\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+
+			// ── Comments between statements ────────────────────────────────
+			// 32: Comment between code and misplaced import — preserved in fix
+			{
+				Code: "import a from 'a';\nvar x = 1;\n// this import is misplaced\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\n// this import is misplaced\nimport b from 'b';\nvar x = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+
+			// ── Multiple legal imports then misplaced ──────────────────────
+			// 33: Three legal imports, code, then misplaced — fix inserts after 3rd legal
+			{
+				Code: "import a from 'a';\nimport b from 'b';\nimport c from 'c';\nvar x = 1;\nimport d from 'd';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nimport c from 'c';\nimport d from 'd';\nvar x = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 5, Column: 1},
+				},
+			},
+
+			// ── Autofix edge cases ─────────────────────────────────────────
+			// 34: Moving import with complex multiline code between
+			{
+				Code: "import a from 'a';\nconst obj = {\n  key: 'value',\n};\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\nimport b from 'b';\nconst obj = {\n  key: 'value',\n};",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 5, Column: 1},
+				},
+			},
+			// 35: Moving ImportEqualsDeclaration
+			{
+				Code: "var a = 1;\nimport x = require('foo');",
+				Output: []string{
+					"import x = require('foo');\nvar a = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+
+			// ── Multiline import ───────────────────────────────────────────
+			// 36: Multiline destructured import misplaced — entire statement moves
+			{
+				Code: "var x = 1;\nimport {\n  a,\n  b,\n  c\n} from 'foo';",
+				Output: []string{
+					"import {\n  a,\n  b,\n  c\n} from 'foo';\nvar x = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 37: Multiline comment before misplaced import — comment moves with it
+			{
+				Code: "import a from 'a';\nvar x = 1;\n/**\n * Module B\n */\nimport b from 'b';",
+				Output: []string{
+					"import a from 'a';\n/**\n * Module B\n */\nimport b from 'b';\nvar x = 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 6, Column: 1},
+				},
+			},
+
+			// ── Multiple non-imports before first import ───────────────────
+			// 38: Several non-import statements then import — all code stays, import moves to top
+			{
+				Code: "var a = 1;\nvar b = 2;\nvar c = 3;\nimport x from 'x';",
+				Output: []string{
+					"import x from 'x';\nvar a = 1;\nvar b = 2;\nvar c = 3;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+
+			// ── Reference checking (shouldSort) ───────────────────────────
+			// The first misplaced import always gets a fix (lastSortNodesIndex
+			// starts at 0).  The reference check only prevents BATCH fixing:
+			// once shouldSort becomes false, later imports are excluded from the
+			// current fix pass and handled in subsequent passes.
+
+			// 39: Imported variable referenced before import — only first import
+			// is fixed per pass.  Three fix passes are required.
+			{
+				Code: "var a = 1;\nimport { y } from './bar';\nif (true) { x() };\nimport { x } from './foo';\nimport { z } from './baz';",
+				Output: []string{
+					// Pass 1: import { y } moved to top (y not referenced before it)
+					"import { y } from './bar';\nvar a = 1;\nif (true) { x() };\nimport { x } from './foo';\nimport { z } from './baz';",
+					// Pass 2: import { x } moved (first misplaced always fixable)
+					"import { y } from './bar';\nimport { x } from './foo';\nvar a = 1;\nif (true) { x() };\nimport { z } from './baz';",
+					// Pass 3: import { z } moved
+					"import { y } from './bar';\nimport { x } from './foo';\nimport { z } from './baz';\nvar a = 1;\nif (true) { x() };",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 4, Column: 1},
+					{MessageId: "first", Line: 5, Column: 1},
+				},
+			},
+			// 40: No reference before import — all imports are fixable in one pass
+			{
+				Code: "var a = 1;\nimport { y } from './bar';\nvar b = 2;\nimport { z } from './baz';",
+				Output: []string{
+					"import { y } from './bar';\nimport { z } from './baz';\nvar a = 1;\nvar b = 2;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+			// 41: Side-effect import (no bindings) — no references to check, always sortable
+			{
+				Code: "var a = 1;\nimport './side-effect';\nvar b = 2;\nimport { x } from './foo';",
+				Output: []string{
+					"import './side-effect';\nimport { x } from './foo';\nvar a = 1;\nvar b = 2;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+			// 42: Default import referenced before import — first import always
+			// gets fix; second import fixed in pass 2.
+			{
+				Code: "console.log(foo);\nimport foo from './foo';\nimport bar from './bar';",
+				Output: []string{
+					// Pass 1: import foo moved (first misplaced always fixable),
+					// import bar has no fix (shouldSort=false).
+					"import foo from './foo';\nconsole.log(foo);\nimport bar from './bar';",
+					// Pass 2: import bar moved after import foo.
+					"import foo from './foo';\nimport bar from './bar';\nconsole.log(foo);",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 3, Column: 1},
+				},
+			},
+			// 43: Namespace import referenced before import — still fixed (first always fixable)
+			{
+				Code: "ns.doSomething();\nimport * as ns from './mod';",
+				Output: []string{
+					"import * as ns from './mod';\nns.doSomething();",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 44: Reference in nested function — still fixed (first always fixable)
+			{
+				Code: "function setup() { x(); }\nimport { x } from './foo';",
+				Output: []string{
+					"import { x } from './foo';\nfunction setup() { x(); }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 45: Type annotation with same name does NOT suppress fix (symbol-based check)
+			{
+				Code: "const x: Foo = {} as Foo;\nimport type { Foo } from './foo';",
+				Output: []string{
+					"import type { Foo } from './foo';\nconst x: Foo = {} as Foo;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 46: Declaration name with same name does NOT suppress fix
+			{
+				Code: "function foo() {}\nimport { foo } from './mod';",
+				Output: []string{
+					"import { foo } from './mod';\nfunction foo() {}",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 47: Renamed import — only local name matters, not original name
+			{
+				Code: "console.log(bar);\nimport { foo as bar } from './mod';",
+				Output: []string{
+					// bar IS referenced → but first import always fixable
+					"import { foo as bar } from './mod';\nconsole.log(bar);",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 48: Multiple bindings, one referenced — suppresses fix for all
+			{
+				Code: "var v = 1;\nimport { a } from './a';\nconsole.log(b);\nimport { b, c } from './bc';",
+				Output: []string{
+					// Pass 1: import { a } moved (a not referenced),
+					// import { b, c } not moved (b is referenced before it)
+					"import { a } from './a';\nvar v = 1;\nconsole.log(b);\nimport { b, c } from './bc';",
+					// Pass 2: import { b, c } moved (first misplaced always fixable)
+					"import { a } from './a';\nimport { b, c } from './bc';\nvar v = 1;\nconsole.log(b);",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+			// 49: Default + named import — default name referenced
+			{
+				Code: "foo();\nimport foo, { bar } from './mod';",
+				Output: []string{
+					// First always fixable despite reference
+					"import foo, { bar } from './mod';\nfoo();",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+			// 50: Reference in various expression positions
+			{
+				Code: "var v = 1;\nimport { a } from './a';\nvar r = x + 1;\nimport { x } from './x';",
+				Output: []string{
+					// a not referenced → sortable; x referenced in binary expr → shouldSort=false
+					"import { a } from './a';\nvar v = 1;\nvar r = x + 1;\nimport { x } from './x';",
+					// pass 2
+					"import { a } from './a';\nimport { x } from './x';\nvar v = 1;\nvar r = x + 1;",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+					{MessageId: "first", Line: 4, Column: 1},
+				},
+			},
+			// 51: Parameter shadows imported name — should NOT suppress fix
+			{
+				Code: "function bar(x: number) { return x; }\nimport { x } from './mod';",
+				Output: []string{
+					"import { x } from './mod';\nfunction bar(x: number) { return x; }",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "first", Line: 2, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1129,6 +1129,53 @@ func GetDeclarationIdentifier(decl *ast.Node) *ast.Node {
 	return nil
 }
 
+// GetImportBindingNodes returns the local binding identifier nodes declared by
+// an import statement. Returns nil for side-effect imports (e.g. `import 'foo'`).
+// Handles ImportDeclaration (default, named, namespace) and ImportEqualsDeclaration.
+func GetImportBindingNodes(node *ast.Node) []*ast.Node {
+	var nodes []*ast.Node
+	switch node.Kind {
+	case ast.KindImportDeclaration:
+		importDecl := node.AsImportDeclaration()
+		if importDecl.ImportClause == nil {
+			return nil
+		}
+		clause := importDecl.ImportClause.AsImportClause()
+		if clause == nil {
+			return nil
+		}
+		if clause.Name() != nil {
+			nodes = append(nodes, clause.Name())
+		}
+		if clause.NamedBindings != nil {
+			nb := clause.NamedBindings
+			switch nb.Kind {
+			case ast.KindNamespaceImport:
+				nsImport := nb.AsNamespaceImport()
+				if nsImport != nil && nsImport.Name() != nil {
+					nodes = append(nodes, nsImport.Name())
+				}
+			case ast.KindNamedImports:
+				namedImports := nb.AsNamedImports()
+				if namedImports != nil && namedImports.Elements != nil {
+					for _, elem := range namedImports.Elements.Nodes {
+						importSpec := elem.AsImportSpecifier()
+						if importSpec != nil && importSpec.Name() != nil {
+							nodes = append(nodes, importSpec.Name())
+						}
+					}
+				}
+			}
+		}
+	case ast.KindImportEqualsDeclaration:
+		importEquals := node.AsImportEqualsDeclaration()
+		if importEquals.Name() != nil {
+			nodes = append(nodes, importEquals.Name())
+		}
+	}
+	return nodes
+}
+
 // VisitDestructuringIdentifiers calls fn for each identifier target in a
 // destructuring assignment pattern (object/array literal on the left side
 // of an assignment expression). Handles shorthand properties, renamed

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -248,6 +248,23 @@ func GetOptionsMap(opts any) map[string]interface{} {
 	return optsMap
 }
 
+// GetOptionsString extracts a string option from the weakly-typed options parameter.
+// It handles both direct string format ("value") and array format (["value"]).
+func GetOptionsString(opts any) string {
+	if opts == nil {
+		return ""
+	}
+	if s, ok := opts.(string); ok {
+		return s
+	}
+	if arr, ok := opts.([]interface{}); ok && len(arr) > 0 {
+		if s, ok := arr[0].(string); ok {
+			return s
+		}
+	}
+	return ""
+}
+
 // NaturalCompare compares two strings using natural sort order,
 // where embedded numeric segments are compared by their numeric value
 // (e.g., "a2" < "a10" instead of "a10" < "a2").

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
     // eslint-plugin-import
+    './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/first.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/first.test.ts
@@ -1,0 +1,126 @@
+import { test } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('first', null as never, {
+  valid: [
+    // Import statement variants
+    test({
+      code: "import { x } from './foo'; import { y } from './bar';\nexport { x, y }",
+    }),
+    test({ code: "import a from 'a';\nimport b from 'b';" }),
+    test({ code: "import * as ns from 'foo';\nimport { x } from 'bar';" }),
+    test({ code: "import 'foo';\nimport 'bar';" }),
+    test({
+      code: "import a from 'a';\nimport { b } from 'b';\nimport * as c from 'c';\nimport 'd';",
+    }),
+    test({
+      code: "import type { Foo } from './foo';\nimport { bar } from './bar';",
+    }),
+    test({ code: "import y = require('bar');\nimport { x } from 'foo';" }),
+
+    // Directive handling
+    test({ code: "'use directive';\nimport { x } from 'foo';" }),
+    test({ code: "'use strict';\n'use asm';\nimport { x } from 'foo';" }),
+
+    // absolute-first option
+    test({ code: "import { x } from 'foo'; import { y } from './bar'" }),
+    test({ code: "import { x } from './foo'; import { y } from 'bar'" }),
+    test({
+      code: "import { x } from './foo'; import { y } from 'bar'",
+      options: ['disable-absolute-first'],
+    }),
+    test({
+      code: "import a from 'a';\nimport b from './b';",
+      options: ['absolute-first'],
+    }),
+    test({
+      code: "import a from '@scope/pkg';\nimport b from './b';",
+      options: ['absolute-first'],
+    }),
+
+    // Edge cases
+    test({ code: '' }),
+    test({ code: 'var a = 1;' }),
+  ],
+  invalid: [
+    // Basic misplaced import detection
+    test({
+      code: "import { x } from './foo';\nexport { x };\nimport { y } from './bar';",
+      errors: 1,
+    }),
+    test({
+      code: "import { x } from './foo';\nexport { x };\nimport { y } from './bar';\nimport { z } from './baz';",
+      errors: 2,
+    }),
+    test({
+      code: "var a = 1;\nimport { y } from './bar';",
+      errors: 1,
+    }),
+    test({
+      code: "if (true) { console.log(1) }import a from 'b'",
+      errors: 1,
+    }),
+
+    // Directive after first import
+    test({
+      code: "import { x } from 'foo';\n'use directive';\nimport { y } from 'bar';",
+      errors: 1,
+    }),
+
+    // Import statement variants (misplaced)
+    test({ code: "var a = 1;\nimport x from './foo';", errors: 1 }),
+    test({ code: "var a = 1;\nimport * as ns from './foo';", errors: 1 }),
+    test({ code: "var a = 1;\nimport './foo';", errors: 1 }),
+    test({ code: "var a = 1;\nimport type { Foo } from './foo';", errors: 1 }),
+    test({ code: "var a = 1;\nimport x = require('./foo');", errors: 1 }),
+
+    // Interleaved imports and code
+    test({
+      code: "import a from 'a';\nvar x = 1;\nvar y = 2;\nimport b from 'b';",
+      errors: 1,
+    }),
+    test({
+      code: "import a from 'a';\nfunction foo() {}\nimport b from 'b';",
+      errors: 1,
+    }),
+    test({
+      code: "import a from 'a';\nvar x = 1;\nimport b from 'b';\nvar y = 2;\nimport c from 'c';",
+      errors: 2,
+    }),
+    test({
+      code: "var x = 1;\nimport a from 'a';\nimport b from 'b';",
+      errors: 2,
+    }),
+
+    // absolute-first option
+    test({
+      code: "import { x } from './foo'; import { y } from 'bar'",
+      options: ['absolute-first'],
+      errors: 1,
+    }),
+    test({
+      code: "import a from './a';\nimport b from 'b';\nimport c from 'c';",
+      options: ['absolute-first'],
+      errors: 2,
+    }),
+    test({
+      code: "import a from './a';\nimport b from '@scope/pkg';",
+      options: ['absolute-first'],
+      errors: 1,
+    }),
+
+    // Dynamic import() is NOT an import statement
+    test({
+      code: "const a = import('foo');\nimport { x } from 'bar';",
+      errors: 1,
+    }),
+    // Re-export is NOT an import statement
+    test({
+      code: "import { x } from 'foo';\nexport { y } from 'bar';\nimport { z } from 'baz';",
+      errors: 1,
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `import/first` rule from `eslint-plugin-import` to rslint.

This rule ensures all import statements appear before other statements in a module body. Supports:
- All import variants: default, named, namespace, side-effect, type-only, `import = require()`
- `absolute-first` / `disable-absolute-first` options
- Autofix: moves misplaced imports to the top, with reference checking (symbol-based via TypeChecker) to avoid unsafe reordering
- Directive handling: `'use strict'` etc. are allowed before imports

Also extracts two shared utilities:
- `utils.GetOptionsString()` — string option extraction (pattern used by 6+ rules)
- `utils.GetImportBindingNodes()` — import binding node extraction (shared with `no-import-assign`)

## Related Links

- ESLint rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/first.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/first.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).