### PR TITLE
feat: port rule no-dupe-class-members

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,6 +33,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_delete"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_base_to_string"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_confusing_void_expression"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dupe_class_members"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_duplicate_enum_values"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_duplicate_type_constituents"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dynamic_delete"
@@ -415,6 +416,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-delete", no_array_delete.NoArrayDeleteRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-base-to-string", no_base_to_string.NoBaseToStringRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-confusing-void-expression", no_confusing_void_expression.NoConfusingVoidExpressionRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-dupe-class-members", no_dupe_class_members.NoDupeClassMembersRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-duplicate-enum-values", no_duplicate_enum_values.NoDuplicateEnumValuesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-duplicate-type-constituents", no_duplicate_type_constituents.NoDuplicateTypeConstituentsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-dynamic-delete", no_dynamic_delete.NoDynamicDeleteRule)

--- a/internal/plugins/typescript/rules/no_dupe_class_members/eslint_alignment_test.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/eslint_alignment_test.go
@@ -1,0 +1,273 @@
+package no_dupe_class_members
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestESLintCoreAlignment verifies 1:1 parity with every ESLint core
+// no-dupe-class-members test case (v10.x).
+func TestESLintCoreAlignment(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDupeClassMembersRule,
+
+		// ── ESLint core VALID (29 cases) ──
+		[]rule_tester.ValidTestCase{
+			{Code: `class A { foo() {} bar() {} }`},
+			{Code: `class A { static foo() {} foo() {} }`},
+			{Code: `class A { get foo() {} set foo(value) {} }`},
+			{Code: `class A { static foo() {} get foo() {} set foo(value) {} }`},
+			{Code: "class A { foo() {} }\nclass B { foo() {} }"},
+			{Code: `class A { [foo]() {} foo() {} }`},
+			{Code: `class A { 'foo'() {} 'bar'() {} baz() {} }`},
+			{Code: `class A { *'foo'() {} *'bar'() {} *baz() {} }`},
+			{Code: `class A { get 'foo'() {} get 'bar'() {} get baz() {} }`},
+			{Code: `class A { 1() {} 2() {} }`},
+			// computed bracket
+			{Code: `class A { ['foo']() {} ['bar']() {} }`},
+			{Code: "class A { [`foo`]() {} [`bar`]() {} }"},
+			{Code: `class A { [12]() {} [123]() {} }`},
+			// numeric format differences
+			{Code: `class A { [1.0]() {} ['1.0']() {} }`},
+			{Code: "class A { [0x1]() {} [`0x1`]() {} }"},
+			{Code: `class A { [null]() {} ['']() {} }`},
+			// computed getter+setter
+			{Code: `class A { get ['foo']() {} set ['foo'](value) {} }`},
+			// computed vs static
+			{Code: `class A { ['foo']() {} static ['foo']() {} }`},
+			// constructor keyword interactions
+			{Code: `class A { ['constructor']() {} constructor() {} }`},
+			{Code: "class A { 'constructor'() {} [`constructor`]() {} }"},
+			{Code: "class A { constructor() {} get [`constructor`]() {} }"},
+			{Code: `class A { 'constructor'() {} set ['constructor'](value) {} }`},
+			// non-statically-known computed
+			{Code: `class A { ['foo' + '']() {} ['foo']() {} }`},
+			{Code: "class A { [`foo${''}`]() {} [`foo`]() {} }"},
+			{Code: `class A { [-1]() {} ['-1']() {} }`},
+			// dynamic computed
+			{Code: `class A { [foo]() {} [foo]() {} }`},
+			// private / static fields
+			{Code: `class A { foo; static foo; }`},
+			{Code: `class A { foo; #foo; }`},
+			{Code: `class A { '#foo'; #foo; }`},
+		},
+
+		// ── ESLint core INVALID (28 cases) ──
+		[]rule_tester.InvalidTestCase{
+			// 1. basic
+			{
+				Code:   `class A { foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 2. class expression
+			{
+				Code:   `!class A { foo() {} foo() {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 3. string literal
+			{
+				Code:   `class A { 'foo'() {} 'foo'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 4. numeric equivalence
+			{
+				Code:   `class A { 10() {} 1e1() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 5. computed bracket
+			{
+				Code:   `class A { ['foo']() {} ['foo']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 6. static computed + static literal
+			{
+				Code:   `class A { static ['foo']() {} static foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 7. set with different syntax
+			{
+				Code:   `class A { set 'foo'(value) {} set ['foo'](val) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 8. empty string
+			{
+				Code:   `class A { ''() {} ['']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 9. template literal
+			{
+				Code:   "class A { [`foo`]() {} [`foo`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 10. static get template + bracket
+			{
+				Code:   "class A { static get [`foo`]() {} static get ['foo']() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 11. identifier + template
+			{
+				Code:   "class A { foo() {} [`foo`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 12. get template + string literal
+			{
+				Code:   "class A { get [`foo`]() {} 'foo'() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 13. static string + static template
+			{
+				Code:   "class A { static 'foo'() {} static [`foo`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 14. computed 'constructor' duplicate
+			{
+				Code:   `class A { ['constructor']() {} ['constructor']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 15. static template constructor + static constructor
+			{
+				Code:   "class A { static [`constructor`]() {} static constructor() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 16. static constructor + static string 'constructor'
+			{
+				Code:   `class A { static constructor() {} static 'constructor'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 17. computed numeric
+			{
+				Code:   `class A { [123]() {} [123]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 18. hex + decimal
+			{
+				Code:   `class A { [0x10]() {} 16() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 19. bracket numeric + scientific
+			{
+				Code:   `class A { [100]() {} [1e2]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 20. float + template
+			{
+				Code:   "class A { [123.00]() {} [`123`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 21. static string + static octal
+			{
+				Code:   `class A { static '65'() {} static [0o101]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 22. BigInt + numeric
+			{
+				Code:   `class A { [123n]() {} 123() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 23. null keyword + string 'null'
+			{
+				Code:   `class A { [null]() {} 'null'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 24. triple duplicate
+			{
+				Code: `class A { foo() {} foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
+					{MessageId: "unexpected"},
+				},
+			},
+			// 25. static duplicate
+			{
+				Code:   `class A { static foo() {} static foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 26. method then getter
+			{
+				Code:   `class A { foo() {} get foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 27. setter then method
+			{
+				Code:   `class A { set foo(value) {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			// 28. duplicate properties
+			{
+				Code:   `class A { foo; foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+		},
+	)
+}
+
+// TestTypeScriptESLintAlignment verifies 1:1 parity with every
+// typescript-eslint no-dupe-class-members test case.
+func TestTypeScriptESLintAlignment(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDupeClassMembersRule,
+
+		// ── typescript-eslint VALID (11 cases) ──
+		[]rule_tester.ValidTestCase{
+			{Code: `class A { foo() {} bar() {} }`},
+			{Code: `class A { static foo() {} foo() {} }`},
+			{Code: `class A { get foo() {} set foo(value) {} }`},
+			{Code: `class A { static foo() {} get foo() {} set foo(value) {} }`},
+			{Code: "class A { foo() {} }\nclass B { foo() {} }"},
+			{Code: `class A { [foo]() {} foo() {} }`},
+			{Code: `class A { foo() {} bar() {} baz() {} }`},
+			{Code: `class A { *foo() {} *bar() {} *baz() {} }`},
+			{Code: `class A { get foo() {} get bar() {} get baz() {} }`},
+			{Code: `class A { 1() {} 2() {} }`},
+			// TypeScript method overloads (the key TS-eslint addition)
+			{Code: "class Foo {\n  foo(a: string): string;\n  foo(a: number): number;\n  foo(a: any): any {}\n}"},
+		},
+
+		// ── typescript-eslint INVALID (10 cases) ──
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `class A { foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `!class A { foo() {} foo() {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `class A { 'foo'() {} 'foo'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `class A { 10() {} 1e1() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code: `class A { foo() {} foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected"},
+					{MessageId: "unexpected"},
+				},
+			},
+			{
+				Code:   `class A { static foo() {} static foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `class A { foo() {} get foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `class A { set foo(value) {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `class A { foo; foo = 42; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+			{
+				Code:   `class A { foo; foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpected"}},
+			},
+		},
+	)
+}

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.go
@@ -1,0 +1,118 @@
+package no_dupe_class_members
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var NoDupeClassMembersRule = rule.CreateRule(rule.Rule{
+	Name: "no-dupe-class-members",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		checkClass := func(node *ast.Node) {
+			type memberState struct {
+				init bool
+				get  bool
+				set  bool
+			}
+			type stateEntry struct {
+				nonStatic memberState
+				static    memberState
+			}
+			stateMap := make(map[string]*stateEntry)
+
+			for _, member := range node.Members() {
+				// Skip the class constructor. In TypeScript-Go's AST, both keyword
+				// constructor() and string-literal 'constructor'() parse as
+				// KindConstructor. ESLint skips both (kind="constructor"), so we
+				// do the same — but only for non-static members. Static constructor()
+				// is a regular static method in ESLint (kind="method").
+				if ast.IsConstructorDeclaration(member) && !ast.IsStatic(member) {
+					continue
+				}
+				// Overload signatures and abstract declarations (methods, getters,
+				// setters) have no body. Skip them so only concrete implementations
+				// participate in duplicate checking. PropertyDeclaration never has a
+				// body and must not be skipped.
+				if !ast.IsPropertyDeclaration(member) && member.Body() == nil {
+					continue
+				}
+
+				// Determine the duplicate-detection category.
+				// get + set for the same name is allowed; any other combination is a duplicate.
+				var kind string
+				switch {
+				case ast.IsGetAccessorDeclaration(member):
+					kind = "get"
+				case ast.IsSetAccessorDeclaration(member):
+					kind = "set"
+				case ast.IsMethodDeclaration(member), ast.IsPropertyDeclaration(member):
+					kind = "init"
+				case ast.IsConstructorDeclaration(member):
+					// Static constructor — treated as a static method named "constructor".
+					kind = "init"
+				default:
+					continue
+				}
+
+				// Get member name. Static constructors have name=nil in
+				// TypeScript-Go's AST; use "constructor" directly.
+				var name string
+				nameNode := ast.GetNameOfDeclaration(member)
+				if nameNode != nil {
+					var ok bool
+					name, ok = utils.GetStaticPropertyName(nameNode)
+					if !ok {
+						continue // computed property with non-static expression
+					}
+				} else if ast.IsConstructorDeclaration(member) {
+					name = "constructor"
+				} else {
+					continue
+				}
+
+				// "$" prefix avoids collisions with built-in object keys like "__proto__".
+				key := "$" + name
+				if stateMap[key] == nil {
+					stateMap[key] = &stateEntry{}
+				}
+
+				state := &stateMap[key].nonStatic
+				if ast.IsStatic(member) {
+					state = &stateMap[key].static
+				}
+
+				var isDuplicate bool
+				switch kind {
+				case "get":
+					isDuplicate = state.init || state.get
+					state.get = true
+				case "set":
+					isDuplicate = state.init || state.set
+					state.set = true
+				default: // "init"
+					isDuplicate = state.init || state.get || state.set
+					state.init = true
+				}
+
+				if isDuplicate {
+					reportNode := nameNode
+					if reportNode == nil {
+						reportNode = member // static constructor (no name node)
+					}
+					ctx.ReportNode(reportNode, rule.RuleMessage{
+						Id:          "unexpected",
+						Description: fmt.Sprintf("Duplicate name '%s'.", name),
+					})
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: checkClass,
+			ast.KindClassExpression:  checkClass,
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.md
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members.md
@@ -1,0 +1,59 @@
+# no-dupe-class-members
+
+## Rule Details
+
+Disallow duplicate class members.
+
+If there are declarations of the same name in class members, the last declaration overwrites other declarations silently. It can cause unexpected behaviors.
+
+This rule extends the base ESLint `no-dupe-class-members` rule to support TypeScript method overload signatures, which should not be flagged as duplicates.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+class A {
+  foo() {}
+  foo() {}
+}
+
+class B {
+  foo;
+  foo() {}
+}
+
+class C {
+  static bar() {}
+  static bar() {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+class A {
+  foo() {}
+  bar() {}
+}
+
+class B {
+  get foo() {}
+  set foo(value) {}
+}
+
+class C {
+  static foo() {}
+  foo() {}
+}
+
+// TypeScript method overloads are allowed
+class D {
+  foo(a: string): string;
+  foo(a: number): number;
+  foo(a: any): any {}
+}
+```
+
+## Original Documentation
+
+- [ESLint `no-dupe-class-members`](https://eslint.org/docs/latest/rules/no-dupe-class-members)
+- [TypeScript-ESLint `no-dupe-class-members`](https://typescript-eslint.io/rules/no-dupe-class-members/)

--- a/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members_test.go
+++ b/internal/plugins/typescript/rules/no_dupe_class_members/no_dupe_class_members_test.go
@@ -1,0 +1,554 @@
+package no_dupe_class_members
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDupeClassMembersRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDupeClassMembersRule, []rule_tester.ValidTestCase{
+		// ─── basic: different names ───
+		{Code: `class A { foo() {} bar() {} }`},
+		{Code: `class A { foo() {} bar() {} baz() {} }`},
+		{Code: `class A { *foo() {} *bar() {} *baz() {} }`},
+		{Code: `class A { get foo() {} get bar() {} get baz() {} }`},
+		{Code: `class A { 1() {} 2() {} }`},
+		{Code: `class A { foo; bar; }`},
+
+		// ─── static vs non-static (same name allowed) ───
+		{Code: `class A { static foo() {} foo() {} }`},
+		{Code: `class A { foo; static foo; }`},
+		{Code: `class A { static foo() {} get foo() {} set foo(value) {} }`},
+		{Code: `class A { ['foo']() {} static ['foo']() {} }`},
+		{Code: `class A { static get foo() {} get foo() {} }`},
+		{Code: `class A { static set foo(v) {} set foo(v) {} }`},
+		{Code: `class A { static foo = 1; foo() {} }`},
+
+		// ─── getter + setter pair (allowed) ───
+		{Code: `class A { get foo() {} set foo(value) {} }`},
+		{Code: `class A { set foo(value) {} get foo() {} }`},
+		{Code: `class A { get ['foo']() {} set ['foo'](value) {} }`},
+		{Code: `class A { static get foo() {} static set foo(value) {} }`},
+
+		// ─── computed properties ───
+		{Code: `class A { [foo]() {} foo() {} }`},
+		{Code: `class A { [foo]() {} [foo]() {} }`},
+		{Code: `class A { ['foo']() {} ['bar']() {} }`},
+		{Code: "class A { [`foo`]() {} [`bar`]() {} }"},
+		{Code: `class A { [Symbol.iterator]() {} [Symbol.hasInstance]() {} }`},
+		{Code: `class A { [foo + bar]() {} [foo + bar]() {} }`},
+		// non-expression computed properties share syntax but resolve to different strings
+		{Code: `class A { [1.0]() {} ['1.0']() {} }`},
+		{Code: `class A { [0x1]() {} ['0x1']() {} }`},
+		// expression with side effects — not statically analyzed
+		{Code: `class A { [a++]() {} [a++]() {} }`},
+
+		// ─── constructor keyword ───
+		{Code: `class A { ['constructor']() {} constructor() {} }`},
+		{Code: `class A { constructor() {} ['constructor']() {} }`},
+
+		// ─── private fields vs public ───
+		{Code: `class A { foo; #foo; }`},
+		{Code: `class A { '#foo'; #foo; }`},
+
+		// ─── same name in different classes ───
+		{Code: "class A { foo() {} }\nclass B { foo() {} }"},
+
+		// ─── TypeScript method overloads ───
+		{Code: "class Foo {\n  foo(a: string): string;\n  foo(a: number): number;\n  foo(a: any): any {}\n}"},
+		// many overloads before implementation
+		{Code: `class A { foo(a: string): void; foo(a: number): void; foo(a: boolean): void; foo(a: any) {} }`},
+		// static overloads
+		{Code: `class A { static foo(a: string): void; static foo(a: number): void; static foo(a: any) {} }`},
+		// overloaded constructor
+		{Code: `class A { constructor(a: string); constructor(a: number); constructor(a: any) {} }`},
+		// overload signature does not conflict with getter
+		{Code: `class A { foo(a: string): void; get foo() { return ''; } }`},
+
+		// ─── abstract methods (no body, like overloads) ───
+		{Code: `abstract class A { abstract foo(): void; foo() {} }`},
+		{Code: `abstract class A { abstract foo(): void; abstract bar(): void; }`},
+
+		// ─── nested classes: inner members don't conflict with outer ───
+		{Code: `class Outer { foo() {} bar() { class Inner { foo() {} } } }`},
+		{Code: `class Outer { foo = class Inner { foo() {} }; }`},
+		{Code: `class Outer { foo() {} method() { return class { foo() {} }; } }`},
+		// deeply nested (3 levels)
+		{Code: `class L1 { foo() {} bar() { class L2 { foo() {} baz() { class L3 { foo() {} } } } } }`},
+		// class expression in static block
+		{Code: `class Outer { static foo() {} static { class Inner { foo() {} } } }`},
+
+		// ─── class with extends (child duplicates only matter within the child) ───
+		{Code: `class Base { foo() {} } class Child extends Base { foo() {} }`},
+
+		// ─── empty / single member ───
+		{Code: `class A {}`},
+		{Code: `class A { foo() {} }`},
+
+		// ─── mixed member types (no conflict) ───
+		{Code: `class A { get foo() {} set foo(v) {} bar() {} baz; }`},
+
+		// ─── semicolon class elements are silently ignored ───
+		{Code: `class A { ; foo() {} ; bar() {} ; }`},
+
+		// ─── async / generator are still methods ───
+		{Code: `class A { async foo() {} bar() {} }`},
+		{Code: `class A { *foo() {} bar() {} }`},
+		{Code: `class A { async *foo() {} bar() {} }`},
+
+		// ─── __proto__ as single member (no collision) ───
+		{Code: `class A { __proto__() {} }`},
+
+		// ─── property with function-expression initializer (single, no dup) ───
+		{Code: `class A { foo = () => {} }`},
+		{Code: `class A { foo = function() {} }`},
+
+		// ─── computed + identifier mixed accessor pair (allowed) ───
+		{Code: `class A { get ['foo']() {} set foo(v) {} }`},
+		{Code: `class A { get foo() {} set ['foo'](v) {} }`},
+
+		// ─── index signature does not interfere ───
+		{Code: `class A { [key: string]: any; foo() {} bar() {} }`},
+
+		// ─── dup getter then setter is OK (dup getter already reported, setter still pairs) ───
+		{Code: `class A { get foo() {} set foo(v) {} }`},
+
+		// ─── declare property alone (no dup) ───
+		{Code: `class A { declare foo: string; }`},
+
+		// ─── abstract getter/setter: no body → must be skipped like overloads ───
+		{Code: `abstract class A { abstract get foo(): string; foo = 1; }`},
+		{Code: `abstract class A { abstract set foo(v: string); foo = 1; }`},
+		{Code: `abstract class A { abstract get foo(): string; abstract set foo(v: string); }`},
+
+		// ─── constructor: non-static KindConstructor skipped (matches ESLint) ───
+		// In ESLint, both constructor() and 'constructor'() have kind="constructor"
+		// and are skipped. TypeScript-Go parses them as the same KindConstructor.
+		{Code: `class A { 'constructor'() {} }`},
+		{Code: `class A { 'constructor'() {} constructor() {} }`},
+		{Code: `class A { 'constructor'() {} 'constructor'() {} }`},
+		// static + non-static don't conflict
+		{Code: `class A { static constructor() {} constructor() {} }`},
+	}, []rule_tester.InvalidTestCase{
+		// ─── basic duplicates ───
+		{
+			Code: `class A { foo() {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 20},
+			},
+		},
+		{
+			Code: `!class A { foo() {} foo() {} };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 21},
+			},
+		},
+		// triple duplicate
+		{
+			Code: `class A { foo() {} foo() {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 20},
+				{MessageId: "unexpected", Line: 1, Column: 29},
+			},
+		},
+
+		// ─── string / numeric literal names ───
+		{
+			Code: `class A { 'foo'() {} 'foo'() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 22},
+			},
+		},
+		// empty string duplicate
+		{
+			Code: `class A { ''() {} ['']() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 19},
+			},
+		},
+		// 10 == 1e1
+		{
+			Code: `class A { 10() {} 1e1() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 19},
+			},
+		},
+		// 0x10 == 16
+		{
+			Code: `class A { [0x10]() {} 16() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 23},
+			},
+		},
+		// [100] == [1e2]
+		{
+			Code: `class A { [100]() {} [1e2]() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 22},
+			},
+		},
+		// BigInt [123n] == 123
+		{
+			Code: `class A { [123n]() {} 123() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 23},
+			},
+		},
+
+		// ─── computed (static expression) duplicates ───
+		{
+			Code: `class A { ['foo']() {} ['foo']() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		{
+			Code: "class A { [`foo`]() {} [`foo`]() {} }",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		// identifier + template literal
+		{
+			Code: "class A { foo() {} [`foo`]() {} }",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 20},
+			},
+		},
+		// computed 'constructor' duplicates (not the keyword constructor)
+		{
+			Code: `class A { ['constructor']() {} ['constructor']() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 32},
+			},
+		},
+		// three different syntaxes, same resolved name
+		{
+			Code: "class A { foo() {} ['foo']() {} [`foo`]() {} }",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 20},
+				{MessageId: "unexpected", Line: 1, Column: 33},
+			},
+		},
+
+		// ─── static duplicates ───
+		{
+			Code: `class A { static foo() {} static foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 34},
+			},
+		},
+		{
+			Code: `class A { static ['foo']() {} static foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 38},
+			},
+		},
+
+		// ─── method / accessor cross-kind conflicts ───
+		// method then getter
+		{
+			Code: `class A { foo() {} get foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		// setter then method
+		{
+			Code: `class A { set foo(value) {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 29},
+			},
+		},
+		// getter then method
+		{
+			Code: `class A { get foo() {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		// method then setter
+		{
+			Code: `class A { foo() {} set foo(v) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		// duplicate getters
+		{
+			Code: `class A { get foo() {} get foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 28},
+			},
+		},
+		// duplicate setters
+		{
+			Code: `class A { set foo(v) {} set foo(v) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 29},
+			},
+		},
+		// getter+setter pair then method (method conflicts with both)
+		{
+			Code: `class A { get foo() {} set foo(v) {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 38},
+			},
+		},
+		// static getter then static property (cross-kind within static)
+		{
+			Code: `class A { static get foo() {} static foo = 1; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 38},
+			},
+		},
+
+		// ─── property conflicts ───
+		{
+			Code: `class A { foo; foo = 42; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 16},
+			},
+		},
+		// property then method
+		{
+			Code: `class A { foo; foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 16},
+			},
+		},
+		// method then property
+		{
+			Code: `class A { foo() {} foo = 1; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 20},
+			},
+		},
+		// property then getter
+		{
+			Code: `class A { foo = 1; get foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		// property then setter
+		{
+			Code: `class A { foo = 1; set foo(v) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+		// property with arrow function initializer duplicate
+		{
+			Code: `class A { foo = () => {}; foo = () => {}; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 27},
+			},
+		},
+
+		// ─── nested classes: inner duplicates still reported ───
+		{
+			Code: `class Outer { bar() {} foo() { class Inner { baz() {} baz() {} } } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 55},
+			},
+		},
+		// class expression with duplicates
+		{
+			Code: `var x = class { foo() {} foo() {} };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 26},
+			},
+		},
+		// duplicates in both outer and inner class
+		{
+			Code: `class Outer { foo() {} foo() {} bar() { class Inner { baz() {} baz() {} } } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+				{MessageId: "unexpected", Line: 1, Column: 64},
+			},
+		},
+		// deeply nested: duplicate at innermost level
+		{
+			Code: `class L1 { a() { class L2 { b() { class L3 { foo() {} foo() {} } } } } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 55},
+			},
+		},
+		// class expression as property initializer with duplicates
+		{
+			Code: `class Outer { inner = class { foo() {} foo() {} }; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 40},
+			},
+		},
+
+		// ─── overload edge cases ───
+		// overload + implementation + extra implementation = duplicate
+		{
+			Code: `class A { foo(a: string): void; foo(a: any) {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 48},
+			},
+		},
+
+		// ─── async / generator duplicates ───
+		{
+			Code: `class A { async foo() {} async foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 32},
+			},
+		},
+		{
+			Code: `class A { *foo() {} *foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 22},
+			},
+		},
+		{
+			Code: `class A { async *foo() {} async *foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 34},
+			},
+		},
+		// async and non-async with same name
+		{
+			Code: `class A { foo() {} async foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 26},
+			},
+		},
+
+		// ─── __proto__ duplicate ───
+		{
+			Code: `class A { __proto__() {} __proto__() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 26},
+			},
+		},
+
+		// ─── class with extends: duplicates in child class still detected ───
+		{
+			Code: `class Base { foo() {} } class Child extends Base { foo() {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 61},
+			},
+		},
+
+		// ─── init before accessor pair → two errors (init taints both get and set) ───
+		{
+			Code: `class A { foo = 1; get foo() {} set foo(v) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+				{MessageId: "unexpected", Line: 1, Column: 37},
+			},
+		},
+
+		// ─── multiple independent duplicates (state isolation per name) ───
+		{
+			Code: `class A { foo() {} bar() {} foo() {} bar() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 29},
+				{MessageId: "unexpected", Line: 1, Column: 38},
+			},
+		},
+
+		// ─── dup getter, then setter: only getter errors, setter still pairs ───
+		{
+			Code: `class A { get foo() {} get foo() {} set foo(v) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 28},
+			},
+		},
+
+		// ─── method + dup getter + setter: method taints get, dup getter also errors ───
+		{
+			Code: `class A { foo() {} get foo() {} get foo() {} set foo(v) {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+				{MessageId: "unexpected", Line: 1, Column: 37},
+				{MessageId: "unexpected", Line: 1, Column: 50},
+			},
+		},
+
+		// ─── computed property declaration + method ───
+		{
+			Code: `class A { ['foo'] = 1; foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+
+		// ─── declare property + method (declare is still a PropertyDeclaration) ───
+		{
+			Code: `class A { declare foo: string; foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 32},
+			},
+		},
+
+		// ─── index signature skipped but duplicates still caught ───
+		{
+			Code: `class A { [key: string]: any; foo() {} foo() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 40},
+			},
+		},
+
+		// ─── definite assignment (!) doesn't affect name ───
+		{
+			Code: `class A { foo!: string; foo!: number; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 25},
+			},
+		},
+
+		// ─── [null] resolves to "null" ───
+		{
+			Code: `class A { [null]() {} 'null'() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 23},
+			},
+		},
+
+		// ─── octal [0o101] resolves to "65" ───
+		{
+			Code: `class A { [0o101]() {} 65() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 24},
+			},
+		},
+
+		// ─── binary [0b1010] resolves to "10" ───
+		{
+			Code: `class A { [0b1010]() {} 10() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 25},
+			},
+		},
+
+		// ─── static constructor duplicates (static constructor is a method, not the class constructor) ───
+		{
+			Code: `class A { static constructor() {} static constructor() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 35},
+			},
+		},
+		// static template constructor + static constructor
+		{
+			Code: "class A { static [`constructor`]() {} static constructor() {} }",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 39},
+			},
+		},
+		// static constructor + static string 'constructor'
+		{
+			Code: `class A { static constructor() {} static 'constructor'() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unexpected", Line: 1, Column: 35},
+			},
+		},
+	})
+}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -803,6 +803,8 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 			return NormalizeBigIntLiteral(expr.AsBigIntLiteral().Text), true
 		case ast.KindNoSubstitutionTemplateLiteral:
 			return expr.AsNoSubstitutionTemplateLiteral().Text, true
+		case ast.KindNullKeyword:
+			return "null", true
 		}
 		return "", false
 	default:
@@ -814,6 +816,14 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 // normalized string representation, matching ESLint's String(node.value) behavior.
 // e.g., "0x1" -> "1", "1.0" -> "1", "1e2" -> "100"
 func NormalizeNumericLiteral(text string) string {
+	// ParseFloat doesn't handle JS octal (0o) or binary (0b) prefixes.
+	// Parse them as integers first, then convert to float.
+	if len(text) > 2 && text[0] == '0' && (text[1] == 'o' || text[1] == 'O' || text[1] == 'b' || text[1] == 'B') {
+		if i, err := strconv.ParseInt(text, 0, 64); err == nil {
+			return strconv.FormatInt(i, 10)
+		}
+		return text
+	}
 	f, err := strconv.ParseFloat(text, 64)
 	if err != nil {
 		// ParseFloat returns +/-Inf with ErrRange for overflow (e.g. 1e309).

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"math"
+	"math/big"
 	"slices"
 	"strconv"
 	"strings"
@@ -817,10 +818,12 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 // e.g., "0x1" -> "1", "1.0" -> "1", "1e2" -> "100"
 func NormalizeNumericLiteral(text string) string {
 	// ParseFloat doesn't handle JS octal (0o) or binary (0b) prefixes.
-	// Parse them as integers first, then convert to float.
+	// Use big.Int to handle arbitrary precision, then convert to float64
+	// to match JavaScript's String(Number(...)) behavior.
 	if len(text) > 2 && text[0] == '0' && (text[1] == 'o' || text[1] == 'O' || text[1] == 'b' || text[1] == 'B') {
-		if i, err := strconv.ParseInt(text, 0, 64); err == nil {
-			return strconv.FormatInt(i, 10)
+		if n, ok := new(big.Int).SetString(text, 0); ok {
+			f, _ := new(big.Float).SetInt(n).Float64()
+			return strconv.FormatFloat(f, 'f', -1, 64)
 		}
 		return text
 	}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -131,7 +131,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/no-confusing-non-null-assertion.test.ts',
     './tests/typescript-eslint/rules/no-confusing-void-expression.test.ts',
     // './tests/typescript-eslint/rules/no-deprecated.test.ts',
-    // './tests/typescript-eslint/rules/no-dupe-class-members.test.ts',
+    './tests/typescript-eslint/rules/no-dupe-class-members.test.ts',
     './tests/typescript-eslint/rules/no-duplicate-enum-values.test.ts',
     './tests/typescript-eslint/rules/no-duplicate-type-constituents.test.ts',
     './tests/typescript-eslint/rules/no-dynamic-delete.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-dupe-class-members.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-dupe-class-members.test.ts.snap
@@ -1,0 +1,327 @@
+// Rstest Snapshot v1
+
+exports[`no-dupe-class-members > invalid 1`] = `
+{
+  "code": "
+class A {
+  foo() {}
+  foo() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 2`] = `
+{
+  "code": "
+!class A {
+  foo() {}
+  foo() {}
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 3`] = `
+{
+  "code": "
+class A {
+  'foo'() {}
+  'foo'() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 4`] = `
+{
+  "code": "
+class A {
+  10() {}
+  1e1() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '10'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 5`] = `
+{
+  "code": "
+class A {
+  foo() {}
+  foo() {}
+  foo() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 6`] = `
+{
+  "code": "
+class A {
+  static foo() {}
+  static foo() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 4,
+        },
+        "start": {
+          "column": 10,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 7`] = `
+{
+  "code": "
+class A {
+  foo() {}
+  get foo() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 8`] = `
+{
+  "code": "
+class A {
+  set foo(value) {}
+  foo() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 9`] = `
+{
+  "code": "
+class A {
+  foo;
+  foo = 42;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 10`] = `
+{
+  "code": "
+class A {
+  foo;
+  foo() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-dupe-class-members.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-dupe-class-members.test.ts
@@ -146,7 +146,7 @@ class A {
 }
       `,
       errors: [
-        { column: 3, data: { name: 'foo' }, line: 4, messageId: 'unexpected' },
+        { column: 10, data: { name: 'foo' }, line: 4, messageId: 'unexpected' },
       ],
     },
     {
@@ -157,7 +157,7 @@ class A {
 }
       `,
       errors: [
-        { column: 3, data: { name: 'foo' }, line: 4, messageId: 'unexpected' },
+        { column: 7, data: { name: 'foo' }, line: 4, messageId: 'unexpected' },
       ],
     },
     {


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/no-dupe-class-members` rule from typescript-eslint to rslint.

Disallows duplicate class members. Supports TypeScript method overload signatures (not flagged as duplicates) and abstract declarations. Handles all member types: methods, properties, getters, setters, computed property names, static members, and nested classes.

Also fixes two shared utility functions for better ESLint alignment:
- `GetStaticPropertyName`: handle `[null]` computed property (→ `"null"`)
- `NormalizeNumericLiteral`: handle JS octal (`0o`) and binary (`0b`) prefixes

## Related Links

- TypeScript-ESLint rule: https://typescript-eslint.io/rules/no-dupe-class-members/
- ESLint core rule: https://eslint.org/docs/latest/rules/no-dupe-class-members

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).