### PR TITLE
feat: port rule import/no-duplicates

### DIFF
--- a/internal/plugins/import/all.go
+++ b/internal/plugins/import/all.go
@@ -3,6 +3,7 @@ package import_plugin
 import (
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/first"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/newline_after_import"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_mutable_exports"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_self_import"
 	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_webpack_loader_syntax"
@@ -13,6 +14,7 @@ func GetAllRules() []rule.Rule {
 	return []rule.Rule{
 		first.FirstRule,
 		newline_after_import.NewlineAfterImportRule,
+		no_duplicates.NoDuplicatesRule,
 		no_mutable_exports.NoMutableExportsRule,
 		no_self_import.NoSelfImportRule,
 		no_webpack_loader_syntax.NoWebpackLoaderSyntax,

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.go
@@ -106,6 +106,9 @@ func processScope(ctx rule.RuleContext, statements []*ast.Node, opts ruleOptions
 		}
 
 		resolvedPath := resolveImportPath(importDecl.ModuleSpecifier, ctx, opts, sourceText)
+		if resolvedPath == "" {
+			continue
+		}
 
 		importMap := getImportMap(importDecl, opts, imported, nsImported, defaultTypesImported, namedTypesImported)
 		importMap[resolvedPath] = append(importMap[resolvedPath], stmt)

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.go
@@ -1,0 +1,770 @@
+package no_duplicates
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/utils"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	rslintUtils "github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type ruleOptions struct {
+	considerQueryString bool
+	preferInline        bool
+}
+
+func parseOptions(options any) ruleOptions {
+	opts := ruleOptions{}
+	optsMap := rslintUtils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["considerQueryString"]; ok {
+			if b, ok := v.(bool); ok {
+				opts.considerQueryString = b
+			}
+		}
+		if v, ok := optsMap["prefer-inline"]; ok {
+			if b, ok := v.(bool); ok {
+				opts.preferInline = b
+			}
+		}
+	}
+	return opts
+}
+
+// See: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md
+var NoDuplicatesRule = rule.Rule{
+	Name: "import/no-duplicates",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		sourceFile := ctx.SourceFile
+		if sourceFile == nil || sourceFile.Statements == nil {
+			return rule.RuleListeners{}
+		}
+
+		sourceText := sourceFile.Text()
+
+		// ESLint groups imports by parent scope (n.parent), so imports inside
+		// `declare module` blocks are checked independently from top-level imports.
+		// We replicate this by processing each scope's statements separately.
+		processScope(ctx, sourceFile.Statements.Nodes, opts, sourceText)
+
+		// Recursively process imports inside `declare module` / `declare namespace` blocks.
+		walkModuleDeclarations(ctx, sourceFile.Statements.Nodes, opts, sourceText)
+
+		return rule.RuleListeners{}
+	},
+}
+
+// walkModuleDeclarations recursively finds ModuleDeclaration nodes and processes
+// their body statements as independent scopes.
+func walkModuleDeclarations(ctx rule.RuleContext, statements []*ast.Node, opts ruleOptions, sourceText string) {
+	for _, stmt := range statements {
+		if stmt.Kind != ast.KindModuleDeclaration {
+			continue
+		}
+		body := stmt.AsModuleDeclaration().Body
+		if body == nil {
+			continue
+		}
+		// ModuleDeclaration body can be a ModuleBlock or another ModuleDeclaration (nested namespaces).
+		switch body.Kind {
+		case ast.KindModuleBlock:
+			blockStatements := body.AsModuleBlock().Statements
+			if blockStatements != nil && len(blockStatements.Nodes) > 0 {
+				processScope(ctx, blockStatements.Nodes, opts, sourceText)
+				walkModuleDeclarations(ctx, blockStatements.Nodes, opts, sourceText)
+			}
+		case ast.KindModuleDeclaration:
+			// `declare module A.B { ... }` nests as ModuleDeclaration → ModuleDeclaration → ModuleBlock
+			walkModuleDeclarations(ctx, []*ast.Node{body}, opts, sourceText)
+		}
+	}
+}
+
+// processScope collects and checks duplicate imports within a single scope (statement list).
+func processScope(ctx rule.RuleContext, statements []*ast.Node, opts ruleOptions, sourceText string) {
+	// Four maps mirror the ESLint rule's import categorization.
+	imported := make(map[string][]*ast.Node)
+	nsImported := make(map[string][]*ast.Node)
+	defaultTypesImported := make(map[string][]*ast.Node)
+	namedTypesImported := make(map[string][]*ast.Node)
+
+	for _, stmt := range statements {
+		if stmt.Kind != ast.KindImportDeclaration {
+			continue
+		}
+
+		importDecl := stmt.AsImportDeclaration()
+		if importDecl.ModuleSpecifier == nil {
+			continue
+		}
+
+		resolvedPath := resolveImportPath(importDecl.ModuleSpecifier, ctx, opts, sourceText)
+
+		importMap := getImportMap(importDecl, opts, imported, nsImported, defaultTypesImported, namedTypesImported)
+		importMap[resolvedPath] = append(importMap[resolvedPath], stmt)
+	}
+
+	checkImports(ctx, imported, sourceText, opts)
+	checkImports(ctx, nsImported, sourceText, opts)
+	checkImports(ctx, defaultTypesImported, sourceText, opts)
+	checkImports(ctx, namedTypesImported, sourceText, opts)
+}
+
+// getModuleSpecifierText returns the string content of a module specifier node.
+// Falls back to extracting text from source when the AST field is empty
+// (can happen when the module specifier resolves to an empty filename).
+func getModuleSpecifierText(moduleSpecifier *ast.Node, sourceText string) string {
+	if moduleSpecifier == nil {
+		return ""
+	}
+	// Use the standard utility to get the string literal value.
+	if text := rslintUtils.GetStaticStringValue(moduleSpecifier); text != "" {
+		return text
+	}
+	// Fallback: extract text directly from source, stripping quotes.
+	pos := scanner.SkipTrivia(sourceText, moduleSpecifier.Pos())
+	end := moduleSpecifier.End()
+	if pos >= end || pos >= len(sourceText) || end > len(sourceText) {
+		return ""
+	}
+	raw := sourceText[pos:end]
+	if len(raw) >= 2 {
+		first := raw[0]
+		last := raw[len(raw)-1]
+		if (first == '\'' && last == '\'') || (first == '"' && last == '"') || (first == '`' && last == '`') {
+			return raw[1 : len(raw)-1]
+		}
+	}
+	return raw
+}
+
+// resolveImportPath resolves the module specifier to a canonical path for grouping.
+// When considerQueryString is true, query strings are preserved so that
+// `./mod?a` and `./mod?b` are treated as different modules.
+// When false (default), query strings are stripped for comparison.
+func resolveImportPath(moduleSpecifier *ast.Node, ctx rule.RuleContext, opts ruleOptions, sourceText string) string {
+	if moduleSpecifier == nil || !ast.IsStringLiteralLike(moduleSpecifier) {
+		return ""
+	}
+
+	sourcePath := getModuleSpecifierText(moduleSpecifier, sourceText)
+
+	if opts.considerQueryString {
+		idx := strings.Index(sourcePath, "?")
+		if idx >= 0 {
+			query := sourcePath[idx:]
+			if resolved, ok := utils.Resolve(moduleSpecifier, ctx); ok && resolved != "" {
+				return resolved + query
+			}
+			return sourcePath[:idx] + query
+		}
+	}
+
+	if resolved, ok := utils.Resolve(moduleSpecifier, ctx); ok && resolved != "" {
+		return resolved
+	}
+
+	// Strip query strings when not considering them, so `./bar?a` and `./bar?b`
+	// map to the same key.
+	if !opts.considerQueryString {
+		if idx := strings.Index(sourcePath, "?"); idx >= 0 {
+			return sourcePath[:idx]
+		}
+	}
+	return sourcePath
+}
+
+// getImportMap determines which import map an ImportDeclaration should be routed to,
+// mirroring the ESLint rule's `getImportMap` function.
+func getImportMap(
+	importDecl *ast.ImportDeclaration,
+	opts ruleOptions,
+	imported, nsImported, defaultTypesImported, namedTypesImported map[string][]*ast.Node,
+) map[string][]*ast.Node {
+	clause := importDecl.ImportClause
+	if clause == nil {
+		// Side-effect-only import: `import './foo'`
+		return imported
+	}
+
+	importClause := clause.AsImportClause()
+
+	if !opts.preferInline && importClause.IsTypeOnly() {
+		// `import type X from ...` → defaultTypesImported
+		// `import type {X} from ...` → namedTypesImported
+		if importClause.Name() != nil && importClause.NamedBindings == nil {
+			return defaultTypesImported
+		}
+		return namedTypesImported
+	}
+
+	// `import { type x } from './foo'` → namedTypesImported (when not prefer-inline)
+	if !opts.preferInline && hasInlineTypeSpecifiers(importClause) {
+		return namedTypesImported
+	}
+
+	if importClause.NamedBindings != nil && ast.IsNamespaceImport(importClause.NamedBindings) {
+		return nsImported
+	}
+
+	return imported
+}
+
+// hasInlineTypeSpecifiers checks if any import specifier has the inline `type` modifier
+// (e.g., `import { type x } from './foo'`).
+func hasInlineTypeSpecifiers(clause *ast.ImportClause) bool {
+	if clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
+		return false
+	}
+	namedImports := clause.NamedBindings.AsNamedImports()
+	if namedImports.Elements == nil {
+		return false
+	}
+	for _, elem := range namedImports.Elements.Nodes {
+		spec := elem.AsImportSpecifier()
+		if spec != nil && spec.IsTypeOnly {
+			return true
+		}
+	}
+	return false
+}
+
+// hasNamedSpecifiers returns true if the import has non-default, non-namespace specifiers
+// (i.e., `import { x, y }` or `import { type z }`).
+func hasNamedSpecifiers(node *ast.Node) bool {
+	importDecl := node.AsImportDeclaration()
+	if importDecl.ImportClause == nil {
+		return false
+	}
+	clause := importDecl.ImportClause.AsImportClause()
+	if clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
+		return false
+	}
+	namedImports := clause.NamedBindings.AsNamedImports()
+	return namedImports.Elements != nil && len(namedImports.Elements.Nodes) > 0
+}
+
+// getDefaultImportName returns the default import identifier name, or empty string.
+func getDefaultImportName(node *ast.Node) string {
+	importDecl := node.AsImportDeclaration()
+	if importDecl.ImportClause == nil {
+		return ""
+	}
+	nameNode := importDecl.ImportClause.AsImportClause().Name()
+	if nameNode != nil {
+		return nameNode.AsIdentifier().Text
+	}
+	return ""
+}
+
+// hasNamespaceImport returns true if the import uses `* as ns` binding.
+func hasNamespaceImport(node *ast.Node) bool {
+	importDecl := node.AsImportDeclaration()
+	if importDecl.ImportClause == nil {
+		return false
+	}
+	nb := importDecl.ImportClause.AsImportClause().NamedBindings
+	return nb != nil && ast.IsNamespaceImport(nb)
+}
+
+// isTypeOnlyImport returns true for `import type ...` declarations.
+func isTypeOnlyImport(node *ast.Node) bool {
+	importDecl := node.AsImportDeclaration()
+	if importDecl.ImportClause == nil {
+		return false
+	}
+	return importDecl.ImportClause.AsImportClause().IsTypeOnly()
+}
+
+func makeMessage(module string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noDuplicates",
+		Description: fmt.Sprintf("'%s' imported multiple times.", module),
+	}
+}
+
+// checkImports reports errors for every module that has more than one import.
+// The autofix (if applicable) is attached to the first import; all others get plain reports.
+// Groups are reported in document order (by position of first import in each group).
+func checkImports(ctx rule.RuleContext, importMap map[string][]*ast.Node, text string, opts ruleOptions) {
+	// Collect groups that have duplicates.
+	type group struct {
+		module string
+		nodes  []*ast.Node
+	}
+	var groups []group
+	for module, nodes := range importMap {
+		if len(nodes) > 1 {
+			groups = append(groups, group{module, nodes})
+		}
+	}
+
+	// Sort by position of the first import to ensure deterministic, document-order output.
+	slices.SortFunc(groups, func(a, b group) int {
+		return a.nodes[0].Pos() - b.nodes[0].Pos()
+	})
+
+	for _, g := range groups {
+		msg := makeMessage(g.module)
+		first := g.nodes[0]
+		rest := g.nodes[1:]
+
+		fixes := getFix(ctx, first, rest, text, opts)
+
+		firstSource := first.AsImportDeclaration().ModuleSpecifier
+		if fixes != nil {
+			ctx.ReportNodeWithFixes(firstSource, msg, fixes...)
+		} else {
+			ctx.ReportNode(firstSource, msg)
+		}
+
+		for _, node := range rest {
+			ctx.ReportNode(node.AsImportDeclaration().ModuleSpecifier, msg)
+		}
+	}
+}
+
+type specifierInfo struct {
+	importNode  *ast.Node
+	identifiers []string // raw identifier text segments split by ","
+	isEmpty     bool     // true when braces contain no actual specifiers (e.g., `import {} from ...`)
+}
+
+// getFix builds autofix operations to merge duplicate imports into the first one.
+// Returns nil when autofix is not possible (comments, namespace imports, conflicting defaults).
+func getFix(ctx rule.RuleContext, first *ast.Node, rest []*ast.Node, text string, opts ruleOptions) []rule.RuleFix {
+	sourceFile := ctx.SourceFile
+
+	// Bail: first import has comments or is a namespace import.
+	if hasProblematicComments(first, text, sourceFile) || hasNamespaceImport(first) {
+		return nil
+	}
+
+	// Bail: multiple different default import names (user must choose which to keep).
+	defaultNames := make(map[string]bool)
+	if name := getDefaultImportName(first); name != "" {
+		defaultNames[name] = true
+	}
+	for _, node := range rest {
+		if name := getDefaultImportName(node); name != "" {
+			defaultNames[name] = true
+		}
+	}
+	if len(defaultNames) > 1 {
+		return nil
+	}
+
+	// Skip rest nodes with comments or namespace imports — they can't be auto-merged.
+	var restWithoutComments []*ast.Node
+	for _, node := range rest {
+		if !hasProblematicComments(node, text, sourceFile) && !hasNamespaceImport(node) {
+			restWithoutComments = append(restWithoutComments, node)
+		}
+	}
+
+	// Collect specifier text from each mergeable rest import that has named bindings.
+	var specifiers []specifierInfo
+	for _, node := range restWithoutComments {
+		importDecl := node.AsImportDeclaration()
+		if importDecl.ImportClause == nil {
+			continue
+		}
+		clause := importDecl.ImportClause.AsImportClause()
+		if clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
+			continue
+		}
+
+		openBrace, closeBrace := findBraces(node, text)
+		if openBrace < 0 || closeBrace < 0 {
+			continue
+		}
+
+		specifiers = append(specifiers, specifierInfo{
+			importNode:  node,
+			identifiers: strings.Split(text[openBrace+1:closeBrace], ","),
+			isEmpty:     !hasNamedSpecifiers(node),
+		})
+	}
+
+	// Unnecessary imports: no named specifiers, no namespace — pure side-effect or redundant default.
+	var unnecessaryImports []*ast.Node
+	for _, node := range restWithoutComments {
+		if hasNamedSpecifiers(node) || hasNamespaceImport(node) {
+			continue
+		}
+		isSpecifier := false
+		for _, s := range specifiers {
+			if s.importNode == node {
+				isSpecifier = true
+				break
+			}
+		}
+		if !isSpecifier {
+			unnecessaryImports = append(unnecessaryImports, node)
+		}
+	}
+
+	shouldAddDefault := getDefaultImportName(first) == "" && len(defaultNames) == 1
+	shouldAddSpecifiers := len(specifiers) > 0
+	shouldRemoveUnnecessary := len(unnecessaryImports) > 0
+
+	if !shouldAddDefault && !shouldAddSpecifiers && !shouldRemoveUnnecessary {
+		return nil
+	}
+
+	// --- Build merged specifier text, deduplicating identifiers ---
+
+	firstOpenBrace, firstCloseBrace := findBraces(first, text)
+	firstHasTrailingComma := false
+	firstIsEmpty := !hasNamedSpecifiers(first)
+
+	existingIdentifiers := make(map[string]bool)
+	if firstOpenBrace >= 0 && firstCloseBrace >= 0 && !firstIsEmpty {
+		for _, id := range strings.Split(text[firstOpenBrace+1:firstCloseBrace], ",") {
+			if trimmed := strings.TrimSpace(id); trimmed != "" {
+				existingIdentifiers[trimmed] = true
+			}
+		}
+		trimmedInside := strings.TrimRight(text[firstOpenBrace+1:firstCloseBrace], " \t\n\r")
+		firstHasTrailingComma = strings.HasSuffix(trimmedInside, ",")
+	}
+
+	// Snapshot of first import's specifiers before merge (for prefer-inline conversion).
+	firstSpecifierNames := make(map[string]bool, len(existingIdentifiers))
+	for k := range existingIdentifiers {
+		firstSpecifierNames[k] = true
+	}
+
+	// Build specifiersText following ESLint's reduce pattern:
+	// `needsComma` tracks whether the next segment needs a leading comma.
+	var specBuf strings.Builder
+	needsComma := !firstHasTrailingComma && !firstIsEmpty
+
+	for _, spec := range specifiers {
+		isTypeSpec := isTypeOnlyImport(spec.importNode)
+
+		// Build text for this specifier's identifiers, deduplicating.
+		var specTextBuf strings.Builder
+		for _, id := range spec.identifiers {
+			trimmed := strings.TrimSpace(id)
+			if trimmed == "" || existingIdentifiers[trimmed] {
+				continue
+			}
+			existingIdentifiers[trimmed] = true
+
+			curWithType := id
+			if opts.preferInline && isTypeSpec {
+				curWithType = "type " + trimmed
+			}
+
+			if specTextBuf.Len() > 0 {
+				specTextBuf.WriteString(",")
+			}
+			specTextBuf.WriteString(curWithType)
+		}
+
+		specText := specTextBuf.String()
+		if specText == "" {
+			if !spec.isEmpty {
+				needsComma = true
+			}
+			continue
+		}
+
+		if needsComma && !spec.isEmpty {
+			specBuf.WriteString(",")
+		}
+		specBuf.WriteString(specText)
+
+		if !spec.isEmpty {
+			needsComma = true
+		}
+	}
+
+	specifiersText := specBuf.String()
+
+	// --- Build fix operations ---
+
+	var fixes []rule.RuleFix
+	firstDecl := first.AsImportDeclaration()
+	firstTrimmedPos := scanner.SkipTrivia(text, first.Pos())
+	importKeywordEnd := firstTrimmedPos + len("import")
+
+	// prefer-inline: convert `import type {a}` → `import {type a}`.
+	if shouldAddSpecifiers && opts.preferInline && isTypeOnlyImport(first) {
+		// Remove the `type` keyword after `import`.
+		if typeRange := findTypeKeyword(first, text); typeRange.Pos() >= 0 {
+			fixes = append(fixes, rule.RuleFix{Range: typeRange, Text: ""})
+		}
+		// Prefix each existing specifier in the first import with `type`.
+		if firstOpenBrace >= 0 && firstCloseBrace >= 0 {
+			clause := firstDecl.ImportClause.AsImportClause()
+			if clause.NamedBindings != nil && clause.NamedBindings.Kind == ast.KindNamedImports {
+				for _, elem := range clause.NamedBindings.AsNamedImports().Elements.Nodes {
+					spec := elem.AsImportSpecifier()
+					if spec != nil && !spec.IsTypeOnly {
+						nameNode := spec.Name()
+						if nameNode != nil {
+							nameText := nameNode.AsIdentifier().Text
+							if firstSpecifierNames[nameText] {
+								trimmedNamePos := scanner.SkipTrivia(text, nameNode.Pos())
+								fixes = append(fixes, rule.RuleFix{
+									Range: core.NewTextRange(trimmedNamePos, nameNode.End()),
+									Text:  "type " + nameText,
+								})
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Determine the default import name to add (if any).
+	var defaultImportName string
+	if shouldAddDefault {
+		for name := range defaultNames {
+			defaultImportName = name
+			break
+		}
+	}
+
+	// Insert specifiers / default import into the first import.
+	switch {
+	case shouldAddDefault && firstOpenBrace < 0 && shouldAddSpecifiers:
+		// `import './foo'` → `import def, {...} from './foo'`
+		fixes = append(fixes, rule.RuleFix{
+			Range: core.NewTextRange(importKeywordEnd, importKeywordEnd),
+			Text:  fmt.Sprintf(" %s, {%s} from", defaultImportName, specifiersText),
+		})
+	case shouldAddDefault && firstOpenBrace < 0 && !shouldAddSpecifiers:
+		// `import './foo'` → `import def from './foo'`
+		fixes = append(fixes, rule.RuleFix{
+			Range: core.NewTextRange(importKeywordEnd, importKeywordEnd),
+			Text:  fmt.Sprintf(" %s from", defaultImportName),
+		})
+	case shouldAddDefault && firstOpenBrace >= 0:
+		// `import {...} from './foo'` → `import def, {...} from './foo'`
+		fixes = append(fixes, rule.RuleFix{
+			Range: core.NewTextRange(importKeywordEnd, importKeywordEnd),
+			Text:  fmt.Sprintf(" %s,", defaultImportName),
+		})
+		if shouldAddSpecifiers {
+			fixes = append(fixes, rule.RuleFix{
+				Range: core.NewTextRange(firstCloseBrace, firstCloseBrace),
+				Text:  specifiersText,
+			})
+		}
+	case !shouldAddDefault && firstOpenBrace < 0 && shouldAddSpecifiers:
+		if firstDecl.ImportClause != nil && firstDecl.ImportClause.AsImportClause().Name() != nil {
+			// `import def from './foo'` → `import def, {...} from './foo'`
+			defName := firstDecl.ImportClause.AsImportClause().Name()
+			fixes = append(fixes, rule.RuleFix{
+				Range: core.NewTextRange(defName.End(), defName.End()),
+				Text:  fmt.Sprintf(", {%s}", specifiersText),
+			})
+		} else {
+			// `import './foo'` → `import {...} from './foo'`
+			fixes = append(fixes, rule.RuleFix{
+				Range: core.NewTextRange(importKeywordEnd, importKeywordEnd),
+				Text:  fmt.Sprintf(" {%s} from", specifiersText),
+			})
+		}
+	case !shouldAddDefault && firstOpenBrace >= 0 && shouldAddSpecifiers:
+		// `import {...} from './foo'` → `import {..., ...} from './foo'`
+		fixes = append(fixes, rule.RuleFix{
+			Range: core.NewTextRange(firstCloseBrace, firstCloseBrace),
+			Text:  specifiersText,
+		})
+	}
+
+	// Remove merged and unnecessary imports.
+	for _, spec := range specifiers {
+		fixes = append(fixes, rule.RuleFix{
+			Range: getRemoveRange(spec.importNode, text),
+			Text:  "",
+		})
+	}
+	for _, node := range unnecessaryImports {
+		fixes = append(fixes, rule.RuleFix{
+			Range: getRemoveRange(node, text),
+			Text:  "",
+		})
+	}
+
+	if len(fixes) == 0 {
+		return nil
+	}
+	return fixes
+}
+
+// getRemoveRange returns the text range to delete an import node,
+// including the trailing newline if present.
+func getRemoveRange(node *ast.Node, text string) core.TextRange {
+	trimmedPos := scanner.SkipTrivia(text, node.Pos())
+	end := node.End()
+	if end < len(text) && text[end] == '\n' {
+		end++
+	}
+	return core.NewTextRange(trimmedPos, end)
+}
+
+// findBraces returns the source positions of `{` and `}` in an import's named bindings.
+// Returns (-1, -1) when the import has no named bindings.
+func findBraces(node *ast.Node, text string) (openBrace int, closeBrace int) {
+	importDecl := node.AsImportDeclaration()
+	if importDecl.ImportClause == nil {
+		return -1, -1
+	}
+	clause := importDecl.ImportClause.AsImportClause()
+	if clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
+		return -1, -1
+	}
+
+	namedImports := clause.NamedBindings.AsNamedImports()
+	pos := namedImports.Pos()
+	end := namedImports.End()
+
+	openBrace = -1
+	for i := pos; i < end; i++ {
+		if text[i] == '{' {
+			openBrace = i
+			break
+		}
+	}
+
+	closeBrace = -1
+	for i := end - 1; i > pos; i-- {
+		if text[i] == '}' {
+			closeBrace = i
+			break
+		}
+	}
+	return
+}
+
+// findTypeKeyword locates the `type` keyword in `import type {...}` and returns
+// its range including the trailing space, so removing it converts to `import {...}`.
+func findTypeKeyword(node *ast.Node, text string) core.TextRange {
+	trimmedPos := scanner.SkipTrivia(text, node.Pos())
+	searchStart := trimmedPos + len("import")
+	importDecl := node.AsImportDeclaration()
+	if importDecl.ImportClause == nil {
+		return core.NewTextRange(-1, -1)
+	}
+
+	searchEnd := importDecl.ImportClause.End()
+	if searchEnd > len(text) {
+		searchEnd = len(text)
+	}
+
+	idx := strings.Index(text[searchStart:searchEnd], "type")
+	if idx < 0 {
+		return core.NewTextRange(-1, -1)
+	}
+
+	typeStart := searchStart + idx
+	typeEnd := typeStart + len("type")
+	// Include trailing space so `import type {` becomes `import {`.
+	if typeEnd < len(text) && text[typeEnd] == ' ' {
+		typeEnd++
+	}
+	return core.NewTextRange(typeStart, typeEnd)
+}
+
+// ---------------------------------------------------------------------------
+// Comment detection — autofix bails when comments make merging ambiguous.
+// ---------------------------------------------------------------------------
+
+// hasProblematicComments returns true when comments near the import make autofix risky.
+// This mirrors ESLint's hasProblematicComments: it checks before, after, and inside
+// the import (but outside the `{ ... }` specifier list).
+func hasProblematicComments(node *ast.Node, text string, sourceFile *ast.SourceFile) bool {
+	return hasCommentBefore(node, text, sourceFile) ||
+		hasCommentAfter(node, text, sourceFile) ||
+		hasCommentInsideNonSpecifiers(node, text, sourceFile)
+}
+
+// hasCommentBefore returns true if a leading comment ends on the line before or
+// the same line as the import starts.
+func hasCommentBefore(node *ast.Node, text string, sourceFile *ast.SourceFile) bool {
+	lineStarts := sourceFile.ECMALineMap()
+	trimmedPos := scanner.SkipTrivia(text, node.Pos())
+	nodeLine := scanner.ComputeLineOfPosition(lineStarts, trimmedPos)
+
+	nodeFactory := &ast.NodeFactory{}
+	for commentRange := range scanner.GetLeadingCommentRanges(nodeFactory, text, node.Pos()) {
+		if scanner.ComputeLineOfPosition(lineStarts, commentRange.End()) >= nodeLine-1 {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCommentAfter returns true if a trailing comment starts on the same line
+// as the import ends.
+func hasCommentAfter(node *ast.Node, text string, sourceFile *ast.SourceFile) bool {
+	lineStarts := sourceFile.ECMALineMap()
+	nodeEndLine := scanner.ComputeLineOfPosition(lineStarts, node.End())
+
+	nodeFactory := &ast.NodeFactory{}
+	for commentRange := range scanner.GetTrailingCommentRanges(nodeFactory, text, node.End()) {
+		if scanner.ComputeLineOfPosition(lineStarts, commentRange.Pos()) == nodeEndLine {
+			return true
+		}
+	}
+	return false
+}
+
+// hasCommentInsideNonSpecifiers returns true if there's a comment inside the import
+// statement but outside the `{ ... }` specifier list — e.g., `import/* c */{x} from './foo'`
+// or `import{y}from/* c */'./foo'`.
+// Uses direct text scanning because scanner-based APIs (GetLeadingCommentRanges,
+// GetTrailingCommentRanges) only detect comments adjacent to line boundaries,
+// missing inline comments between tokens on the same line.
+func hasCommentInsideNonSpecifiers(node *ast.Node, text string, sourceFile *ast.SourceFile) bool {
+	importDecl := node.AsImportDeclaration()
+	if importDecl == nil || importDecl.ModuleSpecifier == nil {
+		return false
+	}
+
+	trimmedPos := scanner.SkipTrivia(text, node.Pos())
+	importEnd := trimmedPos + len("import")
+	specStart := scanner.SkipTrivia(text, importDecl.ModuleSpecifier.Pos())
+
+	openBrace, closeBrace := findBraces(node, text)
+
+	// Region 1: between `import` keyword and `{` (or module specifier if no braces).
+	region1End := specStart
+	if openBrace >= 0 {
+		region1End = openBrace + 1
+	}
+	if hasCommentInRegion(text, importEnd, region1End) {
+		return true
+	}
+
+	// Region 2: between `}` and module specifier (only when braces exist).
+	if closeBrace >= 0 && hasCommentInRegion(text, closeBrace, specStart) {
+		return true
+	}
+	return false
+}
+
+// hasCommentInRegion checks for `//` or `/*` comment tokens in a text range.
+func hasCommentInRegion(text string, start, end int) bool {
+	if start < 0 || end < 0 || start >= end || start >= len(text) {
+		return false
+	}
+	if end > len(text) {
+		end = len(text)
+	}
+	region := text[start:end]
+	return strings.Contains(region, "/*") || strings.Contains(region, "//")
+}

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates.md
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates.md
@@ -1,0 +1,57 @@
+# import/no-duplicates
+
+## Rule Details
+
+Reports if a resolved path is imported more than once.
+
+This rule is similar to ESLint core's `no-duplicate-imports`, but differs in two key ways:
+
+1. The paths in the source code don't have to exactly match — they just have to point to the same module on the filesystem (e.g., `./foo` and `./foo.js`).
+2. This version distinguishes `type` imports from standard imports.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import { x } from './foo';
+import { y } from './foo';
+```
+
+```javascript
+import SomeDefaultClass from './mod';
+import * as names from './mod';
+import { something } from './mod.js';
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import SomeDefaultClass, * as names from './mod';
+import type SomeType from './mod';
+```
+
+```javascript
+import { x } from './foo';
+import { y } from './bar';
+```
+
+## Options
+
+### `considerQueryString`
+
+When set to `true`, imports with different query strings are treated as different modules.
+
+```json
+"import/no-duplicates": ["error", { "considerQueryString": true }]
+```
+
+### `prefer-inline`
+
+When set to `true`, supports TypeScript inline type imports, allowing `import type { X }` to be merged into `import { type X }`.
+
+```json
+"import/no-duplicates": ["error", { "prefer-inline": true }]
+```
+
+## Original Documentation
+
+- [eslint-plugin-import/no-duplicates](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md)

--- a/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
+++ b/internal/plugins/import/rules/no_duplicates/no_duplicates_test.go
@@ -1,0 +1,711 @@
+package no_duplicates_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/import/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/import/rules/no_duplicates"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDuplicatesRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&no_duplicates.NoDuplicatesRule,
+		[]rule_tester.ValidTestCase{
+			// --- Different modules ---
+			{Code: `import { x } from './foo'; import { y } from './bar'`},
+			{Code: `import foo from "module-a"; import { bar } from "module-b"`},
+
+			// --- Namespace + named from same module (cannot be merged into one line) ---
+			{Code: `import * as ns from './foo'; import {y} from './foo'`},
+			{Code: `import {y} from './foo'; import * as ns from './foo'`},
+
+			// --- Type import + value import (separate categories when not prefer-inline) ---
+			{Code: `import type { x } from './foo'; import y from './foo'`},
+			{Code: `import type x from './foo'; import type y from './bar'`},
+			{Code: `import type {x} from './foo'; import type {y} from './bar'`},
+			// Type default + type named from same module → different categories
+			{Code: `import type x from './foo'; import type {y} from './foo'`},
+			// Empty type import + regular import from different modules
+			{Code: "import type {} from './module';\nimport {} from './module2';"},
+
+			// --- considerQueryString option ---
+			{
+				Code:    `import x from './bar?optionX'; import y from './bar?optionY';`,
+				Options: map[string]interface{}{"considerQueryString": true},
+			},
+
+			// --- Inline type specifier + value import (not prefer-inline) ---
+			{Code: `import { type x } from './foo'; import y from './foo'`},
+			{Code: `import { type x } from './foo'; import { y } from './foo'`},
+			// Inline type + type import from different module
+			{Code: `import { type x } from './foo'; import type y from 'bar'`},
+
+			// --- Single import (no duplicate) ---
+			{Code: `import { x } from './foo'`},
+			{Code: `import './foo'`},
+			{Code: `import type { x } from './foo'`},
+
+			// --- declare module scoping ---
+			// Top-level + declare module imports are separate scopes → not duplicates
+			{Code: "import type { Identifier } from 'module';\n\ndeclare module 'module2' {\n  import type { Identifier } from 'module';\n}"},
+			// Two different declare module blocks → separate scopes
+			{Code: "declare module 'a' {\n  import { x } from 'bar';\n}\ndeclare module 'b' {\n  import { x } from 'bar';\n}"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Basic merge scenarios
+			// ============================================================
+
+			// 0: Two named imports
+			{
+				Code:   `import { x } from './foo'; import { y } from './foo'`,
+				Output: []string{`import { x , y } from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 19},
+					{MessageId: "noDuplicates", Line: 1, Column: 46},
+				},
+			},
+			// 1: Three-way merge
+			{
+				Code:   `import {x} from './foo'; import {y} from './foo'; import { z } from './foo'`,
+				Output: []string{`import {x,y, z } from './foo';  `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+					{MessageId: "noDuplicates", Line: 1, Column: 69},
+				},
+			},
+			// 2: Side-effect + named
+			{
+				Code:   `import './foo'; import {x} from './foo'`,
+				Output: []string{`import {x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 8},
+					{MessageId: "noDuplicates", Line: 1, Column: 33},
+				},
+			},
+			// 3: Side-effect + default
+			{
+				Code:   `import './foo'; import def from './foo'`,
+				Output: []string{`import def from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 8},
+					{MessageId: "noDuplicates", Line: 1, Column: 33},
+				},
+			},
+			// 4: Default + named
+			{
+				Code:   `import def from './foo'; import {x} from './foo'`,
+				Output: []string{`import def, {x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+				},
+			},
+			// 5: Named + default (reverse order)
+			{
+				Code:   `import {x} from './foo'; import def from './foo'`,
+				Output: []string{`import def, {x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+				},
+			},
+			// 6: Duplicate side-effect imports
+			{
+				Code:   `import './foo'; import './foo'`,
+				Output: []string{`import './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 8},
+					{MessageId: "noDuplicates", Line: 1, Column: 24},
+				},
+			},
+			// 7: Named + empty braces
+			{
+				Code:   `import {x} from './foo'; import {} from './foo'`,
+				Output: []string{`import {x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 41},
+				},
+			},
+			// 8: Empty braces + named (reverse)
+			{
+				Code:   `import { } from './foo'; import {x} from './foo'`,
+				Output: []string{`import { x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+				},
+			},
+			// 9: Side-effect + default,named combo
+			{
+				Code:   `import './foo'; import def, {x} from './foo'`,
+				Output: []string{`import def, {x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 8},
+					{MessageId: "noDuplicates", Line: 1, Column: 38},
+				},
+			},
+			// 10: Named + default,named combo
+			{
+				Code:   `import {x} from './foo'; import def, {y} from './foo'`,
+				Output: []string{`import def, {x,y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 47},
+				},
+			},
+
+			// ============================================================
+			// Autofix bail scenarios
+			// ============================================================
+
+			// 11: Different default names → no autofix
+			{
+				Code: `import foo from 'non-existent'; import bar from 'non-existent';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 49},
+				},
+			},
+			// 12: Namespace imports cannot be merged
+			{
+				Code: `import * as ns1 from './foo'; import * as ns2 from './foo'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 52},
+				},
+			},
+
+			// ============================================================
+			// Comment-related autofix bail
+			// ============================================================
+
+			// 13: Comment before second import → bail on second (rest has comment)
+			{
+				Code: "import {x} from './foo'\n// comment\nimport {y} from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 3, Column: 17},
+				},
+			},
+			// 14: Trailing comment on first import → bail on all (first has comment)
+			{
+				Code: "import {x} from './foo' // line comment\nimport {y} from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 2, Column: 17},
+				},
+			},
+			// 15: Trailing comment on second import → bail on second
+			{
+				Code: "import {x} from './foo'\nimport {y} from './foo' // line comment",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 2, Column: 17},
+				},
+			},
+			// 16: Block comment before second import → bail
+			{
+				Code: "import {x} from './foo'\n/* comment */ import {y} from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 2, Column: 31},
+				},
+			},
+			// 17: Comment inside non-specifiers: `import/* c */{y}`
+			{
+				Code: "import {x} from './foo'\nimport/* comment */{y} from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 2, Column: 29},
+				},
+			},
+			// 18: Comment between `from` and path: `import{y}from/* c */'./foo'`
+			{
+				Code: "import {x} from './foo'\nimport{y}from/* comment */'./foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 2, Column: 27},
+				},
+			},
+			// 19: Comment between `from` and module path on separate lines → bail on first
+			{
+				Code: "import {x} from\n// some-tool-disable-next-line\n'./foo'\nimport {y} from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 3, Column: 1},
+					{MessageId: "noDuplicates", Line: 4, Column: 17},
+				},
+			},
+			// 20: Comment after all imports does NOT bail autofix
+			{
+				Code:   "import {x} from './foo'\nimport {y} from './foo'\n// some-tool-disable-next-line",
+				Output: []string{"import {x,y} from './foo'\n// some-tool-disable-next-line"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 2, Column: 17},
+				},
+			},
+			// 20: Comment separated by blank line from import does NOT bail
+			{
+				Code:   "import {x} from './foo'\n// comment\n\nimport {y} from './foo'",
+				Output: []string{"import {x,y} from './foo'\n// comment\n\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 4, Column: 17},
+				},
+			},
+
+			// ============================================================
+			// Whitespace edge cases
+			// ============================================================
+
+			// 21: No space after import keyword
+			{
+				Code:   `import'./foo'; import {x} from './foo'`,
+				Output: []string{`import {x} from'./foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 7},
+					{MessageId: "noDuplicates", Line: 1, Column: 32},
+				},
+			},
+			// 22: No space before braces
+			{
+				Code:   `import{x} from './foo'; import def from './foo'`,
+				Output: []string{`import def,{x} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 16},
+					{MessageId: "noDuplicates", Line: 1, Column: 41},
+				},
+			},
+
+			// ============================================================
+			// Multiline imports
+			// ============================================================
+
+			// 23: Multiline with trailing newline removal (#2027)
+			{
+				Code:   "import { Foo } from './foo';\nimport { Bar } from './foo';\nexport const value = {}",
+				Output: []string{"import { Foo , Bar } from './foo';\nexport const value = {}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 21},
+					{MessageId: "noDuplicates", Line: 2, Column: 21},
+				},
+			},
+			// 24: Multiline with default import merge (#2027)
+			{
+				Code:   "import { Foo } from './foo';\nimport Bar from './foo';\nexport const value = {}",
+				Output: []string{"import Bar, { Foo } from './foo';\nexport const value = {}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 21},
+					{MessageId: "noDuplicates", Line: 2, Column: 17},
+				},
+			},
+			// 25: Multi-line named imports with trailing commas
+			{
+				Code:   "import {A1,} from 'foo';\nimport {B1,} from 'foo';\nimport {C1,} from 'foo';",
+				Output: []string{"import {A1,B1,C1} from 'foo';\n"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 19},
+					{MessageId: "noDuplicates", Line: 2, Column: 19},
+					{MessageId: "noDuplicates", Line: 3, Column: 19},
+				},
+			},
+
+			// ============================================================
+			// Namespace mixed scenarios
+			// ============================================================
+
+			// 26: Namespace + named + named: partial merge (named merged, ns untouched)
+			{
+				Code:   `import * as ns from './foo'; import {x} from './foo'; import {y} from './foo'`,
+				Output: []string{`import * as ns from './foo'; import {x,y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 46},
+					{MessageId: "noDuplicates", Line: 1, Column: 71},
+				},
+			},
+			// 27: Named + namespace + named + side-effect: merge named+side-effect, skip ns
+			// imported map has: {x}, {y}, './foo' (side-effect) → 3 errors
+			{
+				Code:   "import {x} from './foo'; import * as ns from './foo'; import {y} from './foo'; import './foo'",
+				Output: []string{"import {x,y} from './foo'; import * as ns from './foo';  "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 71},
+					{MessageId: "noDuplicates", Line: 1, Column: 87},
+				},
+			},
+
+			// ============================================================
+			// Query strings
+			// ============================================================
+
+			// 28: Without considerQueryString, query strings stripped
+			{
+				Code: `import x from './bar?optionX'; import y from './bar?optionY';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 15},
+					{MessageId: "noDuplicates", Line: 1, Column: 46},
+				},
+			},
+
+			// ============================================================
+			// TypeScript type-only imports
+			// ============================================================
+
+			// 29: Duplicate type-only named imports
+			{
+				Code:   `import type {x} from './foo'; import type {y} from './foo'`,
+				Output: []string{`import type {x,y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 52},
+				},
+			},
+			// 30: Duplicate type-only default imports (different names → no autofix)
+			{
+				Code: `import type x from './foo'; import type y from './foo'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 20},
+					{MessageId: "noDuplicates", Line: 1, Column: 48},
+				},
+			},
+			// 31: Duplicate type-only default imports with SAME name → autofix removes dup
+			{
+				Code:   `import type x from './foo'; import type x from './foo'`,
+				Output: []string{`import type x from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 20},
+					{MessageId: "noDuplicates", Line: 1, Column: 48},
+				},
+			},
+			// 32: Inline type + type-only without prefer-inline → grouped as namedTypes
+			{
+				Code:   `import {type x} from './foo'; import type {y} from './foo'`,
+				Output: []string{`import {type x,y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 52},
+				},
+			},
+			// 33: Inline type imports without prefer-inline
+			{
+				Code:   `import {type x} from './foo'; import {type y} from './foo'`,
+				Output: []string{`import {type x,type y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 52},
+				},
+			},
+
+			// ============================================================
+			// prefer-inline option
+			// ============================================================
+
+			// 34: Value + type import
+			{
+				Code:    `import {AValue} from './foo'; import type {AType} from './foo'`,
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{`import {AValue,type AType} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 56},
+				},
+			},
+			// 35: Inline type + type-only import
+			{
+				Code:    `import {type x} from 'foo'; import type {y} from 'foo'`,
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{`import {type x,type y} from 'foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 50},
+				},
+			},
+			// 36: Type-only + inline type (reverse)
+			{
+				Code:    `import type {x} from 'foo'; import {type y} from 'foo'`,
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{`import {type x,type y} from 'foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 50},
+				},
+			},
+			// 37: Both inline type
+			{
+				Code:    `import {type x} from './foo'; import {type y} from './foo'`,
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{`import {type x,type y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 52},
+				},
+			},
+			// 38: Mixed value + inline type + type import
+			{
+				Code:    `import {AValue, type x, BValue} from './foo'; import {type y} from './foo'`,
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{`import {AValue, type x, BValue,type y} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 38},
+					{MessageId: "noDuplicates", Line: 1, Column: 68},
+				},
+			},
+			// 39: prefer-inline: fix should not corrupt imports named 'from' (#3224)
+			{
+				Code:    `import type {Observable} from './foo'; import {from} from './foo'`,
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{`import {type Observable,from} from './foo'; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 31},
+					{MessageId: "noDuplicates", Line: 1, Column: 59},
+				},
+			},
+
+			// ============================================================
+			// 4+ duplicate imports
+			// ============================================================
+
+			// 40: Four named imports from same module
+			{
+				Code:   "import {a} from './foo'; import {b} from './foo'; import {c} from './foo'; import {d} from './foo'",
+				Output: []string{"import {a,b,c,d} from './foo';   "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+					{MessageId: "noDuplicates", Line: 1, Column: 67},
+					{MessageId: "noDuplicates", Line: 1, Column: 92},
+				},
+			},
+
+			// ============================================================
+			// Identifier deduplication
+			// ============================================================
+
+			// 41: Duplicate identifier across imports → deduplicated in merge
+			{
+				Code:   "import {a,b} from './foo'; import { b, c } from './foo'",
+				Output: []string{"import {a,b, c } from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 19},
+					{MessageId: "noDuplicates", Line: 1, Column: 49},
+				},
+			},
+
+			// ============================================================
+			// Renamed specifiers
+			// ============================================================
+
+			// 42: Renamed specifiers preserved during merge
+			{
+				Code:   "import { x as a } from './foo'; import { y as b } from './foo'",
+				Output: []string{"import { x as a , y as b } from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 24},
+					{MessageId: "noDuplicates", Line: 1, Column: 56},
+				},
+			},
+
+			// ============================================================
+			// Mixed scenarios with default + namespace + named
+			// ============================================================
+
+			// 43: Side-effect + default + named all in `imported` → 3-way merge
+			{
+				Code:   "import './foo'; import def from './foo'; import {x} from './foo'",
+				Output: []string{"import def, {x} from './foo';  "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 8},
+					{MessageId: "noDuplicates", Line: 1, Column: 33},
+					{MessageId: "noDuplicates", Line: 1, Column: 58},
+				},
+			},
+
+			// ============================================================
+			// prefer-inline: type-only first + value second
+			// ============================================================
+
+			// 44: prefer-inline: first is type-only named, second is value named
+			{
+				Code:    "import type {A} from './foo'; import {B} from './foo'",
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{"import {type A,B} from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 47},
+				},
+			},
+
+			// 45: prefer-inline: first is value named, second is type-only with multiple specifiers
+			{
+				Code:    "import {A} from './foo'; import type {B, C} from './foo'",
+				Options: map[string]interface{}{"prefer-inline": true},
+				Output:  []string{"import {A,type B,type C} from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 50},
+				},
+			},
+
+			// ============================================================
+			// Double-quoted and backtick module specifiers
+			// ============================================================
+
+			// ============================================================
+			// Comments inside braces (preserved during merge)
+			// ============================================================
+
+			// 46: Block comment inside braces is preserved during merge
+			{
+				Code:   "import { x /* comment */ } from './foo'; import {y} from './foo'",
+				Output: []string{"import { x /* comment */ ,y} from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 33},
+					{MessageId: "noDuplicates", Line: 1, Column: 58},
+				},
+			},
+			// 47: 4-way with empty braces + comment-containing braces + named
+			{
+				Code:   "import {x} from './foo'; import {} from './foo'; import {/*c*/} from './foo'; import {y} from './foo'",
+				Output: []string{"import {x/*c*/,y} from './foo';   "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates"},
+					{MessageId: "noDuplicates"},
+					{MessageId: "noDuplicates"},
+					{MessageId: "noDuplicates"},
+				},
+			},
+
+			// ============================================================
+			// Renamed specifiers
+			// ============================================================
+
+			// 49: Renamed specifiers preserved during merge
+			{
+				Code:   "import { x as a } from './foo'; import { y as b } from './foo'",
+				Output: []string{"import { x as a , y as b } from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 24},
+					{MessageId: "noDuplicates", Line: 1, Column: 56},
+				},
+			},
+			// 50: Renamed specifier NOT deduplicated with plain specifier
+			// `{x}` and `{x as y}` are different specifier strings → both kept
+			{
+				Code:   "import {x} from './foo'; import { x as y } from './foo'",
+				Output: []string{"import {x, x as y } from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 49},
+				},
+			},
+
+			// ============================================================
+			// Both imports have default + named
+			// ============================================================
+
+			// 51: Same default + different named → merge named into first
+			{
+				Code:   "import def, {x} from './foo'; import def, {y} from './foo'",
+				Output: []string{"import def, {x,y} from './foo'; "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 22},
+					{MessageId: "noDuplicates", Line: 1, Column: 52},
+				},
+			},
+			// 52: Different defaults + named → no autofix (conflicting defaults)
+			{
+				Code: "import def1, {x} from './foo'; import def2, {y} from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 23},
+					{MessageId: "noDuplicates", Line: 1, Column: 54},
+				},
+			},
+
+			// ============================================================
+			// Mixed scenarios
+			// ============================================================
+
+			// 53: Side-effect + default + named → 3-way merge
+			{
+				Code:   "import './foo'; import def from './foo'; import {x} from './foo'",
+				Output: []string{"import def, {x} from './foo';  "},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 8},
+					{MessageId: "noDuplicates", Line: 1, Column: 33},
+					{MessageId: "noDuplicates", Line: 1, Column: 58},
+				},
+			},
+
+			// ============================================================
+			// Double-quoted module paths
+			// ============================================================
+
+			// 54: Double-quoted module paths
+			{
+				Code:   `import {x} from "./foo"; import {y} from "./foo"`,
+				Output: []string{`import {x,y} from "./foo"; `},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+				},
+			},
+
+			// ============================================================
+			// Type namespace imports
+			// ============================================================
+
+			// 55: Duplicate `import type * as ns` → reported, no autofix (namespace can't merge)
+			{
+				Code: "import type * as ns1 from './foo'; import type * as ns2 from './foo'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 1, Column: 27},
+					{MessageId: "noDuplicates", Line: 1, Column: 62},
+				},
+			},
+
+			// ============================================================
+			// Multiple duplicate groups (tests deterministic ordering)
+			// ============================================================
+
+			// ============================================================
+			// declare module scope
+			// ============================================================
+
+			// 57: Duplicates INSIDE a declare module block → reported + merged
+			{
+				Code:   "declare module 'foo' {\n  import { x } from 'bar';\n  import { y } from 'bar';\n}",
+				Output: []string{"declare module 'foo' {\n  import { x , y } from 'bar';\n  }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noDuplicates", Line: 2, Column: 21},
+					{MessageId: "noDuplicates", Line: 3, Column: 21},
+				},
+			},
+
+			// 58: Two different modules each with duplicates → errors in document order
+			{
+				Code: "import {a} from './foo'; import {b} from './bar'; import {c} from './foo'; import {d} from './bar'",
+				// Fixes are applied in two passes: first ./foo merge, then ./bar merge.
+				Output: []string{
+					"import {a,c} from './foo'; import {b} from './bar';  import {d} from './bar'",
+					"import {a,c} from './foo'; import {b,d} from './bar';  ",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					// ./foo group first (appears earlier in source)
+					{MessageId: "noDuplicates", Line: 1, Column: 17},
+					{MessageId: "noDuplicates", Line: 1, Column: 67},
+					// ./bar group second
+					{MessageId: "noDuplicates", Line: 1, Column: 42},
+					{MessageId: "noDuplicates", Line: 1, Column: 92},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -59,6 +59,7 @@ export default defineConfig({
     // eslint-plugin-import
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',
+    './tests/eslint-plugin-import/rules/no-duplicates.test.ts',
     './tests/eslint-plugin-import/rules/no-self-import.test.ts',
     './tests/eslint-plugin-import/rules/no-mutable-exports.test.ts',
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-duplicates.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-import/rules/no-duplicates.test.ts
@@ -1,0 +1,150 @@
+import { RuleTester } from '../rule-tester.js';
+
+const ruleTester = new RuleTester();
+const rule = null as never;
+
+ruleTester.run('no-duplicates', rule, {
+  valid: [
+    // Different modules
+    { code: "import { x } from './foo'; import { y } from './bar'" },
+
+    // Unresolved modules with different names
+    { code: 'import foo from "234artaf"; import { shoop } from "234q25ad"' },
+
+    // Namespace + named from same module is allowed (cannot be merged)
+    { code: "import * as ns from './foo'; import {y} from './foo'" },
+    { code: "import {y} from './foo'; import * as ns from './foo'" },
+
+    // Type import + value import (not prefer-inline)
+    { code: "import type { x } from './foo'; import y from './foo'" },
+
+    // Different type imports
+    { code: "import type x from './foo'; import type y from './bar'" },
+    { code: "import type {x} from './foo'; import type {y} from './bar'" },
+
+    // Type default + type named from same module
+    { code: "import type x from './foo'; import type {y} from './foo'" },
+
+    // Different query strings with considerQueryString
+    {
+      code: "import x from './bar?optionX'; import y from './bar?optionY';",
+      options: [{ considerQueryString: true }],
+    },
+
+    // Inline type specifier + value import (not prefer-inline)
+    { code: "import { type x } from './foo'; import y from './foo'" },
+    { code: "import { type x } from './foo'; import { y } from './foo'" },
+  ],
+  invalid: [
+    // Basic duplicate named imports
+    {
+      code: "import { x } from './foo'; import { y } from './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Three-way merge
+    {
+      code: "import {x} from './foo'; import {y} from './foo'; import { z } from './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Side-effect import + named import
+    {
+      code: "import './foo'; import {x} from './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Default + named import merge
+    {
+      code: "import def from './foo'; import {x} from './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Duplicate side-effect imports
+    {
+      code: "import './foo'; import './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Duplicate unresolved modules
+    {
+      code: "import foo from 'non-existent'; import bar from 'non-existent';",
+      errors: [
+        { message: "'non-existent' imported multiple times." },
+        { message: "'non-existent' imported multiple times." },
+      ],
+    },
+
+    // TypeScript: duplicate type-only named imports
+    {
+      code: "import type {x} from './foo'; import type {y} from './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // prefer-inline: type + value imports
+    {
+      code: "import {AValue} from './foo'; import type {AType} from './foo'",
+      options: [{ 'prefer-inline': true }],
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // prefer-inline: both inline type imports
+    {
+      code: "import {type x} from './foo'; import {type y} from './foo'",
+      options: [{ 'prefer-inline': true }],
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Namespace imports cannot be merged (but still reported)
+    {
+      code: "import * as ns1 from './foo'; import * as ns2 from './foo'",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+
+    // Query strings without considerQueryString
+    {
+      code: "import x from './bar?optionX'; import y from './bar?optionY';",
+      errors: [
+        { message: "'./bar' imported multiple times." },
+        { message: "'./bar' imported multiple times." },
+      ],
+    },
+
+    // Multiline with trailing newline removal
+    {
+      code: "import { Foo } from './foo';\nimport { Bar } from './foo';\nexport const value = {}",
+      errors: [
+        { message: "'./foo' imported multiple times." },
+        { message: "'./foo' imported multiple times." },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `import/no-duplicates` rule from eslint-plugin-import to rslint.

Reports if a resolved path is imported more than once, with autofix to merge duplicate imports. Supports `considerQueryString` and `prefer-inline` options, TypeScript type-only imports, namespace imports, and `declare module` scope isolation.

## Related Links

- Rule documentation: https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-duplicates.md
- Source code: https://github.com/import-js/eslint-plugin-import/blob/main/src/rules/no-duplicates.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).