### PR TITLE
feat: port rule no-new-func

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,40 +51,8 @@ jobs:
       - name: Unit Test
         run: go test -parallel 8 ./internal/...
 
-  # Windows pipeline: build-go-windows produces the CLI binary and warms the
-  # Go build cache. test-go-windows and test-node-windows both depend on it
-  # so they can reuse the cached build artifacts.
-  build-go-windows:
-    name: Build Go (rspack-windows-2022-large)
-    runs-on: rspack-windows-2022-large
-    strategy:
-      matrix:
-        go-version: ['1.26.0']
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          submodules: true
-          fetch-depth: 1
-      - name: Setup Go
-        uses: ./.github/actions/setup-go
-        with:
-          go-version: ${{ matrix.go-version }}
-          cache-name: ci-go-windows
-      - name: Build CLI binary
-        run: go build -o rslint-windows.exe ./cmd/rslint
-        env:
-          GOMAXPROCS: 4
-      - name: Upload CLI binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        with:
-          name: ci-rslint-windows-binary
-          path: rslint-windows.exe
-          retention-days: 1
-
   test-go-windows:
     name: Test Go (rspack-windows-2022-large)
-    needs: build-go-windows
     runs-on: rspack-windows-2022-large
     strategy:
       matrix:
@@ -142,7 +110,6 @@ jobs:
 
   test-node-windows:
     name: Test npm packages (windows-latest)
-    needs: build-go-windows
     runs-on: windows-latest
     steps:
       - name: Checkout code
@@ -150,18 +117,17 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+        with:
+          go-version: 1.26.0
+          cache-name: ci-go-windows-node
+
       - name: Setup Node.js
         uses: ./.github/actions/setup-node
 
-      - name: Download Go binary
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: ci-rslint-windows-binary
-          path: packages/rslint/bin
-
-      - name: Rename binary
-        shell: bash
-        run: mv packages/rslint/bin/rslint-windows.exe packages/rslint/bin/rslint.exe
+      - name: Build Go binary
+        run: go build -o packages/rslint/bin/rslint.exe ./cmd/rslint
 
       - name: Build JS packages
         shell: bash
@@ -342,7 +308,6 @@ jobs:
   done:
     needs:
       - test-go
-      - build-go-windows
       - test-go-windows
       - test-node
       - test-node-windows

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -145,6 +145,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
+	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
@@ -530,6 +531,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
+	GlobalRuleRegistry.Register("no-new-func", no_new_func.NoNewFuncRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
 	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)

--- a/internal/rules/no_new_func/no_new_func.go
+++ b/internal/rules/no_new_func/no_new_func.go
@@ -1,0 +1,105 @@
+package no_new_func
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-new-func
+
+// skipTransparent skips parentheses and TS type assertions (as, angle-bracket,
+// non-null !, satisfies) so that e.g. (Function as any)("code") is still caught.
+const skipTransparent = ast.OEKParentheses | ast.OEKAssertions
+
+var callMethods = map[string]bool{
+	"call":  true,
+	"apply": true,
+	"bind":  true,
+}
+
+var msg = rule.RuleMessage{
+	Id:          "noFunctionConstructor",
+	Description: "The Function constructor is eval.",
+}
+
+var NoNewFuncRule = rule.Rule{
+	Name: "no-new-func",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// isGlobalFunction checks whether an identifier resolves to the
+		// built-in Function (from lib.d.ts), not a user-declared one.
+		//
+		// Strategy: TypeChecker accurately resolves symbols inside function
+		// scopes, but at the top level TypeScript's declaration merging can
+		// cause GetSymbolAtLocation to return the global symbol even when a
+		// local class/function with the same name exists. So we use both:
+		//   1. TypeChecker (when available) — authoritative for non-top-level
+		//   2. IsShadowed — catches top-level shadowing that TypeChecker misses
+		isGlobalFunction := func(id *ast.Node) bool {
+			if utils.IsShadowed(id, "Function") {
+				return false
+			}
+			if ctx.TypeChecker != nil {
+				symbol := ctx.TypeChecker.GetSymbolAtLocation(id)
+				if symbol == nil {
+					return false
+				}
+				return !utils.IsSymbolDeclaredInFile(symbol, ctx.SourceFile)
+			}
+			return true
+		}
+
+		check := func(node *ast.Node) {
+			var callee *ast.Node
+			if node.Kind == ast.KindNewExpression {
+				callee = node.AsNewExpression().Expression
+			} else {
+				callee = node.AsCallExpression().Expression
+			}
+
+			if callee == nil {
+				return
+			}
+
+			// Unwrap parentheses and TS assertions so that patterns like
+			// (Function)(...), (Function as any)(...), Function!(...) are all caught.
+			unwrapped := ast.SkipOuterExpressions(callee, skipTransparent)
+
+			// Case 1: new Function(...), Function(...), (Function)(...)
+			if unwrapped.Kind == ast.KindIdentifier && unwrapped.AsIdentifier().Text == "Function" {
+				if !isGlobalFunction(unwrapped) {
+					return
+				}
+				ctx.ReportNode(node, msg)
+				return
+			}
+
+			// Case 2: Function.call(...), Function.apply(...), Function.bind(...)
+			// Only applies to CallExpression (not NewExpression)
+			if node.Kind != ast.KindCallExpression {
+				return
+			}
+
+			propName, ok := utils.AccessExpressionStaticName(unwrapped)
+			if !ok || !callMethods[propName] {
+				return
+			}
+
+			obj := ast.SkipOuterExpressions(utils.AccessExpressionObject(unwrapped), skipTransparent)
+			if obj == nil || obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != "Function" {
+				return
+			}
+
+			if !isGlobalFunction(obj) {
+				return
+			}
+
+			ctx.ReportNode(node, msg)
+		}
+
+		return rule.RuleListeners{
+			ast.KindNewExpression:  check,
+			ast.KindCallExpression: check,
+		}
+	},
+}

--- a/internal/rules/no_new_func/no_new_func.md
+++ b/internal/rules/no_new_func/no_new_func.md
@@ -1,0 +1,28 @@
+# no-new-func
+
+## Rule Details
+
+Disallows creating functions from strings using the `Function` constructor. Passing a string to the `Function` constructor requires the engine to parse that string, similar to `eval`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = new Function('a', 'b', 'return a + b');
+var b = Function('a', 'b', 'return a + b');
+var c = Function.call(null, 'a', 'b', 'return a + b');
+var d = Function.apply(null, ['a', 'b', 'return a + b']);
+var e = Function.bind(null, 'a', 'b', 'return a + b')();
+var f = Function.bind(null, 'a', 'b', 'return a + b');
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var x = function (a, b) {
+  return a + b;
+};
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-new-func

--- a/internal/rules/no_new_func/no_new_func_test.go
+++ b/internal/rules/no_new_func/no_new_func_test.go
@@ -1,0 +1,326 @@
+package no_new_func
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoNewFuncRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNewFuncRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// --- Not the global Function ---
+			{Code: `var a = new _function("b", "c", "return b+c");`},
+			{Code: `var a = _function("b", "c", "return b+c");`},
+
+			// --- Function as a value reference, not invoked ---
+			{Code: `call(Function)`},
+			{Code: `new Class(Function)`},
+			{Code: `var x = [Function]`},
+			{Code: `var x = Function`},
+			{Code: `typeof Function`},
+
+			// --- Non-matching method calls ---
+			{Code: `Function.toString()`},
+			{Code: `Function.hasOwnProperty("call")`},
+			{Code: `Function.prototype`},
+
+			// --- Dynamic/computed property: not statically "call"/"apply"/"bind" ---
+			{Code: `foo[Function]()`},
+			{Code: `Function[call]()`},
+
+			// --- Accessing but not calling .bind/.call/.apply ---
+			{Code: `foo(Function.bind)`},
+			{Code: `var x = Function.call`},
+			{Code: `var x = Function.apply`},
+
+			// --- Shadowing: class declaration ---
+			{Code: `class Function {}; new Function()`},
+			{Code: `const fn = () => { class Function {}; new Function() }`},
+
+			// --- Shadowing: function declaration ---
+			{Code: `function Function() {}; Function()`},
+			{Code: `var fn = function () { function Function() {}; Function() }`},
+
+			// --- Shadowing: function expression name ---
+			{Code: `var x = function Function() { Function(); }`},
+
+			// --- Shadowing: var (hoisted across blocks) ---
+			{Code: `function test() { var Function = function(){}; return new Function(); }`},
+			{Code: `function test() { var x = new Function("code"); var Function = function() {}; }`},
+			{Code: `function test() { if (true) { var Function = 42; } new Function(); }`},
+			{Code: `function test() { for (var Function = 0; Function < 1; Function++) {} new Function(); }`},
+			{Code: `function test() { for (var Function in {}) {} new Function(); }`},
+			{Code: `function test() { for (var Function of []) {} new Function(); }`},
+			{Code: `function test() { switch (0) { case 0: var Function = 1; } new Function(); }`},
+
+			// --- Shadowing: let/const ---
+			{Code: `function test() { let Function = class {}; return new Function(); }`},
+			{Code: `function test() { const Function = class {}; return Function(); }`},
+
+			// --- Shadowing: parameter ---
+			{Code: `function test(Function) { return new Function(); }`},
+			{Code: `function test({ Function }) { return new Function(); }`},
+			{Code: `function test([Function]) { return new Function(); }`},
+			{Code: `function test(...Function) { return new Function(); }`},
+			{Code: `function test(Function = class {}) { return new Function(); }`},
+			{Code: `var fn = (Function) => Function();`},
+			{Code: `function* gen(Function) { yield new Function(); }`},
+			{Code: `async function af(Function) { return new Function(); }`},
+
+			// --- Shadowing: catch clause ---
+			{Code: `try {} catch (Function) { new Function(); }`},
+
+			// --- Shadowing: nested scopes ---
+			{Code: `function test() { var Function = class {}; function inner() { return new Function(); } }`},
+			{Code: `function test() { var Function = class {}; var fn = () => new Function(); }`},
+
+			// --- Shadowing: method/constructor parameters ---
+			{Code: `var obj = { m(Function) { return new Function(); } };`},
+			{Code: `class C { m(Function) { return new Function(); } }`},
+			{Code: `class C { constructor(Function) { this.x = new Function(); } }`},
+
+			// --- Shadowing: for-let/of (inside loop body) ---
+			{Code: `function test() { for (let Function in {}) { new Function(); } }`},
+			{Code: `function test() { for (let Function of []) { new Function(); } }`},
+
+			// --- Shadowing applies to .call/.apply/.bind too ---
+			{Code: `function test(Function) { return Function.call(null, "code"); }`},
+			{Code: `function test() { var Function = class {}; Function.apply(null, ["code"]); }`},
+
+			// --- Tagged template (not a call) ---
+			{Code: "Function`code`"},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// === Direct: new Function(...) ===
+			{
+				Code:   `var a = new Function("b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			// No arguments
+			{
+				Code:   `new Function()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+
+			// === Direct: Function(...) ===
+			{
+				Code:   `var a = Function("b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+
+			// === Parenthesized callee ===
+			{
+				Code:   `(Function)("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `((Function))("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `new (Function)("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+
+			// === Optional call ===
+			{
+				Code:   `Function?.("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+
+			// === Method: .call / .apply / .bind (dot notation) ===
+			{
+				Code:   `var a = Function.call(null, "b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `var a = Function.apply(null, ["b", "c", "return b+c"]);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `var a = Function.bind(null, "b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			// .bind(...)() — only the inner Function.bind(...) call is reported
+			{
+				Code:   `var a = Function.bind(null, "b", "c", "return b+c")();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+
+			// === Method: bracket notation ===
+			{
+				Code:   `var a = Function["call"](null, "b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `var a = Function["apply"](null, ["b", "c", "return b+c"]);`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			{
+				Code:   `var a = Function["bind"](null, "b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+			// Template literal bracket notation
+			{
+				Code:   "var a = Function[`call`](null, \"code\")",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 9}},
+			},
+
+			// === Optional chaining on method ===
+			{
+				Code:   `(Function?.call)(null, "b", "c", "return b+c");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `Function?.call(null, "code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `Function?.apply(null, ["code"])`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `Function?.bind(null, "code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+
+			// === Parenthesized object in method call ===
+			{
+				Code:   `(Function).call(null, "code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `(Function).apply(null, ["code"])`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+
+			// === TypeScript assertions on callee ===
+			{
+				Code:   `(Function as any)("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `(<any>Function)("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `Function!("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `(Function satisfies any)("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `new (Function as any)("code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+			// TypeScript assertion on object of method call
+			{
+				Code:   `(Function as any).call(null, "code")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 1}},
+			},
+
+			// === Nested new wrapping a Function call ===
+			{
+				Code:   `new (Function("code"))`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 6}},
+			},
+
+			// === Nesting: inside various constructs ===
+			{
+				Code:   `function f() { return new Function("code"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 23}},
+			},
+			{
+				Code:   `var f = () => new Function("code");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 15}},
+			},
+			{
+				Code:   `if (true) { var x = new Function("code"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 21}},
+			},
+			{
+				Code:   `class C { m() { return new Function("code"); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 24}},
+			},
+			{
+				Code:   `class C { constructor() { this.x = new Function("code"); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 36}},
+			},
+			{
+				Code:   `function outer() { function inner() { return new Function("code"); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 46}},
+			},
+
+			// === Multiple errors in one statement ===
+			{
+				Code: `var a = new Function("a"); var b = Function("b");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noFunctionConstructor", Line: 1, Column: 9},
+					{MessageId: "noFunctionConstructor", Line: 1, Column: 36},
+				},
+			},
+
+			// === Expressions: ternary, logical, comma ===
+			{
+				Code: `var x = true ? new Function("a") : Function("b");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noFunctionConstructor", Line: 1, Column: 16},
+					{MessageId: "noFunctionConstructor", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code:   `var x = foo || new Function("code");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `var x = foo ?? new Function("code");`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 16}},
+			},
+
+			// === Scoping: inner shadow does NOT reach outer ===
+			{
+				Code:   `const fn = () => { class Function {} }; new Function('', '')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 41}},
+			},
+			{
+				Code:   `var fn = function () { function Function() {} }; Function('', '')`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 50}},
+			},
+			// let in sibling block does not shadow
+			{
+				Code:   `function f() { { let Function = class {}; } var x = new Function("code"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 53}},
+			},
+			// var in inner function does NOT hoist to outer
+			{
+				Code:   `function f() { var x = new Function("code"); (function() { var Function = 1; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 24}},
+			},
+			// arrow param does not shadow outer scope
+			{
+				Code:   `function f() { var fn = (Function) => Function; var x = new Function("code"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 57}},
+			},
+			// catch variable does not shadow outside catch block
+			{
+				Code:   `function f() { try {} catch (Function) {} var x = new Function("code"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 51}},
+			},
+			// for-let does not shadow outside the loop
+			{
+				Code:   `function f() { for (let Function of []) {} var x = new Function("code"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noFunctionConstructor", Line: 1, Column: 52}},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -48,6 +48,7 @@ export default defineConfig({
     './tests/eslint/rules/no-global-assign.test.ts',
     './tests/eslint/rules/no-import-assign.test.ts',
     './tests/eslint/rules/no-inner-declarations.test.ts',
+    './tests/eslint/rules/no-new-func.test.ts',
     './tests/eslint/rules/no-new-wrappers.test.ts',
     './tests/eslint/rules/no-self-assign.test.ts',
     './tests/eslint/rules/no-undef.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new-func.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new-func.test.ts.snap
@@ -1,0 +1,1201 @@
+// Rstest Snapshot v1
+
+exports[`no-new-func > invalid 1`] = `
+{
+  "code": "var a = new Function("b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 2`] = `
+{
+  "code": "new Function()",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 3`] = `
+{
+  "code": "var a = Function("b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 4`] = `
+{
+  "code": "(Function)("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 5`] = `
+{
+  "code": "((Function))("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 6`] = `
+{
+  "code": "new (Function)("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 7`] = `
+{
+  "code": "Function?.("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 8`] = `
+{
+  "code": "var a = Function.call(null, "b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 9`] = `
+{
+  "code": "var a = Function.apply(null, ["b", "c", "return b+c"]);",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 10`] = `
+{
+  "code": "var a = Function.bind(null, "b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 11`] = `
+{
+  "code": "var a = Function.bind(null, "b", "c", "return b+c")();",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 12`] = `
+{
+  "code": "var a = Function["call"](null, "b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 13`] = `
+{
+  "code": "var a = Function["apply"](null, ["b", "c", "return b+c"]);",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 14`] = `
+{
+  "code": "var a = Function["bind"](null, "b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 15`] = `
+{
+  "code": "var a = Function[\`call\`](null, "code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 16`] = `
+{
+  "code": "(Function?.call)(null, "b", "c", "return b+c");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 17`] = `
+{
+  "code": "Function?.call(null, "code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 18`] = `
+{
+  "code": "Function?.apply(null, ["code"])",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 19`] = `
+{
+  "code": "Function?.bind(null, "code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 20`] = `
+{
+  "code": "(Function).call(null, "code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 21`] = `
+{
+  "code": "(Function).apply(null, ["code"])",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 22`] = `
+{
+  "code": "(Function as any)("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 23`] = `
+{
+  "code": "(<any>Function)("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 24`] = `
+{
+  "code": "Function!("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 25`] = `
+{
+  "code": "(Function satisfies any)("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 26`] = `
+{
+  "code": "new (Function as any)("code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 27`] = `
+{
+  "code": "(Function as any).call(null, "code")",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 28`] = `
+{
+  "code": "new (Function("code"))",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 29`] = `
+{
+  "code": "function f() { return new Function("code"); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 30`] = `
+{
+  "code": "var f = () => new Function("code");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 31`] = `
+{
+  "code": "if (true) { var x = new Function("code"); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 32`] = `
+{
+  "code": "class C { m() { return new Function("code"); } }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 33`] = `
+{
+  "code": "class C { constructor() { this.x = new Function("code"); } }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 34`] = `
+{
+  "code": "function outer() { function inner() { return new Function("code"); } }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 35`] = `
+{
+  "code": "var a = new Function("a"); var b = Function("b");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 36`] = `
+{
+  "code": "var x = true ? new Function("a") : Function("b");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 37`] = `
+{
+  "code": "var x = foo || new Function("code");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 38`] = `
+{
+  "code": "var x = foo ?? new Function("code");",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 39`] = `
+{
+  "code": "const fn = () => { class Function {} }; new Function('', '')",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 40`] = `
+{
+  "code": "var fn = function () { function Function() {} }; Function('', '')",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 41`] = `
+{
+  "code": "function f() { { let Function = class {}; } var x = new Function("code"); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 42`] = `
+{
+  "code": "function f() { var x = new Function("code"); (function() { var Function = 1; })(); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 43`] = `
+{
+  "code": "function f() { var fn = (Function) => Function; var x = new Function("code"); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 44`] = `
+{
+  "code": "function f() { try {} catch (Function) {} var x = new Function("code"); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-func > invalid 45`] = `
+{
+  "code": "function f() { for (let Function of []) {} var x = new Function("code"); }",
+  "diagnostics": [
+    {
+      "message": "The Function constructor is eval.",
+      "messageId": "noFunctionConstructor",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-new-func.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-new-func.test.ts
@@ -1,0 +1,312 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-new-func', {
+  valid: [
+    // --- Not the global Function ---
+    'var a = new _function("b", "c", "return b+c");',
+    'var a = _function("b", "c", "return b+c");',
+
+    // --- Function as a value reference, not invoked ---
+    'call(Function)',
+    'new Class(Function)',
+    'foo[Function]()',
+    'var x = [Function]',
+    'var x = Function',
+
+    // --- Non-matching method calls ---
+    'Function.toString()',
+    'Function.hasOwnProperty("call")',
+
+    // --- Dynamic/computed property: not statically "call"/"apply"/"bind" ---
+    'Function[call]()',
+
+    // --- Accessing but not calling .bind/.call/.apply ---
+    'foo(Function.bind)',
+    'var x = Function.call',
+
+    // --- Shadowing: class declaration ---
+    {
+      code: 'class Function {}; new Function()',
+    },
+    {
+      code: 'const fn = () => { class Function {}; new Function() }',
+    },
+
+    // --- Shadowing: function declaration ---
+    'function Function() {}; Function()',
+    'var fn = function () { function Function() {}; Function() }',
+
+    // --- Shadowing: function expression name ---
+    'var x = function Function() { Function(); }',
+
+    // --- Shadowing: var (hoisted across blocks) ---
+    'function test() { var Function = function(){}; return new Function(); }',
+    "function test() { var x = new Function('code'); var Function = function() {}; }",
+    'function test() { if (true) { var Function = 42; } new Function(); }',
+    'function test() { for (var Function = 0; Function < 1; Function++) {} new Function(); }',
+    'function test() { for (var Function in {}) {} new Function(); }',
+    'function test() { for (var Function of []) {} new Function(); }',
+    'function test() { switch (0) { case 0: var Function = 1; } new Function(); }',
+
+    // --- Shadowing: let/const ---
+    'function test() { let Function = class {}; return new Function(); }',
+    'function test() { const Function = class {}; return Function(); }',
+
+    // --- Shadowing: parameter ---
+    'function test(Function) { return new Function(); }',
+    'function test({ Function }) { return new Function(); }',
+    'function test([Function]) { return new Function(); }',
+    'function test(...Function) { return new Function(); }',
+    'var fn = (Function) => Function();',
+    'function* gen(Function) { yield new Function(); }',
+    'async function af(Function) { return new Function(); }',
+
+    // --- Shadowing: catch clause ---
+    'try {} catch (Function) { new Function(); }',
+
+    // --- Shadowing: nested scopes ---
+    'function test() { var Function = class {}; function inner() { return new Function(); } }',
+    'function test() { var Function = class {}; var fn = () => new Function(); }',
+
+    // --- Shadowing: method/constructor parameters ---
+    'var obj = { m(Function) { return new Function(); } };',
+    'class C { m(Function) { return new Function(); } }',
+    'class C { constructor(Function) { this.x = new Function(); } }',
+
+    // --- Shadowing: for-let/of (inside loop body) ---
+    'function test() { for (let Function in {}) { new Function(); } }',
+    'function test() { for (let Function of []) { new Function(); } }',
+
+    // --- Shadowing applies to .call/.apply/.bind too ---
+    'function test(Function) { return Function.call(null, "code"); }',
+    'function test() { var Function = class {}; Function.apply(null, ["code"]); }',
+
+    // --- Tagged template (not a call) ---
+    'Function`code`',
+  ],
+  invalid: [
+    // === Direct: new Function(...) ===
+    {
+      code: 'var a = new Function("b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'new Function()',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Direct: Function(...) ===
+    {
+      code: 'var a = Function("b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Parenthesized callee ===
+    {
+      code: '(Function)("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: '((Function))("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'new (Function)("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Optional call ===
+    {
+      code: 'Function?.("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Method: .call / .apply / .bind (dot notation) ===
+    {
+      code: 'var a = Function.call(null, "b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'var a = Function.apply(null, ["b", "c", "return b+c"]);',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'var a = Function.bind(null, "b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // .bind(...)() — only the inner Function.bind(...) is reported
+    {
+      code: 'var a = Function.bind(null, "b", "c", "return b+c")();',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Method: bracket notation ===
+    {
+      code: 'var a = Function["call"](null, "b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'var a = Function["apply"](null, ["b", "c", "return b+c"]);',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'var a = Function["bind"](null, "b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // Template literal bracket notation
+    {
+      code: 'var a = Function[`call`](null, "code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Optional chaining on method ===
+    {
+      code: '(Function?.call)(null, "b", "c", "return b+c");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'Function?.call(null, "code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'Function?.apply(null, ["code"])',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'Function?.bind(null, "code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Parenthesized object in method call ===
+    {
+      code: '(Function).call(null, "code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: '(Function).apply(null, ["code"])',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === TypeScript assertions on callee ===
+    {
+      code: '(Function as any)("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: '(<any>Function)("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'Function!("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: '(Function satisfies any)("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'new (Function as any)("code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // TypeScript assertion on object of method call
+    {
+      code: '(Function as any).call(null, "code")',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Nested new wrapping a Function call ===
+    {
+      code: 'new (Function("code"))',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Nesting: inside various constructs ===
+    {
+      code: 'function f() { return new Function("code"); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'var f = () => new Function("code");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'if (true) { var x = new Function("code"); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'class C { m() { return new Function("code"); } }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'class C { constructor() { this.x = new Function("code"); } }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'function outer() { function inner() { return new Function("code"); } }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Multiple errors in one statement ===
+    {
+      code: 'var a = new Function("a"); var b = Function("b");',
+      errors: [
+        { messageId: 'noFunctionConstructor' },
+        { messageId: 'noFunctionConstructor' },
+      ],
+    },
+
+    // === Expressions: ternary, logical ===
+    {
+      code: 'var x = true ? new Function("a") : Function("b");',
+      errors: [
+        { messageId: 'noFunctionConstructor' },
+        { messageId: 'noFunctionConstructor' },
+      ],
+    },
+    {
+      code: 'var x = foo || new Function("code");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: 'var x = foo ?? new Function("code");',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+
+    // === Scoping: inner shadow does NOT reach outer ===
+    {
+      code: "const fn = () => { class Function {} }; new Function('', '')",
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    {
+      code: "var fn = function () { function Function() {} }; Function('', '')",
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // let in sibling block does not shadow
+    {
+      code: 'function f() { { let Function = class {}; } var x = new Function("code"); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // var in inner function does NOT hoist to outer
+    {
+      code: 'function f() { var x = new Function("code"); (function() { var Function = 1; })(); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // arrow param does not shadow outer scope
+    {
+      code: 'function f() { var fn = (Function) => Function; var x = new Function("code"); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // catch variable does not shadow outside catch block
+    {
+      code: 'function f() { try {} catch (Function) {} var x = new Function("code"); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+    // for-let does not shadow outside the loop
+    {
+      code: 'function f() { for (let Function of []) {} var x = new Function("code"); }',
+      errors: [{ messageId: 'noFunctionConstructor' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-new-func` ESLint rule to rslint.

Disallows creating functions from strings using the `Function` constructor (`new Function(...)`, `Function(...)`, `Function.call/apply/bind(...)`), as it is equivalent to `eval`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-new-func
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-new-func.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).