### PR TITLE
ci: free disk space before Go build on Windows runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,11 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-go-windows
       - name: Build CLI binary
-        run: go build -o rslint-windows.exe ./cmd/rslint
+        shell: pwsh
+        run: |
+          Remove-Item 'C:\Program Files (x86)\Microsoft Visual Studio' -Recurse -Force -ErrorAction SilentlyContinue
+          Remove-Item 'C:\Program Files (x86)\Windows Kits' -Recurse -Force -ErrorAction SilentlyContinue
+          go build -o rslint-windows.exe ./cmd/rslint
       - name: Upload CLI binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary

- Remove unused Visual Studio (~10.5 GB) and Windows SDK (~5.4 GB) before `go build` in `build-go-windows` to prevent disk exhaustion during compilation on the self-hosted `rspack-windows-2022-large` runner.

## Related Links

- CI disk space exhaustion on `rspack-windows-2022-large` during `build-go-windows`

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).