### PR TITLE
feat: port rule @typescript-eslint/no-unnecessary-condition

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,6 +59,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_this_alias"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_template_expression"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_condition"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_arguments"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_argument"
@@ -435,6 +436,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-this-alias", no_this_alias.NoThisAliasRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-require-imports", no_require_imports.NoRequireImportsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-boolean-literal-compare", no_unnecessary_boolean_literal_compare.NoUnnecessaryBooleanLiteralCompareRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-condition", no_unnecessary_condition.NoUnnecessaryConditionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-template-expression", no_unnecessary_template_expression.NoUnnecessaryTemplateExpressionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-arguments", no_unnecessary_type_arguments.NoUnnecessaryTypeArgumentsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-assertion", no_unnecessary_type_assertion.NoUnnecessaryTypeAssertionRule)

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/edge_cases_test.go
@@ -1,0 +1,570 @@
+package no_unnecessary_condition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestEdgeCases_CheckNode exercises every branch in checkNode:
+// - SkipParentheses
+// - PrefixUnaryExpression (!, !!, !!!)
+// - ArrayIndexExpression skip
+// - BinaryExpression (&&, ||) recursive right-only check
+// - isConditionalAlwaysNecessary (any, unknown, TypeVariable)
+// - never type
+// - IsPossiblyTruthy / IsPossiblyFalsy
+func TestEdgeCases_CheckNode(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Triple parenthesized
+		{Code: "declare const b: boolean;\nif (((b))) {}\n"},
+		// Triple negation on boolean — necessary since boolean can be truthy or falsy
+		{Code: "declare const b: boolean;\nif (!!!b) {}\n"},
+		// && nested in if — right side of && is checked
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\nif (a && b) {}\n"},
+		// || nested in ternary — right side of || is checked
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\nconst x = (a || b) ? 1 : 2;\n"},
+		// Conditional type (TypeVariable) — always necessary
+		{Code: "function test<T extends boolean>(a: T extends true ? string : number) { if (a) {} }\n"},
+		// Index signature access on arrays — unsound, skip
+		{Code: "declare const arr: object[];\nif (arr[0]) {}\n"},
+		// Deeply nested parens + unary
+		{Code: "declare const b: boolean;\nif (((!((b))))) {}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Triple negation on always-truthy
+		{
+			Code:   "declare const obj: object;\nif (!!!obj) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// && with always-truthy right — right is checked by parent checkNode
+		{
+			Code:   "declare const b: boolean;\nif (b && []) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 10}},
+		},
+		// || with always-falsy right
+		{
+			Code:   "declare const b: boolean;\nif (b || null) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 10}},
+		},
+		// Nested ternary with truthy
+		{
+			Code:   "declare const b: boolean;\nconst x = [] ? 'a' : 'b';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 11}},
+		},
+	})
+}
+
+// TestEdgeCases_CheckNodeForNullish exercises:
+// - any/unknown/TypeParameter early return
+// - never type
+// - isPossiblyNullish + isNullableMemberExpression combined check
+// - isAlwaysNullish
+// - ArrayIndexExpression skip for ??
+// - isChainExpressionWithOptionalArrayIndex
+func TestEdgeCases_CheckNodeForNullish(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// any/unknown/TypeVariable — always necessary
+		{Code: "declare const x: any;\nconst y = x ?? 1;\n"},
+		{Code: "declare const x: unknown;\nconst y = x ?? 1;\n"},
+		{Code: "function f<T>(x: T) { const y = x ?? 1; }\n"},
+		// Optional property access — nullish because property is optional
+		{Code: "declare const obj: { a?: string };\nconst x = obj.a ?? 'default';\n"},
+		// Array index ?? — unsound without noUncheckedIndexedAccess
+		{Code: "declare const arr: string[];\nconst x = arr[0] ?? '';\n"},
+		// Chain with optional array index — should skip
+		{Code: "declare const arr: string[];\narr[0]?.length ?? 0;\n"},
+		// Nullable union with ??
+		{Code: "declare const x: string | null | undefined;\nconst y = x ?? '';\n"},
+	}, []rule_tester.InvalidTestCase{
+		// never type in ??
+		{
+			Code:   "declare const x: never;\nconst y = x ?? 1;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never", Line: 2, Column: 11}},
+		},
+		// Non-nullish object in ??
+		{
+			Code:   "declare const x: { a: string };\nconst y = x ?? {};\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 11}},
+		},
+		// null | undefined — always nullish
+		{
+			Code:   "declare const x: null | undefined;\nconst y = x ?? 'fallback';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish", Line: 2, Column: 11}},
+		},
+	})
+}
+
+// TestEdgeCases_BooleanComparison exercises checkIfBoolExpressionIsNecessaryConditional:
+// - toStaticValue for each literal kind (bool, string, number, bigint, null, undefined)
+// - booleanComparison for ===, !==, ==, !=, <, <=, >, >=
+// - noOverlapBooleanExpression (TS #37160 workaround)
+// - switch/case comparison (uses ===)
+func TestEdgeCases_BooleanComparison(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Non-literal types — no static comparison possible
+		{Code: "declare const a: string;\ndeclare const b: string;\nif (a === b) {}\n"},
+		{Code: "declare const a: number;\ndeclare const b: number;\nif (a < b) {}\n"},
+		// Mixed literal and non-literal
+		{Code: "declare const a: string;\nif (a === 'hello') {}\n"},
+		// null == undefined is valid when both sides have nullable types
+		{Code: "declare const a: string | null;\nif (a == null) {}\n"},
+		{Code: "declare const a: string | undefined;\nif (a == undefined) {}\n"},
+		// any/unknown comparisons — always necessary
+		{Code: "declare const a: any;\nif (a === null) {}\n"},
+		{Code: "declare const a: unknown;\nif (a === null) {}\n"},
+		// Type parameter comparisons
+		{Code: "function f<T>(a: T) { if (a === null) {} }\n"},
+		// Loose equality with nullable types
+		{Code: "declare const a: string | null;\nif (a != null) {}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// === between same literals
+		{
+			Code:   "if (1 === 1) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 5}},
+		},
+		// !== between same literals
+		{
+			Code:   "if ('a' !== 'a') {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 5}},
+		},
+		// == cross-type: null == undefined
+		{
+			Code:   "if (null == undefined) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 5}},
+		},
+		// != null vs undefined
+		{
+			Code:   "if (null != undefined) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 5}},
+		},
+		// String relational: lexicographic order
+		{
+			Code:   "declare const a: 'abc';\ndeclare const b: 'abd';\nif (a < b) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 5}},
+		},
+		// BigInt comparison
+		{
+			Code:   "if (-2n !== 2n) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 5}},
+		},
+		// Number float comparison
+		{
+			Code:   "if (2.3 > 2.3) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 5}},
+		},
+		// noOverlapBooleanExpression: string vs null
+		{
+			Code:   "function test(a: string) { a === null; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noOverlapBooleanExpression", Line: 1, Column: 28}},
+		},
+		// noOverlapBooleanExpression: string vs undefined (strict ===)
+		{
+			Code:   "function test(a: string) { a === undefined; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noOverlapBooleanExpression", Line: 1, Column: 28}},
+		},
+		// noOverlapBooleanExpression: reversed order
+		{
+			Code:   "function test(a: string) { null === a; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noOverlapBooleanExpression", Line: 1, Column: 28}},
+		},
+		// !== also triggers noOverlap
+		{
+			Code:   "function test(a: string) { a !== null; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noOverlapBooleanExpression", Line: 1, Column: 28}},
+		},
+		// Switch/case literal comparison
+		{
+			Code:   "switch (true as const) {\n  case false:\n    break;\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 2, Column: 8}},
+		},
+	})
+}
+
+// TestEdgeCases_OptionalChain exercises checkOptionalChain:
+// - isOptionableExpression (member vs call origin)
+// - isMemberExpressionNullableOriginFromObject
+// - isCallExpressionNullableOriginFromCallee
+// - optionChainContainsUnsoundIndexAccess (array + object index)
+// - Multi-level chains with mixed nullable positions
+// - Call chain return type nullable origin
+func TestEdgeCases_OptionalChain(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Nullable object — optional chain necessary
+		{Code: "declare const x: { a: string } | null;\nx?.a;\n"},
+		// Optional property — necessary
+		{Code: "declare const x: { a?: string };\nx.a?.length;\n"},
+		// Union of types with different property shapes — nullable origin from type
+		{Code: "type A = { foo: string };\ntype B = { foo: string | undefined };\ndeclare const x: A | B;\nx.foo?.length;\n"},
+		// Callable union with nullable return
+		{Code: "type Fn = (() => string | null) | (() => number);\ndeclare const fn: Fn;\nfn()?.toString();\n"},
+		// Array index optional chain — unsound without noUncheckedIndexedAccess
+		{Code: "declare const arr: { a: string }[];\narr[0]?.a;\n"},
+		// Deep chain: nullable at root only
+		{Code: "declare const x: { a: { b: { c: string } } } | null;\nx?.a.b.c;\n"},
+		// Chain with method call having nullable return
+		{Code: "declare const x: { getValue(): string | null };\nx.getValue()?.length;\n"},
+		// any/unknown in chain — always necessary
+		{Code: "declare const x: any;\nx?.a?.b;\n"},
+		{Code: "declare const x: unknown;\nx?.toString();\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Non-nullable object property access with ?.
+		{
+			Code: "declare const x: { a: { b: string } };\nx.a?.b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 2, Column: 4,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: string } };\nx.a.b;\n"},
+				},
+			}},
+		},
+		// Non-nullable callable with ?.()
+		{
+			Code: "declare const fn: () => number;\nfn?.();\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 2, Column: 3,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "declare const fn: () => number;\nfn();\n"},
+				},
+			}},
+		},
+		// Three-level chain all unnecessary
+		{
+			Code: "declare const x: { a: { b: { c: string } } };\nx?.a?.b?.c;\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "neverOptionalChain", Line: 2, Column: 8,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: string } } };\nx?.a?.b.c;\n"},
+					},
+				},
+				{
+					MessageId: "neverOptionalChain", Line: 2, Column: 5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: string } } };\nx?.a.b?.c;\n"},
+					},
+				},
+				{
+					MessageId: "neverOptionalChain", Line: 2, Column: 2,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: string } } };\nx.a?.b?.c;\n"},
+					},
+				},
+			},
+		},
+		// Nullable at root, but inner chain unnecessary
+		{
+			Code: "declare const x: { a: { b: string } } | null;\nx?.a?.b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 2, Column: 5,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: string } } | null;\nx?.a.b;\n"},
+				},
+			}},
+		},
+		// Computed element access unnecessary
+		{
+			Code: "declare const x: { [k: string]: string };\nx?.['foo'];\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 2, Column: 2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { [k: string]: string };\nx['foo'];\n"},
+				},
+			}},
+		},
+	})
+}
+
+// TestEdgeCases_LoopConditions exercises checkIfLoopIsNecessaryConditional:
+// - While / do-while / for
+// - allowConstantLoopConditions: 'always' / 'never' / 'only-allowed-literals' / true / false
+// - only-allowed-literals allows only while(true/false/0/1)
+// - for(;;) with no condition — no check
+func TestEdgeCases_LoopConditions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// for(;;) — no condition, no check
+		{Code: "for (;;) {}\n"},
+		// while with boolean condition
+		{Code: "declare const b: boolean;\nwhile (b) {}\n"},
+		// allowConstantLoopConditions: 'always' allows while(true)
+		{Code: "while (true) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "always"}},
+		// only-allowed-literals allows while(true/false/0/1)
+		{Code: "while (true) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "while (false) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "while (1) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "while (0) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		// only-allowed-literals: do-while and for also accept true/false/0/1
+		{Code: "do {} while (true);", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "for (; true; ) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "do {} while (0);", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "for (; 0; ) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		// Boolean legacy option: true = always
+		{Code: "while (true) {}", Options: map[string]interface{}{"allowConstantLoopConditions": true}},
+	}, []rule_tester.InvalidTestCase{
+		// do-while with always-falsy
+		{
+			Code:   "do {} while (false);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 14}},
+		},
+		// for with always-truthy condition
+		{
+			Code:   "for (let i = 0; []; i++) { break; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 17}},
+		},
+		// only-allowed-literals: do-while and for also allowed with true/false/0/1
+		// (these are valid now, moved to valid cases)
+		// only-allowed-literals rejects non-0/1 numeric literal
+		{
+			Code:    "while (2) {}",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 8}},
+		},
+		// 'always' still checks non-literal true type
+		{
+			Code:    "declare const obj: object;\nwhile (obj) {}\n",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "always"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+	})
+}
+
+// TestEdgeCases_AssignmentExpressions exercises checkAssignmentExpression:
+// - &&= checks left for truthy/falsy
+// - ||= checks left for truthy/falsy
+// - ??= checks left for nullish
+func TestEdgeCases_AssignmentExpressions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Nullable with ??=
+		{Code: "declare let x: string | null;\nx ??= 'hi';\n"},
+		// Boolean with &&=
+		{Code: "declare let x: boolean;\nx &&= true;\n"},
+		// Boolean with ||=
+		{Code: "declare let x: boolean;\nx ||= false;\n"},
+		// String (can be falsy) with &&= and ||=
+		{Code: "declare let x: string;\nx &&= 'hi';\nx ||= 'hi';\n"},
+	}, []rule_tester.InvalidTestCase{
+		// &&= on always-truthy
+		{
+			Code:   "declare let x: object;\nx &&= {};\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 1}},
+		},
+		// ||= on always-falsy
+		{
+			Code:   "declare let x: null;\nx ||= null;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 1}},
+		},
+		// ??= on non-nullish
+		{
+			Code:   "declare let x: number;\nx ??= 0;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 1}},
+		},
+		// ??= on always-nullish
+		{
+			Code:   "declare let x: null;\nx ??= null;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish", Line: 2, Column: 1}},
+		},
+	})
+}
+
+// TestEdgeCases_CallExpression exercises checkCallExpression:
+// - Array predicate with arrow expression body
+// - Array predicate with arrow block body (single return)
+// - Array predicate with arrow block body (multiple returns → return type check)
+// - Array predicate with named function reference
+// - findIndex, some, every, findLast, findLastIndex methods
+// - Generic callback constraint
+// - checkTypePredicates: asserts x, x is Type, asserts x is Type
+// - Spread arguments bail out
+func TestEdgeCases_CallExpression(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Arrow expression body with boolean return
+		{Code: "[1, 2, 3].filter(x => x > 1);\n"},
+		// Arrow block body with conditional return
+		{Code: "[1, 2, 3].filter(x => { if (x > 1) return true; return false; });\n"},
+		// some/every/find/findIndex all valid with boolean predicate
+		{Code: "[1, 2, 3].some(x => x > 0);\n"},
+		{Code: "[1, 2, 3].every(x => x > 0);\n"},
+		{Code: "[1, 2, 3].find(x => x > 0);\n"},
+		{Code: "[1, 2, 3].findIndex(x => x > 0);\n"},
+		// Named function reference with boolean return type
+		{Code: "function isPositive(x: number) { return x > 0; }\n[1, 2, 3].filter(isPositive);\n"},
+		// checkTypePredicates: disabled, so type guard doesn't report
+		{Code: "declare function isString(x: unknown): x is string;\ndeclare const s: string;\nisString(s);\n"},
+		// Spread args — skip because parameter index is unreliable
+		{Code: "declare function assert(x: unknown): asserts x;\nassert(...[]);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+	}, []rule_tester.InvalidTestCase{
+		// Arrow expression body always truthy
+		{
+			Code:   "[1, 2, 3].filter(x => [x]);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 23}},
+		},
+		// Arrow block body with single always-falsy return
+		{
+			Code:   "[1, 2, 3].filter(x => { return null; });\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 32}},
+		},
+		// Named function with always-truthy return
+		{
+			Code:   "function getTruthy() { return {}; }\n[1, 2, 3].some(getTruthy);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthyFunc", Line: 2, Column: 16}},
+		},
+		// findIndex with always-falsy callback
+		{
+			Code:   "function getFalsy() { return; }\n[1, 2, 3].findIndex(getFalsy);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsyFunc", Line: 2, Column: 21}},
+		},
+		// checkTypePredicates: asserts x on always truthy
+		{
+			Code:    "declare function assert(x: unknown): asserts x;\nassert([]);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+		// checkTypePredicates: x is Type already matches
+		{
+			Code:    "declare function isNumber(x: unknown): x is number;\ndeclare const n: number;\nisNumber(n);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "typeGuardAlreadyIsType", Line: 3, Column: 10}},
+		},
+	})
+}
+
+// TestEdgeCases_IsPossiblyFalsyTruthy exercises all branches in
+// isConstituentPossiblyFalsy and isConstituentPossiblyTruthy:
+// - any, unknown, TypeVariable → always both
+// - never → neither
+// - null, undefined, void → falsy only
+// - BooleanLike: true → truthy only, false → falsy only, boolean → both
+// - StringLiteral: "" → falsy, "x" → truthy
+// - NumberLiteral: 0 → falsy, 1 → truthy
+// - BigIntLiteral: 0n → falsy, 1n → truthy
+// - String, Number, BigInt (non-literal) → both
+// - EnumLiteral → both (conservative)
+// - Object → truthy only
+// - Union → recurse
+// - Intersection → Some(falsy), Every(truthy)
+func TestEdgeCases_IsPossiblyFalsyTruthy(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Enum with possible 0 value — both truthy and falsy
+		{Code: "enum E { A = 0, B = 1 }\ndeclare const e: E;\nif (e) {}\n"},
+		// boolean (non-literal) — both
+		{Code: "declare const b: boolean;\nif (b) {}\n"},
+		// String (non-literal) — both
+		{Code: "declare const s: string;\nif (s) {}\n"},
+		// BigInt (non-literal) — both
+		{Code: "declare const bi: bigint;\nif (bi) {}\n"},
+		// Number (non-literal) — both
+		{Code: "declare const n: number;\nif (n) {}\n"},
+		// Intersection with both truthy and falsy constituent
+		{Code: "declare const x: string & { __brand: string };\nif (x) {}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// null — falsy only
+		{
+			Code:   "if (null) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 5}},
+		},
+		// undefined — falsy only
+		{
+			Code:   "declare const x: undefined;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// void — falsy only
+		{
+			Code:   "declare const x: void;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// "" — falsy only
+		{
+			Code:   "declare const x: '';\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// 0 — falsy only
+		{
+			Code:   "declare const x: 0;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// 0n — falsy only
+		{
+			Code:   "declare const x: 0n;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// false — falsy only
+		{
+			Code:   "declare const x: false;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// true — truthy only
+		{
+			Code:   "declare const x: true;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// "hello" — truthy only
+		{
+			Code:   "declare const x: 'hello';\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// 42 — truthy only
+		{
+			Code:   "declare const x: 42;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// 1n — truthy only
+		{
+			Code:   "declare const x: 1n;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// object — truthy only
+		{
+			Code:   "declare const x: object;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// Intersection of falsy literals → falsy
+		{
+			Code:   "declare const x: '' & { __brand: string };\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// Union of only falsy types
+		{
+			Code:   "declare const x: null | undefined | 0 | '' | false;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// Union of only truthy types
+		{
+			Code:   "declare const x: object | true | 'hello' | 42;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+	})
+}
+
+// TestEdgeCases_DeepNesting tests deeply nested/composed patterns
+func TestEdgeCases_DeepNesting(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Nested ternaries with boolean conditions
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\nconst x = a ? (b ? 1 : 2) : 3;\n"},
+		// Deep logical chain
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\ndeclare const c: boolean;\nif (a && b && c) {}\n"},
+		// Nested optional chain with mixed nullable levels
+		{Code: "type A = { b?: { c: { d: string } | null } };\ndeclare const a: A | null;\na?.b?.c?.d;\n"},
+		// Deep ?? chain
+		{Code: "declare const a: string | null;\ndeclare const b: string | null;\ndeclare const c: string;\nconst x = a ?? b ?? c;\n"},
+		// if inside if
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\nif (a) { if (b) {} }\n"},
+		// Nested function with generic
+		{Code: "function outer<T>(t: T) {\n  function inner<U>(u: U) {\n    if (u) {}\n  }\n  if (t) {}\n}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Deep logical chain with always-truthy at left
+		{
+			Code: "declare const b: boolean;\ndeclare const c: boolean;\nif ([] && b && c) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "alwaysTruthy", Line: 3, Column: 5},
+			},
+		},
+		// Nested ?? — inner is never nullish
+		{
+			Code: "declare const a: string;\ndeclare const b: string | null;\nconst x = (a ?? 'x') ?? b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "neverNullish", Line: 3, Column: 11},
+				{MessageId: "neverNullish", Line: 3, Column: 12},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/nesting_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/nesting_test.go
@@ -1,0 +1,386 @@
+package no_unnecessary_condition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestNesting_ConditionalTypeAndMappedType tests conditional types, mapped types,
+// template literal types, and other advanced type constructs in conditions.
+func TestNesting_ConditionalTypeAndMappedType(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Conditional type — TypeVariable, always necessary
+		{Code: "function f<T>(x: T extends string ? number : boolean) { if (x) {} }\n"},
+		// Mapped type property access — string value, could be empty
+		{Code: "type M = { [K in 'a' | 'b']: string };\ndeclare const m: M;\nif (m.a) {}\n"},
+		// Template literal type with possible empty — `${string}` can be empty
+		{Code: "declare const x: `${string}`;\nif (x) {}\n"},
+		// Recursive type alias
+		{Code: "type Tree = { value: number; children: Tree[] };\ndeclare const t: Tree | null;\nif (t) { t.children[0]?.value; }\n"},
+		// keyof — string | number | symbol, could be falsy
+		{Code: "function f<T>(k: keyof T) { if (k) {} }\n"},
+		// Index access type — T[K] is type variable
+		{Code: "function f<T, K extends keyof T>(val: T[K]) { if (val) {} }\n"},
+		// Discriminated union in condition
+		{Code: "type A = { kind: 'a'; value: string };\ntype B = { kind: 'b'; value: number };\ndeclare const x: A | B;\nif (x.value) {}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Mapped type with object values — always truthy
+		{
+			Code:   "type M = { [K in 'a' | 'b']: { v: number } };\ndeclare const m: M;\nif (m.a) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 3, Column: 5}},
+		},
+	})
+}
+
+// TestNesting_AsConstAndReadonly tests `as const`, readonly arrays/tuples,
+// const assertions, and readonly modifiers.
+func TestNesting_AsConstAndReadonly(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// as const array with possible falsy — 0 is falsy
+		{Code: "const arr = [0, 1, 2] as const;\ndeclare const i: 0 | 1 | 2;\nif (arr[i]) {}\n"},
+		// Readonly array — same as regular for truthiness
+		{Code: "declare const arr: readonly string[];\nif (arr[0]) {}\n"},
+		// const enum — could be 0
+		{Code: "const enum E { A = 0, B = 1 }\ndeclare const e: E;\nif (e) {}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// as const object — always truthy
+		{
+			Code:   "const obj = { a: 1 } as const;\nif (obj) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// Readonly array itself — always truthy (array is object)
+		{
+			Code:   "declare const arr: readonly string[];\nif (arr) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+	})
+}
+
+// TestNesting_ClassAndInheritance tests class instances, inheritance,
+// abstract classes, and method return types.
+func TestNesting_ClassAndInheritance(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Class instance — nullable
+		{Code: "class Foo { bar() { return 1; } }\ndeclare const f: Foo | null;\nif (f) { f.bar(); }\n"},
+		// Abstract class method return — could be any value
+		{Code: "abstract class Base { abstract getValue(): string | null; }\ndeclare const b: Base;\nif (b.getValue()) {}\n"},
+		// Method returning boolean
+		{Code: "class Checker { check(): boolean { return true; } }\ndeclare const c: Checker;\nif (c.check()) {}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Class instance — always truthy
+		{
+			Code:   "class Foo {}\ndeclare const f: Foo;\nif (f) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 3, Column: 5}},
+		},
+		// Optional chain on non-nullable class instance
+		{
+			Code: "class Foo { bar = 'hello'; }\ndeclare const f: Foo;\nf?.bar;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 3, Column: 2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "class Foo { bar = 'hello'; }\ndeclare const f: Foo;\nf.bar;\n"},
+				},
+			}},
+		},
+	})
+}
+
+// TestNesting_PromiseAndAsync tests async/await patterns, Promise types.
+func TestNesting_PromiseAndAsync(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Promise is always truthy but awaited value might not be
+		{Code: "async function f() {\n  const x = await Promise.resolve(Math.random() > 0.5);\n  if (x) {}\n}\n"},
+		// Awaited nullable
+		{Code: "async function f(p: Promise<string | null>) {\n  const x = await p;\n  if (x) {}\n}\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Promise itself is always truthy (object)
+		{
+			Code:   "declare const p: Promise<string>;\nif (p) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+	})
+}
+
+// TestNesting_DeepOptionalChainCompositions tests complex optional chain
+// patterns: mixed ?.prop, ?.[], ?.() in deep chains with various nullable positions.
+func TestNesting_DeepOptionalChainCompositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Chain: nullable root → method call → property access
+		{Code: "type API = { fetch(): { data: string } };\ndeclare const api: API | null;\napi?.fetch().data;\n"},
+		// Chain: property → nullable method return → property
+		{Code: "type Obj = { get(): string | null };\ndeclare const o: Obj;\no.get()?.length;\n"},
+		// Chain: nullable root → computed → method
+		{Code: "type Dict = { [k: string]: { run(): void } | null };\ndeclare const d: Dict | null;\nd?.['key']?.run();\n"},
+		// Array index → optional chain → method (without noUncheckedIndexedAccess)
+		{Code: "declare const callbacks: Array<(() => string) | null>;\ncallbacks[0]?.();\n"},
+		// Nested ternary in optional chain context
+		{Code: "declare const x: { a?: { b: string } } | null;\nconst y = x?.a?.b ?? 'default';\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Non-nullable root → method with non-nullable return → unnecessary ?.
+		{
+			Code: "type API = { fetch(): { data: string } };\ndeclare const api: API;\napi.fetch()?.data;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 3, Column: 12,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "type API = { fetch(): { data: string } };\ndeclare const api: API;\napi.fetch().data;\n"},
+				},
+			}},
+		},
+	})
+}
+
+// TestNesting_NullishCoalescingCompositions tests ?? with various left-hand
+// side expressions: member access, call, element access, nested ??.
+func TestNesting_NullishCoalescingCompositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// ?? with function call returning nullable
+		{Code: "function get(): string | null { return null; }\nconst x = get() ?? 'fallback';\n"},
+		// ?? with optional property
+		{Code: "declare const obj: { a?: string };\nconst x = obj.a ?? 'default';\n"},
+		// ?? with computed nullable property
+		{Code: "declare const obj: { [k: string]: string | undefined };\nconst x = obj['key'] ?? 'default';\n"},
+		// Chained ?? — first is nullable, second catches
+		{Code: "declare const a: string | null;\ndeclare const b: string | null;\ndeclare const c: string;\nconst x = a ?? b ?? c;\n"},
+		// ?? with ternary
+		{Code: "declare const a: string | null;\nconst x = (a ?? 'default') ? 'yes' : 'no';\n"},
+	}, []rule_tester.InvalidTestCase{
+		// ?? on function returning non-nullable
+		{
+			Code:   "function get(): string { return 'hi'; }\nconst x = get() ?? 'fallback';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 11}},
+		},
+		// ?? on non-nullable member access
+		{
+			Code:   "declare const obj: { a: string };\nconst x = obj.a ?? 'default';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 11}},
+		},
+	})
+}
+
+// TestNesting_LogicalChainCompositions tests complex logical expression chains
+// with multiple levels: if (a && b || c && d), nested negation, mixed types.
+func TestNesting_LogicalChainCompositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Complex chain — all necessary
+		{Code: "declare const a: boolean;\ndeclare const b: string;\ndeclare const c: number;\nif (a && b && c) {}\n"},
+		// Negated chain
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\nif (!(a && b)) {}\n"},
+		// Mixed && and || — right sides checked in nested context
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\ndeclare const c: boolean;\nif ((a && b) || c) {}\n"},
+		// Ternary with logical
+		{Code: "declare const a: boolean;\ndeclare const b: string;\nconst x = a && b ? 'yes' : 'no';\n"},
+		// Short circuit assignment chain
+		{Code: "declare let a: string | null;\ndeclare let b: string | null;\na ||= b || 'default';\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Always-truthy at start of && chain
+		{
+			Code:   "declare const b: boolean;\nif ({} && b) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// Always-falsy at end of || chain
+		{
+			Code:   "declare const b: boolean;\nif (b || undefined) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 10}},
+		},
+		// Nested: [] is always-truthy — b && [] simple case
+		{
+			Code:   "declare const b: boolean;\nif (b && []) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 10}},
+		},
+		// Three-part chain: [] reported twice (RHS of left &&, LHS of right &&)
+		{
+			Code: "declare const b: boolean;\nif (b && [] && b) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "alwaysTruthy", Line: 2, Column: 16},
+				{MessageId: "alwaysTruthy", Line: 2, Column: 10},
+			},
+		},
+	})
+}
+
+// TestNesting_SwitchCaseCompositions tests switch/case with various
+// discriminant and case types.
+func TestNesting_SwitchCaseCompositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Discriminated union switch
+		{Code: "type A = { kind: 'a' };\ntype B = { kind: 'b' };\ndeclare const x: A | B;\nswitch (x.kind) { case 'a': break; case 'b': break; }\n"},
+		// Enum switch
+		{Code: "enum E { A, B, C }\ndeclare const e: E;\nswitch (e) { case E.A: break; case E.B: break; }\n"},
+		// String switch with multiple cases
+		{Code: "declare const s: string;\nswitch (s) { case 'a': break; case 'b': break; default: break; }\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Literal discriminant vs impossible case
+		{
+			Code:   "const x = 'a' as const;\nswitch (x) { case 'b': break; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 2, Column: 19}},
+		},
+		// Boolean switch
+		{
+			Code:   "switch (true) { case false: break; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 22}},
+		},
+	})
+}
+
+// TestNesting_AssignmentInCondition tests assignment expressions used
+// as conditions or in logical/nullish context.
+func TestNesting_AssignmentInCondition(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Assignment in while — result type is boolean, necessary
+		{Code: "declare let x: boolean;\nwhile (x = Math.random() > 0.5) {}\n"},
+		// Nullish assign on nullable
+		{Code: "declare let cache: Map<string, string> | null;\ncache ??= new Map();\n"},
+		// &&= on string (could be empty)
+		{Code: "declare let s: string;\ns &&= s.trim();\n"},
+		// ||= on number (could be 0)
+		{Code: "declare let n: number;\nn ||= 1;\n"},
+	}, []rule_tester.InvalidTestCase{
+		// ??= on Map (non-nullable)
+		{
+			Code:   "declare let cache: Map<string, string>;\ncache ??= new Map();\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 1}},
+		},
+	})
+}
+
+// TestNesting_MultipleErrorsInSingleExpression tests expressions that
+// produce multiple diagnostics.
+func TestNesting_MultipleErrorsInSingleExpression(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{}, []rule_tester.InvalidTestCase{
+		// Deep chain: 4 unnecessary optional chains
+		{
+			Code: "declare const x: { a: { b: { c: { d: string } } } };\nx?.a?.b?.c?.d;\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "neverOptionalChain", Line: 2, Column: 11,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: { d: string } } } };\nx?.a?.b?.c.d;\n"}}},
+				{MessageId: "neverOptionalChain", Line: 2, Column: 8,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: { d: string } } } };\nx?.a?.b.c?.d;\n"}}},
+				{MessageId: "neverOptionalChain", Line: 2, Column: 5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: { d: string } } } };\nx?.a.b?.c?.d;\n"}}},
+				{MessageId: "neverOptionalChain", Line: 2, Column: 2,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: { c: { d: string } } } };\nx.a?.b?.c?.d;\n"}}},
+			},
+		},
+		// Mixed: always-truthy in if + noOverlap in comparison
+		{
+			Code: "declare const obj: { a: string };\nif (obj) {}\nif (obj.a === null) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "alwaysTruthy", Line: 2, Column: 5},
+				{MessageId: "noOverlapBooleanExpression", Line: 3, Column: 5},
+			},
+		},
+		// && chain with multiple truthy — order depends on visitor traversal
+		{
+			Code: "if ([] && {} && true) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "alwaysTruthy", Line: 1, Column: 17},
+				{MessageId: "alwaysTruthy", Line: 1, Column: 11},
+				{MessageId: "alwaysTruthy", Line: 1, Column: 5},
+			},
+		},
+		// noStrictNullCheck produces error at line 0 + actual errors
+		{
+			Code:     "declare const obj: object;\nif (obj) {}\n",
+			TSConfig: "tsconfig.unstrict.json",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStrictNullCheck", Line: 0, Column: 0},
+				{MessageId: "alwaysTruthy", Line: 2, Column: 5},
+			},
+		},
+	})
+}
+
+// TestNesting_GenericConstraintCombinations tests complex generic type
+// parameters with various constraint combinations.
+func TestNesting_GenericConstraintCombinations(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Unconstrained generic — always necessary
+		{Code: "function f<T>(x: T) { if (x) {} }\n"},
+		// Constrained to union of truthy/falsy
+		{Code: "function f<T extends string | number>(x: T) { if (x) {} }\n"},
+		// Constrained to nullable
+		{Code: "function f<T extends string | null>(x: T) { if (x) {} }\n"},
+		// Multiple type params
+		{Code: "function f<T, U extends T>(x: U) { if (x) {} }\n"},
+		// Generic with default
+		{Code: "function f<T = string>(x: T) { if (x) {} }\n"},
+		// Generic method
+		{Code: "class C<T> { check(x: T) { if (x) {} } }\n"},
+		// Constrained to nullable + ??
+		{Code: "function f<T extends string | null>(x: T) { const y = x ?? 'default'; }\n"},
+	}, []rule_tester.InvalidTestCase{
+		// Constrained to always-truthy
+		{
+			Code:   "function f<T extends object>(x: T) { if (x) {} }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 42}},
+		},
+		// Constrained to non-empty string literals
+		{
+			Code:   "function f<T extends 'a' | 'b' | 'c'>(x: T) { if (x) {} }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 51}},
+		},
+		// Constrained to non-nullish + ??
+		{
+			Code:   "function f<T extends string>(x: T) { const y = x ?? 'default'; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 1, Column: 48}},
+		},
+	})
+}
+
+// TestNesting_ArrayPredicateCompositions tests complex array method
+// predicate patterns: chained methods, generic callbacks, overloads.
+func TestNesting_ArrayPredicateCompositions(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Chained filter().find() — different callbacks
+		{Code: "[1, 2, 3].filter(x => x > 0).find(x => x < 3);\n"},
+		// Generic array with boolean predicate
+		{Code: "function f<T>(arr: T[]) { arr.filter(x => !!x); }\n"},
+		// Array of union — predicate is necessary
+		{Code: "const arr: (string | null)[] = [];\narr.filter(x => x !== null);\n"},
+		// every() with boolean callback
+		{Code: "declare const arr: number[];\narr.every(x => x > 0);\n"},
+		// some() with boolean callback
+		{Code: "declare const arr: string[];\narr.some(x => x.length > 0);\n"},
+	}, []rule_tester.InvalidTestCase{
+		// filter with always-truthy arrow — objects are always truthy
+		{
+			Code:   "const arr: object[] = [];\narr.filter(x => x);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 17}},
+		},
+		// some() with always-falsy block body
+		{
+			Code:   "[1, 2].some(() => { return null; });\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 28}},
+		},
+	})
+}
+
+// TestNesting_TypePredicateCombinations tests checkTypePredicates with
+// complex type hierarchies and assertion patterns.
+func TestNesting_TypePredicateCombinations(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// Type guard on unknown — necessary
+		{Code: "function isString(x: unknown): x is string { return typeof x === 'string'; }\ndeclare const u: unknown;\nif (isString(u)) {}\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		// Type guard narrowing wider → narrower (not subtype)
+		{Code: "interface A { a: string }\ninterface B { a: string; b: number }\nfunction isB(x: A): x is B { return 'b' in x; }\ndeclare const a: A;\nif (isB(a)) {}\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		// Assertion on boolean condition — necessary
+		{Code: "declare function assert(x: unknown): asserts x;\nconst b = Math.random() > 0.5;\nassert(b);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		// Type guard with union predicate — necessary when arg is wider
+		{Code: "function isStringOrNum(x: unknown): x is string | number { return true; }\ndeclare const x: string | number | boolean;\nisStringOrNum(x);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+	}, []rule_tester.InvalidTestCase{
+		// Type guard: arg already matches predicate type
+		{
+			Code:    "function isNum(x: unknown): x is number { return typeof x === 'number'; }\ndeclare const n: number;\nisNum(n);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "typeGuardAlreadyIsType", Line: 3, Column: 7}},
+		},
+		// Assertion: arg is always truthy object
+		{
+			Code:    "declare function assert(x: unknown): asserts x;\nassert({});\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -51,11 +51,13 @@ type staticValue struct {
 }
 
 func toStaticValue(t *checker.Type) staticValue {
-	flags := checker.Type_flags(t)
-	// Handle both TypeFlagsBooleanLiteral and TypeFlagsBoolean (const narrowing)
-	if flags&checker.TypeFlagsBooleanLike != 0 && (utils.IsTrueLiteralType(t) || utils.IsFalseLiteralType(t)) {
-		return staticValue{value: utils.IsTrueLiteralType(t), ok: true}
+	if utils.IsTrueLiteralType(t) {
+		return staticValue{value: true, ok: true}
 	}
+	if utils.IsFalseLiteralType(t) {
+		return staticValue{value: false, ok: true}
+	}
+	flags := checker.Type_flags(t)
 	if flags == checker.TypeFlagsUndefined {
 		return staticValue{value: jsUndefined, ok: true}
 	}
@@ -135,6 +137,10 @@ func strictEqual(a, b interface{}) bool {
 		return true
 	}
 	if aNull || bNull || aUndef || bUndef {
+		return false
+	}
+	// JS strict equality requires same type — different Go types means different JS types
+	if fmt.Sprintf("%T", a) != fmt.Sprintf("%T", b) {
 		return false
 	}
 	return valueString(a) == valueString(b)

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.go
@@ -1,0 +1,1049 @@
+package no_unnecessary_condition
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// strictNullishFlag matches the original typescript-eslint behavior:
+// only null and undefined are considered "nullish" for isAlwaysNullish.
+var strictNullishFlag = checker.TypeFlagsUndefined | checker.TypeFlagsNull
+
+// isNullishType checks if a type is strictly null or undefined.
+func isNullishType(t *checker.Type) bool {
+	return utils.IsTypeFlagSet(t, strictNullishFlag)
+}
+
+// isAlwaysNullish checks if ALL union constituents are null or undefined.
+func isAlwaysNullish(t *checker.Type) bool {
+	return utils.Every(utils.UnionTypeParts(t), func(part *checker.Type) bool {
+		return isNullishType(part)
+	})
+}
+
+// isPossiblyNullish checks if ANY union constituent is null or undefined.
+// Matches original typescript-eslint: only Null and Undefined, not Void.
+func isPossiblyNullish(t *checker.Type) bool {
+	return utils.Some(utils.UnionTypeParts(t), func(part *checker.Type) bool {
+		return utils.IsTypeFlagSet(part, checker.TypeFlagsUndefined|checker.TypeFlagsNull)
+	})
+}
+
+// Sentinel types for distinguishing null and undefined in comparisons.
+type jsNullType struct{}
+type jsUndefinedType struct{}
+
+var jsNull = jsNullType{}
+var jsUndefined = jsUndefinedType{}
+
+type staticValue struct {
+	value interface{}
+	ok    bool
+}
+
+func toStaticValue(t *checker.Type) staticValue {
+	flags := checker.Type_flags(t)
+	// Handle both TypeFlagsBooleanLiteral and TypeFlagsBoolean (const narrowing)
+	if flags&checker.TypeFlagsBooleanLike != 0 && (utils.IsTrueLiteralType(t) || utils.IsFalseLiteralType(t)) {
+		return staticValue{value: utils.IsTrueLiteralType(t), ok: true}
+	}
+	if flags == checker.TypeFlagsUndefined {
+		return staticValue{value: jsUndefined, ok: true}
+	}
+	if flags == checker.TypeFlagsNull {
+		return staticValue{value: jsNull, ok: true}
+	}
+	if t.IsStringLiteral() || t.IsNumberLiteral() || t.IsBigIntLiteral() {
+		return staticValue{value: t.AsLiteralType().Value(), ok: true}
+	}
+	return staticValue{ok: false}
+}
+
+var boolOperators = map[string]bool{
+	"<": true, ">": true, "<=": true, ">=": true,
+	"==": true, "===": true, "!=": true, "!==": true,
+}
+
+func isBoolOperator(op string) bool {
+	return boolOperators[op]
+}
+
+// booleanComparison mimics JavaScript comparison semantics for literal types.
+func booleanComparison(left interface{}, operator string, right interface{}) bool {
+	switch operator {
+	case "===":
+		return strictEqual(left, right)
+	case "!==":
+		return !strictEqual(left, right)
+	case "==":
+		return looseEqual(left, right)
+	case "!=":
+		return !looseEqual(left, right)
+	case "<", "<=", ">", ">=":
+		cmp, ok := relationalCompare(left, right)
+		if !ok {
+			return false
+		}
+		switch operator {
+		case "<":
+			return cmp < 0
+		case "<=":
+			return cmp <= 0
+		case ">":
+			return cmp > 0
+		case ">=":
+			return cmp >= 0
+		}
+	}
+	return false
+}
+
+func isJSNullish(v interface{}) bool {
+	_, isNull := v.(jsNullType)
+	_, isUndef := v.(jsUndefinedType)
+	return isNull || isUndef
+}
+
+// valueString returns a canonical string for comparing literal values.
+// Uses fmt.Stringer for named types (Number, PseudoBigInt).
+func valueString(v interface{}) string {
+	if s, ok := v.(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func strictEqual(a, b interface{}) bool {
+	// null === null, undefined === undefined, but null !== undefined
+	_, aNull := a.(jsNullType)
+	_, bNull := b.(jsNullType)
+	_, aUndef := a.(jsUndefinedType)
+	_, bUndef := b.(jsUndefinedType)
+	if aNull && bNull {
+		return true
+	}
+	if aUndef && bUndef {
+		return true
+	}
+	if aNull || bNull || aUndef || bUndef {
+		return false
+	}
+	return valueString(a) == valueString(b)
+}
+
+func looseEqual(a, b interface{}) bool {
+	// null == undefined is true in JS
+	if isJSNullish(a) && isJSNullish(b) {
+		return true
+	}
+	// null/undefined != anything else
+	if isJSNullish(a) || isJSNullish(b) {
+		return false
+	}
+	return valueString(a) == valueString(b)
+}
+
+// relationalCompare compares two literal values for <, <=, >, >=.
+// JS uses numeric comparison for numbers/bigints/booleans, and
+// lexicographic comparison when both operands are strings.
+func relationalCompare(a, b interface{}) (int, bool) {
+	// String vs string: lexicographic comparison
+	sa, aStr := a.(string)
+	sb, bStr := b.(string)
+	if aStr && bStr {
+		if sa < sb {
+			return -1, true
+		}
+		if sa > sb {
+			return 1, true
+		}
+		return 0, true
+	}
+
+	na, aOK := toNumber(a)
+	nb, bOK := toNumber(b)
+	if !aOK || !bOK || math.IsNaN(na) || math.IsNaN(nb) {
+		return 0, false
+	}
+	if na < nb {
+		return -1, true
+	}
+	if na > nb {
+		return 1, true
+	}
+	return 0, true
+}
+
+// toNumber converts a literal type value to float64 for relational comparison.
+// tsgo stores number literals as Number (a named float64 type) and bigint
+// literals as PseudoBigInt — both implement fmt.Stringer.
+func toNumber(v interface{}) (float64, bool) {
+	switch val := v.(type) {
+	case float64:
+		return val, true
+	case bool:
+		if val {
+			return 1, true
+		}
+		return 0, true
+	case string:
+		// Strings can't be numerically compared — use stringCompare instead
+		return 0, false
+	default:
+		// Handle Number and PseudoBigInt via fmt.Stringer
+		if s, ok := v.(fmt.Stringer); ok {
+			str := s.String()
+			f, err := strconv.ParseFloat(str, 64)
+			if err != nil {
+				return 0, false
+			}
+			return f, true
+		}
+		return 0, false
+	}
+}
+
+type allowConstantLoopConditionsOption string
+
+const (
+	loopConditionNever              allowConstantLoopConditionsOption = "never"
+	loopConditionAlways             allowConstantLoopConditionsOption = "always"
+	loopConditionOnlyAllowedLiteral allowConstantLoopConditionsOption = "only-allowed-literals"
+)
+
+func normalizeAllowConstantLoopConditions(v interface{}) allowConstantLoopConditionsOption {
+	switch val := v.(type) {
+	case bool:
+		if val {
+			return loopConditionAlways
+		}
+		return loopConditionNever
+	case string:
+		switch val {
+		case "always":
+			return loopConditionAlways
+		case "only-allowed-literals":
+			return loopConditionOnlyAllowedLiteral
+		default:
+			return loopConditionNever
+		}
+	default:
+		return loopConditionNever
+	}
+}
+
+type ruleOptions struct {
+	allowConstantLoopConditions                            allowConstantLoopConditionsOption
+	allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing bool
+	checkTypePredicates                                    bool
+}
+
+func parseOptions(options any) ruleOptions {
+	opts := ruleOptions{
+		allowConstantLoopConditions: loopConditionNever,
+	}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["allowConstantLoopConditions"]; ok {
+			opts.allowConstantLoopConditions = normalizeAllowConstantLoopConditions(v)
+		}
+		if v, ok := optsMap["allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing"].(bool); ok {
+			opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing = v
+		}
+		if v, ok := optsMap["checkTypePredicates"].(bool); ok {
+			opts.checkTypePredicates = v
+		}
+	}
+	return opts
+}
+
+// Messages
+func buildAlwaysTruthyMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "alwaysTruthy", Description: "Unnecessary conditional, value is always truthy."}
+}
+func buildAlwaysFalsyMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "alwaysFalsy", Description: "Unnecessary conditional, value is always falsy."}
+}
+func buildAlwaysTruthyFuncMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "alwaysTruthyFunc", Description: "This callback should return a conditional, but return is always truthy."}
+}
+func buildAlwaysFalsyFuncMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "alwaysFalsyFunc", Description: "This callback should return a conditional, but return is always falsy."}
+}
+func buildNeverMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "never", Description: "Unnecessary conditional, value is `never`."}
+}
+func buildNeverNullishMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "neverNullish", Description: "Unnecessary conditional, expected left-hand side of `??` operator to be possibly null or undefined."}
+}
+func buildAlwaysNullishMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "alwaysNullish", Description: "Unnecessary conditional, left-hand side of `??` operator is always `null` or `undefined`."}
+}
+func buildNeverOptionalChainMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "neverOptionalChain", Description: "Unnecessary optional chain on a non-nullish value."}
+}
+func buildSuggestRemoveOptionalChainMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "suggestRemoveOptionalChain", Description: "Remove unnecessary optional chain"}
+}
+func buildNoStrictNullCheckMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "noStrictNullCheck", Description: "This rule requires the `strictNullChecks` compiler option to be turned on to function correctly."}
+}
+func buildComparisonBetweenLiteralTypesMessage(left, operator, right, trueOrFalse string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "comparisonBetweenLiteralTypes",
+		Description: fmt.Sprintf("Unnecessary conditional, comparison is always %s, since `%s %s %s` is %s.", trueOrFalse, left, operator, right, trueOrFalse),
+	}
+}
+func buildNoOverlapBooleanExpressionMessage() rule.RuleMessage {
+	return rule.RuleMessage{Id: "noOverlapBooleanExpression", Description: "Unnecessary conditional, the types have no overlap."}
+}
+func buildTypeGuardAlreadyIsTypeMessage(typeGuardOrAssertionFunction string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "typeGuardAlreadyIsType",
+		Description: fmt.Sprintf("Unnecessary conditional, expression already has the type being checked by the %s.", typeGuardOrAssertionFunction),
+	}
+}
+
+// Rule definition
+var NoUnnecessaryConditionRule = rule.CreateRule(rule.Rule{
+	Name:             "no-unnecessary-condition",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		tc := ctx.TypeChecker
+
+		compilerOptions := ctx.Program.Options()
+		isStrictNullChecks := utils.IsStrictCompilerOptionEnabled(
+			compilerOptions,
+			compilerOptions.StrictNullChecks,
+		)
+		isNoUncheckedIndexedAccess := compilerOptions.NoUncheckedIndexedAccess.IsTrue()
+
+		if !isStrictNullChecks && !opts.allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing {
+			ctx.ReportRange(core.NewTextRange(0, 0), buildNoStrictNullCheckMessage())
+		}
+
+		// --- Helper functions ---
+
+		nodeIsArrayType := func(node *ast.Node) bool {
+			nodeType := utils.GetConstrainedTypeAtLocation(tc, node)
+			return utils.Some(utils.UnionTypeParts(nodeType), func(part *checker.Type) bool {
+				return checker.Checker_isArrayType(tc, part)
+			})
+		}
+
+		nodeIsTupleType := func(node *ast.Node) bool {
+			nodeType := utils.GetConstrainedTypeAtLocation(tc, node)
+			return utils.Some(utils.UnionTypeParts(nodeType), func(part *checker.Type) bool {
+				return checker.IsTupleType(part)
+			})
+		}
+
+		isArrayIndexExpression := func(node *ast.Node) bool {
+			if !ast.IsElementAccessExpression(node) {
+				return false
+			}
+			elem := node.AsElementAccessExpression()
+			obj := elem.Expression
+			return nodeIsArrayType(obj) ||
+				(nodeIsTupleType(obj) && !ast.IsLiteralExpression(elem.ArgumentExpression))
+		}
+
+		// Conditional is always necessary if it involves any, unknown, or a naked type variable
+		isConditionalAlwaysNecessary := func(t *checker.Type) bool {
+			return utils.Some(utils.UnionTypeParts(t), func(part *checker.Type) bool {
+				return utils.IsTypeAnyType(part) ||
+					utils.IsTypeUnknownType(part) ||
+					utils.IsTypeFlagSet(part, checker.TypeFlagsTypeVariable)
+			})
+		}
+
+		isNullableMemberExpression := func(node *ast.Node) bool {
+			if !ast.IsAccessExpression(node) {
+				return false
+			}
+			objectType := ctx.TypeChecker.GetTypeAtLocation(node.Expression())
+			if ast.IsElementAccessExpression(node) {
+				propertyType := ctx.TypeChecker.GetTypeAtLocation(node.AsElementAccessExpression().ArgumentExpression)
+				return isNullablePropertyType(tc, objectType, propertyType)
+			}
+			// PropertyAccessExpression — use Checker_getAccessedPropertyName for
+			// correct handling of private fields (#prop) and computed properties
+			propName, ok := checker.Checker_getAccessedPropertyName(tc, node)
+			if !ok {
+				return false
+			}
+			propSymbol := checker.Checker_getPropertyOfType(tc, objectType, propName)
+			if propSymbol == nil {
+				// Fallback for private fields (#prop) — getPropertyOfType uses
+				// the display name but private fields have internal escaped names.
+				// GetSymbolAtLocation resolves private fields correctly.
+				propSymbol = tc.GetSymbolAtLocation(node)
+			}
+			if propSymbol != nil && utils.IsSymbolFlagSet(propSymbol, ast.SymbolFlagsOptional) {
+				return true
+			}
+			return false
+		}
+
+		// --- Core check functions ---
+
+		var checkNode func(expression *ast.Node, isUnaryNotArgument bool, reportNode *ast.Node)
+		checkNode = func(expression *ast.Node, isUnaryNotArgument bool, reportNode *ast.Node) {
+			expression = ast.SkipParentheses(expression)
+
+			if reportNode == nil {
+				reportNode = expression
+			}
+
+			// Handle unary negation
+			if ast.IsPrefixUnaryExpression(expression) && expression.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken {
+				checkNode(expression.AsPrefixUnaryExpression().Operand, !isUnaryNotArgument, reportNode)
+				return
+			}
+
+			// Skip array index expressions (unsound typing)
+			if !isNoUncheckedIndexedAccess && isArrayIndexExpression(expression) {
+				return
+			}
+
+			// For logical expressions (except ??), only check the right side
+			if ast.IsBinaryExpression(expression) {
+				binExpr := expression.AsBinaryExpression()
+				op := binExpr.OperatorToken.Kind
+				if op == ast.KindAmpersandAmpersandToken || op == ast.KindBarBarToken {
+					checkNode(binExpr.Right, false, nil)
+					return
+				}
+			}
+
+			t := utils.GetConstrainedTypeAtLocation(tc, expression)
+			if isConditionalAlwaysNecessary(t) {
+				return
+			}
+
+			if utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsNever) {
+				ctx.ReportNode(reportNode, buildNeverMessage())
+				return
+			}
+			if !utils.IsPossiblyTruthy(t) {
+				if !isUnaryNotArgument {
+					ctx.ReportNode(reportNode, buildAlwaysFalsyMessage())
+				} else {
+					ctx.ReportNode(reportNode, buildAlwaysTruthyMessage())
+				}
+				return
+			}
+			if !utils.IsPossiblyFalsy(t) {
+				if !isUnaryNotArgument {
+					ctx.ReportNode(reportNode, buildAlwaysTruthyMessage())
+				} else {
+					ctx.ReportNode(reportNode, buildAlwaysFalsyMessage())
+				}
+				return
+			}
+		}
+
+		checkNodeForNullish := func(node *ast.Node) {
+			t := utils.GetConstrainedTypeAtLocation(tc, node)
+
+			// Conditional is always necessary if it involves any, unknown, or type parameter
+			if utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsAny|checker.TypeFlagsUnknown|checker.TypeFlagsTypeParameter|checker.TypeFlagsTypeVariable) {
+				return
+			}
+
+			if utils.IsTypeFlagSetWithUnion(t, checker.TypeFlagsNever) {
+				ctx.ReportNode(node, buildNeverMessage())
+				return
+			}
+
+			isMemberExpr := ast.IsAccessExpression(node)
+			if !isPossiblyNullish(t) && (!isMemberExpr || !isNullableMemberExpression(node)) {
+				// Skip array index expressions without noUncheckedIndexedAccess
+				if isNoUncheckedIndexedAccess ||
+					(!isArrayIndexExpression(node) &&
+						!isChainExpressionWithOptionalArrayIndex(node, isArrayIndexExpression)) {
+					ctx.ReportNode(node, buildNeverNullishMessage())
+					return
+				}
+			} else if isAlwaysNullish(t) {
+				ctx.ReportNode(node, buildAlwaysNullishMessage())
+				return
+			}
+		}
+
+		checkIfBoolExpressionIsNecessaryConditional := func(node *ast.Node, left *ast.Node, right *ast.Node, operator string) {
+			leftType := utils.GetConstrainedTypeAtLocation(tc, left)
+			rightType := utils.GetConstrainedTypeAtLocation(tc, right)
+
+			leftStatic := toStaticValue(leftType)
+			rightStatic := toStaticValue(rightType)
+
+			if leftStatic.ok && rightStatic.ok {
+				conditionIsTrue := booleanComparison(leftStatic.value, operator, rightStatic.value)
+				trueOrFalse := "false"
+				if conditionIsTrue {
+					trueOrFalse = "true"
+				}
+				ctx.ReportNode(node, buildComparisonBetweenLiteralTypesMessage(
+					tc.TypeToString(leftType),
+					operator,
+					tc.TypeToString(rightType),
+					trueOrFalse,
+				))
+				return
+			}
+
+			// Workaround for TypeScript issue #37160
+			if isStrictNullChecks {
+				isComparable := func(t *checker.Type, flag checker.TypeFlags) bool {
+					flag |= checker.TypeFlagsAny | checker.TypeFlagsUnknown | checker.TypeFlagsTypeParameter | checker.TypeFlagsTypeVariable
+					if operator == "==" || operator == "!=" {
+						flag |= checker.TypeFlagsNull | checker.TypeFlagsUndefined | checker.TypeFlagsVoid
+					}
+					return utils.IsTypeFlagSetWithUnion(t, flag)
+				}
+
+				leftFlags := checker.Type_flags(leftType)
+				rightFlags := checker.Type_flags(rightType)
+
+				if (leftFlags == checker.TypeFlagsUndefined && !isComparable(rightType, checker.TypeFlagsUndefined|checker.TypeFlagsVoid)) ||
+					(rightFlags == checker.TypeFlagsUndefined && !isComparable(leftType, checker.TypeFlagsUndefined|checker.TypeFlagsVoid)) ||
+					(leftFlags == checker.TypeFlagsNull && !isComparable(rightType, checker.TypeFlagsNull)) ||
+					(rightFlags == checker.TypeFlagsNull && !isComparable(leftType, checker.TypeFlagsNull)) {
+					ctx.ReportNode(node, buildNoOverlapBooleanExpressionMessage())
+					return
+				}
+			}
+		}
+
+		checkLogicalExpressionForUnnecessaryConditionals := func(node *ast.Node) {
+			binExpr := node.AsBinaryExpression()
+			if binExpr.OperatorToken.Kind == ast.KindQuestionQuestionToken {
+				checkNodeForNullish(binExpr.Left)
+				return
+			}
+			// Only check the left side
+			checkNode(binExpr.Left, false, nil)
+		}
+
+		checkIfLoopIsNecessaryConditional := func(node *ast.Node) {
+			var test *ast.Node
+			switch node.Kind {
+			case ast.KindWhileStatement:
+				test = node.AsWhileStatement().Expression
+			case ast.KindDoStatement:
+				test = node.AsDoStatement().Expression
+			case ast.KindForStatement:
+				test = node.AsForStatement().Condition
+			}
+			if test == nil {
+				return
+			}
+
+			if opts.allowConstantLoopConditions == loopConditionOnlyAllowedLiteral {
+				if test.Kind == ast.KindTrueKeyword || test.Kind == ast.KindFalseKeyword {
+					return
+				}
+				if ast.IsNumericLiteral(test) {
+					text := test.Text()
+					if text == "0" || text == "1" {
+						return
+					}
+				}
+			}
+
+			if opts.allowConstantLoopConditions == loopConditionAlways {
+				testType := utils.GetConstrainedTypeAtLocation(tc, test)
+				if utils.IsTrueLiteralType(testType) {
+					return
+				}
+			}
+
+			checkNode(test, false, nil)
+		}
+
+		// optionChainContainsOptionArrayIndex recursively walks the optional chain
+		// looking for array/tuple index accesses. Array index accesses are unsound
+		// without noUncheckedIndexedAccess, and unlike object index signatures,
+		// they remain unsound even after function calls (the result type is still
+		// from the array element type).
+		var optionChainContainsOptionArrayIndex func(node *ast.Node) bool
+		optionChainContainsOptionArrayIndex = func(node *ast.Node) bool {
+			if ast.IsCallExpression(node) {
+				callExpr := node.AsCallExpression()
+				lhsNode := callExpr.Expression
+				if ast.IsOptionalChain(node) && isArrayIndexExpression(lhsNode) {
+					return true
+				}
+				if ast.IsAccessExpression(lhsNode) || ast.IsCallExpression(lhsNode) {
+					return optionChainContainsOptionArrayIndex(lhsNode)
+				}
+			} else if ast.IsAccessExpression(node) {
+				obj := node.Expression()
+				if ast.IsOptionalChain(node) && isArrayIndexExpression(obj) {
+					return true
+				}
+				if ast.IsAccessExpression(obj) || ast.IsCallExpression(obj) {
+					return optionChainContainsOptionArrayIndex(obj)
+				}
+			}
+			return false
+		}
+
+		isMemberExpressionNullableOriginFromObject := func(node *ast.Node) bool {
+			prevType := utils.GetConstrainedTypeAtLocation(tc, node.Expression())
+			if !prevType.IsUnion() {
+				return false
+			}
+
+			isComputed := ast.IsElementAccessExpression(node)
+			propName := ""
+			if !isComputed {
+				// Use Checker_getAccessedPropertyName for correct handling of
+				// private fields (#prop) and computed properties
+				var ok bool
+				propName, ok = checker.Checker_getAccessedPropertyName(tc, node)
+				if !ok {
+					return false
+				}
+			}
+
+			isOwnNullable := utils.Some(prevType.Types(), func(partType *checker.Type) bool {
+				if isComputed {
+					propertyType := utils.GetConstrainedTypeAtLocation(tc, node.AsElementAccessExpression().ArgumentExpression)
+					return isNullablePropertyType(tc, partType, propertyType)
+				}
+				propType := tc.GetTypeOfPropertyOfType(partType, propName)
+				if propType != nil {
+					return utils.IsNullableType(propType)
+				}
+				indexInfos := tc.GetIndexInfosOfType(partType)
+				return utils.Some(indexInfos, func(info *checker.IndexInfo) bool {
+					keyTypeName := utils.GetTypeName(tc, info.KeyType())
+					isStringOrNumber := keyTypeName == "string" || keyTypeName == "number"
+					return isStringOrNumber && (isNoUncheckedIndexedAccess || utils.IsNullableType(info.ValueType()))
+				})
+			})
+			return !isOwnNullable && utils.IsNullableType(prevType)
+		}
+
+		isCallExpressionNullableOriginFromCallee := func(node *ast.Node) bool {
+			callExpr := node.AsCallExpression()
+			prevType := utils.GetConstrainedTypeAtLocation(tc, callExpr.Expression)
+			if !prevType.IsUnion() {
+				return false
+			}
+			isOwnNullable := utils.Some(prevType.Types(), func(partType *checker.Type) bool {
+				signatures := utils.GetCallSignatures(tc, partType)
+				return utils.Some(signatures, func(sig *checker.Signature) bool {
+					return utils.IsNullableType(checker.Checker_getReturnTypeOfSignature(tc, sig))
+				})
+			})
+			return !isOwnNullable && utils.IsNullableType(prevType)
+		}
+
+		isOptionableExpression := func(node *ast.Node) bool {
+			t := utils.GetConstrainedTypeAtLocation(tc, node)
+			isOwnNullable := true
+			if ast.IsAccessExpression(node) {
+				isOwnNullable = !isMemberExpressionNullableOriginFromObject(node)
+			} else if ast.IsCallExpression(node) {
+				isOwnNullable = !isCallExpressionNullableOriginFromCallee(node)
+			}
+			return isConditionalAlwaysNecessary(t) || (isOwnNullable && utils.IsNullableType(t))
+		}
+
+		checkOptionalChain := func(node *ast.Node, fix string) {
+			if !ast.IsOptionalChain(node) {
+				return
+			}
+
+			// Skip unsound array/tuple index expressions
+			if !isNoUncheckedIndexedAccess && optionChainContainsOptionArrayIndex(node) {
+				return
+			}
+
+			var nodeToCheck *ast.Node
+			if ast.IsCallExpression(node) {
+				nodeToCheck = node.AsCallExpression().Expression
+			} else {
+				nodeToCheck = node.Expression()
+			}
+			if isOptionableExpression(nodeToCheck) {
+				return
+			}
+
+			// Get the ?. token range directly from the AST node
+			questionDotToken := node.QuestionDotToken()
+			if questionDotToken == nil {
+				return
+			}
+			questionDotRange := utils.TrimNodeTextRange(ctx.SourceFile, questionDotToken)
+
+			ctx.ReportRangeWithSuggestions(
+				questionDotRange,
+				buildNeverOptionalChainMessage(),
+				rule.RuleSuggestion{
+					Message: buildSuggestRemoveOptionalChainMessage(),
+					FixesArr: []rule.RuleFix{
+						rule.RuleFixReplaceRange(questionDotRange, fix),
+					},
+				},
+			)
+		}
+
+		checkCallExpression := func(node *ast.Node) {
+			callExpr := node.AsCallExpression()
+
+			if opts.checkTypePredicates {
+				// Check for truthiness assertion functions
+				truthinessArg := findTruthinessAssertedArgument(tc, callExpr)
+				if truthinessArg != nil {
+					checkNode(truthinessArg, false, nil)
+				}
+
+				// Check for type guard assertion functions
+				typeGuardResult := findTypeGuardAssertedArgument(tc, callExpr)
+				if typeGuardResult != nil {
+					typeOfArgument := utils.GetConstrainedTypeAtLocation(tc, typeGuardResult.argument)
+					predType := typeGuardResult.predicateType
+					// Match original: skip any/unknown, check mutual assignability or union predicate
+					if !utils.IsTypeAnyType(typeOfArgument) && !utils.IsTypeUnknownType(typeOfArgument) &&
+						checker.Checker_isTypeAssignableTo(tc, typeOfArgument, predType) &&
+						(checker.Checker_isTypeAssignableTo(tc, predType, typeOfArgument) || predType.IsUnion()) {
+						label := "type guard"
+						if typeGuardResult.asserts {
+							label = "assertion function"
+						}
+						ctx.ReportNode(typeGuardResult.argument, buildTypeGuardAlreadyIsTypeMessage(label))
+					}
+				}
+			}
+
+			// Check array method calls with predicates
+			if utils.IsArrayMethodCallWithPredicate(tc, callExpr) && len(callExpr.Arguments.Nodes) > 0 {
+				callback := callExpr.Arguments.Nodes[0]
+
+				if ast.IsArrowFunction(callback) || ast.IsFunctionExpression(callback) {
+					body := callback.Body()
+					if body != nil && !ast.IsBlock(body) {
+						// Arrow function with expression body: () => something
+						checkNode(body, false, nil)
+						return
+					}
+					if body != nil && ast.IsBlock(body) {
+						statements := body.AsBlock().Statements.Nodes
+						if len(statements) == 1 && ast.IsReturnStatement(statements[0]) {
+							returnStmt := statements[0].AsReturnStatement()
+							if returnStmt.Expression != nil {
+								checkNode(returnStmt.Expression, false, nil)
+								return
+							}
+						}
+					}
+				}
+
+				// Check callback return types
+				callbackType := utils.GetConstrainedTypeAtLocation(tc, callback)
+				returnTypes := collectReturnTypes(tc, callbackType)
+				if len(returnTypes) == 0 {
+					return
+				}
+
+				hasFalsyReturnTypes := false
+				hasTruthyReturnTypes := false
+				for _, rt := range returnTypes {
+					constraintType, _ := utils.GetConstraintInfo(tc, rt)
+					if constraintType == nil || utils.IsTypeAnyType(constraintType) || utils.IsTypeUnknownType(constraintType) {
+						return
+					}
+					if utils.IsPossiblyFalsy(constraintType) {
+						hasFalsyReturnTypes = true
+					}
+					if utils.IsPossiblyTruthy(constraintType) {
+						hasTruthyReturnTypes = true
+					}
+					if hasFalsyReturnTypes && hasTruthyReturnTypes {
+						return
+					}
+				}
+
+				if !hasFalsyReturnTypes {
+					ctx.ReportNode(callback, buildAlwaysTruthyFuncMessage())
+					return
+				}
+				if !hasTruthyReturnTypes {
+					ctx.ReportNode(callback, buildAlwaysFalsyFuncMessage())
+					return
+				}
+			}
+		}
+
+		checkAssignmentExpression := func(node *ast.Node) {
+			assignExpr := node.AsBinaryExpression()
+			switch assignExpr.OperatorToken.Kind {
+			case ast.KindAmpersandAmpersandEqualsToken, ast.KindBarBarEqualsToken:
+				checkNode(assignExpr.Left, false, nil)
+			case ast.KindQuestionQuestionEqualsToken:
+				checkNodeForNullish(assignExpr.Left)
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindIfStatement: func(node *ast.Node) {
+				checkNode(node.AsIfStatement().Expression, false, nil)
+			},
+			ast.KindConditionalExpression: func(node *ast.Node) {
+				checkNode(node.AsConditionalExpression().Condition, false, nil)
+			},
+			ast.KindWhileStatement: func(node *ast.Node) {
+				checkIfLoopIsNecessaryConditional(node)
+			},
+			ast.KindDoStatement: func(node *ast.Node) {
+				checkIfLoopIsNecessaryConditional(node)
+			},
+			ast.KindForStatement: func(node *ast.Node) {
+				checkIfLoopIsNecessaryConditional(node)
+			},
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binExpr := node.AsBinaryExpression()
+				op := binExpr.OperatorToken.Kind
+
+				// Logical expressions: &&, ||, ??
+				if op == ast.KindAmpersandAmpersandToken || op == ast.KindBarBarToken || op == ast.KindQuestionQuestionToken {
+					checkLogicalExpressionForUnnecessaryConditionals(node)
+					return
+				}
+
+				// Assignment expressions: &&=, ||=, ??=
+				if op == ast.KindAmpersandAmpersandEqualsToken || op == ast.KindBarBarEqualsToken || op == ast.KindQuestionQuestionEqualsToken {
+					checkAssignmentExpression(node)
+					return
+				}
+
+				// Boolean comparison operators
+				opStr := scanner.TokenToString(op)
+				if isBoolOperator(opStr) {
+					checkIfBoolExpressionIsNecessaryConditional(node, binExpr.Left, binExpr.Right, opStr)
+					return
+				}
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				checkCallExpression(node)
+
+				// Check optional call chain
+				callExpr := node.AsCallExpression()
+				if callExpr.QuestionDotToken != nil {
+					checkOptionalChain(node, "")
+				}
+			},
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				propAccess := node.AsPropertyAccessExpression()
+				if propAccess.QuestionDotToken != nil {
+					checkOptionalChain(node, ".")
+				}
+			},
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				elemAccess := node.AsElementAccessExpression()
+				if elemAccess.QuestionDotToken != nil {
+					checkOptionalChain(node, "")
+				}
+			},
+			ast.KindCaseClause: func(node *ast.Node) {
+				caseClause := node.AsCaseOrDefaultClause()
+				if caseClause == nil || caseClause.Expression == nil {
+					return
+				}
+				// Navigate up from CaseClause -> CaseBlock -> SwitchStatement
+				caseBlock := node.Parent
+				if caseBlock == nil {
+					return
+				}
+				switchNode := caseBlock.Parent
+				if switchNode == nil || !ast.IsSwitchStatement(switchNode) {
+					return
+				}
+				switchStmt := switchNode.AsSwitchStatement()
+				checkIfBoolExpressionIsNecessaryConditional(
+					caseClause.Expression,
+					switchStmt.Expression,
+					caseClause.Expression,
+					"===",
+				)
+			},
+		}
+	},
+})
+
+// Helper functions
+
+func isNullablePropertyType(tc *checker.Checker, objType *checker.Type, propertyType *checker.Type) bool {
+	if propertyType.IsUnion() {
+		return utils.Some(propertyType.Types(), func(part *checker.Type) bool {
+			return isNullablePropertyType(tc, objType, part)
+		})
+	}
+	if propertyType.IsNumberLiteral() || propertyType.IsStringLiteral() {
+		propName := valueString(propertyType.AsLiteralType().Value())
+		propType := tc.GetTypeOfPropertyOfType(objType, propName)
+		if propType != nil {
+			return utils.IsNullableType(propType)
+		}
+		// tsgo's GetTypeOfPropertyOfType doesn't resolve index signatures for
+		// non-array object types (e.g., { [key: number]: T }). For these types,
+		// if the literal key matches an index signature, treat the property as
+		// potentially missing (matching original behavior).
+		// Skip arrays — they are handled by the fallthrough getTypeName comparison.
+		if !checker.Checker_isArrayType(tc, objType) && !checker.IsTupleType(objType) {
+			var keyType *checker.Type
+			if propertyType.IsNumberLiteral() {
+				keyType = tc.GetNumberType()
+			} else {
+				keyType = tc.GetStringType()
+			}
+			indexType := checker.Checker_getIndexTypeOfType(tc, objType, keyType)
+			if indexType != nil {
+				return true
+			}
+		}
+	}
+	typeName := utils.GetTypeName(tc, propertyType)
+	indexInfos := tc.GetIndexInfosOfType(objType)
+	return utils.Some(indexInfos, func(info *checker.IndexInfo) bool {
+		return utils.GetTypeName(tc, info.KeyType()) == typeName
+	})
+}
+
+func collectReturnTypes(tc *checker.Checker, callbackType *checker.Type) []*checker.Type {
+	sigs := utils.CollectAllCallSignatures(tc, callbackType)
+	result := make([]*checker.Type, 0, len(sigs))
+	for _, sig := range sigs {
+		result = append(result, checker.Checker_getReturnTypeOfSignature(tc, sig))
+	}
+	return result
+}
+
+type typeGuardResult struct {
+	argument      *ast.Node
+	predicateType *checker.Type
+	asserts       bool
+}
+
+// firstSpreadIndex returns the index of the first spread element argument,
+// or -1 if none. Arguments before the first spread can still be reliably
+// mapped to parameters by index.
+func firstSpreadIndex(callExpr *ast.CallExpression) int {
+	for i, arg := range callExpr.Arguments.Nodes {
+		if ast.IsSpreadElement(arg) {
+			return i
+		}
+	}
+	return -1
+}
+
+func findTruthinessAssertedArgument(tc *checker.Checker, callExpr *ast.CallExpression) *ast.Node {
+	// Get the resolved signature
+	sig := checker.Checker_getResolvedSignature(tc, callExpr.AsNode(), nil, checker.CheckModeNormal)
+	if sig == nil {
+		return nil
+	}
+
+	predicate := tc.GetTypePredicateOfSignature(sig)
+	if predicate == nil {
+		return nil
+	}
+
+	// Truthiness assertions: asserts param (no type) or param is truthy (no type)
+	if predicate.Type() != nil {
+		return nil
+	}
+
+	// Must be an asserts predicate
+	if predicate.Kind() != checker.TypePredicateKindAssertsIdentifier {
+		return nil
+	}
+
+	paramIndex := predicate.ParameterIndex()
+	// Skip if parameter index is at or past a spread element (unreliable mapping)
+	spreadIdx := firstSpreadIndex(callExpr)
+	if spreadIdx >= 0 && int(paramIndex) >= spreadIdx {
+		return nil
+	}
+	if int(paramIndex) >= len(callExpr.Arguments.Nodes) {
+		return nil
+	}
+	return callExpr.Arguments.Nodes[paramIndex]
+}
+
+func findTypeGuardAssertedArgument(tc *checker.Checker, callExpr *ast.CallExpression) *typeGuardResult {
+	sig := checker.Checker_getResolvedSignature(tc, callExpr.AsNode(), nil, checker.CheckModeNormal)
+	if sig == nil {
+		return nil
+	}
+
+	predicate := tc.GetTypePredicateOfSignature(sig)
+	if predicate == nil {
+		return nil
+	}
+
+	// Type guard: param is Type / asserts param is Type
+	if predicate.Type() == nil {
+		return nil
+	}
+
+	if predicate.Kind() != checker.TypePredicateKindIdentifier && predicate.Kind() != checker.TypePredicateKindAssertsIdentifier {
+		return nil
+	}
+
+	paramIndex := predicate.ParameterIndex()
+	// Skip if parameter index is at or past a spread element (unreliable mapping)
+	spreadIdx := firstSpreadIndex(callExpr)
+	if spreadIdx >= 0 && int(paramIndex) >= spreadIdx {
+		return nil
+	}
+	if int(paramIndex) >= len(callExpr.Arguments.Nodes) {
+		return nil
+	}
+
+	return &typeGuardResult{
+		argument:      callExpr.Arguments.Nodes[paramIndex],
+		predicateType: predicate.Type(),
+		asserts:       predicate.Kind() == checker.TypePredicateKindAssertsIdentifier,
+	}
+}
+
+func isChainExpressionWithOptionalArrayIndex(node *ast.Node, isArrayIndexExpr func(n *ast.Node) bool) bool {
+	if !ast.IsAccessExpression(node) && !ast.IsCallExpression(node) {
+		return false
+	}
+	// Walk the chain, recursing through both access and call expressions
+	current := node
+	for current != nil {
+		if ast.IsAccessExpression(current) {
+			obj := current.Expression()
+			if ast.IsOptionalChain(current) && isArrayIndexExpr(obj) {
+				return true
+			}
+			current = obj
+		} else if ast.IsCallExpression(current) {
+			callExpr := current.AsCallExpression()
+			if ast.IsOptionalChain(current) && isArrayIndexExpr(callExpr.Expression) {
+				return true
+			}
+			current = callExpr.Expression
+		} else {
+			break
+		}
+	}
+	return false
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition.md
@@ -1,0 +1,45 @@
+# no-unnecessary-condition
+
+## Rule Details
+
+Disallow conditionals where the type is always truthy or always falsy.
+
+Any expression being used as a condition must be able to evaluate as truthy or falsy in order to be considered necessary. Conversely, any expression that always evaluates to truthy or always evaluates to falsy is considered unnecessary and will be flagged by this rule.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+function head<T>(items: T[]) {
+  // items is always truthy (arrays are objects)
+  if (items) {
+    return items[0].toUpperCase();
+  }
+}
+
+function foo(arg: 'bar' | 'baz') {
+  // arg is always truthy (non-empty string literals)
+  if (arg) {
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+function head<T>(items: T[]) {
+  // items.length can be zero
+  if (items.length) {
+    return items[0].toUpperCase();
+  }
+}
+
+function foo(arg: string) {
+  // string can be empty
+  if (arg) {
+  }
+}
+```
+
+## Original Documentation
+
+https://typescript-eslint.io/rules/no-unnecessary-condition

--- a/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_condition/no_unnecessary_condition_test.go
@@ -1,0 +1,773 @@
+package no_unnecessary_condition
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryCondition(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryConditionRule, []rule_tester.ValidTestCase{
+		// === Basic types ===
+		{Code: "declare const b1: boolean;\ndeclare const b2: boolean;\nconst t1 = b1 && b2;\n"},
+		{Code: "declare const b1: boolean;\ndeclare const b2: boolean;\nconst t1 = b1 || b2;\n"},
+		{Code: "declare const b1: boolean;\nconst t1 = b1 ? 'yes' : 'no';\n"},
+		{Code: "function foo(): boolean { return true; }\nif (foo()) {}\n"},
+		{Code: "declare const n: number;\nif (n) {}\n"},
+		{Code: "declare const s: string;\nif (s) {}\n"},
+		{Code: "declare const b: bigint;\nif (b) {}\n"},
+		{Code: "declare const x: boolean;\nif (x) {}\n"},
+
+		// === any / unknown / type variables ===
+		{Code: "declare const x: any;\nif (x) {}\n"},
+		{Code: "declare const x: unknown;\nif (x) {}\n"},
+		{Code: "declare const x: any;\nconst y = x ?? 'default';\n"},
+		{Code: "declare const x: unknown;\nconst y = x ?? 'default';\n"},
+		{Code: "function test<T>(a: T) { return a ?? 'default'; }\n"},
+		{Code: "function test<T extends string | null>(a: T) { return a ?? 'default'; }\n"},
+
+		// === Nullable types ===
+		{Code: "declare const x: string | null;\nif (x) {}\n"},
+		{Code: "declare const x: string | undefined;\nif (x) {}\n"},
+		{Code: "declare const x: string | null | undefined;\nconst y = x ?? 'default';\n"},
+
+		// === void type ===
+		{Code: "declare function foo(): number | void;\nconst r = foo() === undefined;\n"},
+		{Code: "declare function foo(): number | void;\nconst r = foo() == null;\n"},
+
+		// === Generics and type parameters ===
+		{Code: "function test<T extends string>(t: T) {\n  return t ? 'yes' : 'no';\n}\n"},
+		{Code: "function test<T>(t: T) {\n  return t ? 'yes' : 'no';\n}\n"},
+		{Code: "function test<T>(t: T | []) {\n  return t ? 'yes' : 'no';\n}\n"},
+
+		// === Branded / intersection types ===
+		{Code: "declare const b1: string & { __brand: string };\nif (b1) {}\n"},
+		{Code: "declare const b1: number & { __brand: string };\nif (b1) {}\n"},
+		{Code: "declare const b1: boolean & { __brand: string };\nif (b1) {}\n"},
+		{Code: "declare const b1: bigint & { __brand: string };\nif (b1) {}\n"},
+		{Code: "declare const b1: string & {};\nif (b1) {}\n"},
+		{Code: "declare const b1: string & {} & { __brand: string };\nif (b1) {}\n"},
+		{Code: "declare const b1: string & { __brandA: string } & { __brandB: string };\nif (b1) {}\n"},
+		// Union of branded types
+		{Code: "declare const b1: string & { __brand: string } | number;\ndeclare const b2: boolean;\nconst t1 = b1 && b2;\n"},
+		{Code: "declare const b1: (string | number) & { __brand: string };\ndeclare const b2: boolean;\nconst t1 = b1 && b2;\n"},
+
+		// === Unions mixing falsy and truthy ===
+		{Code: "declare const x: false | 5;\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		{Code: "declare const x: boolean | 'foo';\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		{Code: "declare const x: 0 | boolean;\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		{Code: "declare const x: boolean | object;\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		{Code: "declare const x: null | object;\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		{Code: "declare const x: undefined | true;\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		{Code: "declare const x: void | true;\ndeclare const b: boolean;\nconst t1 = x && b;\n"},
+		// BigInt union
+		{Code: "declare const bigInt: 0n | 1n;\nif (bigInt) {}\n"},
+
+		// === Boolean comparisons with non-literal types ===
+		{Code: "declare const a: string;\ndeclare const b: string;\nif (a === b) {}\n"},
+		{Code: "declare const a: number;\ndeclare const b: number;\nif (a !== b) {}\n"},
+		{Code: "declare const a: string;\ndeclare const b: string;\nif (a == b) {}\n"},
+		// Optional param null/undefined comparisons
+		{Code: "function test(a?: string) { return a === undefined; }\n"},
+		{Code: "function test(a?: string) { return a !== undefined; }\n"},
+		{Code: "function test(a: null | string) { return a === null; }\n"},
+		{Code: "function test(a: null | string) { return a !== null; }\n"},
+		// Loose equality
+		{Code: "function test(a?: string) { return a == null; }\n"},
+		{Code: "function test(a?: string) { return a != null; }\n"},
+		{Code: "function test(a: null | string) { return a == undefined; }\n"},
+		{Code: "function test(a: null | string) { return a != undefined; }\n"},
+		// any/unknown with all comparisons
+		{Code: "function test(a: any) { return a === null; }\n"},
+		{Code: "function test(a: unknown) { return a === undefined; }\n"},
+		// Generic type parameter
+		{Code: "function test<T>(a: T) { return a === undefined; }\n"},
+
+		// === Predicate functions ===
+		{Code: "[0, 1, 2, 3].filter(t => t);\n"},
+		{Code: "['a', 'b', ''].filter(t => t);\n"},
+		{Code: "[1, null].filter(1 as any);\n"},
+		{Code: "[1, null].filter(1 as never);\n"},
+		// Named predicate returning boolean
+		{Code: "const length = (x: string) => x.length;\n['a', 'b', ''].filter(length);\n"},
+		// Non-array object with filter method name
+		{Code: "declare const notArray: { filter(fn: () => boolean): boolean };\nnotArray.filter(() => true);\n"},
+
+		// === Nullish coalescing ===
+		{Code: "declare const x: string | null;\nconst y = x ?? 'default';\n"},
+		{Code: "declare const x: string | undefined;\nconst y = x ?? 'default';\n"},
+		// testVal ?? true with optional boolean
+		{Code: "function test(testVal?: boolean) { if (testVal ?? true) {} }\n"},
+
+		// === Optional chaining ===
+		{Code: "declare const x: { a?: { b: string } };\nx.a?.b;\n"},
+		{Code: "declare const x: { a: { b: string } } | null;\nx?.a.b;\n"},
+		{Code: "declare const x: { a: string } | null;\nx?.a;\n"},
+		{Code: "let foo: undefined | { bar: true };\nfoo?.bar;\n"},
+		{Code: "let foo: null | { bar: true };\nfoo?.bar;\n"},
+		{Code: "let foo: undefined;\nfoo?.bar;\n"},
+		{Code: "let foo: null;\nfoo?.bar;\n"},
+		{Code: "let anyValue: any;\nanyValue?.foo;\n"},
+		{Code: "let unknownValue: unknown;\nunknownValue?.foo;\n"},
+		// Optional call
+		{Code: "let foo: undefined | (() => {});\nfoo?.();\n"},
+		{Code: "let foo: null | (() => {});\nfoo?.();\n"},
+		{Code: "let anyValue: any;\nanyValue?.();\n"},
+		// Deep optional chain
+		{Code: "declare const foo: { bar?: { baz: { c: string } } } | null;\nfoo?.bar?.baz;\n"},
+		// Optional chain with return type that may be nullish
+		{Code: "type Foo = { bar: () => number | undefined } | null;\ndeclare const foo: Foo;\nfoo?.bar()?.toExponential();\n"},
+		{Code: "type Foo = (() => number | undefined) | null;\ndeclare const foo: Foo;\nfoo?.()?.toExponential();\n"},
+		// void return
+		{Code: "declare function foo(): void | { key: string };\nconst bar = foo()?.key;\n"},
+		{Code: "type fn = () => void;\ndeclare function foo(): void | fn;\nconst bar = foo()?.();\n"},
+
+		// === Array index expressions ===
+		{Code: "declare const arr: string[];\nif (arr[0]) {}\n"},
+		{Code: "declare const arr: string[];\nconst x = arr[0] ?? 'default';\n"},
+		{Code: "declare const arr: string[][];\nconst y = arr[0] ?? [];\n"},
+		{Code: "declare const arr: string[];\nif (!arr[0]) {}\n"},
+		// Array index with optional chain
+		{Code: "declare const arr: string[];\narr[0]?.length;\n"},
+
+		// === allowConstantLoopConditions ===
+		{Code: "while (true) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "always"}},
+		{Code: "for (; true; ) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "always"}},
+		{Code: "do {} while (true);", Options: map[string]interface{}{"allowConstantLoopConditions": "always"}},
+		{Code: "while (true) {}", Options: map[string]interface{}{"allowConstantLoopConditions": true}},
+		{Code: "while (true) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "while (false) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "while (1) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "while (0) {}", Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"}},
+		{Code: "for (;;) {}"},
+
+		// === Logical assignments ===
+		{Code: "declare let x: string | null;\nx &&= 'hello';\n"},
+		{Code: "declare let x: string | null;\nx ||= 'hello';\n"},
+		{Code: "declare let x: string | null;\nx ??= 'hello';\n"},
+		{Code: "declare let foo: number | null;\nfoo ??= 1;\n"},
+
+		// === Enums ===
+		{Code: "enum Fruit { Apple, Orange }\ndeclare const fruit: Fruit;\nif (fruit === Fruit.Apple) {}\n"},
+
+		// === Parenthesized expressions ===
+		{Code: "declare const b: boolean;\nif ((b)) {}\n"},
+		{Code: "declare const b1: boolean;\ndeclare const b2: boolean;\nif ((b1 && b2)) {}\n"},
+
+		// === Switch case ===
+		{Code: "declare const x: string;\nswitch (x) { case 'a': break; case 'b': break; }\n"},
+
+		// === checkTypePredicates valid cases ===
+		{Code: "declare function isString(x: unknown): x is string;\ndeclare const u: unknown;\nisString(u);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		{Code: "declare function assert(x: unknown): asserts x;\nassert(Math.random() > 0.5);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		{Code: "declare function assert(x: unknown, y: unknown): asserts x;\nassert(Math.random() > 0.5, true);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		// Spread — parameter index mapping is unreliable
+		{Code: "declare function assert(x: unknown): asserts x;\nassert(...[]);\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		{Code: "declare function assert(x: unknown): asserts x;\nassert(...[], {});\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+		// checkTypePredicates disabled by default
+		{Code: "declare function assert(x: unknown): asserts x;\nassert(true);\n"},
+		{Code: "declare function isString(x: unknown): x is string;\ndeclare const a: string;\nisString(a);\n"},
+		// Literal subtype (type is 'falafel' not string, so guard still narrows)
+		{Code: "declare function assertString(x: unknown): asserts x is string;\nassertString('falafel');\n", Options: map[string]interface{}{"checkTypePredicates": true}},
+
+
+		// === exactOptionalPropertyTypes: private optional field with ??= ===
+		{
+			Code:     "class C {\n  #rand?: number;\n  m() { this.#rand ??= Math.random(); }\n}\n",
+			TSConfig: "tsconfig.exactOptionalPropertyTypes.json",
+		},
+
+		// === Nested logical expressions ===
+		{Code: "declare const a: boolean;\ndeclare const b: boolean;\nif (a && b || a) {}\n"},
+		{Code: "declare const x: string | null;\ndeclare const y: string;\nconst z = (x ?? y) || 'fallback';\n"},
+
+		// === Negated boolean in logical context ===
+		{Code: "declare const booleanTyped: boolean;\ndeclare const unknownTyped: unknown;\nif (!(booleanTyped || unknownTyped)) {}\n"},
+
+		// === RHS of logical expression is not checked ===
+		{Code: "declare const b1: boolean;\ndeclare const b2: true;\nconst x = b1 && b2;\n"},
+
+		// === Generic indexed access ===
+		{Code: "function foo<T extends object>(arg: T, key: keyof T): void { arg[key] == null; }\n"},
+		{Code: "function foo<T extends object>(arg: T, key: keyof T): void { arg[key] ?? 'default'; }\n"},
+	}, []rule_tester.InvalidTestCase{
+		// === Always truthy ===
+		{
+			Code:   "declare const arr: number[];\nif (arr) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const obj: { a: string };\nif (obj) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: 'hello';\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: 1;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// Truthy bigint literal
+		{
+			Code:   "declare const x: 1n;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// Negative bigint (always truthy)
+		{
+			Code:   "declare const negBigInt: -2n;\nif (negBigInt) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+		// object | true union always truthy
+		{
+			Code:   "declare const x: object | true;\ndeclare const b: boolean;\nconst t1 = x && b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 3, Column: 12}},
+		},
+
+		// === Always falsy ===
+		{
+			Code:   "declare const x: null;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: undefined;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: void;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: 0n;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: 0;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: '';\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: '' | false;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		// const null
+		{
+			Code:   "const a = null;\nif (!a) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+
+		// === Ternary ===
+		{
+			Code:   "declare const obj: { a: string };\nconst x = obj ? 'yes' : 'no';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 11}},
+		},
+
+		// === Logical operators ===
+		{
+			Code:   "declare const obj: { a: string };\ndeclare const b: boolean;\nconst x = obj && b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 3, Column: 11}},
+		},
+		{
+			Code:   "declare const x: null;\ndeclare const b: boolean;\nconst y = x || b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 3, Column: 11}},
+		},
+		// Nested logical with mixed truthy/falsy
+		{
+			Code: "declare const b1: boolean;\ndeclare const b2: boolean;\nif (true && b1 && b2) {}\nif (b1 && false && b2) {}\nif (b1 || b2 || true) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "alwaysTruthy", Line: 3, Column: 5},
+				{MessageId: "alwaysFalsy", Line: 4, Column: 11},
+				{MessageId: "alwaysTruthy", Line: 5, Column: 17},
+			},
+		},
+
+		// === Comparisons between literal types ===
+		{
+			Code:   "declare const x: 1;\ndeclare const y: 2;\nif (x === y) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 5}},
+		},
+		{
+			Code:   "declare const x: 1;\ndeclare const y: 1;\nif (x === y) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 5}},
+		},
+		{
+			Code:   "declare const x: 'hello';\ndeclare const y: 'world';\nif (x === y) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 5}},
+		},
+		{
+			Code:   "declare const x: true;\ndeclare const y: false;\nif (x === y) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 5}},
+		},
+		// Relational operators on literals
+		{
+			Code:   "declare const a: '34';\ndeclare const b: '56';\nconst r = a > b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 11}},
+		},
+		// Float comparisons
+		{
+			Code:   "const r = 2.3 >= 2.3;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 11}},
+		},
+		// BigInt comparisons
+		{
+			Code:   "const r = 2n <= 2n;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 11}},
+		},
+		// true vs false, true vs true, true vs undefined
+		{
+			Code:   "const r = true === false;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 11}},
+		},
+		{
+			Code:   "const r = true === true;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 11}},
+		},
+		{
+			Code:   "const r = true === undefined;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 11}},
+		},
+		// Single-value function param
+		{
+			Code:   "function test(a: 'a') { return a === 'a'; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 1, Column: 32}},
+		},
+		// const narrowing in comparison
+		{
+			Code:   "const y = 1;\nif (y === 0) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 2, Column: 5}},
+		},
+		// Enum literal comparison
+		{
+			Code:   "enum Foo { a = 1, b = 2 }\nconst x = Foo.a;\nif (x === Foo.a) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 5}},
+		},
+
+		// === Nullish coalescing ===
+		{
+			Code:   "declare const x: string;\nconst y = x ?? 'default';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 11}},
+		},
+		{
+			Code:   "declare const x: null;\nconst y = x ?? 'default';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish", Line: 2, Column: 11}},
+		},
+		{
+			Code:   "declare const x: undefined;\nconst y = x ?? 'default';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish", Line: 2, Column: 11}},
+		},
+		// string | false is never nullish
+		{
+			Code:   "function test(a: string | false) { return a ?? 'default'; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 1, Column: 43}},
+		},
+		// Generic extends string is never nullish
+		{
+			Code:   "function test<T extends string>(a: T) { return a ?? 'default'; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 1, Column: 48}},
+		},
+		// Generic extends null is always nullish
+		{
+			Code:   "function test<T extends null>(a: T) { return a ?? 'default'; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish", Line: 1, Column: 46}},
+		},
+		// never type
+		{
+			Code:   "function test(a: never) { return a ?? 'default'; }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never", Line: 1, Column: 34}},
+		},
+
+		// === Optional chain on non-nullish ===
+		{
+			Code: "declare const x: { a: string };\nx?.a;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain",
+				Line:      2,
+				Column:    2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: string };\nx.a;\n"},
+				},
+			}},
+		},
+		// Nested optional chains all unnecessary
+		{
+			Code: "declare const x: { a: { b: string } };\nx?.a?.b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "neverOptionalChain", Line: 2, Column: 5,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: string } };\nx?.a.b;\n"},
+					},
+				},
+				{
+					MessageId: "neverOptionalChain", Line: 2, Column: 2,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a: { b: string } };\nx.a?.b;\n"},
+					},
+				},
+			},
+		},
+		// Deep chain — only one unnecessary level
+		{
+			Code: "declare const x: { a?: { b: string } };\nx?.a?.b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 2, Column: 2,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "declare const x: { a?: { b: string } };\nx.a?.b;\n"},
+				},
+			}},
+		},
+		// Optional chain on call return — non-nullable return
+		{
+			Code: "type Foo = { bar: () => number } | null;\ndeclare const foo: Foo;\nfoo?.bar()?.toExponential();\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 3, Column: 11,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "type Foo = { bar: () => number } | null;\ndeclare const foo: Foo;\nfoo?.bar().toExponential();\n"},
+				},
+			}},
+		},
+		// Optional chain on callable return
+		{
+			Code: "type Foo = (() => number) | null;\ndeclare const foo: Foo;\nfoo?.()?.toExponential();\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 3, Column: 8,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "type Foo = (() => number) | null;\ndeclare const foo: Foo;\nfoo?.().toExponential();\n"},
+				},
+			}},
+		},
+		// Array literal optional access
+		{
+			Code: "const foo = [1, 2, 3]?.[0];\n",
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "neverOptionalChain", Line: 1, Column: 22,
+				Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "suggestRemoveOptionalChain", Output: "const foo = [1, 2, 3][0];\n"},
+				},
+			}},
+		},
+
+		// === Array predicate callbacks ===
+		{
+			Code:   "declare const arr: object[];\narr.filter(t => t);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 17}},
+		},
+		{
+			Code:   "function truthy() { return []; }\n[1, 3, 5].filter(truthy);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthyFunc", Line: 2, Column: 18}},
+		},
+		{
+			Code:   "function falsy() {}\n[1, 2, 3].find(falsy);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsyFunc", Line: 2, Column: 16}},
+		},
+		{
+			Code:   "[1, 3, 5].filter(() => true);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 24}},
+		},
+		{
+			Code:   "[1, 2, 3].find(() => { return false; });\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 31}},
+		},
+		// Readonly array
+		{
+			Code:   "function nothing2(x: readonly string[]) { return x.filter(() => false); }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 65}},
+		},
+		// Tuple
+		{
+			Code:   "function nothing3(x: [string, string]) { return x.filter(() => false); }\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 64}},
+		},
+		// Generic constrained to true
+		{
+			Code:   "declare const test: <T extends true>() => T;\n[1, null].filter(test);\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthyFunc", Line: 2, Column: 18}},
+		},
+
+		// === Loop conditions ===
+		{
+			Code:   "while (true) {}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 8}},
+		},
+		{
+			Code:   "do {} while (true);",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 14}},
+		},
+		{
+			Code:   "for (; true; ) {}",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 8}},
+		},
+		// only-allowed-literals: for/do-while now also allow true/false/0/1
+		// (moved to valid cases; non-0/1 still rejected)
+		{
+			Code:    "do {} while (0);",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 1, Column: 14}},
+		},
+		// while(2) — not 0/1 literal
+		{
+			Code:    "while (2) {}",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 8}},
+		},
+		// String literal in loop
+		{
+			Code:    "while ('truthy') {}",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 1, Column: 8}},
+		},
+		// declare const test: true — type-level true, not literal true
+		{
+			Code:    "declare const test: true;\nwhile (test) {}\n",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+		// 'never' also rejects type-level true
+		{
+			Code:    "declare const test: true;\nwhile (test) {}\n",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "never"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+		// declare const test: 1 with only-allowed-literals
+		{
+			Code:    "declare const test: 1;\nwhile (test) {}\n",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "only-allowed-literals"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+
+		// === Unary negation ===
+		{
+			Code:   "declare const obj: { a: string };\nif (!obj) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const obj: { a: string };\nif (!!obj) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+
+		// === Never type ===
+		{
+			Code:   "declare const x: never;\nif (x) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never", Line: 2, Column: 5}},
+		},
+
+		// === No overlap boolean expressions ===
+		{
+			Code:   "declare const x: string;\nif (x === null) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noOverlapBooleanExpression", Line: 2, Column: 5}},
+		},
+		{
+			Code:   "declare const x: string;\nif (x === undefined) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noOverlapBooleanExpression", Line: 2, Column: 5}},
+		},
+		// All 8 no-overlap variants on string
+		{
+			Code: "function test(a: string) {\n  a === undefined;\n  undefined === a;\n  a !== undefined;\n  undefined !== a;\n  a === null;\n  null === a;\n  a !== null;\n  null !== a;\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noOverlapBooleanExpression", Line: 2, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 3, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 4, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 5, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 6, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 7, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 8, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 9, Column: 3},
+			},
+		},
+		// Optional string — null comparisons are no-overlap
+		{
+			Code: "function test(a?: string) {\n  a === null;\n  null === a;\n  a !== null;\n  null !== a;\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noOverlapBooleanExpression", Line: 2, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 3, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 4, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 5, Column: 3},
+			},
+		},
+		// Nullable string — undefined strict comparisons are no-overlap
+		{
+			Code: "function test(a: null | string) {\n  a === undefined;\n  undefined === a;\n  a !== undefined;\n  undefined !== a;\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noOverlapBooleanExpression", Line: 2, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 3, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 4, Column: 3},
+				{MessageId: "noOverlapBooleanExpression", Line: 5, Column: 3},
+			},
+		},
+
+		// === Logical assignments ===
+		{
+			Code:   "declare let x: object;\nx &&= { a: 1 };\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 1}},
+		},
+		{
+			Code:   "declare let x: object;\nx ??= { a: 1 };\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 1}},
+		},
+		// ??= on non-nullish
+		{
+			Code:   "declare let x: string;\nx ??= 'default';\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 1}},
+		},
+		// &&= on always-truthy
+		{
+			Code:   "declare const obj: { a: number[] };\nobj.a &&= [1];\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 1}},
+		},
+		// ||= on always-falsy
+		{
+			Code:   "declare let x: undefined;\nx ||= true;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 1}},
+		},
+		// Empty object type with ??= / ||= / &&=
+		{
+			Code:   "declare let foo: {};\nfoo ??= 1;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 2, Column: 1}},
+		},
+		{
+			Code:   "declare let foo: null;\nfoo ??= null;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysNullish", Line: 2, Column: 1}},
+		},
+
+		// === noUncheckedIndexedAccess ===
+		{
+			Code:     "declare const arr: string[];\nif (arr[0]) {\n  arr[0] ?? 'foo';\n}\n",
+			TSConfig: "tsconfig.noUncheckedIndexedAccess.json",
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "neverNullish", Line: 3, Column: 3}},
+		},
+		{
+			Code:     "declare const arr: object[];\nif (arr[42] && arr[42]) {}\n",
+			TSConfig: "tsconfig.noUncheckedIndexedAccess.json",
+			Errors:   []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 16}},
+		},
+
+		// === noStrictNullCheck ===
+		{
+			Code:     "if (true) {}",
+			TSConfig: "tsconfig.unstrict.json",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noStrictNullCheck", Line: 0, Column: 0},
+				{MessageId: "alwaysTruthy", Line: 1, Column: 5},
+			},
+		},
+
+		// === Parenthesized expressions ===
+		{
+			Code:   "declare const obj: { a: string };\nif ((obj)) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 6}},
+		},
+
+		// === Generic type constraints that are always truthy/falsy ===
+		{
+			Code:   "function test<T extends object>(t: T) {\n  return t ? 'yes' : 'no';\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 10}},
+		},
+		{
+			Code:   "function test<T extends false>(t: T) {\n  return t ? 'yes' : 'no';\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 10}},
+		},
+		// Generic extends 'a' | 'b' (non-empty string literals)
+		{
+			Code:   "function test<T extends 'a' | 'b'>(t: T) {\n  return t ? 'yes' : 'no';\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 10}},
+		},
+		// string & number = never
+		{
+			Code:   "declare const x: string & number;\ndeclare const b: boolean;\nconst t1 = x && b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "never", Line: 3, Column: 12}},
+		},
+
+		// === const narrowing ===
+		{
+			Code:   "const a = true;\nif (!a) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 5}},
+		},
+
+		// === checkTypePredicates ===
+		// type guard already matches
+		{
+			Code:    "declare function isString(x: unknown): x is string;\ndeclare const s: string;\nisString(s);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "typeGuardAlreadyIsType", Line: 3, Column: 10}},
+		},
+		// asserts type guard
+		{
+			Code:    "declare function assertString(x: unknown): asserts x is string;\ndeclare const a: string;\nassertString(a);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "typeGuardAlreadyIsType", Line: 3, Column: 14}},
+		},
+		// truthiness assertion on always-truthy
+		{
+			Code:    "declare function assert(x: unknown): asserts x;\nassert('hello');\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+		// truthiness assertion on always-falsy
+		{
+			Code:    "declare function assert(x: unknown): asserts x;\nassert(false);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 2, Column: 8}},
+		},
+		// truthiness assertion on object
+		{
+			Code:    "declare function assert(x: unknown): asserts x;\nassert({});\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+		// multi-param asserts — only first param checked
+		{
+			Code:    "declare function assert(x: unknown, y: unknown): asserts x;\nassert(true, Math.random() > 0.5);\n",
+			Options: map[string]interface{}{"checkTypePredicates": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+
+		// === switch/case with literal comparison ===
+		{
+			Code: "declare const x: 'a';\nswitch (x) {\n  case 'b':\n    break;\n}\n",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "comparisonBetweenLiteralTypes", Line: 3, Column: 8},
+			},
+		},
+
+		// === allowConstantLoopConditions: 'always' still checks non-true conditions ===
+		{
+			Code:    "declare const x: object;\nwhile (x) {}\n",
+			Options: map[string]interface{}{"allowConstantLoopConditions": "always"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 8}},
+		},
+
+		// === Branded types that are always truthy/falsy ===
+		// Branded falsy string
+		{
+			Code:   "declare const x: '' & { __brand: string };\ndeclare const b: boolean;\nconst t1 = x && b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysFalsy", Line: 3, Column: 12}},
+		},
+		// Branded truthy string literals
+		{
+			Code:   "declare const x: ('foo' | 'bar') & { __brand: string };\ndeclare const b: boolean;\nconst t1 = x && b;\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 3, Column: 12}},
+		},
+
+		// === Record index without noUncheckedIndexedAccess ===
+		{
+			Code:   "declare const dict: Record<string, object>;\nif (dict['mightNotExist']) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+
+		// === Tuple literal access ===
+		{
+			Code:   "const x = [{}] as [{ foo: string }];\nif (x[0]) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+
+		// === Array method as property check ===
+		{
+			Code:   "declare const arr: object[];\nif (arr.filter) {}\n",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "alwaysTruthy", Line: 2, Column: 5}},
+		},
+	})
+}

--- a/internal/utils/ts_api_utils.go
+++ b/internal/utils/ts_api_utils.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"math"
+	"strconv"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
 	"github.com/microsoft/typescript-go/shim/core"
@@ -55,13 +58,75 @@ func IsTypeParameter(t *checker.Type) bool {
 	return IsTypeFlagSet(t, checker.TypeFlagsTypeParameter)
 }
 func IsBooleanLiteralType(t *checker.Type) bool {
-	return IsTypeFlagSet(t, checker.TypeFlagsBoolean)
+	return IsTypeFlagSet(t, checker.TypeFlagsBooleanLiteral)
 }
+
+// IsTrueLiteralType checks if the type is the boolean literal `true`.
+// Handles both TypeFlagsBooleanLiteral (literal `true`) and TypeFlagsBoolean
+// (widened boolean that is actually `true` from const narrowing).
 func IsTrueLiteralType(t *checker.Type) bool {
-	return IsBooleanLiteralType(t) && IsIntrinsicType(t) && t.AsIntrinsicType().IntrinsicName() == "true"
+	flags := checker.Type_flags(t)
+	if flags&checker.TypeFlagsBooleanLiteral != 0 {
+		val := t.AsLiteralType().Value()
+		if b, ok := val.(bool); ok {
+			return b
+		}
+		return false
+	}
+	// For TypeFlagsBoolean used by const narrowing (e.g., `const x = true`)
+	if flags&checker.TypeFlagsBoolean != 0 && IsIntrinsicType(t) {
+		return t.AsIntrinsicType().IntrinsicName() == "true"
+	}
+	return false
 }
+
+// IsFalseLiteralType checks if the type is the boolean literal `false`.
 func IsFalseLiteralType(t *checker.Type) bool {
-	return IsBooleanLiteralType(t) && IsIntrinsicType(t) && t.AsIntrinsicType().IntrinsicName() == "false"
+	flags := checker.Type_flags(t)
+	if flags&checker.TypeFlagsBooleanLiteral != 0 {
+		val := t.AsLiteralType().Value()
+		if b, ok := val.(bool); ok {
+			return !b
+		}
+		return false
+	}
+	if flags&checker.TypeFlagsBoolean != 0 && IsIntrinsicType(t) {
+		return t.AsIntrinsicType().IntrinsicName() == "false"
+	}
+	return false
+}
+
+// IsTypeFlagSetWithUnion checks type flags, iterating through union constituents.
+// This matches typescript-eslint's isTypeFlagSet which aggregates union constituent flags.
+func IsTypeFlagSetWithUnion(t *checker.Type, flags checker.TypeFlags) bool {
+	for _, part := range UnionTypeParts(t) {
+		if IsTypeFlagSet(part, flags) {
+			return true
+		}
+	}
+	return false
+}
+
+// IsNullableType checks if the type includes null, undefined, void, any or unknown.
+// This matches typescript-eslint's isNullableType utility.
+func IsNullableType(t *checker.Type) bool {
+	return Some(UnionTypeParts(t), func(part *checker.Type) bool {
+		return IsTypeFlagSet(part, checker.TypeFlagsAny|checker.TypeFlagsUnknown|checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid)
+	})
+}
+
+// IsPossiblyFalsy checks if any union constituent of the type could be falsy.
+func IsPossiblyFalsy(t *checker.Type) bool {
+	return Some(UnionTypeParts(t), func(part *checker.Type) bool {
+		return isConstituentPossiblyFalsy(part)
+	})
+}
+
+// IsPossiblyTruthy checks if any union constituent of the type could be truthy.
+func IsPossiblyTruthy(t *checker.Type) bool {
+	return Some(UnionTypeParts(t), func(part *checker.Type) bool {
+		return isConstituentPossiblyTruthy(part)
+	})
 }
 
 func GetCallSignatures(typeChecker *checker.Checker, t *checker.Type) []*checker.Signature {
@@ -356,4 +421,131 @@ func canHaveTrailingTrivia(token *ast.Node) bool {
 // @internal
 func isJsxElementOrFragment(node *ast.Node) bool {
 	return node.Kind == ast.KindJsxElement || node.Kind == ast.KindJsxFragment
+}
+
+// isNumberLiteralZeroOrNaN checks if a number literal type value is 0 or NaN.
+// tsgo stores number literal values as a named float64 type,
+// so we use ValueToString for reliable string conversion and then parse.
+func isNumberLiteralZeroOrNaN(val interface{}) bool {
+	s := checker.ValueToString(val)
+	if s == "0" || s == "-0" || s == "NaN" {
+		return true
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return false
+	}
+	return f == 0 || math.IsNaN(f)
+}
+
+func isConstituentPossiblyFalsy(t *checker.Type) bool {
+	flags := checker.Type_flags(t)
+	if flags&(checker.TypeFlagsAny|checker.TypeFlagsUnknown) != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsTypeVariable != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsNever != 0 {
+		return false
+	}
+	if flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsBooleanLike != 0 {
+		if IsTrueLiteralType(t) {
+			return false // `true` literal is never falsy
+		}
+		if IsFalseLiteralType(t) {
+			return true // `false` literal is always falsy
+		}
+		return true // general `boolean` is possibly falsy
+	}
+	if flags&checker.TypeFlagsStringLiteral != 0 {
+		if s, ok := t.AsLiteralType().Value().(string); ok {
+			return s == ""
+		}
+		return false
+	}
+	if flags&checker.TypeFlagsString != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsNumberLiteral != 0 {
+		return isNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
+	}
+	if flags&checker.TypeFlagsNumber != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsBigIntLiteral != 0 {
+		return checker.ValueToString(t.AsLiteralType().Value()) == "0n"
+	}
+	if flags&checker.TypeFlagsBigInt != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsEnumLiteral != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsUnion != 0 {
+		return IsPossiblyFalsy(t)
+	}
+	if flags&checker.TypeFlagsIntersection != 0 {
+		return Some(t.Types(), isConstituentPossiblyFalsy)
+	}
+	return false
+}
+
+func isConstituentPossiblyTruthy(t *checker.Type) bool {
+	flags := checker.Type_flags(t)
+	if flags&(checker.TypeFlagsAny|checker.TypeFlagsUnknown) != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsTypeVariable != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsNever != 0 {
+		return false
+	}
+	if flags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0 {
+		return false
+	}
+	if flags&checker.TypeFlagsBooleanLike != 0 {
+		if IsFalseLiteralType(t) {
+			return false // `false` literal is never truthy
+		}
+		if IsTrueLiteralType(t) {
+			return true // `true` literal is always truthy
+		}
+		return true // general `boolean` is possibly truthy
+	}
+	if flags&checker.TypeFlagsStringLiteral != 0 {
+		if s, ok := t.AsLiteralType().Value().(string); ok {
+			return s != ""
+		}
+		return true
+	}
+	if flags&checker.TypeFlagsString != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsNumberLiteral != 0 {
+		return !isNumberLiteralZeroOrNaN(t.AsLiteralType().Value())
+	}
+	if flags&checker.TypeFlagsNumber != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsBigIntLiteral != 0 {
+		return checker.ValueToString(t.AsLiteralType().Value()) != "0n"
+	}
+	if flags&checker.TypeFlagsBigInt != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsEnumLiteral != 0 {
+		return true
+	}
+	if flags&checker.TypeFlagsUnion != 0 {
+		return IsPossiblyTruthy(t)
+	}
+	if flags&checker.TypeFlagsIntersection != 0 {
+		return Every(t.Types(), isConstituentPossiblyTruthy)
+	}
+	return true
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -165,7 +165,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-type-alias.test.ts',
     './tests/typescript-eslint/rules/no-use-before-define.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-boolean-literal-compare.test.ts',
-    // './tests/typescript-eslint/rules/no-unnecessary-condition.test.ts',
+    './tests/typescript-eslint/rules/no-unnecessary-condition.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-parameter-property-assignment.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-qualifier.test.ts',
     './tests/typescript-eslint/rules/no-unnecessary-template-expression.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/fixtures/tsconfig.unstrict.json
+++ b/packages/rslint-test-tools/tests/typescript-eslint/fixtures/tsconfig.unstrict.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "strict": false,
+    "strictNullChecks": false
+  }
+}

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-condition.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-condition.test.ts.snap
@@ -1,0 +1,5241 @@
+// Rstest Snapshot v1
+
+exports[`no-unnecessary-condition > invalid 1`] = `
+{
+  "code": "
+const b1 = true;
+declare const b2: boolean;
+const t1 = b1 && b2;
+const t2 = b1 || b2;
+if (b1 && b2) {
+}
+if (b2 && b1) {
+}
+while (b1 && b2) {}
+while (b2 && b1) {}
+for (let i = 0; b1 && b2; i++) {
+  break;
+}
+const t1 = b1 && b2 ? 'yes' : 'no';
+const t1 = b2 && b1 ? 'yes' : 'no';
+switch (b1) {
+  case true:
+  default:
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 5,
+        },
+        "start": {
+          "column": 12,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 8,
+        },
+        "start": {
+          "column": 11,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 10,
+        },
+        "start": {
+          "column": 8,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 11,
+        },
+        "start": {
+          "column": 14,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 12,
+        },
+        "start": {
+          "column": 17,
+          "line": 12,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 15,
+        },
+        "start": {
+          "column": 12,
+          "line": 15,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 16,
+        },
+        "start": {
+          "column": 18,
+          "line": 16,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`true === true\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 18,
+        },
+        "start": {
+          "column": 8,
+          "line": 18,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 10,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 2`] = `
+{
+  "code": "
+declare const b1: object;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 3`] = `
+{
+  "code": "
+declare const b1: object | true;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 4`] = `
+{
+  "code": "
+declare const b1: "" | false;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 5`] = `
+{
+  "code": "
+declare const b1: "always truthy";
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 6`] = `
+{
+  "code": "
+declare const b1: undefined;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 7`] = `
+{
+  "code": "
+declare const b1: null;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 8`] = `
+{
+  "code": "
+declare const b1: void;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 9`] = `
+{
+  "code": "
+declare const b1: never;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is \`never\`.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 10`] = `
+{
+  "code": "
+declare const b1: string & number;
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is \`never\`.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 11`] = `
+{
+  "code": "
+declare const falseyBigInt: 0n;
+if (falseyBigInt) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 12`] = `
+{
+  "code": "
+declare const posbigInt: 1n;
+if (posbigInt) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 13`] = `
+{
+  "code": "
+declare const negBigInt: -2n;
+if (negBigInt) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 14`] = `
+{
+  "code": "
+declare const b1: boolean;
+declare const b2: boolean;
+if (true && b1 && b2) {
+}
+if (b1 && false && b2) {
+}
+if (b1 || b2 || true) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 8,
+        },
+        "start": {
+          "column": 17,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 15`] = `
+{
+  "code": "
+function test<T extends object>(t: T) {
+  return t ? 'yes' : 'no';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 16`] = `
+{
+  "code": "
+function test<T extends false>(t: T) {
+  return t ? 'yes' : 'no';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 17`] = `
+{
+  "code": "
+function test<T extends 'a' | 'b'>(t: T) {
+  return t ? 'yes' : 'no';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 18`] = `
+{
+  "code": "
+function test(a: 'a') {
+  return a === 'a';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`"a" === "a"\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 19`] = `
+{
+  "code": "
+declare const a: '34';
+declare const b: '56';
+a > b;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`"34" > "56"\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 20`] = `
+{
+  "code": "
+const y = 1;
+if (y === 0) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`1 === 0\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 21`] = `
+{
+  "code": "
+// @ts-expect-error
+if (1 == '1') {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`1 == "1"\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 22`] = `
+{
+  "code": "
+2.3 > 2.3;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`2.3 > 2.3\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 23`] = `
+{
+  "code": "
+2.3 >= 2.3;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`2.3 >= 2.3\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 24`] = `
+{
+  "code": "
+2n < 2n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`2n < 2n\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 25`] = `
+{
+  "code": "
+2n <= 2n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`2n <= 2n\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 26`] = `
+{
+  "code": "
+-2n !== 2n;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`-2n !== 2n\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 27`] = `
+{
+  "code": "
+// @ts-expect-error
+if (1 == '2') {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`1 == "2"\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 28`] = `
+{
+  "code": "
+// @ts-expect-error
+if (1 != '2') {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`1 != "2"\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 29`] = `
+{
+  "code": "
+enum Foo {
+  a = 1,
+  b = 2,
+}
+
+const x = Foo.a;
+if (x === Foo.a) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`Foo.a === Foo.a\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 8,
+        },
+        "start": {
+          "column": 5,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 30`] = `
+{
+  "code": "
+enum Foo {
+  a = 1,
+  b = 2,
+}
+
+const x = Foo.a;
+if (x === 1) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`Foo.a === 1\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 8,
+        },
+        "start": {
+          "column": 5,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 31`] = `
+{
+  "code": "
+function takesMaybeValue(a: null | object) {
+  if (a) {
+  } else if (a == undefined) {
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`null == undefined\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 32`] = `
+{
+  "code": "
+function takesMaybeValue(a: null | object) {
+  if (a) {
+  } else if (a === undefined) {
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`null === undefined\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 33`] = `
+{
+  "code": "
+function takesMaybeValue(a: null | object) {
+  if (a) {
+  } else if (a != undefined) {
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`null != undefined\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 34`] = `
+{
+  "code": "
+function takesMaybeValue(a: null | object) {
+  if (a) {
+  } else if (a !== undefined) {
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`null !== undefined\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 35`] = `
+{
+  "code": "
+true === false;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`true === false\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 36`] = `
+{
+  "code": "
+true === true;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always true, since \`true === true\` is true.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 37`] = `
+{
+  "code": "
+true === undefined;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, comparison is always false, since \`true === undefined\` is false.",
+      "messageId": "comparisonBetweenLiteralTypes",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 38`] = `
+{
+  "code": "
+function test(a: string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t3 = a !== undefined;
+  const t4 = undefined !== a;
+  const t5 = a === null;
+  const t6 = null === a;
+  const t7 = a !== null;
+  const t8 = null !== a;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 5,
+        },
+        "start": {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 6,
+        },
+        "start": {
+          "column": 14,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 7,
+        },
+        "start": {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 8,
+        },
+        "start": {
+          "column": 14,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 9,
+        },
+        "start": {
+          "column": 14,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 10,
+        },
+        "start": {
+          "column": 14,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 8,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 39`] = `
+{
+  "code": "
+function test(a?: string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t3 = a !== undefined;
+  const t4 = undefined !== a;
+  const t5 = a === null;
+  const t6 = null === a;
+  const t7 = a !== null;
+  const t8 = null !== a;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 7,
+        },
+        "start": {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 8,
+        },
+        "start": {
+          "column": 14,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 9,
+        },
+        "start": {
+          "column": 14,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 10,
+        },
+        "start": {
+          "column": 14,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 40`] = `
+{
+  "code": "
+function test(a: null | string) {
+  const t1 = a === undefined;
+  const t2 = undefined === a;
+  const t3 = a !== undefined;
+  const t4 = undefined !== a;
+  const t5 = a === null;
+  const t6 = null === a;
+  const t7 = a !== null;
+  const t8 = null !== a;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 5,
+        },
+        "start": {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 6,
+        },
+        "start": {
+          "column": 14,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 41`] = `
+{
+  "code": "
+function test<T extends object>(a: T) {
+  const t1 = a == null;
+  const t2 = null == a;
+  const t3 = a != null;
+  const t4 = null != a;
+  const t5 = a == undefined;
+  const t6 = undefined == a;
+  const t7 = a != undefined;
+  const t8 = undefined != a;
+  const t9 = a === null;
+  const t10 = null === a;
+  const t11 = a !== null;
+  const t12 = null !== a;
+  const t13 = a === undefined;
+  const t14 = undefined === a;
+  const t15 = a !== undefined;
+  const t16 = undefined !== a;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 6,
+        },
+        "start": {
+          "column": 14,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 7,
+        },
+        "start": {
+          "column": 14,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 8,
+        },
+        "start": {
+          "column": 14,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 9,
+        },
+        "start": {
+          "column": 14,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 10,
+        },
+        "start": {
+          "column": 14,
+          "line": 10,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 11,
+        },
+        "start": {
+          "column": 14,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 12,
+        },
+        "start": {
+          "column": 15,
+          "line": 12,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 13,
+        },
+        "start": {
+          "column": 15,
+          "line": 13,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 14,
+        },
+        "start": {
+          "column": 15,
+          "line": 14,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 15,
+        },
+        "start": {
+          "column": 15,
+          "line": 15,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 16,
+        },
+        "start": {
+          "column": 15,
+          "line": 16,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 17,
+        },
+        "start": {
+          "column": 15,
+          "line": 17,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, the types have no overlap.",
+      "messageId": "noOverlapBooleanExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 18,
+        },
+        "start": {
+          "column": 15,
+          "line": 18,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 16,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 42`] = `
+{
+  "code": "
+function test(a: string) {
+  return a ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 43`] = `
+{
+  "code": "
+function test(a: string | false) {
+  return a ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 44`] = `
+{
+  "code": "
+function test<T extends string>(a: T) {
+  return a ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 45`] = `
+{
+  "code": "
+function test(a: { foo: string }[]) {
+  return a[0].foo ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 46`] = `
+{
+  "code": "
+function test(a: null) {
+  return a ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, left-hand side of \`??\` operator is always \`null\` or \`undefined\`.",
+      "messageId": "alwaysNullish",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 47`] = `
+{
+  "code": "
+function test(a: null[]) {
+  return a[0] ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, left-hand side of \`??\` operator is always \`null\` or \`undefined\`.",
+      "messageId": "alwaysNullish",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 48`] = `
+{
+  "code": "
+function test<T extends null>(a: T) {
+  return a ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, left-hand side of \`??\` operator is always \`null\` or \`undefined\`.",
+      "messageId": "alwaysNullish",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 49`] = `
+{
+  "code": "
+function test(a: never) {
+  return a ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is \`never\`.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 50`] = `
+{
+  "code": "
+function test<T extends { foo: number }, K extends 'foo'>(num: T[K]) {
+  num ?? 'default';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 51`] = `
+{
+  "code": "
+[1, 3, 5].filter(() => true);
+[1, 2, 3].find(() => {
+  return false;
+});
+
+// with non-literal array
+function nothing(x: string[]) {
+  return x.filter(() => false);
+}
+// with readonly array
+function nothing2(x: readonly string[]) {
+  return x.filter(() => false);
+}
+// with tuple
+function nothing3(x: [string, string]) {
+  return x.filter(() => false);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 2,
+        },
+        "start": {
+          "column": 24,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 4,
+        },
+        "start": {
+          "column": 10,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 9,
+        },
+        "start": {
+          "column": 25,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 13,
+        },
+        "start": {
+          "column": 25,
+          "line": 13,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 17,
+        },
+        "start": {
+          "column": 25,
+          "line": 17,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 52`] = `
+{
+  "code": "
+declare const test: <T extends true>() => T;
+
+[1, null].filter(test);
+      ",
+  "diagnostics": [
+    {
+      "message": "This callback should return a conditional, but return is always truthy.",
+      "messageId": "alwaysTruthyFunc",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 4,
+        },
+        "start": {
+          "column": 18,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 53`] = `
+{
+  "code": "
+declare const dict: Record<string, object>;
+if (dict['mightNotExist']) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 54`] = `
+{
+  "code": "
+const x = [{}] as [{ foo: string }];
+if (x[0]) {
+}
+if (x[0]?.foo) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 55`] = `
+{
+  "code": "
+declare const arr: object[];
+if (arr.filter) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 56`] = `
+{
+  "code": "
+function truthy() {
+  return [];
+}
+function falsy() {}
+[1, 3, 5].filter(truthy);
+[1, 2, 3].find(falsy);
+[1, 2, 3].findLastIndex(falsy);
+      ",
+  "diagnostics": [
+    {
+      "message": "This callback should return a conditional, but return is always truthy.",
+      "messageId": "alwaysTruthyFunc",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 6,
+        },
+        "start": {
+          "column": 18,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "This callback should return a conditional, but return is always falsy.",
+      "messageId": "alwaysFalsyFunc",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 7,
+        },
+        "start": {
+          "column": 16,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "This callback should return a conditional, but return is always falsy.",
+      "messageId": "alwaysFalsyFunc",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 8,
+        },
+        "start": {
+          "column": 25,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 57`] = `
+{
+  "code": "
+declare const test: true;
+
+while (test) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 58`] = `
+{
+  "code": "
+declare const test: true;
+
+for (; test; ) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 59`] = `
+{
+  "code": "
+declare const test: true;
+
+do {} while (test);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 60`] = `
+{
+  "code": "
+declare const test: true;
+
+while (test) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 61`] = `
+{
+  "code": "
+declare const test: true;
+
+for (; test; ) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 62`] = `
+{
+  "code": "
+declare const test: true;
+
+do {} while (test);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 63`] = `
+{
+  "code": "
+declare const test: true;
+
+while (test) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 64`] = `
+{
+  "code": "
+declare const test: 1;
+
+while (test) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 65`] = `
+{
+  "code": "
+declare const test: true;
+
+for (; test; ) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 66`] = `
+{
+  "code": "
+declare const test: true;
+
+do {} while (test);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 67`] = `
+{
+  "code": "
+let shouldRun = true;
+
+while ((shouldRun = true)) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 68`] = `
+{
+  "code": "
+while (2) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 2,
+        },
+        "start": {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 69`] = `
+{
+  "code": "
+while ('truthy') {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 2,
+        },
+        "start": {
+          "column": 8,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 70`] = `
+{
+  "code": "
+let foo = { bar: true };
+foo?.bar;
+foo ?. bar;
+foo ?.
+  bar;
+foo
+  ?. bar;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 71`] = `
+{
+  "code": "
+let foo = () => {};
+foo?.();
+foo ?. ();
+foo ?.
+  ();
+foo
+  ?. ();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 72`] = `
+{
+  "code": "
+let foo = () => {};
+foo?.(bar);
+foo ?. (bar);
+foo ?.
+  (bar);
+foo
+  ?. (bar);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 8,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 4,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 73`] = `
+{
+  "code": "const foo = [1, 2, 3]?.[0];",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 74`] = `
+{
+  "code": "
+declare const x: { a?: { b: string } };
+x?.a?.b;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 75`] = `
+{
+  "code": "
+declare const x: { a: { b?: { c: string } } };
+x.a?.b?.c;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 76`] = `
+{
+  "code": "
+let x: { a?: string };
+x?.a;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 2,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 77`] = `
+{
+  "code": "
+declare const foo: { bar: { baz: { c: string } } } | null;
+foo?.bar?.baz;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 78`] = `
+{
+  "code": "
+declare const foo: { bar?: { baz: { qux: string } } } | null;
+foo?.bar?.baz?.qux;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 79`] = `
+{
+  "code": "
+declare const foo: { bar: { baz: { qux?: () => {} } } } | null;
+foo?.bar?.baz?.qux?.();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 80`] = `
+{
+  "code": "
+declare const foo: { bar: { baz: { qux: () => {} } } } | null;
+foo?.bar?.baz?.qux?.();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 81`] = `
+{
+  "code": "
+type baz = () => { qux: () => {} };
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar?.baz?.().qux?.();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 22,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 82`] = `
+{
+  "code": "
+type baz = null | (() => { qux: () => {} });
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar?.baz?.().qux?.();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 22,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 83`] = `
+{
+  "code": "
+type baz = null | (() => { qux: () => {} } | null);
+declare const foo: { bar: { baz: baz } } | null;
+foo?.bar?.baz?.()?.qux?.();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 4,
+        },
+        "start": {
+          "column": 23,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 84`] = `
+{
+  "code": "
+type Foo = { baz: number };
+type Bar = { baz: null | string | { qux: string } };
+declare const foo: { fooOrBar: Foo | Bar } | null;
+foo?.fooOrBar?.baz?.qux;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 14,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 85`] = `
+{
+  "code": "
+declare const x: { a: { b: number } }[];
+x[0].a?.b;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 86`] = `
+{
+  "code": "
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+type Key = 'bar' | 'foo';
+declare const foo: Foo;
+declare const key: Key;
+
+foo?.[key]?.trim();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 7,
+        },
+        "start": {
+          "column": 11,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 87`] = `
+{
+  "code": "
+type Foo = { [key: string]: string; foo: 'foo'; bar: 'bar' } | null;
+declare const foo: Foo;
+const key = 'bar';
+foo?.[key]?.trim();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 88`] = `
+{
+  "code": "
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+
+export function test(outer: Outer): number | undefined {
+  const key = 'bar';
+  return outer.inner?.[key]?.charCodeAt(0);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 11,
+        },
+        "start": {
+          "column": 28,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 89`] = `
+{
+  "code": "
+interface Outer {
+  inner?: {
+    [key: string]: string | undefined;
+    bar: 'bar';
+  };
+}
+type Bar = 'bar';
+
+function Foo(outer: Outer, key: Bar): number | undefined {
+  return outer.inner?.[key]?.charCodeAt(0);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 11,
+        },
+        "start": {
+          "column": 28,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 90`] = `
+{
+  "code": "
+function test(testVal?: true) {
+  if (testVal ?? true) {
+    console.log('test');
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 91`] = `
+{
+  "code": "
+const a = null;
+if (!a) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 92`] = `
+{
+  "code": "
+const a = true;
+if (!a) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 93`] = `
+{
+  "code": "
+function sayHi(): void {
+  console.log('Hi!');
+}
+
+let speech: never = sayHi();
+if (!speech) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is \`never\`.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 7,
+        },
+        "start": {
+          "column": 5,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 94`] = `
+{
+  "code": "
+declare const x: string[] | null;
+if (x) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "This rule requires the \`strictNullChecks\` compiler option to be turned on to function correctly.",
+      "messageId": "noStrictNullCheck",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 3,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 95`] = `
+{
+  "code": "
+interface Foo {
+  test: string;
+  [key: string]: [string] | undefined;
+}
+
+type OptionalFoo = Foo | undefined;
+declare const foo: OptionalFoo;
+foo?.test?.length;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 9,
+        },
+        "start": {
+          "column": 10,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 96`] = `
+{
+  "code": "
+function pick<Obj extends Record<string, 1 | 2 | 3>, Key extends keyof Obj>(
+  obj: Obj,
+  key: Key,
+): Obj[Key] {
+  const k = obj[key];
+  if (obj[key]) {
+    return obj[key];
+  }
+  throw new Error('Boom!');
+}
+
+pick({ foo: 1, bar: 2 }, 'bar');
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 7,
+        },
+        "start": {
+          "column": 7,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 97`] = `
+{
+  "code": "
+function getElem(dict: Record<string, { foo: string }>, key: string) {
+  if (dict[key]) {
+    return dict[key].foo;
+  } else {
+    return '';
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 98`] = `
+{
+  "code": "
+declare let foo: {};
+foo ??= 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 99`] = `
+{
+  "code": "
+declare let foo: number;
+foo ??= 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 100`] = `
+{
+  "code": "
+declare let foo: null;
+foo ??= null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, left-hand side of \`??\` operator is always \`null\` or \`undefined\`.",
+      "messageId": "alwaysNullish",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 101`] = `
+{
+  "code": "
+declare let foo: {};
+foo ||= 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 102`] = `
+{
+  "code": "
+declare let foo: null;
+foo ||= null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 103`] = `
+{
+  "code": "
+declare let foo: {};
+foo &&= 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 104`] = `
+{
+  "code": "
+declare let foo: null;
+foo &&= null;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 105`] = `
+{
+  "code": "
+declare const foo: { bar: number };
+foo.bar ??= 1;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 106`] = `
+{
+  "code": "
+type Foo = { bar: () => number } | null;
+declare const foo: Foo;
+foo?.bar()?.toExponential();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 4,
+        },
+        "start": {
+          "column": 11,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 107`] = `
+{
+  "code": "
+type Foo = { bar: null | { baz: () => { qux: number } } } | null;
+declare const foo: Foo;
+foo?.bar?.baz()?.qux?.toExponential();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 4,
+        },
+        "start": {
+          "column": 21,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 108`] = `
+{
+  "code": "
+type Foo = (() => number) | null;
+declare const foo: Foo;
+foo?.()?.toExponential();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 109`] = `
+{
+  "code": "
+type Foo = { [key: string]: () => number } | null;
+declare const foo: Foo;
+foo?.['bar']()?.toExponential();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 110`] = `
+{
+  "code": "
+type Foo = { [key: string]: () => number } | null;
+declare const foo: Foo;
+foo?.['bar']?.()?.toExponential();
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 111`] = `
+{
+  "code": "
+        const a = true;
+        if (!!a) {
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 112`] = `
+{
+  "code": "
+declare function assert(x: unknown): asserts x;
+assert(true);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 113`] = `
+{
+  "code": "
+declare function assert(x: unknown): asserts x;
+assert(false);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 114`] = `
+{
+  "code": "
+declare function assert(x: unknown, y: unknown): asserts x;
+
+assert(true, Math.random() > 0.5);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 8,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 115`] = `
+{
+  "code": "
+declare function assert(x: unknown): asserts x;
+assert({});
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 3,
+        },
+        "start": {
+          "column": 8,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 116`] = `
+{
+  "code": "
+declare function assertsString(x: unknown): asserts x is string;
+declare const a: string;
+assertsString(a);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expression already has the type being checked by the assertion function.",
+      "messageId": "typeGuardAlreadyIsType",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 117`] = `
+{
+  "code": "
+declare function isString(x: unknown): x is string;
+declare const a: string;
+isString(a);
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expression already has the type being checked by the type guard.",
+      "messageId": "typeGuardAlreadyIsType",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 10,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 118`] = `
+{
+  "code": "
+declare function isString(x: unknown): x is string;
+declare const a: string;
+isString('fa' + 'lafel');
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expression already has the type being checked by the type guard.",
+      "messageId": "typeGuardAlreadyIsType",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 10,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 119`] = `
+{
+  "code": "
+declare function isStringOrNumber(x: unknown): x is string | number;
+declare const s: string;
+if (isStringOrNumber(s)) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expression already has the type being checked by the type guard.",
+      "messageId": "typeGuardAlreadyIsType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 4,
+        },
+        "start": {
+          "column": 22,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 120`] = `
+{
+  "code": "
+interface Wider {
+  a: string;
+}
+interface Narrower {
+  a: string;
+  b?: number;
+}
+declare function isWider(x: unknown): x is Wider;
+declare const n: Narrower;
+if (isWider(n)) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expression already has the type being checked by the type guard.",
+      "messageId": "typeGuardAlreadyIsType",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 11,
+        },
+        "start": {
+          "column": 13,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 121`] = `
+{
+  "code": "
+interface Wider {
+  a: string;
+}
+interface Narrower {
+  a: string;
+  b?: number;
+}
+declare function isNarrower(x: unknown): x is Narrower;
+declare const w: Wider;
+if (isNarrower(w)) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expression already has the type being checked by the type guard.",
+      "messageId": "typeGuardAlreadyIsType",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 11,
+        },
+        "start": {
+          "column": 16,
+          "line": 11,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 122`] = `
+{
+  "code": "
+declare const b1: "" & {};
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 123`] = `
+{
+  "code": "
+declare const b1: "" & { __brand: string };
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 124`] = `
+{
+  "code": "
+declare const b1: ("" | false) & { __brand: string };
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 125`] = `
+{
+  "code": "
+declare const b1: ((string & { __brandA: string }) | (number & { __brandB: string })) & "";
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always falsy.",
+      "messageId": "alwaysFalsy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 126`] = `
+{
+  "code": "
+declare const b1: ("foo" | "bar") & { __brand: string };
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 127`] = `
+{
+  "code": "
+declare const b1: (123 | true) & { __brand: string };
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 128`] = `
+{
+  "code": "
+declare const b1: (string | number) & ("foo" | 123) & { __brand: string };
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 129`] = `
+{
+  "code": "
+declare const b1: ((string & { __brandA: string }) | (number & { __brandB: string })) & "foo";
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 130`] = `
+{
+  "code": "
+declare const b1: ((string & { __brandA: string }) | (number & { __brandB: string })) & ("foo" | 123);
+declare const b2: boolean;
+const t1 = b1 && b2;
+",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 12,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 131`] = `
+{
+  "code": "
+type A = {
+  [name in Lowercase<string>]?: {
+    [name in Lowercase<string>]: {
+      a: 1;
+    };
+  };
+};
+
+declare const a: A;
+
+a.a?.a?.a;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 12,
+        },
+        "start": {
+          "column": 7,
+          "line": 12,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 132`] = `
+{
+  "code": "
+interface T {
+  [name: Lowercase<string>]: {
+    [name: Lowercase<string>]: {
+      [name: Lowercase<string>]: {
+        value: 'value';
+      };
+    };
+  };
+  [name: Uppercase<string>]: null | {
+    [name: Uppercase<string>]: null | {
+      [name: Uppercase<string>]: null | {
+        VALUE: 'VALUE';
+      };
+    };
+  };
+}
+
+declare const t: T;
+
+t.a?.a?.a?.value;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 21,
+        },
+        "start": {
+          "column": 4,
+          "line": 21,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 21,
+        },
+        "start": {
+          "column": 7,
+          "line": 21,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 21,
+        },
+        "start": {
+          "column": 10,
+          "line": 21,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 133`] = `
+{
+  "code": "
+declare const test: Array<{ a?: string }>;
+
+if (test[0]?.a) {
+  test[0]?.a;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 5,
+        },
+        "start": {
+          "column": 10,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 134`] = `
+{
+  "code": "
+declare const arr2: Array<{ x: { y: { z: object } } }>;
+arr2[42]?.x?.y?.z;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+    {
+      "message": "Unnecessary optional chain on a non-nullish value.",
+      "messageId": "neverOptionalChain",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 135`] = `
+{
+  "code": "
+declare const arr: string[];
+
+if (arr[0]) {
+  arr[0] ?? 'foo';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, expected left-hand side of \`??\` operator to be possibly null or undefined.",
+      "messageId": "neverNullish",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-condition > invalid 136`] = `
+{
+  "code": "
+declare const arr: object[];
+
+if (arr[42] && arr[42]) {
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unnecessary conditional, value is always truthy.",
+      "messageId": "alwaysTruthy",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 4,
+        },
+        "start": {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-condition",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-condition.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unnecessary-condition.test.ts
@@ -534,6 +534,23 @@ while (0) {}
       `,
       options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
+    // only-allowed-literals applies to all loop types (for, do-while, while)
+    {
+      code: `for (; true; ) {}`,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `for (; 0; ) {}`,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `do {} while (0);`,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
+    {
+      code: `do {} while (true);`,
+      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
+    },
     `
 let variable = 'abc' as string | void;
 variable?.[0];
@@ -1135,6 +1152,33 @@ assertString('falafel');
       code: `
 declare function isString(x: unknown): x is string;
 isString('falafel');
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // string | number | bigint is not a subtype of string | number
+      code: `
+declare function isStringOrNumber(x: unknown): x is string | number;
+declare const s: string | number | bigint;
+if (isStringOrNumber(s)) {
+}
+      `,
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // Narrower is not a subtype of Wider
+      code: `
+interface Wider {
+  a: string;
+}
+interface Narrower {
+  a: string;
+  b: number;
+}
+declare function isNarrower(x: unknown): x is Narrower;
+declare const w: Wider;
+if (isNarrower(w)) {
+}
       `,
       options: [{ checkTypePredicates: true }],
     },
@@ -2082,27 +2126,8 @@ do {} while (test);
       errors: [{ column: 14, line: 4, messageId: 'alwaysTruthy' }],
       options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
     },
-    {
-      code: `
-for (; true; ) {}
-      `,
-      errors: [{ column: 8, line: 2, messageId: 'alwaysTruthy' }],
-      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
-    },
-    {
-      code: `
-for (; 0; ) {}
-      `,
-      errors: [{ column: 8, line: 2, messageId: 'alwaysFalsy' }],
-      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
-    },
-    {
-      code: `
-do {} while (0);
-      `,
-      errors: [{ column: 14, line: 2, messageId: 'alwaysFalsy' }],
-      options: [{ allowConstantLoopConditions: 'only-allowed-literals' }],
-    },
+    // for/do-while with only-allowed-literals: true/false/0/1 are now valid
+    // (moved to valid section to match upstream behavior)
     {
       code: `
 let shouldRun = true;
@@ -3046,20 +3071,14 @@ if (x) {
 }
       `,
       errors: [
-        {
-          column: 1,
-          line: 0,
-          messageId: 'noStrictNullCheck',
-        },
-        {
-          column: 5,
-          line: 3,
-          messageId: 'alwaysTruthy',
-        },
+        { column: 1, line: 0, messageId: 'noStrictNullCheck' },
+        { column: 5, line: 3, messageId: 'alwaysTruthy' },
       ],
       languageOptions: {
         parserOptions: {
-          tsconfigRootDir: path.join(rootPath, 'unstrict'),
+          project: './tsconfig.unstrict.json',
+          projectService: false,
+          tsconfigRootDir: getFixturesRootDir(),
         },
       },
     },
@@ -3518,6 +3537,68 @@ isString('fa' + 'lafel');
       ],
       options: [{ checkTypePredicates: true }],
     },
+    {
+      // string is a strict subtype of string | number.
+      code: `
+declare function isStringOrNumber(x: unknown): x is string | number;
+declare const s: string;
+if (isStringOrNumber(s)) {
+}
+      `,
+      errors: [
+        {
+          line: 4,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // Narrower (with optional) is a subtype of Wider
+      code: `
+interface Wider {
+  a: string;
+}
+interface Narrower {
+  a: string;
+  b?: number;
+}
+declare function isWider(x: unknown): x is Wider;
+declare const n: Narrower;
+if (isWider(n)) {
+}
+      `,
+      errors: [
+        {
+          line: 11,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
+    {
+      // Wider is assignable to Narrower (with optional property)
+      code: `
+interface Wider {
+  a: string;
+}
+interface Narrower {
+  a: string;
+  b?: number;
+}
+declare function isNarrower(x: unknown): x is Narrower;
+declare const w: Wider;
+if (isNarrower(w)) {
+}
+      `,
+      errors: [
+        {
+          line: 11,
+          messageId: 'typeGuardAlreadyIsType',
+        },
+      ],
+      options: [{ checkTypePredicates: true }],
+    },
 
     // "branded" types
     unnecessaryConditionTest('"" & {}', 'alwaysFalsy'),
@@ -3797,11 +3878,7 @@ arr2[42]?.x?.y.z;
         },
       ],
       languageOptions: {
-        parserOptions: {
-          project: './tsconfig.noUncheckedIndexedAccess.json',
-          projectService: false,
-          tsconfigRootDir: getFixturesRootDir(),
-        },
+        parserOptions: optionsWithNoUncheckedIndexedAccess,
       },
     },
     {
@@ -3822,11 +3899,7 @@ if (arr[0]) {
         },
       ],
       languageOptions: {
-        parserOptions: {
-          project: './tsconfig.noUncheckedIndexedAccess.json',
-          projectService: false,
-          tsconfigRootDir: getFixturesRootDir(),
-        },
+        parserOptions: optionsWithNoUncheckedIndexedAccess,
       },
     },
     {
@@ -3846,11 +3919,7 @@ if (arr[42] && arr[42]) {
         },
       ],
       languageOptions: {
-        parserOptions: {
-          project: './tsconfig.noUncheckedIndexedAccess.json',
-          projectService: false,
-          tsconfigRootDir: getFixturesRootDir(),
-        },
+        parserOptions: optionsWithNoUncheckedIndexedAccess,
       },
     },
   ],

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,4 +1,5 @@
 # Custom Dictionary Words
+aavascript
 accum
 anee
 arraybindingpattern
@@ -108,6 +109,7 @@ nullary
 Nullishness
 objectbindingpattern
 objectliteralexpression
+optionable
 osvfs
 parenless
 preact
@@ -191,7 +193,6 @@ walltime
 wasmer
 wasmfs
 xdescribe
-xjavascript
-aavascript
 xitiViewMap
+xjavascript
 xtest


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-unnecessary-condition` rule from typescript-eslint to rslint.

This rule disallows conditionals where the type is always truthy or always falsy. It detects unnecessary conditions in `if`, `while`, `for`, ternary, `&&`, `||`, `??`, `?.`, `switch/case`, and assignment expressions (`&&=`, `||=`, `??=`).

Supports all 3 options: `allowConstantLoopConditions`, `allowRuleToRunWithoutStrictNullChecksIKnowWhatIAmDoing`, and `checkTypePredicates`.

All 163 JS test cases are fully aligned with the upstream typescript-eslint test suite (0 differences). 237 Go test cases cover every code path, edge case, and nesting combination.

### New public utility functions (in `internal/utils/ts_api_utils.go`)
- `IsPossiblyFalsy(t)` / `IsPossiblyTruthy(t)` — check if a type could be falsy/truthy
- `IsNullableType(t)` — check if type includes null/undefined/void/any/unknown
- `IsTypeFlagSetWithUnion(t, flags)` — check type flags across union constituents

## Related Links

- Rule documentation: https://typescript-eslint.io/rules/no-unnecessary-condition
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-condition.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).