### PR TITLE
ci: reduce GOMAXPROCS for Windows build to avoid disk exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,9 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache-name: ci-go-windows
       - name: Build CLI binary
-        shell: pwsh
-        run: |
-          Remove-Item 'C:\Program Files (x86)\Microsoft Visual Studio' -Recurse -Force -ErrorAction SilentlyContinue
-          Remove-Item 'C:\Program Files (x86)\Windows Kits' -Recurse -Force -ErrorAction SilentlyContinue
-          go build -o rslint-windows.exe ./cmd/rslint
+        run: go build -o rslint-windows.exe ./cmd/rslint
+        env:
+          GOMAXPROCS: 4
       - name: Upload CLI binary
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:


### PR DESCRIPTION
## Summary

- Lower `GOMAXPROCS` from 8 to 4 in `build-go-windows` to reduce peak GOCACHE disk usage during compilation, preventing disk exhaustion on the self-hosted `rspack-windows-2022-large` runner.
- Remove the ineffective `Remove-Item` commands (verified in #652 that they do not free any space).

## Related Links

- #652

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).