### PR TITLE
feat: port rule no-new-object

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -146,6 +146,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
+	"github.com/web-infra-dev/rslint/internal/rules/no_new_object"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
@@ -552,6 +553,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-setter-return", no_setter_return.NoSetterReturnRule)
 	GlobalRuleRegistry.Register("no-unsafe-negation", no_unsafe_negation.NoUnsafeNegationRule)
 	GlobalRuleRegistry.Register("no-obj-calls", no_obj_calls.NoObjCallsRule)
+	GlobalRuleRegistry.Register("no-new-object", no_new_object.NoNewObjectRule)
 	GlobalRuleRegistry.Register("no-new-symbol", no_new_symbol.NoNewSymbolRule)
 	GlobalRuleRegistry.Register("use-isnan", use_isnan.UseIsNaNRule)
 	GlobalRuleRegistry.Register("eqeqeq", eqeqeq.EqeqeqRule)

--- a/internal/rules/no_new_object/no_new_object.go
+++ b/internal/rules/no_new_object/no_new_object.go
@@ -1,0 +1,39 @@
+package no_new_object
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var NoNewObjectRule = rule.Rule{
+	Name: "no-new-object",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindNewExpression: func(node *ast.Node) {
+				callee := node.Expression()
+				if callee == nil {
+					return
+				}
+
+				// Unwrap parentheses and TS type assertions so that
+				// new (Object)(), new (Object as any)() are caught.
+				unwrapped := ast.SkipOuterExpressions(callee, ast.OEKParentheses|ast.OEKAssertions)
+				if unwrapped.Kind != ast.KindIdentifier || unwrapped.Text() != "Object" {
+					return
+				}
+
+				// If Object is shadowed by a local declaration (var, function, class, import),
+				// it's not the global built-in — skip reporting.
+				if utils.IsShadowed(unwrapped, "Object") {
+					return
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "preferLiteral",
+					Description: "The object literal notation {} is preferable.",
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_new_object/no_new_object.md
+++ b/internal/rules/no_new_object/no_new_object.md
@@ -1,0 +1,27 @@
+# no-new-object
+
+## Rule Details
+
+Disallow `Object` constructors. The object literal notation `{}` is preferable.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var myObject = new Object();
+
+new Object();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var myObject = {};
+
+var myObject = new CustomObject();
+
+var foo = new foo.Object();
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-new-object

--- a/internal/rules/no_new_object/no_new_object_test.go
+++ b/internal/rules/no_new_object/no_new_object_test.go
@@ -1,0 +1,592 @@
+package no_new_object
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoNewObjectRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNewObjectRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// Dimension 1: Non-matching AST shapes (not NewExpression + Identifier("Object"))
+			// ============================================================
+
+			// Object literal — not a NewExpression
+			{Code: `var myObject = {};`},
+
+			// Custom constructor — callee name is not "Object"
+			{Code: `var myObject = new CustomObject();`},
+
+			// Object() without new — CallExpression, not NewExpression
+			{Code: `var foo = Object("foo");`},
+			{Code: `Object();`},
+
+			// Callee is a property access, not a bare Identifier
+			{Code: `var foo = new foo.Object()`},
+			{Code: `var foo = new foo.bar.Object()`},
+			{Code: `var foo = new foo['Object']()`},
+
+			// Callee is not "Object" even if it references Object indirectly
+			{Code: `var x = something ? MyClass : Object; var y = new x();`},
+			{Code: `var Obj = Object; new Obj();`},
+
+			// Shadowed via rest destructuring
+			{Code: `var { ...Object } = foo; new Object();`},
+
+			// Shadowed via ambient (declare) declarations
+			{Code: `declare class Object {} new Object();`},
+			{Code: `declare function Object(): void; new Object();`},
+
+			// ============================================================
+			// Dimension 2: Shadowing — all declaration forms
+			// ============================================================
+
+			// var / let / const
+			{Code: `var Object = function() {}; new Object();`},
+			{Code: `var Object = function Object() {}; new Object();`},
+			{Code: `var Object; new Object();`},
+			{Code: `let Object = 1; new Object();`},
+			{Code: `const Object = null; new Object();`},
+
+			// function / class
+			{Code: `function Object() {} new Object();`},
+			{Code: `class Object { constructor(){} } new Object();`},
+
+			// TypeScript enum / namespace
+			{Code: `enum Object { A, B } new Object();`},
+			{Code: `namespace Object { export const x = 1; } new Object();`},
+
+			// ============================================================
+			// Dimension 3: Shadowing — parameter variants
+			// ============================================================
+
+			{Code: `function bar(Object) { var baz = new Object(); }`},
+			{Code: `const f = (Object) => { new Object(); };`},
+			{Code: `function f(...Object) { new Object(); }`},
+			{Code: `function f({ Object }) { new Object(); }`},
+			{Code: `function f([Object]) { new Object(); }`},
+			{Code: `function f(Object = 1) { new Object(); }`},
+			{Code: `function f({ a: Object }) { new Object(); }`},
+			{Code: `function f({ a: { Object } }) { new Object(); }`},
+
+			// ============================================================
+			// Dimension 4: Shadowing — destructuring in declarations
+			// ============================================================
+
+			{Code: `var { Object } = obj; new Object();`},
+			{Code: `var [Object] = arr; new Object();`},
+			{Code: `var { a: { Object } } = obj; new Object();`},
+			{Code: `var { ["Object"]: Object } = obj; new Object();`},
+			{Code: `let { Object } = obj; new Object();`},
+			{Code: `const [, Object] = arr; new Object();`},
+
+			// ============================================================
+			// Dimension 5: Shadowing — loop variables
+			// ============================================================
+
+			{Code: `for (var Object = 0;;) { new Object(); }`},
+			{Code: `for (var Object in obj) { new Object(); }`},
+			{Code: `for (let Object of arr) { new Object(); }`},
+			{Code: `for (const Object of arr) { new Object(); }`},
+
+			// ============================================================
+			// Dimension 6: Shadowing — catch clause
+			// ============================================================
+
+			{Code: `try {} catch(Object) { new Object(); }`},
+
+			// ============================================================
+			// Dimension 7: Shadowing — imports
+			// ============================================================
+
+			{Code: `import { Object } from './mod'; new Object();`},
+			{Code: `import { X as Object } from './mod'; new Object();`},
+			{Code: `import Object from './mod'; new Object();`},
+			{Code: `import * as Object from './mod'; new Object();`},
+
+			// ============================================================
+			// Dimension 8: Shadowing scope propagation (top-level shadow
+			// reaches into nested scopes)
+			// ============================================================
+
+			{Code: `function Object() {} function f() { new Object(); }`},
+			{Code: `var Object = 1; function f() { new Object(); }`},
+			{Code: `var Object = 1; const f = () => new Object();`},
+			{Code: `var Object = 1; class C { m() { new Object(); } }`},
+			{Code: `var Object = 1; function a() { function b() { function c() { new Object(); } } }`},
+			{Code: `var Object = 1; (() => { (() => { new Object(); })(); })();`},
+			{Code: `class Object {} class C extends Object { m() { new Object(); } }`},
+
+			// ============================================================
+			// Dimension 9: Hoisting — var/function declarations hoist to scope top
+			// ============================================================
+
+			{Code: `new Object(); var Object = 1;`},
+			{Code: `new Object(); function Object() {}`},
+			{Code: `function f() { new Object(); var Object = 1; }`},
+
+			// ============================================================
+			// Dimension 10: Shadow inside inner scope, new Object() also inside
+			// that same scope (both shadowed — valid)
+			// ============================================================
+
+			{Code: `function f(Object) { new Object(); }`},
+			{Code: `{ let Object = 1; new Object(); }`},
+			{Code: `for (let Object of arr) { new Object(); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// Dimension 1: Basic forms
+			// ============================================================
+
+			{
+				Code:   `var foo = new Object()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `new Object();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `const a = new Object()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `let x = new Object()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 9}},
+			},
+
+			// With arguments — ESLint still reports regardless of arguments
+			{
+				Code:   `var foo = new Object("foo")`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `new Object(1, 2, 3)`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+
+			// Without parentheses — still a valid NewExpression
+			{
+				Code:   `new Object`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+
+			// Parenthesized callee — SkipOuterExpressions unwraps parens
+			{
+				Code:   `new (Object)()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `new ((Object))()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+
+			// TS type assertions on callee — SkipOuterExpressions unwraps assertions
+			{
+				Code:   `new (Object as any)()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+			{
+				Code:   `new (<any>Object)()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+
+			// TypeScript generic type argument — callee is still Identifier
+			{
+				Code:   `new Object<any>()`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 1}},
+			},
+
+			// ============================================================
+			// Dimension 2: Multiple errors in the same file
+			// ============================================================
+
+			{
+				Code: `new Object(); new Object();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 1, Column: 1},
+					{MessageId: "preferLiteral", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `var x = new Object(), y = new Object();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 1, Column: 9},
+					{MessageId: "preferLiteral", Line: 1, Column: 27},
+				},
+			},
+
+			// ============================================================
+			// Dimension 3: Multiline — verify line/column tracking
+			// ============================================================
+
+			{
+				Code: "var a = 1;\nnew Object();\nvar b = 2;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 2, Column: 1},
+				},
+			},
+			{
+				Code: "function f() {\n  return new Object();\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 2, Column: 10},
+				},
+			},
+
+			// ============================================================
+			// Dimension 4: Non-shadowing scope boundaries
+			// (declaration inside a scope does NOT shadow outside that scope)
+			// ============================================================
+
+			// Nested function expression name doesn't shadow global
+			{
+				Code:   "function bar() { return function Object() {}; } var baz = new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral", Line: 1, Column: 59}},
+			},
+
+			// Block-scoped declarations don't shadow outside the block
+			{
+				Code:   "{ function Object() {} } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "{ let Object = 1; } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "{ const Object = 1; } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "if (true) { let Object = 1; } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "try { let Object = 1; } catch(e) {} new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Function/arrow scoped var doesn't shadow outside
+			{
+				Code:   "function foo() { var Object = 1; } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "const f = () => { var Object = 1; }; new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "function a() { function b() { var Object = 1; } } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// IIFE parameters don't shadow outside
+			{
+				Code:   "(function(Object) {})(1); new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "((Object) => {})(1); new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Class static block scoped var doesn't shadow outside
+			{
+				Code:   "class C { static { var Object = 1; } } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Catch clause var doesn't shadow outside
+			{
+				Code:   "try {} catch(Object) {} new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Loop variable doesn't shadow outside the loop
+			{
+				Code:   "for (let Object of arr) {} new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "for (const Object in obj) {} new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// ============================================================
+			// Dimension 5: new Object() inside various scopes (no shadow anywhere)
+			// ============================================================
+
+			{
+				Code:   "function f() { new Object(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "const f = () => new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "class C { m() { new Object(); } }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "if (true) { if (true) { new Object(); } }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "class C { static { new Object(); } }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Deep nesting without shadow — 3+ levels
+			{
+				Code:   "function a() { function b() { function c() { new Object(); } } }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "(() => { (() => { (() => { new Object(); })(); })(); })();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// ============================================================
+			// Dimension 6: Expression contexts — new Object() as part of
+			// larger expressions
+			// ============================================================
+
+			// Object literal method
+			{
+				Code:   "({ m() { new Object() } })",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Getter / setter
+			{
+				Code:   "({ get x() { return new Object(); } })",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "({ set x(v) { this.v = new Object(); } })",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Computed property key
+			{
+				Code:   "({ [new Object()]: 1 })",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Default parameter value
+			{
+				Code:   "function f(x = new Object()) {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "const f = (x = new Object()) => x;",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Template literal
+			{
+				Code:   "`${new Object()}`",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Conditional / logical
+			{
+				Code:   "condition ? new Object() : {}",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "var x = foo || new Object()",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "var x = foo ?? new Object()",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Array / spread
+			{
+				Code:   "[new Object()]",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "[...new Object()]",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// As function argument
+			{
+				Code:   "foo(new Object())",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "foo(1, new Object(), 'a')",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Destructuring from new Object()
+			{
+				Code:   "const { a } = new Object()",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Assignment
+			{
+				Code:   "x = new Object()",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Return / yield / await
+			{
+				Code:   "function f() { return new Object(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "function* g() { yield new Object(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+			{
+				Code:   "async function f() { await new Object(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Export
+			{
+				Code:   "export default new Object()",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// ============================================================
+			// Dimension 7: Class body contexts
+			// ============================================================
+
+			// Instance property initializer
+			{
+				Code:   "class C { x = new Object() }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Static property initializer
+			{
+				Code:   "class C { static x = new Object() }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Constructor
+			{
+				Code:   "class C { constructor() { this.x = new Object(); } }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Extends clause — callee is not "Object", but new Object() in body
+			{
+				Code:   "class C extends Base { m() { new Object(); } }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// ============================================================
+			// Dimension 8: Other statement contexts
+			// ============================================================
+
+			// Switch
+			{
+				Code:   "switch(x) { case 1: new Object(); }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// try / catch / finally — all three positions report
+			{
+				Code: "try { new Object() } catch(e) { new Object() } finally { new Object() }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral"},
+					{MessageId: "preferLiteral"},
+					{MessageId: "preferLiteral"},
+				},
+			},
+
+			// Labeled statement
+			{
+				Code:   "label: new Object()",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Comma operator
+			{
+				Code:   "(0, new Object())",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// TS type assertion on result (not callee) — still a NewExpression
+			{
+				Code:   "var x = new Object() as any",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Non-null assertion on result
+			{
+				Code:   "var x = new Object()!",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// Re-export does NOT create a local binding
+			{
+				Code:   `export { Object } from './mod'; new Object();`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// ============================================================
+			// Dimension 9: TypeScript — type-level declarations do NOT shadow
+			// ============================================================
+
+			// type alias — does not create a value binding
+			{
+				Code:   "type Object = string; new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// interface — does not create a value binding
+			{
+				Code:   "interface Object { x: number } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "preferLiteral"}},
+			},
+
+			// ============================================================
+			// Dimension 9: Mixed scopes — shadow in one, global in another
+			// ============================================================
+
+			{
+				Code: "function f(Object) { new Object(); } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: "{ let Object = 1; new Object(); } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: "function f() { let Object = 1; new Object(); } function g() { new Object(); }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 1, Column: 63},
+				},
+			},
+			// Shadow inside class method, global outside
+			{
+				Code: "class C { m(Object) { new Object(); } } new Object();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferLiteral", Line: 1, Column: 41},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -49,6 +49,7 @@ export default defineConfig({
     './tests/eslint/rules/no-import-assign.test.ts',
     './tests/eslint/rules/no-inner-declarations.test.ts',
     './tests/eslint/rules/no-new-func.test.ts',
+    './tests/eslint/rules/no-new-object.test.ts',
     './tests/eslint/rules/no-new-wrappers.test.ts',
     './tests/eslint/rules/no-self-assign.test.ts',
     './tests/eslint/rules/no-undef.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new-object.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new-object.test.ts.snap
@@ -1,0 +1,718 @@
+// Rstest Snapshot v1
+
+exports[`no-new-object > invalid 1`] = `
+{
+  "code": "var foo = new Object()",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 2`] = `
+{
+  "code": "new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 3`] = `
+{
+  "code": "new Object",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 4`] = `
+{
+  "code": "var foo = new Object("foo")",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 5`] = `
+{
+  "code": "new (Object)()",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 6`] = `
+{
+  "code": "new (Object as any)()",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 7`] = `
+{
+  "code": "new Object<any>()",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 8`] = `
+{
+  "code": "new Object(); new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 9`] = `
+{
+  "code": "function bar() { return function Object() {}; } var baz = new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 59,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 10`] = `
+{
+  "code": "{ let Object = 1; } new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 11`] = `
+{
+  "code": "function foo() { var Object = 1; } new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 12`] = `
+{
+  "code": "(function(Object) {})(1); new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 13`] = `
+{
+  "code": "try {} catch(Object) {} new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 14`] = `
+{
+  "code": "function f() { new Object(); }",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 15`] = `
+{
+  "code": "const f = () => new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 16`] = `
+{
+  "code": "class C { m() { new Object(); } }",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 17`] = `
+{
+  "code": "function a() { function b() { function c() { new Object(); } } }",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 18`] = `
+{
+  "code": "({ m() { new Object() } })",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 19`] = `
+{
+  "code": "function f(x = new Object()) {}",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 20`] = `
+{
+  "code": "foo(new Object())",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 21`] = `
+{
+  "code": "function f() { return new Object(); }",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 22`] = `
+{
+  "code": "class C { x = new Object() }",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 23`] = `
+{
+  "code": "class C { static x = new Object() }",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 24`] = `
+{
+  "code": "type Object = string; new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 25`] = `
+{
+  "code": "interface Object { x: number } new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 26`] = `
+{
+  "code": "function f(Object) { new Object(); } new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new-object > invalid 27`] = `
+{
+  "code": "{ let Object = 1; new Object(); } new Object();",
+  "diagnostics": [
+    {
+      "message": "The object literal notation {} is preferable.",
+      "messageId": "preferLiteral",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new-object",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-new-object.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-new-object.test.ts
@@ -1,0 +1,138 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-new-object', {
+  valid: [
+    // Non-matching AST shapes
+    'var myObject = {};',
+    'var myObject = new CustomObject();',
+    'var foo = Object("foo");',
+    'var foo = new foo.Object()',
+
+    // Shadowing — key declaration types
+    'var Object = function Object() {}; new Object();',
+    'function Object() {} new Object();',
+    'class Object { constructor(){} } new Object();',
+
+    // Shadowing — parameter / destructuring / catch
+    'function bar(Object) { var baz = new Object(); }',
+    'var { Object } = obj; new Object();',
+    'try {} catch(Object) { new Object(); }',
+
+    // Scope propagation & hoisting
+    'var Object = 1; function f() { new Object(); }',
+    'new Object(); var Object = 1;',
+  ],
+  invalid: [
+    // Basic forms
+    {
+      code: 'var foo = new Object()',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    { code: 'new Object();', errors: [{ messageId: 'preferLiteral' }] },
+    { code: 'new Object', errors: [{ messageId: 'preferLiteral' }] },
+    {
+      code: 'var foo = new Object("foo")',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // Parenthesized callee
+    { code: 'new (Object)()', errors: [{ messageId: 'preferLiteral' }] },
+    // TS type assertion on callee
+    { code: 'new (Object as any)()', errors: [{ messageId: 'preferLiteral' }] },
+    // TS generic type argument
+    { code: 'new Object<any>()', errors: [{ messageId: 'preferLiteral' }] },
+
+    // Multiple errors
+    {
+      code: 'new Object(); new Object();',
+      errors: [{ messageId: 'preferLiteral' }, { messageId: 'preferLiteral' }],
+    },
+
+    // Non-shadowing scope boundaries
+    {
+      code: 'function bar() { return function Object() {}; } var baz = new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '{ let Object = 1; } new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'function foo() { var Object = 1; } new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '(function(Object) {})(1); new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'try {} catch(Object) {} new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // Inside scopes without shadow
+    {
+      code: 'function f() { new Object(); }',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'const f = () => new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'class C { m() { new Object(); } }',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'function a() { function b() { function c() { new Object(); } } }',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // Expression contexts
+    {
+      code: '({ m() { new Object() } })',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'function f(x = new Object()) {}',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    { code: 'foo(new Object())', errors: [{ messageId: 'preferLiteral' }] },
+    {
+      code: 'function f() { return new Object(); }',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // Class body
+    {
+      code: 'class C { x = new Object() }',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'class C { static x = new Object() }',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // TypeScript type-level declarations do NOT shadow
+    {
+      code: 'type Object = string; new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: 'interface Object { x: number } new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+
+    // Mixed scopes
+    {
+      code: 'function f(Object) { new Object(); } new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+    {
+      code: '{ let Object = 1; new Object(); } new Object();',
+      errors: [{ messageId: 'preferLiteral' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-new-object` rule from ESLint to rslint.

Disallows `new Object()` constructor calls, recommending object literal notation `{}` instead. Handles parenthesized callees (`new (Object)()`) and TS type assertions (`new (Object as any)()`) via `SkipOuterExpressions`, consistent with `no-new-func`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-new-object
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-new-object.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).