### PR TITLE
feat: port rule import/no-mutable-exports

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -3,6 +3,7 @@ package import_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_mutable_exports"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_webpack_loader_syntax"
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -12,6 +13,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		first.FirstRule,
 		newline_after_import.NewlineAfterImportRule,
+		no_mutable_exports.NoMutableExportsRule,
 		no_self_import.NoSelfImportRule,
 		no_webpack_loader_syntax.NoWebpackLoaderSyntax,
 	}

--- a/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.go
+++ b/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.go
@@ -1,0 +1,184 @@
+package no_mutable_exports
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-mutable-exports.js
+var NoMutableExportsRule = rule.Rule{
+	Name: "import/no-mutable-exports",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// checkDeclarationList reports if the VariableDeclarationList uses `let` or `var`.
+		checkDeclarationList := func(declList *ast.Node) {
+			if declList == nil || !ast.IsVariableDeclarationList(declList) {
+				return
+			}
+			if ast.IsVarConstLike(declList) {
+				return
+			}
+			kind := "var"
+			if ast.IsVarLet(declList) {
+				kind = "let"
+			}
+			ctx.ReportNode(declList, rule.RuleMessage{
+				Id:          "noMutableExports",
+				Description: fmt.Sprintf("Exporting mutable '%s' binding, use 'const' instead.", kind),
+			})
+		}
+
+		// resolveVarDeclListBySymbol uses TypeChecker to resolve an identifier to
+		// its VariableDeclarationList. SkipAlias is needed because export specifier
+		// names resolve to alias symbols pointing at the specifier itself.
+		resolveVarDeclListBySymbol := func(identNode *ast.Node) *ast.Node {
+			if ctx.TypeChecker == nil {
+				return nil
+			}
+			sym := ctx.TypeChecker.GetSymbolAtLocation(identNode)
+			if sym == nil {
+				return nil
+			}
+			resolved := ctx.TypeChecker.SkipAlias(sym)
+			if resolved == nil || len(resolved.Declarations) == 0 {
+				return nil
+			}
+			decl := resolved.Declarations[0]
+			if !ast.IsVariableDeclaration(decl) {
+				return nil
+			}
+			declList := decl.Parent
+			if declList != nil && ast.IsVariableDeclarationList(declList) {
+				return declList
+			}
+			return nil
+		}
+
+		// findVarDeclListByWalk is the fallback when TypeChecker is unavailable.
+		// It walks top-level VariableStatements to find a declaration by name.
+		findVarDeclListByWalk := func(name string) *ast.Node {
+			if ctx.SourceFile == nil || ctx.SourceFile.Statements == nil {
+				return nil
+			}
+			for _, stmt := range ctx.SourceFile.Statements.Nodes {
+				if !ast.IsVariableStatement(stmt) {
+					continue
+				}
+				declList := stmt.AsVariableStatement().DeclarationList
+				if declList == nil || !ast.IsVariableDeclarationList(declList) {
+					continue
+				}
+				vdl := declList.AsVariableDeclarationList()
+				if vdl.Declarations == nil {
+					continue
+				}
+				for _, decl := range vdl.Declarations.Nodes {
+					if !ast.IsVariableDeclaration(decl) {
+						continue
+					}
+					declName := decl.AsVariableDeclaration().Name()
+					if declName == nil {
+						continue
+					}
+					if utils.HasNameInBindingPattern(declName, name) {
+						return declList
+					}
+				}
+			}
+			return nil
+		}
+
+		// findVarDeclarationList resolves an identifier to its VariableDeclarationList.
+		// TypeChecker when available, otherwise top-level AST walk as fallback.
+		findVarDeclarationList := func(identNode *ast.Node) *ast.Node {
+			if declList := resolveVarDeclListBySymbol(identNode); declList != nil {
+				return declList
+			}
+			if identNode.Kind == ast.KindIdentifier {
+				return findVarDeclListByWalk(identNode.AsIdentifier().Text)
+			}
+			return nil
+		}
+
+		// isModuleLevelNode returns true if the node is a direct child of the
+		// SourceFile. Exports inside namespace/module blocks are TypeScript
+		// namespace exports, not ES module exports, and should not be reported.
+		isModuleLevelNode := func(node *ast.Node) bool {
+			return node.Parent != nil && node.Parent.Kind == ast.KindSourceFile
+		}
+
+		return rule.RuleListeners{
+			// Handle: export let x = 1 / export var x = 1
+			ast.KindVariableStatement: func(node *ast.Node) {
+				if !isModuleLevelNode(node) {
+					return
+				}
+				if !ast.HasSyntacticModifier(node, ast.ModifierFlagsExport) {
+					return
+				}
+				checkDeclarationList(node.AsVariableStatement().DeclarationList)
+			},
+			// Handle: export { x } / export { x as y }
+			ast.KindExportDeclaration: func(node *ast.Node) {
+				if !isModuleLevelNode(node) {
+					return
+				}
+				exportDecl := node.AsExportDeclaration()
+				// Skip re-exports (export { x } from './foo')
+				if exportDecl.ModuleSpecifier != nil {
+					return
+				}
+				if exportDecl.IsTypeOnly {
+					return
+				}
+				if exportDecl.ExportClause == nil || exportDecl.ExportClause.Kind != ast.KindNamedExports {
+					return
+				}
+				namedExports := exportDecl.ExportClause.AsNamedExports()
+				if namedExports.Elements == nil {
+					return
+				}
+				for _, spec := range namedExports.Elements.Nodes {
+					if spec.Kind != ast.KindExportSpecifier {
+						continue
+					}
+					exportSpec := spec.AsExportSpecifier()
+					if exportSpec.IsTypeOnly {
+						continue
+					}
+					// The local name is PropertyName if present (export { local as exported }),
+					// otherwise Name (export { name })
+					localNode := exportSpec.PropertyName
+					if localNode == nil {
+						localNode = exportSpec.Name()
+					}
+					if localNode == nil {
+						continue
+					}
+					if declList := findVarDeclarationList(localNode); declList != nil {
+						checkDeclarationList(declList)
+					}
+				}
+			},
+			// Handle: export default x
+			ast.KindExportAssignment: func(node *ast.Node) {
+				if !isModuleLevelNode(node) {
+					return
+				}
+				exportAssign := node.AsExportAssignment()
+				if exportAssign.IsExportEquals {
+					return
+				}
+				expr := ast.SkipParentheses(exportAssign.Expression)
+				if expr == nil || expr.Kind != ast.KindIdentifier {
+					return
+				}
+				if declList := findVarDeclarationList(expr); declList != nil {
+					checkDeclarationList(declList)
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.go
+++ b/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.go
@@ -45,19 +45,23 @@ var NoMutableExportsRule = rule.Rule{
 			if resolved == nil || len(resolved.Declarations) == 0 {
 				return nil
 			}
-			decl := resolved.Declarations[0]
-			if !ast.IsVariableDeclaration(decl) {
-				return nil
-			}
-			declList := decl.Parent
-			if declList != nil && ast.IsVariableDeclarationList(declList) {
-				return declList
+			// Iterate all declarations to handle declaration merging
+			// (e.g., var Foo + namespace Foo — Declarations[0] may not be the var).
+			for _, decl := range resolved.Declarations {
+				if ast.IsVariableDeclaration(decl) {
+					declList := decl.Parent
+					if declList != nil && ast.IsVariableDeclarationList(declList) {
+						return declList
+					}
+				}
 			}
 			return nil
 		}
 
 		// findVarDeclListByWalk is the fallback when TypeChecker is unavailable.
 		// It walks top-level VariableStatements to find a declaration by name.
+		// Note: does not recurse into blocks for hoisted var — that is covered
+		// by resolveVarDeclListBySymbol when TypeChecker is available.
 		findVarDeclListByWalk := func(name string) *ast.Node {
 			if ctx.SourceFile == nil || ctx.SourceFile.Statements == nil {
 				return nil

--- a/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.md
+++ b/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports.md
@@ -1,0 +1,32 @@
+# no-mutable-exports
+
+## Rule Details
+
+Forbids the use of mutable exports with `var` or `let`.
+
+Mutable exports can lead to hard-to-understand code because importers might not expect the exported value to change after import. Use `const` for exported values, or export functions/classes instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+export let count = 1;
+export var count = 1;
+
+let count = 1;
+export { count };
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+export const count = 1;
+export function getCount() {}
+export class Counter {}
+
+const count = 1;
+export { count };
+```
+
+## Original Documentation
+
+https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-mutable-exports.md

--- a/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports_test.go
+++ b/internal/plugins/import/rules/no_mutable_exports/no_mutable_exports_test.go
@@ -1,0 +1,531 @@
+package no_mutable_exports_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_mutable_exports"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoMutableExportsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_mutable_exports.NoMutableExportsRule,
+		[]rule_tester.ValidTestCase{
+			// === Direct exports ===
+			{Code: `export const count = 1`},
+			{Code: `export function getCount() {}`},
+			{Code: `export class Counter {}`},
+			{Code: `export enum Direction { Up, Down }`},
+			{Code: `export interface Foo {}`},
+			{Code: `export type Foo = {}`},
+			// Multiple const declarations
+			{Code: `export const a = 1, b = 2`},
+			// Const destructuring
+			{Code: `export const { a, b } = obj`},
+			{Code: `export const [a, b] = arr`},
+			// using (const-like)
+			{Code: `export using x = getResource()`},
+
+			// === Default exports ===
+			{Code: `export default function getCount() {}`},
+			{Code: `export default class Counter {}`},
+			// Default export of assignment expression (not a declaration lookup)
+			{Code: `export default count = 1`},
+			// Default export of literals/expressions
+			{Code: `export default 42`},
+			{Code: `export default { x: 1 }`},
+			{Code: `export default [1, 2, 3]`},
+			{Code: `export default () => {}`},
+
+			// === Named exports with const ===
+			{Code: "const count = 1\nexport { count }"},
+			{Code: "const count = 1\nexport { count as counter }"},
+			{Code: "const count = 1\nexport { count as default }"},
+			// Const destructuring then named export
+			{Code: "const { a } = obj\nexport { a }"},
+			{Code: "const [a] = arr\nexport { a }"},
+			{Code: "const { a: b } = obj\nexport { b }"},
+			{Code: "const { a = 1 } = obj\nexport { a }"},
+			{Code: "const { ...rest } = obj\nexport { rest }"},
+			{Code: "const [, b] = arr\nexport { b }"},
+			{Code: "const { a: { b } } = obj\nexport { b }"},
+
+			// === Default export of const ===
+			{Code: "const count = 1\nexport default count"},
+			// Parenthesized const (parens stripped)
+			{Code: "const x = 1\nexport default (x)"},
+
+			// === Function/class then export ===
+			{Code: "function getCount() {}\nexport { getCount }"},
+			{Code: "function getCount() {}\nexport { getCount as getCounter }"},
+			{Code: "function getCount() {}\nexport default getCount"},
+			{Code: "function getCount() {}\nexport { getCount as default }"},
+			{Code: "class Counter {}\nexport { Counter }"},
+			{Code: "class Counter {}\nexport { Counter as Count }"},
+			{Code: "class Counter {}\nexport default Counter"},
+			{Code: "class Counter {}\nexport { Counter as default }"},
+
+			// === Enum then export ===
+			{Code: "enum Direction { Up, Down }\nexport { Direction }"},
+
+			// === Type-only exports ===
+			{Code: "type Foo = {}\nexport type { Foo }"},
+			// Type-only specifier: valid even if x is let
+			{Code: "let x = 1\nexport { type x }"},
+
+			// === Re-exports (has module specifier, always valid) ===
+			{Code: `export { foo } from './foo'`},
+			{Code: `export { foo as bar } from './foo'`},
+			{Code: `export * from './foo'`},
+			{Code: `export * as ns from './foo'`},
+
+			// === Import then re-export by name ===
+			{Code: "import { x } from './first'\nexport { x }"},
+			{Code: "import { x } from './first'\nexport default x"},
+
+			// === Undeclared identifier (no matching declaration, no report) ===
+			{Code: "export { undeclared }"},
+			{Code: "export default undeclared"},
+
+			// === Empty export ===
+			{Code: "export {}"},
+
+			// === TypeScript: export = ===
+			{Code: "const x = 1\nexport = x"},
+
+			// === Mixed specifiers: all const/func (valid) ===
+			{Code: "const a = 1\nfunction b() {}\nexport { a, b }"},
+
+			// === Namespace/module: export let inside namespace is NOT an ES module export ===
+			{Code: "namespace Foo { export let x = 1 }"},
+			{Code: "module Foo { export let x = 1 }"},
+			{Code: "declare namespace Foo { export let x: number }"},
+			{Code: "declare module 'foo' { export let x: number }"},
+			{Code: "namespace A { namespace B { export let x = 1 } }"},
+
+			// === Hoisting boundaries: let/const inside block does NOT hoist ===
+			{Code: "{ let x = 1 }\nexport { x }"},
+			{Code: "{ const x = 1 }\nexport { x }"},
+			{Code: "if (true) { const x = 1 }\nexport { x }"},
+			{Code: "switch (1) { case 1: const x = 1; break; }\nexport { x }"},
+			// var inside function boundary does NOT hoist to module scope
+			{Code: "function foo() { var x = 1 }\nexport { x }"},
+			{Code: "const foo = () => { var x = 1 }\nexport { x }"},
+			{Code: "(function() { var x = 1 })()\nexport { x }"},
+
+			// === Import bindings (immutable, should NOT report) ===
+			{Code: "import x from './first'\nexport { x }"},
+			{Code: "import * as x from './first'\nexport { x }"},
+
+			// === Declaration merging: all immutable ===
+			{Code: "function Foo() {}\nnamespace Foo { export const bar = 1 }\nexport { Foo }"},
+			{Code: "const Foo = 1\nnamespace Foo {}\nexport { Foo }"},
+			{Code: "class Foo {}\nnamespace Foo {}\nexport { Foo }"},
+			{Code: "enum Foo { A }\nnamespace Foo {}\nexport { Foo }"},
+
+			// === Non-identifier default export expressions (not looked up) ===
+			{Code: "let x = 1\nexport default x + 1"},
+			{Code: "let x = 1\nexport default foo(x)"},
+			{Code: "let x = 1\nexport default x!"},
+			{Code: "let x = 1\nexport default x as number"},
+			{Code: "let x = 1\nexport default x satisfies number"},
+
+			// === CommonJS (not handled by this rule) ===
+			{Code: "var x = 1\nmodule.exports = x"},
+			{Code: "let x = 1\nmodule.exports = { x }"},
+
+			// === String literal export name with const ===
+			{Code: `const x = 1; export { x as "foo-bar" }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// === Direct export let/var ===
+			{
+				Code: `export let count = 1`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `export var count = 1`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			// Multiple declarations in one statement (single error on the declaration list)
+			{
+				Code: `export let a = 1, b = 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `export var a = 1, b = 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			// Direct export with destructuring
+			{
+				Code: `export let { a, b } = obj`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `export var { a, b } = obj`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `export let [a, b] = arr`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `export var [a, b] = arr`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			// TypeScript: let with type annotation
+			{
+				Code: `export let x: string = "hello"`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			// TypeScript: declare let export
+			{
+				Code: `export declare let x: number`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 16},
+				},
+			},
+
+			// === Named exports referencing let/var ===
+			{
+				Code: "let count = 1\nexport { count }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "var count = 1\nexport { count }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Named export with alias
+			{
+				Code: "let count = 1\nexport { count as counter }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "var count = 1\nexport { count as counter }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Named export as default
+			{
+				Code: "let count = 1\nexport { count as default }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+
+			// === Default export of let/var ===
+			{
+				Code: "let count = 1\nexport default count",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "var count = 1\nexport default count",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Uninitialized let/var
+			{
+				Code: "let x\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "var x\nexport default x",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+
+			// === Destructuring then named/default export ===
+			// Object destructuring with let
+			{
+				Code: "let { a } = obj\nexport { a }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Array destructuring with let
+			{
+				Code: "let [a] = arr\nexport { a }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Nested destructuring with var
+			{
+				Code: "var { a: { b } } = obj\nexport { b }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Destructured var then default export
+			{
+				Code: "var { x } = obj\nexport default x",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Rest destructuring with let
+			{
+				Code: "let { ...rest } = obj\nexport { rest }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Renamed destructuring with let
+			{
+				Code: "let { a: b } = obj\nexport { b }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Default value destructuring with var
+			{
+				Code: "var { a = 1 } = obj\nexport { a }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Array destructuring with skip + let
+			{
+				Code: "let [, b] = arr\nexport { b }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Array rest destructuring with var
+			{
+				Code: "var [a, ...rest] = arr\nexport { rest }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Deeply nested destructuring
+			{
+				Code: "let { a: { b: [c] } } = obj\nexport { c }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+
+			// === Multiple errors ===
+			// Multiple specifiers from separate declarations
+			{
+				Code: "let a = 1\nlet b = 2\nexport { a, b }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+					{MessageId: "noMutableExports", Line: 2, Column: 1},
+				},
+			},
+			// Mixed specifiers: only the let one is reported
+			{
+				Code: "let a = 1\nconst b = 2\nexport { a, b }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Same variable exported via direct + named → two errors on same declaration
+			{
+				Code: "export let x = 1\nexport { x as y }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+					{MessageId: "noMutableExports", Line: 1, Column: 8},
+				},
+			},
+			// Same variable exported as multiple aliases
+			{
+				Code: "let x = 1\nexport { x, x as y, x as z }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+
+			// === Declaration after export (var hoists) ===
+			{
+				Code: "export { x }\nvar x = 1",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 2, Column: 1},
+				},
+			},
+
+			// === ES2022: string literal export name with let ===
+			{
+				Code: `let x = 1; export { x as "foo-bar" }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			// Type assertion doesn't change mutability (still let)
+			{
+				Code: "let x = 1 as const\nexport default x",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+
+			// === Hoisted var (var inside block hoists to module scope) ===
+			{
+				Code: "{ var x = 1 }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "if (true) { var x = 1 }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "for (var x = 0; x < 1; x++) {}\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "for (var x of []) {}\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "for (var x in {}) {}\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "try { var x = 1 } catch {}\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "{ { { var x = 1 } } }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			{
+				Code: "{ var x = 1 }\nexport default x",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports"},
+				},
+			},
+			// switch / while / do-while / label / else / catch / finally
+			{
+				Code: "switch (1) { case 1: var x = 1; break; }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "while (false) { var x = 1 }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "do { var x = 1 } while (false)\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "label: var x = 1\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "if (false) {} else { var x = 1 }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "try {} catch (e) { var x = 1 }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "try {} finally { var x = 1 }\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			// Hoisted var with alias
+			{
+				Code: "if (true) { var x = 1 }\nexport { x as y }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			// Hoisted var with default export
+			{
+				Code: "switch (1) { default: var x = 1 }\nexport default x",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+
+			// === Declaration merging: mutable binding ===
+			{
+				Code: "var Foo = 1\nnamespace Foo {}\nexport { Foo }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "let Foo: any\ninterface Foo {}\nexport { Foo }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+
+			// === declare var/let (ambient but mutable binding) ===
+			{
+				Code: "declare var x: number\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+			{
+				Code: "declare let x: number\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+
+			// === var redeclaration ===
+			{
+				Code: "var x = 1\nvar x = 2\nexport { x }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noMutableExports"}},
+			},
+
+			// === Parenthesized export default ===
+			{
+				Code: "let x = 1\nexport default (x)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "let x = 1\nexport default (((x)))",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noMutableExports", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -59,6 +59,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
+    './tests/eslint-plugin-import/rules/no-mutable-exports.test.ts',
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',
 
     // eslint-plugin-react

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-mutable-exports.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-mutable-exports.test.ts
@@ -1,0 +1,463 @@
+import { test } from '../utils.js';
+
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-mutable-exports', null as never, {
+  valid: [
+    // === Direct exports ===
+    test({ code: 'export const count = 1' }),
+    test({ code: 'export function getCount() {}' }),
+    test({ code: 'export class Counter {}' }),
+    test({ code: 'export enum Direction { Up, Down }' }),
+    test({ code: 'export interface Foo {}' }),
+    test({ code: 'export type Foo = {}' }),
+    test({ code: 'export const a = 1, b = 2' }),
+    test({ code: 'export const { a, b } = obj' }),
+    test({ code: 'export const [a, b] = arr' }),
+    test({ code: 'export using x = getResource()' }),
+
+    // === Default exports ===
+    test({ code: 'export default function getCount() {}' }),
+    test({ code: 'export default class Counter {}' }),
+    test({ code: 'export default count = 1' }),
+    test({ code: 'export default 42' }),
+    test({ code: 'export default { x: 1 }' }),
+    test({ code: 'export default [1, 2, 3]' }),
+    test({ code: 'export default () => {}' }),
+
+    // === Named exports with const ===
+    test({ code: 'const count = 1\nexport { count }' }),
+    test({ code: 'const count = 1\nexport { count as counter }' }),
+    test({ code: 'const count = 1\nexport { count as default }' }),
+    test({ code: 'const { a } = obj\nexport { a }' }),
+    test({ code: 'const [a] = arr\nexport { a }' }),
+    test({ code: 'const { a: b } = obj\nexport { b }' }),
+    test({ code: 'const { a = 1 } = obj\nexport { a }' }),
+    test({ code: 'const { ...rest } = obj\nexport { rest }' }),
+    test({ code: 'const [, b] = arr\nexport { b }' }),
+    test({ code: 'const { a: { b } } = obj\nexport { b }' }),
+
+    // === Default export of const ===
+    test({ code: 'const count = 1\nexport default count' }),
+    // Parenthesized const (parens stripped)
+    test({ code: 'const x = 1\nexport default (x)' }),
+
+    // === Function/class then export ===
+    test({ code: 'function getCount() {}\nexport { getCount }' }),
+    test({
+      code: 'function getCount() {}\nexport { getCount as getCounter }',
+    }),
+    test({ code: 'function getCount() {}\nexport default getCount' }),
+    test({ code: 'function getCount() {}\nexport { getCount as default }' }),
+    test({ code: 'class Counter {}\nexport { Counter }' }),
+    test({ code: 'class Counter {}\nexport { Counter as Count }' }),
+    test({ code: 'class Counter {}\nexport default Counter' }),
+    test({ code: 'class Counter {}\nexport { Counter as default }' }),
+
+    // === Enum then export ===
+    test({ code: 'enum Direction { Up, Down }\nexport { Direction }' }),
+
+    // === Type-only exports ===
+    test({ code: 'type Foo = {}\nexport type { Foo }' }),
+    test({ code: 'let x = 1\nexport { type x }' }),
+
+    // === Re-exports ===
+    test({ code: "export { foo } from './foo'" }),
+    test({ code: "export { foo as bar } from './foo'" }),
+    test({ code: "export * from './foo'" }),
+    test({ code: "export * as ns from './foo'" }),
+
+    // === Import then re-export ===
+    test({ code: "import { x } from './first'\nexport { x }" }),
+    test({ code: "import { x } from './first'\nexport default x" }),
+
+    // === Undeclared / empty ===
+    test({ code: 'export { undeclared }' }),
+    test({ code: 'export default undeclared' }),
+    test({ code: 'export {}' }),
+
+    // === TypeScript: export = ===
+    test({ code: 'const x = 1\nexport = x' }),
+
+    // === Mixed specifiers: all const/func ===
+    test({ code: 'const a = 1\nfunction b() {}\nexport { a, b }' }),
+
+    // === Namespace/module: export let inside is NOT an ES module export ===
+    test({ code: 'namespace Foo { export let x = 1 }' }),
+    test({ code: 'module Foo { export let x = 1 }' }),
+    test({ code: 'declare namespace Foo { export let x: number }' }),
+    test({ code: "declare module 'foo' { export let x: number }" }),
+    test({ code: 'namespace A { namespace B { export let x = 1 } }' }),
+
+    // === Hoisting boundaries ===
+    test({ code: '{ let x = 1 }\nexport { x }' }),
+    test({ code: '{ const x = 1 }\nexport { x }' }),
+    test({ code: 'function foo() { var x = 1 }\nexport { x }' }),
+    test({ code: 'const foo = () => { var x = 1 }\nexport { x }' }),
+    test({ code: '(function() { var x = 1 })()\nexport { x }' }),
+
+    // === Declaration merging: all immutable ===
+    test({
+      code: 'function Foo() {}\nnamespace Foo { export const bar = 1 }\nexport { Foo }',
+    }),
+    test({ code: 'const Foo = 1\nnamespace Foo {}\nexport { Foo }' }),
+    test({ code: 'class Foo {}\nnamespace Foo {}\nexport { Foo }' }),
+
+    // === Non-identifier default export expressions ===
+    test({ code: 'let x = 1\nexport default x + 1' }),
+    test({ code: 'let x = 1\nexport default x!' }),
+    test({ code: 'let x = 1\nexport default x as number' }),
+
+    // === CommonJS (not handled by this rule) ===
+    test({ code: 'var x = 1\nmodule.exports = x' }),
+    test({ code: 'let x = 1\nmodule.exports = { x }' }),
+
+    // === String literal export name with const ===
+    test({ code: 'const x = 1; export { x as "foo-bar" }' }),
+  ],
+  invalid: [
+    // === Direct export let/var ===
+    test({
+      code: 'export let count = 1',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export var count = 1',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export let a = 1, b = 2',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export var a = 1, b = 2',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    // Direct export with destructuring
+    test({
+      code: 'export let { a, b } = obj',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export var { a, b } = obj',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export let [a, b] = arr',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export var [a, b] = arr',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    // TypeScript: let with type annotation
+    test({
+      code: "export let x: string = 'hello'",
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    // TypeScript: declare let
+    test({
+      code: 'export declare let x: number',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+
+    // === Named exports referencing let/var ===
+    test({
+      code: 'let count = 1\nexport { count }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var count = 1\nexport { count }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let count = 1\nexport { count as counter }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var count = 1\nexport { count as counter }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let count = 1\nexport { count as default }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+
+    // === Default export of let/var ===
+    test({
+      code: 'let count = 1\nexport default count',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var count = 1\nexport default count',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    // Uninitialized
+    test({
+      code: 'let x\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var x\nexport default x',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+
+    // === Destructuring then named/default export ===
+    test({
+      code: 'let { a } = obj\nexport { a }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let [a] = arr\nexport { a }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var { a: { b } } = obj\nexport { b }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var { x } = obj\nexport default x',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let { ...rest } = obj\nexport { rest }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let { a: b } = obj\nexport { b }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var { a = 1 } = obj\nexport { a }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let [, b] = arr\nexport { b }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'var [a, ...rest] = arr\nexport { rest }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let { a: { b: [c] } } = obj\nexport { c }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+
+    // === Multiple errors ===
+    test({
+      code: 'let a = 1\nlet b = 2\nexport { a, b }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let a = 1\nconst b = 2\nexport { a, b }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'export let x = 1\nexport { x as y }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let x = 1\nexport { x, x as y, x as z }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+
+    // === Declaration after export (var hoists, we still find it) ===
+    test({
+      code: 'export { x }\nvar x = 1',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+
+    // === ES2022: string literal export name with let ===
+    test({
+      code: 'let x = 1; export { x as "foo-bar" }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    // Type assertion doesn't change mutability (still let)
+    test({
+      code: 'let x = 1 as const\nexport default x',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+
+    // Hoisted var (var inside block hoists to module scope)
+    test({
+      code: '{ var x = 1 }\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'if (true) { var x = 1 }\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'for (var x = 0; x < 1; x++) {}\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'for (var x of []) {}\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'for (var x in {}) {}\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'try { var x = 1 } catch {}\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: '{ { { var x = 1 } } }\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: '{ var x = 1 }\nexport default x',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    // switch / while / do-while / label / else / catch / finally
+    test({
+      code: 'switch (1) { case 1: var x = 1; break; }\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'while (false) { var x = 1 }\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'do { var x = 1 } while (false)\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    // Declaration merging: mutable binding
+    test({
+      code: 'var Foo = 1\nnamespace Foo {}\nexport { Foo }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    // declare var/let
+    test({
+      code: 'declare var x: number\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'var' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'declare let x: number\nexport { x }',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+
+    // Parenthesized export default
+    test({
+      code: 'let x = 1\nexport default (x)',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+    test({
+      code: 'let x = 1\nexport default (((x)))',
+      errors: [
+        { message: "Exporting mutable 'let' binding, use 'const' instead." },
+      ],
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `import/no-mutable-exports` rule from eslint-plugin-import to rslint.

Forbids exporting variables declared with `let` or `var`. Supports direct exports (`export let x`), named exports (`export { x }`), default exports (`export default x`), destructuring patterns, hoisted `var` declarations, and TypeScript-specific syntax. Uses TypeChecker for accurate symbol resolution with AST-walking fallback.

## Related Links

- ESLint rule: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-mutable-exports.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-mutable-exports.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).