### PR TITLE
feat: port rule no-delete-var

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -126,6 +126,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_constant_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_constructor_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_debugger"
+	"github.com/web-infra-dev/rslint/internal/rules/no_delete_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_args"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_keys"
 	"github.com/web-infra-dev/rslint/internal/rules/no_duplicate_case"
@@ -517,6 +518,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-constant-condition", no_constant_condition.NoConstantConditionRule)
 	GlobalRuleRegistry.Register("no-constructor-return", no_constructor_return.NoConstructorReturnRule)
 	GlobalRuleRegistry.Register("no-debugger", no_debugger.NoDebuggerRule)
+	GlobalRuleRegistry.Register("no-delete-var", no_delete_var.NoDeleteVarRule)
 	GlobalRuleRegistry.Register("no-dupe-args", no_dupe_args.NoDupeArgsRule)
 	GlobalRuleRegistry.Register("no-dupe-keys", no_dupe_keys.NoDupeKeysRule)
 	GlobalRuleRegistry.Register("no-duplicate-case", no_duplicate_case.NoDuplicateCaseRule)

--- a/internal/rules/no_delete_var/no_delete_var.go
+++ b/internal/rules/no_delete_var/no_delete_var.go
@@ -14,7 +14,7 @@ var NoDeleteVarRule = rule.Rule{
 				// SkipParentheses to match ESTree semantics: ESTree strips ParenthesizedExpression,
 				// so ESLint sees `delete (x)` as deleting an Identifier directly.
 				expr := ast.SkipParentheses(node.AsDeleteExpression().Expression)
-				if expr.Kind == ast.KindIdentifier {
+				if expr != nil && expr.Kind == ast.KindIdentifier {
 					ctx.ReportNode(node, rule.RuleMessage{
 						Id:          "unexpected",
 						Description: "Variables should not be deleted.",

--- a/internal/rules/no_delete_var/no_delete_var.go
+++ b/internal/rules/no_delete_var/no_delete_var.go
@@ -1,0 +1,26 @@
+package no_delete_var
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-delete-var
+var NoDeleteVarRule = rule.Rule{
+	Name: "no-delete-var",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindDeleteExpression: func(node *ast.Node) {
+				// SkipParentheses to match ESTree semantics: ESTree strips ParenthesizedExpression,
+				// so ESLint sees `delete (x)` as deleting an Identifier directly.
+				expr := ast.SkipParentheses(node.AsDeleteExpression().Expression)
+				if expr.Kind == ast.KindIdentifier {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "unexpected",
+						Description: "Variables should not be deleted.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_delete_var/no_delete_var.md
+++ b/internal/rules/no_delete_var/no_delete_var.md
@@ -1,0 +1,25 @@
+# no-delete-var
+
+## Rule Details
+
+Disallows the use of the `delete` operator on variables.
+
+The purpose of the `delete` operator is to remove a property from an object. Using the `delete` operator on a variable might lead to unexpected behavior.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x;
+delete x;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var obj = { x: 1 };
+delete obj.x;
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-delete-var

--- a/internal/rules/no_delete_var/no_delete_var_test.go
+++ b/internal/rules/no_delete_var/no_delete_var_test.go
@@ -1,0 +1,186 @@
+package no_delete_var
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDeleteVarRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDeleteVarRule,
+		// Valid cases — delete on non-Identifier expressions
+		[]rule_tester.ValidTestCase{
+			// Property access
+			{Code: `delete x.prop;`},
+			{Code: `delete foo.bar.baz;`},
+			// Element access
+			{Code: `delete obj["key"];`},
+			{Code: `delete obj[0];`},
+			// Optional chaining
+			{Code: `delete a?.b;`},
+			// Computed property
+			{Code: "delete obj[`key`];"},
+			// Parenthesized member expression (inner is not Identifier)
+			{Code: `delete (x.prop);`},
+			{Code: `delete ((obj["key"]));`},
+			// TypeScript type assertion wrapping identifier (ESLint sees TSAsExpression, not Identifier)
+			{Code: `delete (x as any);`},
+			// TypeScript non-null assertion wrapping identifier
+			{Code: `delete x!;`},
+			// TypeScript angle-bracket assertion
+			{Code: `delete (<any>x);`},
+			// TypeScript satisfies expression
+			{Code: `delete (x satisfies any);`},
+			// Comma expression — inner result is not a plain Identifier in ESTree
+			{Code: `delete (0, x);`},
+		},
+		// Invalid cases — delete on Identifier (including parenthesized)
+		[]rule_tester.InvalidTestCase{
+			// Basic
+			{
+				Code: `delete x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// With var declaration
+			{
+				Code: `var x; delete x;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			// With let declaration
+			{
+				Code: `let y = 1; delete y;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			// Parenthesized identifier
+			{
+				Code: `delete (x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Double parenthesized
+			{
+				Code: `delete ((x));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Nested in if
+			{
+				Code: `var x; if (true) { delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			// Nested in function
+			{
+				Code: `function f() { delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			// Nested in arrow function
+			{
+				Code: `const f = () => { delete x; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19},
+				},
+			},
+			// In for loop
+			{
+				Code: `for (;;) { delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			// In try-catch
+			{
+				Code: `try { delete x; } catch(e) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 7},
+				},
+			},
+			// In class method
+			{
+				Code: `class C { m() { delete x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			// Multiple violations
+			{
+				Code: `delete x; delete y;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 11},
+				},
+			},
+			// Special identifier names
+			{
+				Code: `delete arguments;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `delete NaN;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Parenthesized + nested context
+			{
+				Code: `if (true) { delete (x); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			// In switch case
+			{
+				Code: `switch(0) { case 0: delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			// In while
+			{
+				Code: `while (false) { delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			// In async function
+			{
+				Code: `async function f() { delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+			// In generator function
+			{
+				Code: `function* g() { delete x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			// Multi-line
+			{
+				Code: "delete\nx",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -261,6 +261,7 @@ export default defineConfig({
     './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-proto.test.ts',
+    './tests/eslint/rules/no-delete-var.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-delete-var.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-delete-var.test.ts.snap
@@ -1,0 +1,537 @@
+// Rstest Snapshot v1
+
+exports[`no-delete-var > invalid 1`] = `
+{
+  "code": "delete x",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 2`] = `
+{
+  "code": "var x; delete x;",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 3`] = `
+{
+  "code": "let y = 1; delete y;",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 4`] = `
+{
+  "code": "delete (x);",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 5`] = `
+{
+  "code": "delete ((x));",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 6`] = `
+{
+  "code": "var x; if (true) { delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 7`] = `
+{
+  "code": "function f() { delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 8`] = `
+{
+  "code": "const f = () => { delete x; };",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 9`] = `
+{
+  "code": "for (;;) { delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 10`] = `
+{
+  "code": "try { delete x; } catch(e) {}",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 11`] = `
+{
+  "code": "class C { m() { delete x; } }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 12`] = `
+{
+  "code": "delete x; delete y;",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 13`] = `
+{
+  "code": "delete arguments;",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 14`] = `
+{
+  "code": "delete NaN;",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 15`] = `
+{
+  "code": "if (true) { delete (x); }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 16`] = `
+{
+  "code": "switch(0) { case 0: delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 17`] = `
+{
+  "code": "while (false) { delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 18`] = `
+{
+  "code": "async function f() { delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 19`] = `
+{
+  "code": "function* g() { delete x; }",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-delete-var > invalid 20`] = `
+{
+  "code": "delete
+x",
+  "diagnostics": [
+    {
+      "message": "Variables should not be deleted.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-delete-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-delete-var.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-delete-var.test.ts
@@ -1,0 +1,132 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-delete-var', {
+  valid: [
+    // Property access
+    'delete x.prop;',
+    'delete foo.bar.baz;',
+    // Element access
+    'delete obj["key"];',
+    'delete obj[0];',
+    // Optional chaining
+    'delete a?.b;',
+    // Computed property
+    'delete obj[`key`];',
+    // Parenthesized member expression (inner is not Identifier)
+    'delete (x.prop);',
+    'delete ((obj["key"]));',
+    // TypeScript type assertion wrapping identifier (ESLint sees TSAsExpression, not Identifier)
+    'delete (x as any);',
+    // TypeScript non-null assertion wrapping identifier
+    'delete x!;',
+    // TypeScript angle-bracket assertion
+    'delete (<any>x);',
+    // TypeScript satisfies expression
+    'delete (x satisfies any);',
+    // Comma expression — inner result is not a plain Identifier in ESTree
+    'delete (0, x);',
+  ],
+  invalid: [
+    // Basic
+    {
+      code: 'delete x',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // With var declaration
+    {
+      code: 'var x; delete x;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // With let declaration
+    {
+      code: 'let y = 1; delete y;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Parenthesized identifier
+    {
+      code: 'delete (x);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Double parenthesized
+    {
+      code: 'delete ((x));',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Nested in if
+    {
+      code: 'var x; if (true) { delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Nested in function
+    {
+      code: 'function f() { delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Nested in arrow function
+    {
+      code: 'const f = () => { delete x; };',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In for loop
+    {
+      code: 'for (;;) { delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In try-catch
+    {
+      code: 'try { delete x; } catch(e) {}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In class method
+    {
+      code: 'class C { m() { delete x; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Multiple violations
+    {
+      code: 'delete x; delete y;',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    // Special identifier names
+    {
+      code: 'delete arguments;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'delete NaN;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Parenthesized + nested context
+    {
+      code: 'if (true) { delete (x); }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In switch case
+    {
+      code: 'switch(0) { case 0: delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In while
+    {
+      code: 'while (false) { delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In async function
+    {
+      code: 'async function f() { delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // In generator function
+    {
+      code: 'function* g() { delete x; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Multi-line
+    {
+      code: 'delete\nx',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});

--- a/packages/rslint/src/configs/javascript.ts
+++ b/packages/rslint/src/configs/javascript.ts
@@ -7,7 +7,7 @@ const recommended: RslintConfigEntry = {
   rules: {
     'constructor-super': 'error',
     // 'no-control-regex': 'error', // not implemented
-    // 'no-delete-var': 'error', // not implemented
+    'no-delete-var': 'error',
     // 'no-dupe-class-members': 'error', // not implemented
     // 'no-dupe-else-if': 'error', // not implemented
     'no-empty-character-class': 'error',

--- a/packages/rslint/src/configs/typescript.ts
+++ b/packages/rslint/src/configs/typescript.ts
@@ -44,7 +44,7 @@ const recommended: RslintConfigEntry = {
 
     // Remaining eslint:recommended rules (not turned off by TS)
     // 'no-control-regex': 'error', // not implemented
-    // 'no-delete-var': 'error', // not implemented
+    'no-delete-var': 'error',
     // 'no-dupe-else-if': 'error', // not implemented
     'no-empty-character-class': 'error',
     // 'no-empty-static-block': 'error', // not implemented


### PR DESCRIPTION
## Summary

Port the `no-delete-var` rule from ESLint to rslint.

Disallows the use of the `delete` operator on variables. The purpose of the `delete` operator is to remove a property from an object — using it on a variable might lead to unexpected behavior.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-delete-var
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-delete-var.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).