### PR TITLE
feat: port rule require-atomic-updates

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_object"
+	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
@@ -565,6 +566,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-unsafe-finally", no_unsafe_finally.NoUnsafeFinallyRule)
 	GlobalRuleRegistry.Register("no-unmodified-loop-condition", no_unmodified_loop_condition.NoUnmodifiedLoopConditionRule)
 	GlobalRuleRegistry.Register("no-unreachable", no_unreachable.NoUnreachableRule)
+	GlobalRuleRegistry.Register("require-atomic-updates", require_atomic_updates.RequireAtomicUpdatesRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/require_atomic_updates/require_atomic_updates.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.go
@@ -695,8 +695,9 @@ func (a *analyzer) report(assignmentNode *ast.Node, left *ast.Node, targetName s
 }
 
 // stmtAlwaysTerminates returns true if a statement always exits via
-// return/throw (so the state from this branch should NOT merge into
-// the continuation).
+// return/throw/break/continue (so the state from this branch should NOT merge
+// into the continuation). Checks all statements in a block — an early
+// return/throw in the middle means the block terminates even if dead code follows.
 func stmtAlwaysTerminates(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -705,11 +706,12 @@ func stmtAlwaysTerminates(node *ast.Node) bool {
 	case ast.KindReturnStatement, ast.KindThrowStatement:
 		return true
 	case ast.KindBlock:
-		statements := node.AsBlock().Statements.Nodes
-		if len(statements) == 0 {
-			return false
+		for _, stmt := range node.AsBlock().Statements.Nodes {
+			if stmtAlwaysTerminates(stmt) {
+				return true
+			}
 		}
-		return stmtAlwaysTerminates(statements[len(statements)-1])
+		return false
 	case ast.KindIfStatement:
 		ifStmt := node.AsIfStatement()
 		if ifStmt.ElseStatement == nil {
@@ -737,7 +739,6 @@ func (a *analyzer) walkIfStatement(node *ast.Node, state *analysisState) {
 		switch {
 		case thenExits && elseExits:
 			// Both branches exit — code after if is unreachable.
-			// Use either state (doesn't matter).
 			*state = *thenState
 		case thenExits:
 			// Only then exits — continuation only from else path.
@@ -753,9 +754,10 @@ func (a *analyzer) walkIfStatement(node *ast.Node, state *analysisState) {
 	} else {
 		if thenExits {
 			// Then-branch always exits — continuation only from the non-taken path.
-			// state already represents the pre-if state (condition was walked).
+			// state already holds the pre-if state (condition was walked).
 		} else {
-			*state = *thenState
+			// Then-branch may or may not execute — merge both possibilities.
+			state.merge(thenState)
 		}
 	}
 }
@@ -775,6 +777,21 @@ func (a *analyzer) walkConditionalExpression(node *ast.Node, state *analysisStat
 	*state = *consequentState
 }
 
+// clauseTerminates checks whether a case/default clause's statements end with
+// break/return/throw (i.e., no fallthrough to the next case).
+func clauseTerminates(statements []*ast.Node) bool {
+	for _, stmt := range statements {
+		if stmtAlwaysTerminates(stmt) {
+			return true
+		}
+		// break/continue also terminate a case clause
+		if stmt.Kind == ast.KindBreakStatement || stmt.Kind == ast.KindContinueStatement {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *analyzer) walkSwitchStatement(node *ast.Node, state *analysisState) {
 	switchStmt := node.AsSwitchStatement()
 
@@ -785,20 +802,40 @@ func (a *analyzer) walkSwitchStatement(node *ast.Node, state *analysisState) {
 		return
 	}
 
+	// fallthroughState accumulates across cases that don't break/return/throw.
+	// When a case terminates, its state merges into mergedState and fallthroughState resets.
 	mergedState := state.clone()
+	var fallthroughState *analysisState
+
 	for _, clause := range caseBlock.Clauses.Nodes {
-		clauseState := state.clone()
 		caseOrDefault := clause.AsCaseOrDefaultClause()
 		if caseOrDefault == nil {
 			continue
 		}
+
+		// Start from pre-switch state (direct jump to this case).
+		clauseState := state.clone()
+		// If the previous case fell through, merge its accumulated state.
+		if fallthroughState != nil {
+			clauseState.merge(fallthroughState)
+		}
+
 		if clause.Kind == ast.KindCaseClause && caseOrDefault.Expression != nil {
 			a.walkNode(caseOrDefault.Expression, clauseState)
 		}
+		var clauseStatements []*ast.Node
 		if caseOrDefault.Statements != nil {
-			a.walkStatements(caseOrDefault.Statements.Nodes, clauseState)
+			clauseStatements = caseOrDefault.Statements.Nodes
+			a.walkStatements(clauseStatements, clauseState)
 		}
+
 		mergedState.merge(clauseState)
+
+		if clauseTerminates(clauseStatements) {
+			fallthroughState = nil
+		} else {
+			fallthroughState = clauseState
+		}
 	}
 	*state = *mergedState
 }

--- a/internal/rules/require_atomic_updates/require_atomic_updates.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.go
@@ -1,0 +1,877 @@
+package require_atomic_updates
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func messageNonAtomicUpdate(value string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "nonAtomicUpdate",
+		Description: fmt.Sprintf("Possible race condition: `%s` might be reassigned based on an outdated value of `%s`.", value, value),
+	}
+}
+
+func messageNonAtomicObjectUpdate(value, object string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "nonAtomicObjectUpdate",
+		Description: fmt.Sprintf("Possible race condition: `%s` might be assigned based on an outdated state of `%s`.", value, object),
+	}
+}
+
+// analysisState tracks which variables have been read before/after an await/yield.
+//
+// Algorithm (mirrors ESLint's code-path segment approach):
+//   - When a variable is read, it is added to freshReads.
+//   - When an await/yield is encountered, all freshReads move to outdatedReads.
+//   - When an assignment targets an outdated variable, the rule reports.
+//   - Re-reading a variable removes it from outdated (the new read is current).
+type analysisState struct {
+	freshReads    map[string]bool
+	outdatedReads map[string]bool
+}
+
+func newAnalysisState() *analysisState {
+	return &analysisState{
+		freshReads:    make(map[string]bool),
+		outdatedReads: make(map[string]bool),
+	}
+}
+
+func (s *analysisState) clone() *analysisState {
+	fresh := make(map[string]bool, len(s.freshReads))
+	outdated := make(map[string]bool, len(s.outdatedReads))
+	for k := range s.freshReads {
+		fresh[k] = true
+	}
+	for k := range s.outdatedReads {
+		outdated[k] = true
+	}
+	return &analysisState{freshReads: fresh, outdatedReads: outdated}
+}
+
+// merge unions another branch's state into this one (used after if/else, ternary, etc.).
+func (s *analysisState) merge(other *analysisState) {
+	for k := range other.freshReads {
+		s.freshReads[k] = true
+	}
+	for k := range other.outdatedReads {
+		s.outdatedReads[k] = true
+	}
+}
+
+func (s *analysisState) markRead(varName string) {
+	s.freshReads[varName] = true
+	// A re-read after await captures the current value, so the variable is no longer outdated.
+	delete(s.outdatedReads, varName)
+}
+
+// makeOutdated moves all fresh reads to outdated (called on await/yield).
+func (s *analysisState) makeOutdated() {
+	for k := range s.freshReads {
+		s.outdatedReads[k] = true
+	}
+	s.freshReads = make(map[string]bool)
+}
+
+func (s *analysisState) isOutdated(varName string) bool {
+	return s.outdatedReads[varName]
+}
+
+// getIdentifierName returns the name if the node (after stripping parentheses) is an Identifier.
+func getIdentifierName(node *ast.Node) string {
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindIdentifier {
+		return n.AsIdentifier().Text
+	}
+	return ""
+}
+
+// getBaseIdentifierNode walks down a member expression chain (foo.bar[baz].qux)
+// and returns the base identifier node and its name. Unlike ast.GetFirstIdentifier,
+// this handles ElementAccessExpression and returns nil instead of panicking.
+func getBaseIdentifierNode(node *ast.Node) (*ast.Node, string) {
+	n := ast.SkipParentheses(node)
+	for n != nil {
+		switch n.Kind {
+		case ast.KindIdentifier:
+			return n, n.AsIdentifier().Text
+		case ast.KindPropertyAccessExpression:
+			n = ast.SkipParentheses(n.AsPropertyAccessExpression().Expression)
+		case ast.KindElementAccessExpression:
+			n = ast.SkipParentheses(n.AsElementAccessExpression().Expression)
+		default:
+			return nil, ""
+		}
+	}
+	return nil, ""
+}
+
+// normalizedNodeText returns the source text of a node with internal whitespace collapsed.
+// For example, "foo . bar" → "foo.bar". Used in diagnostic messages.
+func normalizedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
+	return strings.Join(strings.Fields(utils.TrimmedNodeText(sourceFile, node)), "")
+}
+
+// analyzer performs the require-atomic-updates analysis within one resumable
+// (async or generator) function. It walks the function body in evaluation order,
+// tracking variable reads relative to await/yield, and reports assignments that
+// may use stale values.
+type analyzer struct {
+	ctx             rule.RuleContext
+	funcNode        *ast.Node
+	allowProperties bool
+
+	// localVarsSafe: true = declared in this function and never referenced in a closure.
+	localVarsSafe map[string]bool
+	paramNames    map[string]bool
+	// declaredOuterVars: variables declared in outer scopes. Together with
+	// localVarsSafe, this is used to distinguish declared variables from
+	// undeclared globals (which are not tracked per ESLint semantics).
+	declaredOuterVars map[string]bool
+}
+
+func newAnalyzer(ctx rule.RuleContext, funcNode *ast.Node, allowProperties bool) *analyzer {
+	a := &analyzer{
+		ctx:               ctx,
+		funcNode:          funcNode,
+		allowProperties:   allowProperties,
+		localVarsSafe:     make(map[string]bool),
+		paramNames:        make(map[string]bool),
+		declaredOuterVars: make(map[string]bool),
+	}
+	a.collectLocalDeclarations()
+	a.collectOuterDeclarations()
+	return a
+}
+
+// collectLocalDeclarations gathers all declarations local to this function
+// and determines which ones escape to closures.
+func (a *analyzer) collectLocalDeclarations() {
+	allLocals := make(map[string]bool)
+	escapedLocals := make(map[string]bool)
+
+	if params := a.funcNode.Parameters(); params != nil {
+		for _, param := range params {
+			utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
+				allLocals[name] = true
+				a.paramNames[name] = true
+			})
+		}
+	}
+
+	body := a.funcNode.Body()
+	if body == nil {
+		return
+	}
+	a.collectDeclsInBlock(body, allLocals)
+	a.findEscapedVars(body, allLocals, escapedLocals, false, nil)
+
+	for name := range allLocals {
+		a.localVarsSafe[name] = !escapedLocals[name]
+	}
+}
+
+// collectOuterDeclarations walks up from the function to the source file,
+// collecting variable declarations in outer scopes. Undeclared globals are
+// not tracked (ESLint skips unresolved references).
+func (a *analyzer) collectOuterDeclarations() {
+	current := a.funcNode.Parent
+	for current != nil {
+		switch current.Kind {
+		case ast.KindSourceFile:
+			for _, stmt := range current.AsSourceFile().Statements.Nodes {
+				a.collectOuterDeclsFromStmt(stmt)
+			}
+		case ast.KindBlock:
+			for _, stmt := range current.AsBlock().Statements.Nodes {
+				a.collectOuterDeclsFromStmt(stmt)
+			}
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindArrowFunction, ast.KindMethodDeclaration:
+			if params := current.Parameters(); params != nil {
+				for _, param := range params {
+					utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
+						a.declaredOuterVars[name] = true
+					})
+				}
+			}
+		case ast.KindCatchClause:
+			cc := current.AsCatchClause()
+			if cc.VariableDeclaration != nil {
+				utils.CollectBindingNames(cc.VariableDeclaration.Name(), func(_ *ast.Node, name string) {
+					a.declaredOuterVars[name] = true
+				})
+			}
+		case ast.KindForStatement:
+			forStmt := current.AsForStatement()
+			if forStmt.Initializer != nil && forStmt.Initializer.Kind == ast.KindVariableDeclarationList {
+				a.collectDeclsFromVarList(forStmt.Initializer, a.declaredOuterVars)
+			}
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			stmt := current.AsForInOrOfStatement()
+			if stmt.Initializer != nil && stmt.Initializer.Kind == ast.KindVariableDeclarationList {
+				a.collectDeclsFromVarList(stmt.Initializer, a.declaredOuterVars)
+			}
+		}
+		current = current.Parent
+	}
+}
+
+func (a *analyzer) collectOuterDeclsFromStmt(stmt *ast.Node) {
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		stmt.ForEachChild(func(declList *ast.Node) bool {
+			if declList.Kind == ast.KindVariableDeclarationList {
+				a.collectDeclsFromVarList(declList, a.declaredOuterVars)
+			}
+			return false
+		})
+	case ast.KindFunctionDeclaration, ast.KindClassDeclaration:
+		if stmt.Name() != nil && stmt.Name().Kind == ast.KindIdentifier {
+			a.declaredOuterVars[stmt.Name().AsIdentifier().Text] = true
+		}
+	}
+}
+
+// collectDeclsFromVarList extracts variable names from a VariableDeclarationList.
+func (a *analyzer) collectDeclsFromVarList(declList *ast.Node, target map[string]bool) {
+	declList.ForEachChild(func(decl *ast.Node) bool {
+		if decl.Kind == ast.KindVariableDeclaration {
+			utils.CollectBindingNames(decl.Name(), func(_ *ast.Node, name string) {
+				target[name] = true
+			})
+		}
+		return false
+	})
+}
+
+// collectDeclsInBlock collects variable declarations from a block without
+// recursing into nested functions. The topLevel flag controls scoping:
+//   - topLevel=true  (function body): collect let/const/var/function/class
+//   - topLevel=false (nested block):  collect only var (it hoists to function scope)
+func (a *analyzer) collectDeclsInBlock(node *ast.Node, locals map[string]bool) {
+	a.collectDeclsInBlockImpl(node, locals, true)
+}
+
+func (a *analyzer) collectDeclsInBlockImpl(node *ast.Node, locals map[string]bool, topLevel bool) {
+	if node == nil {
+		return
+	}
+
+	node.ForEachChild(func(child *ast.Node) bool {
+		switch child.Kind {
+		case ast.KindVariableStatement:
+			child.ForEachChild(func(declList *ast.Node) bool {
+				if declList.Kind == ast.KindVariableDeclarationList {
+					// In nested blocks, only collect var (hoisted); skip let/const (block-scoped).
+					if topLevel || utils.IsVarKeyword(declList) {
+						a.collectDeclsFromVarList(declList, locals)
+					}
+				}
+				return false
+			})
+		case ast.KindFunctionDeclaration:
+			if child.Name() != nil && child.Name().Kind == ast.KindIdentifier {
+				locals[child.Name().AsIdentifier().Text] = true
+			}
+			// Don't recurse into the function body
+		case ast.KindClassDeclaration:
+			if child.Name() != nil && child.Name().Kind == ast.KindIdentifier {
+				locals[child.Name().AsIdentifier().Text] = true
+			}
+		default:
+			if !ast.IsFunctionLikeDeclaration(child) {
+				a.collectDeclsInBlockImpl(child, locals, false)
+			}
+		}
+		return false
+	})
+}
+
+// findEscapedVars finds local variables referenced inside nested functions.
+// shadowed tracks variables redeclared in inner scopes to avoid false positives
+// (e.g., inner `let foo` should not cause outer `foo` to be marked escaped).
+func (a *analyzer) findEscapedVars(node *ast.Node, locals map[string]bool, escaped map[string]bool, inNestedFunc bool, shadowed map[string]bool) {
+	if node == nil {
+		return
+	}
+
+	node.ForEachChild(func(child *ast.Node) bool {
+		if ast.IsFunctionLikeDeclaration(child) {
+			// Collect declarations in the nested function to detect shadowing
+			innerLocals := make(map[string]bool)
+			a.collectNestedFuncDecls(child, innerLocals)
+
+			innerShadowed := make(map[string]bool, len(shadowed)+len(innerLocals))
+			for k := range shadowed {
+				innerShadowed[k] = true
+			}
+			for k := range innerLocals {
+				innerShadowed[k] = true
+			}
+
+			a.findEscapedVars(child, locals, escaped, true, innerShadowed)
+			return false
+		}
+
+		if child.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(child) {
+			name := child.AsIdentifier().Text
+			if inNestedFunc && locals[name] && !shadowed[name] {
+				escaped[name] = true
+			}
+		}
+
+		a.findEscapedVars(child, locals, escaped, inNestedFunc, shadowed)
+		return false
+	})
+}
+
+func (a *analyzer) collectNestedFuncDecls(funcNode *ast.Node, decls map[string]bool) {
+	if params := funcNode.Parameters(); params != nil {
+		for _, param := range params {
+			utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
+				decls[name] = true
+			})
+		}
+	}
+	if body := funcNode.Body(); body != nil {
+		a.collectDeclsInBlock(body, decls)
+	}
+}
+
+// isDeclaredVariable returns true if the variable is declared in any scope
+// (local or outer). Falls back to TypeChecker to resolve globals from type
+// definitions (e.g., `process` from @types/node). Truly undeclared names return false.
+func (a *analyzer) isDeclaredVariable(name string, identNode *ast.Node) bool {
+	_, isLocal := a.localVarsSafe[name]
+	if isLocal || a.declaredOuterVars[name] {
+		return true
+	}
+	// TypeChecker can resolve globals from lib/types (e.g., process, console).
+	if a.ctx.TypeChecker != nil && identNode != nil {
+		sym := a.ctx.TypeChecker.GetSymbolAtLocation(identNode)
+		if sym == nil {
+			return false
+		}
+		// If the symbol is declared inside the current function, it's local (safe).
+		// This covers block-scoped variables (for-loop let, catch var) that our
+		// AST-based collection may have missed.
+		if sym.ValueDeclaration != nil && a.isNodeInsideFunc(sym.ValueDeclaration) {
+			a.localVarsSafe[name] = true
+			return true
+		}
+		return true
+	}
+	return false
+}
+
+// isNodeInsideFunc checks if a node is a descendant of the current function.
+func (a *analyzer) isNodeInsideFunc(node *ast.Node) bool {
+	return ast.FindAncestor(node, func(n *ast.Node) bool {
+		return n == a.funcNode
+	}) != nil
+}
+
+// isLocalVariableWithoutEscape returns true if the variable is local and
+// never referenced in a closure (i.e., no other concurrent code can observe it).
+// For member access on parameters, returns false because the object comes from outside.
+func (a *analyzer) isLocalVariableWithoutEscape(name string, isMemberAccess bool) bool {
+	if isMemberAccess && a.paramNames[name] {
+		return false
+	}
+	safe, exists := a.localVarsSafe[name]
+	return exists && safe
+}
+
+// run performs the analysis on parameter defaults and the function body.
+func (a *analyzer) run() {
+	body := a.funcNode.Body()
+	if body == nil {
+		return
+	}
+	state := newAnalysisState()
+	// Parameter default values are evaluated at call time and may contain await.
+	if params := a.funcNode.Parameters(); params != nil {
+		for _, param := range params {
+			p := param.AsParameterDeclaration()
+			if p != nil && p.Initializer != nil {
+				a.walkNode(p.Initializer, state)
+			}
+		}
+	}
+	a.walkNode(body, state)
+}
+
+// walkNode walks a node in evaluation order, updating the analysis state.
+func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
+	if node == nil {
+		return
+	}
+
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindConstructor,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		// Function boundaries: don't recurse (inner functions are separate scopes)
+		return
+
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		// Class bodies contain methods which are separate function scopes
+		return
+
+	case ast.KindBlock:
+		a.walkStatements(node.AsBlock().Statements.Nodes, state)
+
+	case ast.KindIfStatement:
+		a.walkIfStatement(node, state)
+
+	case ast.KindConditionalExpression:
+		a.walkConditionalExpression(node, state)
+
+	case ast.KindSwitchStatement:
+		a.walkSwitchStatement(node, state)
+
+	case ast.KindTryStatement:
+		a.walkTryStatement(node, state)
+
+	case ast.KindWhileStatement:
+		whileStmt := node.AsWhileStatement()
+		a.walkNode(whileStmt.Expression, state)
+		a.walkNode(whileStmt.Statement, state)
+
+	case ast.KindDoStatement:
+		doStmt := node.AsDoStatement()
+		a.walkNode(doStmt.Statement, state)
+		a.walkNode(doStmt.Expression, state)
+
+	case ast.KindForStatement:
+		a.walkForStatement(node, state)
+
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		stmt := node.AsForInOrOfStatement()
+		a.walkNode(stmt.Expression, state)
+		// for-await-of implicitly awaits on each iteration
+		if stmt.AwaitModifier != nil {
+			state.makeOutdated()
+		}
+		a.walkNode(stmt.Statement, state)
+
+	case ast.KindBinaryExpression:
+		a.walkBinaryExpression(node, state)
+
+	case ast.KindAwaitExpression:
+		// The operand is evaluated BEFORE the await pauses
+		if node.Expression() != nil {
+			a.walkNode(node.Expression(), state)
+		}
+		state.makeOutdated()
+
+	case ast.KindYieldExpression:
+		// The operand is evaluated BEFORE the yield pauses
+		if node.Expression() != nil {
+			a.walkNode(node.Expression(), state)
+		}
+		state.makeOutdated()
+
+	case ast.KindIdentifier:
+		if !utils.IsNonReferenceIdentifier(node) {
+			if name := node.AsIdentifier().Text; name != "" {
+				state.markRead(name)
+			}
+		}
+
+	case ast.KindVariableDeclaration:
+		vd := node.AsVariableDeclaration()
+		// Walk binding pattern defaults (e.g., `const {a = await bar} = obj`)
+		// Declaration identifiers are skipped by IsNonReferenceIdentifier.
+		a.walkBindingDefaults(vd.Name(), state)
+		if vd.Initializer != nil {
+			a.walkNode(vd.Initializer, state)
+		}
+
+	case ast.KindExpressionStatement:
+		a.walkNode(node.Expression(), state)
+
+	case ast.KindReturnStatement, ast.KindThrowStatement:
+		if node.Expression() != nil {
+			a.walkNode(node.Expression(), state)
+		}
+
+	case ast.KindCallExpression:
+		call := node.AsCallExpression()
+		a.walkNode(call.Expression, state)
+		if call.Arguments != nil {
+			for _, arg := range call.Arguments.Nodes {
+				a.walkNode(arg, state)
+			}
+		}
+
+	case ast.KindNewExpression:
+		newExpr := node.AsNewExpression()
+		a.walkNode(newExpr.Expression, state)
+		if newExpr.Arguments != nil {
+			for _, arg := range newExpr.Arguments.Nodes {
+				a.walkNode(arg, state)
+			}
+		}
+
+	case ast.KindTaggedTemplateExpression:
+		tagged := node.AsTaggedTemplateExpression()
+		a.walkNode(tagged.Tag, state)
+		a.walkNode(tagged.Template, state)
+
+	case ast.KindParenthesizedExpression:
+		a.walkNode(node.AsParenthesizedExpression().Expression, state)
+
+	// TypeScript type wrappers: walk the runtime expression, skip the type annotation.
+	// Without this, type reference identifiers (e.g., MyType in `x as MyType`) would
+	// be incorrectly marked as variable reads.
+	case ast.KindAsExpression:
+		a.walkNode(node.AsAsExpression().Expression, state)
+	case ast.KindTypeAssertionExpression:
+		a.walkNode(node.AsTypeAssertion().Expression, state)
+	case ast.KindSatisfiesExpression:
+		a.walkNode(node.AsSatisfiesExpression().Expression, state)
+	case ast.KindNonNullExpression:
+		a.walkNode(node.AsNonNullExpression().Expression, state)
+
+	case ast.KindPropertyAccessExpression:
+		// Walk only the object expression, not the property name
+		a.walkNode(node.AsPropertyAccessExpression().Expression, state)
+
+	case ast.KindElementAccessExpression:
+		elem := node.AsElementAccessExpression()
+		a.walkNode(elem.Expression, state)
+		a.walkNode(elem.ArgumentExpression, state)
+
+	case ast.KindArrayLiteralExpression:
+		for _, elem := range node.AsArrayLiteralExpression().Elements.Nodes {
+			a.walkNode(elem, state)
+		}
+
+	case ast.KindObjectLiteralExpression:
+		for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
+			a.walkNode(prop, state)
+		}
+
+	case ast.KindSpreadElement:
+		a.walkNode(node.Expression(), state)
+
+	default:
+		a.walkChildren(node, state)
+	}
+}
+
+// walkBindingDefaults walks only the default-value initializers inside a
+// destructuring binding pattern (e.g., `{a = await bar}` or `[x = await y]`).
+// This is needed because default values are evaluated at runtime and may contain await.
+func (a *analyzer) walkBindingDefaults(nameNode *ast.Node, state *analysisState) {
+	if nameNode == nil {
+		return
+	}
+	switch nameNode.Kind {
+	case ast.KindObjectBindingPattern, ast.KindArrayBindingPattern:
+		nameNode.ForEachChild(func(child *ast.Node) bool {
+			if child.Kind == ast.KindBindingElement {
+				be := child.AsBindingElement()
+				if be.Initializer != nil {
+					a.walkNode(be.Initializer, state)
+				}
+				// Recurse into nested patterns (e.g., `{a: {b = await c}} = obj`)
+				if be.Name() != nil {
+					a.walkBindingDefaults(be.Name(), state)
+				}
+			}
+			return false
+		})
+	}
+}
+
+func (a *analyzer) walkStatements(statements []*ast.Node, state *analysisState) {
+	for _, stmt := range statements {
+		a.walkNode(stmt, state)
+	}
+}
+
+func (a *analyzer) walkChildren(node *ast.Node, state *analysisState) {
+	node.ForEachChild(func(child *ast.Node) bool {
+		a.walkNode(child, state)
+		return false
+	})
+}
+
+// walkBinaryExpression handles assignments and regular binary operations.
+func (a *analyzer) walkBinaryExpression(node *ast.Node, state *analysisState) {
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		a.walkChildren(node, state)
+		return
+	}
+
+	opKind := binary.OperatorToken.Kind
+
+	if !ast.IsAssignmentOperator(opKind) {
+		a.walkNode(binary.Left, state)
+		a.walkNode(binary.Right, state)
+		return
+	}
+
+	// --- Assignment expression ---
+	// Skip parentheses and TS type assertions (as T, <T>, !, satisfies T) on LHS.
+	left := ast.SkipOuterExpressions(binary.Left, ast.OEKParentheses|ast.OEKAssertions)
+	isCompound := ast.IsCompoundAssignment(opKind)
+	isMember := ast.IsAccessExpression(left)
+
+	// Determine the target variable name and its identifier node
+	var targetName string
+	var targetIdentNode *ast.Node
+	if isMember {
+		targetIdentNode, targetName = getBaseIdentifierNode(left)
+	} else {
+		targetName = getIdentifierName(left)
+		if left.Kind == ast.KindIdentifier {
+			targetIdentNode = left
+		}
+	}
+
+	if targetName == "" {
+		a.walkNode(binary.Left, state)
+		a.walkNode(binary.Right, state)
+		return
+	}
+
+	// Skip undeclared globals (ESLint skips unresolved references)
+	if !a.isDeclaredVariable(targetName, targetIdentNode) {
+		if isCompound {
+			a.walkNode(binary.Left, state)
+		}
+		a.walkNode(binary.Right, state)
+		return
+	}
+
+	// Local variables that don't escape can't have race conditions
+	if a.isLocalVariableWithoutEscape(targetName, isMember) {
+		if isCompound {
+			a.walkNode(binary.Left, state)
+		}
+		a.walkNode(binary.Right, state)
+		return
+	}
+
+	// For compound assignments (+=, -=, etc.), the LHS is read first.
+	// For simple assignment (=), the LHS is NOT marked as a fresh read
+	// (matches ESLint behavior: only the write target is registered).
+	if isCompound {
+		a.walkNode(binary.Left, state)
+	}
+
+	a.walkNode(binary.Right, state)
+
+	// Check if the target variable was outdated when assigned
+	if state.isOutdated(targetName) {
+		a.report(node, left, targetName, isMember)
+	}
+}
+
+func (a *analyzer) report(assignmentNode *ast.Node, left *ast.Node, targetName string, isMemberAccess bool) {
+	if isMemberAccess {
+		if a.allowProperties {
+			return
+		}
+		leftText := normalizedNodeText(a.ctx.SourceFile, left)
+		a.ctx.ReportNode(assignmentNode, messageNonAtomicObjectUpdate(leftText, targetName))
+	} else {
+		a.ctx.ReportNode(assignmentNode, messageNonAtomicUpdate(targetName))
+	}
+}
+
+// stmtAlwaysTerminates returns true if a statement always exits via
+// return/throw (so the state from this branch should NOT merge into
+// the continuation).
+func stmtAlwaysTerminates(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindReturnStatement, ast.KindThrowStatement:
+		return true
+	case ast.KindBlock:
+		statements := node.AsBlock().Statements.Nodes
+		if len(statements) == 0 {
+			return false
+		}
+		return stmtAlwaysTerminates(statements[len(statements)-1])
+	case ast.KindIfStatement:
+		ifStmt := node.AsIfStatement()
+		if ifStmt.ElseStatement == nil {
+			return false
+		}
+		return stmtAlwaysTerminates(ifStmt.ThenStatement) && stmtAlwaysTerminates(ifStmt.ElseStatement)
+	}
+	return false
+}
+
+func (a *analyzer) walkIfStatement(node *ast.Node, state *analysisState) {
+	ifStmt := node.AsIfStatement()
+
+	a.walkNode(ifStmt.Expression, state)
+
+	thenState := state.clone()
+	a.walkNode(ifStmt.ThenStatement, thenState)
+	thenExits := stmtAlwaysTerminates(ifStmt.ThenStatement)
+
+	if ifStmt.ElseStatement != nil {
+		elseState := state.clone()
+		a.walkNode(ifStmt.ElseStatement, elseState)
+		elseExits := stmtAlwaysTerminates(ifStmt.ElseStatement)
+
+		switch {
+		case thenExits && elseExits:
+			// Both branches exit — code after if is unreachable.
+			// Use either state (doesn't matter).
+			*state = *thenState
+		case thenExits:
+			// Only then exits — continuation only from else path.
+			*state = *elseState
+		case elseExits:
+			// Only else exits — continuation only from then path.
+			*state = *thenState
+		default:
+			// Neither exits — merge both paths.
+			thenState.merge(elseState)
+			*state = *thenState
+		}
+	} else {
+		if thenExits {
+			// Then-branch always exits — continuation only from the non-taken path.
+			// state already represents the pre-if state (condition was walked).
+		} else {
+			*state = *thenState
+		}
+	}
+}
+
+func (a *analyzer) walkConditionalExpression(node *ast.Node, state *analysisState) {
+	cond := node.AsConditionalExpression()
+
+	a.walkNode(cond.Condition, state)
+
+	consequentState := state.clone()
+	a.walkNode(cond.WhenTrue, consequentState)
+
+	alternateState := state.clone()
+	a.walkNode(cond.WhenFalse, alternateState)
+
+	consequentState.merge(alternateState)
+	*state = *consequentState
+}
+
+func (a *analyzer) walkSwitchStatement(node *ast.Node, state *analysisState) {
+	switchStmt := node.AsSwitchStatement()
+
+	a.walkNode(switchStmt.Expression, state)
+
+	caseBlock := switchStmt.CaseBlock.AsCaseBlock()
+	if caseBlock == nil {
+		return
+	}
+
+	mergedState := state.clone()
+	for _, clause := range caseBlock.Clauses.Nodes {
+		clauseState := state.clone()
+		caseOrDefault := clause.AsCaseOrDefaultClause()
+		if caseOrDefault == nil {
+			continue
+		}
+		if clause.Kind == ast.KindCaseClause && caseOrDefault.Expression != nil {
+			a.walkNode(caseOrDefault.Expression, clauseState)
+		}
+		if caseOrDefault.Statements != nil {
+			a.walkStatements(caseOrDefault.Statements.Nodes, clauseState)
+		}
+		mergedState.merge(clauseState)
+	}
+	*state = *mergedState
+}
+
+func (a *analyzer) walkTryStatement(node *ast.Node, state *analysisState) {
+	tryStmt := node.AsTryStatement()
+
+	tryState := state.clone()
+	if tryStmt.TryBlock != nil {
+		a.walkNode(tryStmt.TryBlock, tryState)
+	}
+
+	// The catch block may be entered at any point during try execution
+	// (an exception can occur after an await). Use the post-try state so
+	// the catch block sees all reads/outdating from the try block.
+	catchState := tryState.clone()
+	if tryStmt.CatchClause != nil {
+		a.walkNode(tryStmt.CatchClause, catchState)
+	}
+
+	tryState.merge(catchState)
+	*state = *tryState
+
+	if tryStmt.FinallyBlock != nil {
+		a.walkNode(tryStmt.FinallyBlock, state)
+	}
+}
+
+func (a *analyzer) walkForStatement(node *ast.Node, state *analysisState) {
+	forStmt := node.AsForStatement()
+	if forStmt.Initializer != nil {
+		a.walkNode(forStmt.Initializer, state)
+	}
+	if forStmt.Condition != nil {
+		a.walkNode(forStmt.Condition, state)
+	}
+	a.walkNode(forStmt.Statement, state)
+	if forStmt.Incrementor != nil {
+		a.walkNode(forStmt.Incrementor, state)
+	}
+}
+
+// RequireAtomicUpdatesRule disallows assignments that can lead to race conditions
+// due to usage of `await` or `yield`.
+var RequireAtomicUpdatesRule = rule.Rule{
+	Name: "require-atomic-updates",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		allowProperties := false
+		optsMap := utils.GetOptionsMap(options)
+		if optsMap != nil {
+			if v, ok := optsMap["allowProperties"]; ok {
+				if b, ok := v.(bool); ok {
+					allowProperties = b
+				}
+			}
+		}
+
+		enterFunction := func(node *ast.Node) {
+			flags := ast.GetFunctionFlags(node)
+			if flags&(ast.FunctionFlagsAsync|ast.FunctionFlagsGenerator) == 0 {
+				return
+			}
+			a := newAnalyzer(ctx, node, allowProperties)
+			a.run()
+		}
+
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: enterFunction,
+			ast.KindFunctionExpression:  enterFunction,
+			ast.KindArrowFunction:       enterFunction,
+			ast.KindMethodDeclaration:   enterFunction,
+			ast.KindGetAccessor:         enterFunction,
+			ast.KindSetAccessor:         enterFunction,
+		}
+	},
+}

--- a/internal/rules/require_atomic_updates/require_atomic_updates.md
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.md
@@ -1,0 +1,65 @@
+# require-atomic-updates
+
+## Rule Details
+
+Disallow assignments that can lead to race conditions due to usage of `await` or `yield`.
+
+This rule reports assignments to variables or properties in cases where the assignments may be based on outdated values. When a variable is read, then an `await` or `yield` pauses execution, the variable might be modified by another concurrent operation before the assignment completes.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let result;
+
+async function foo() {
+  result += await something;
+}
+
+async function bar() {
+  result = result + (await something);
+}
+
+function* baz() {
+  result += yield;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let result;
+
+async function foo() {
+  result = (await something) + result;
+}
+
+async function bar() {
+  const tmp = await something;
+  result += tmp;
+}
+
+async function baz() {
+  let localVar = 0;
+  localVar += await something;
+}
+```
+
+## Options
+
+### `allowProperties`
+
+When set to `true`, the rule does not report assignments to properties (only variables).
+
+```javascript
+/* eslint require-atomic-updates: ["error", { "allowProperties": true }] */
+
+async function foo(obj) {
+  if (!obj.done) {
+    obj.something = await getSomething(); // OK with allowProperties
+  }
+}
+```
+
+## Original Documentation
+
+[ESLint - require-atomic-updates](https://eslint.org/docs/latest/rules/require-atomic-updates)

--- a/internal/rules/require_atomic_updates/require_atomic_updates_test.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates_test.go
@@ -168,13 +168,34 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			// ---- this.foo: `this` is not a tracked variable ----
 			{Code: `async function x() { this.foo += await bar; }`},
 
-			// ---- Switch: break prevents fallthrough, read in case 1 doesn't affect case 2 ----
+			// ---- Switch: break prevents fallthrough ----
 			{Code: `
 				let foo;
 				async function x() {
 					switch (n) {
 						case 1: foo; break;
 						case 2: await bar; foo = 1; break;
+					}
+				}`},
+
+			// ---- Switch: return prevents fallthrough ----
+			{Code: `
+				let foo;
+				async function x() {
+					switch (n) {
+						case 1: foo; return;
+						case 2: await bar; foo = 1;
+					}
+				}`},
+
+			// ---- Switch: break in middle stops fallthrough to later cases ----
+			{Code: `
+				let foo;
+				async function x() {
+					switch (n) {
+						case 1: foo; break;
+						case 2: await bar;
+						case 3: foo = 1;
 					}
 				}`},
 
@@ -1232,6 +1253,21 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 							case 1: foo;
 							case 2: await bar;
 							case 3: foo = 1;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Switch: default case with fallthrough ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						switch (n) {
+							default: foo;
+							case 1: await bar; foo = 1;
 						}
 					}`,
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/rules/require_atomic_updates/require_atomic_updates_test.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates_test.go
@@ -168,6 +168,16 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			// ---- this.foo: `this` is not a tracked variable ----
 			{Code: `async function x() { this.foo += await bar; }`},
 
+			// ---- Switch: break prevents fallthrough, read in case 1 doesn't affect case 2 ----
+			{Code: `
+				let foo;
+				async function x() {
+					switch (n) {
+						case 1: foo; break;
+						case 2: await bar; foo = 1; break;
+					}
+				}`},
+
 			// ---- Property shorthand: await before shorthand ----
 			{Code: `let foo; async function x() { foo = {bar: await baz, foo}; }`},
 
@@ -216,6 +226,19 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 						await bar;
 						if (inner) return;
 						else throw new Error();
+					}
+					foo = 1;
+				}`},
+
+			// ---- Block with early return (dead code after) still terminates ----
+			{Code: `
+				let foo;
+				async function x() {
+					if (cond) {
+						foo;
+						await bar;
+						return;
+						console.log("dead code");
 					}
 					foo = 1;
 				}`},
@@ -1145,6 +1168,74 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "nonAtomicObjectUpdate"},
 					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- Fix #1: if without else — re-read in then shouldn't clear outdated for the non-taken path ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						await bar;
+						if (cond) { foo; }
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Fix #6: block with return in middle (dead code after) still terminates ----
+			// Then-branch terminates despite dead code after return → no report for code after if.
+			// Instead we test: block without early terminator in then-branch DOES report.
+			{
+				Code: `
+					let foo;
+					async function x() {
+						if (cond) {
+							foo;
+							await bar;
+							doStuff();
+						}
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Fix #7: switch fallthrough — read in case 1 carries to case 2 ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						switch (n) {
+							case 1:
+								foo;
+							case 2:
+								await bar;
+								foo = 1;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Switch: fallthrough across 3 cases ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						switch (n) {
+							case 1: foo;
+							case 2: await bar;
+							case 3: foo = 1;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
 				},
 			},
 		},

--- a/internal/rules/require_atomic_updates/require_atomic_updates_test.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates_test.go
@@ -1,0 +1,1152 @@
+package require_atomic_updates
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireAtomicUpdatesRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireAtomicUpdatesRule,
+		// ================================================================
+		// VALID CASES
+		// ================================================================
+		[]rule_tester.ValidTestCase{
+			// ---- Basic: no await/yield ----
+			{Code: `let foo; async function x() { foo += bar; }`},
+			{Code: `let foo; async function x() { foo = foo + bar; }`},
+			{Code: `let foo; function* x() { foo = bar + foo; }`},
+
+			// ---- Await BEFORE read of target → safe ----
+			{Code: `let foo; async function x() { foo = await bar + foo; }`},
+			{Code: `let foo; async function x() { foo = (await result)(foo); }`},
+			{Code: `let foo; async function x() { foo = bar(await something, foo) }`},
+
+			// ---- Local variable (declared inside function) → safe ----
+			{Code: `async function x() { let foo; foo += await bar; }`},
+			{Code: `function* x() { let foo; foo += yield bar; }`},
+			{Code: `async function x() { const foo = 0; const bar = foo + await baz; }`},
+
+			// ---- var hoisting: var declared after usage is still local ----
+			{Code: `async function x() { foo += await bar; var foo = 0; }`},
+
+			// ---- Parameter destructuring → local ----
+			{Code: `async function f({foo}) { foo += await bar; }`},
+			{Code: `async function f([foo]) { foo += await bar; }`},
+			{Code: `async function f({a: {b: foo}}) { foo += await bar; }`},
+
+			// ---- Object property write without member read before await ----
+			{Code: `const foo = {}; async function x() { foo.bar = await baz; }`},
+			{Code: `const foo = []; async function x() { foo[x] += 1; }`},
+
+			// ---- Ternary: read and await in different branches ----
+			{Code: `let foo; async function x() { foo = condition ? foo : await bar; }`},
+
+			// ---- Closure: inner function doesn't reference outer foo ----
+			{Code: `async function x() { let foo; bar(() => baz += 1); foo += await amount; }`},
+
+			// ---- Shadowed variable in inner closure ----
+			{Code: `async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }`},
+
+			// ---- Read and write before await (separate statements) ----
+			{Code: `let foo; async function x() { foo = foo + 1; await bar; }`},
+
+			// ---- Undeclared global → not tracked ----
+			{Code: `async function x() { foo += await bar; }`},
+
+			// ---- Re-read after await (separate statement) → current value ----
+			{Code: `
+				let count = 0
+				let queue = []
+				async function A(...args) {
+					count += 1
+					await new Promise(resolve=>resolve())
+					count -= 1
+					return
+				}`},
+
+			// ---- Await in unrelated statement, write to undeclared ----
+			{Code: `
+				async function run() {
+					await a;
+					b = 1;
+				}`},
+
+			// ---- Property: local variable declared with let → safe ----
+			{Code: `
+				async function f() {
+					let foo = {}
+					let bar = await get(foo.id);
+					foo.prop = bar.prop;
+				}`},
+
+			// ---- Property: different variable on LHS and RHS after await ----
+			{Code: `
+				async function f(foo) {
+					let bar = await get(foo.id);
+					bar.prop = foo.prop;
+				}`},
+
+			// ---- Property: parameter reassigned after await ----
+			{Code: `
+				async function f(foo) {
+					let bar = await get(foo.id);
+					foo = bar.prop;
+				}`},
+
+			// ---- try/catch: reads in different branches ----
+			{Code: `
+				async function f() {
+					try {
+						this.foo = doSomething();
+					} catch (e) {
+						this.foo = null;
+						await doElse();
+					}
+				}`},
+
+			// ---- records assigned, then used in closure after ----
+			{Code: `
+				async function f() {
+					let records
+					records = await a.records
+					g(() => { records })
+				}`},
+
+			// ---- Arrow function: local variable safe ----
+			{Code: `const f = async () => { let foo; foo += await bar; };`},
+
+			// ---- Arrow function expression body: await before read ----
+			{Code: `let foo; const f = async () => foo = await bar + foo;`},
+
+			// ---- Nested ternary: await before read (left of +) ----
+			{Code: `let foo; async function x() { foo = (await bar) ? foo : baz; }`},
+
+			// ---- Template literal: await before read ----
+			{Code: "let foo; async function x() { foo = `${await bar}${foo}`; }"},
+
+			// ---- Logical OR: no assignment to foo ----
+			{Code: `let foo; async function x() { const r = foo || await bar; }`},
+
+			// ---- for-of: loop variable is local ----
+			{Code: `async function x() { for (let foo of items) { foo += await bar; } }`},
+
+			// ---- for-in: loop variable is local ----
+			{Code: `async function x() { for (let foo in obj) { foo += await bar; } }`},
+
+			// ---- Nested async: inner function is separate scope ----
+			{Code: `let foo; async function x() { async function y() { let foo; foo += await bar; } }`},
+
+			// ---- Block-scoped let in inner block doesn't affect outer ----
+			// The outer foo is declared, inner let foo is block-scoped. No race on outer
+			// because the outer foo is only written, not read-before-await.
+			{Code: `let foo; async function x() { if (true) { let foo = 1; } foo = 1; }`},
+
+			// ---- var in inner block hoists to function scope → local, safe ----
+			{Code: `async function x() { if (true) { var foo = 0; } foo += await bar; }`},
+
+			// ---- TS type assertion: type name not treated as variable read ----
+			{Code: `let MyType = 0; async function x() { let v = (a as MyType); await bar; MyType = 1; }`},
+
+			// ---- NonNull assertion: safe when local ----
+			{Code: `async function x() { let foo: number | null = 1; foo! += await bar; }`},
+
+			// ---- Multiple awaits, but target only read after the last one ----
+			{Code: `let foo; async function x() { await a; await b; foo = foo + 1; }`},
+
+			// ---- Labeled statement wrapping async logic ----
+			{Code: `let foo; async function x() { label: { await bar; foo = 1; } }`},
+
+			// ---- Comma expression: await before read ----
+			{Code: `let foo; async function x() { foo = (await bar, foo); }`},
+
+			// ---- this.foo: `this` is not a tracked variable ----
+			{Code: `async function x() { this.foo += await bar; }`},
+
+			// ---- Property shorthand: await before shorthand ----
+			{Code: `let foo; async function x() { foo = {bar: await baz, foo}; }`},
+
+			// ---- Catch variable shadows outer: catch-local e is safe ----
+			{Code: `let e; async function x() { try { await bar; } catch (e) { e += 1; } }`},
+
+			// ---- for-await-of: loop variable is local ----
+			{Code: `async function x() { for await (const item of gen) { item.foo; } }`},
+
+			// ---- for-await-of: no read of outer var before loop ----
+			{Code: `let foo; async function x() { for await (const item of gen) { foo = item; } }`},
+
+			// ---- yield*: still a yield, but local var is safe ----
+			{Code: `function* x() { let foo; foo += yield* gen; }`},
+
+			// ---- Async IIFE: local variable safe ----
+			{Code: `(async () => { let foo; foo += await bar; })();`},
+
+			// ---- Computed property name: await in key, read in value (safe order) ----
+			{Code: `let foo; async function x() { foo = { [await bar]: foo }; }`},
+
+			// ---- Destructuring default without await: safe ----
+			{Code: `async function x() { let foo; const {a = foo} = obj; foo += await bar; }`},
+
+			// ---- Parameter default without await: safe ----
+			{Code: `let foo; async function x(a = foo) { foo = 1; }`},
+
+			// ---- Read+await inside terminating branch: continuation is safe ----
+			{Code: `
+				let foo;
+				async function x() {
+					if (cond) {
+						foo;
+						await bar;
+						return;
+					}
+					foo = 1;
+				}`},
+
+			// ---- Nested if: both inner branches terminate → outer terminates ----
+			{Code: `
+				let foo;
+				async function x() {
+					if (cond) {
+						foo;
+						await bar;
+						if (inner) return;
+						else throw new Error();
+					}
+					foo = 1;
+				}`},
+
+			// ---- Else terminates, then does not read foo ----
+			{Code: `
+				let foo;
+				async function x() {
+					if (cond) {
+						doStuff();
+					} else {
+						foo;
+						await bar;
+						return;
+					}
+					foo = 1;
+				}`},
+
+			// ---- allowProperties ----
+			{
+				Code: `
+					async function a(foo) {
+						if (foo.bar) {
+							foo.bar = await something;
+						}
+					}`,
+				Options: map[string]interface{}{"allowProperties": true},
+			},
+			{
+				Code: `
+					function* g(foo) {
+						baz = foo.bar;
+						yield something;
+						foo.bar = 1;
+					}`,
+				Options: map[string]interface{}{"allowProperties": true},
+			},
+
+			// ---- Exponential time regression test (many branches) ----
+			{Code: `
+				async function foo() {
+					if (1); if (2); if (3); if (4); if (5);
+					if (6); if (7); if (8); if (9); if (10);
+					if (11); if (12); if (13); if (14); if (15);
+					if (16); if (17); if (18); if (19); if (20);
+				}`},
+		},
+		// ================================================================
+		// INVALID CASES
+		// ================================================================
+		[]rule_tester.InvalidTestCase{
+			// ---- Compound assignment + await in RHS ----
+			{
+				Code: `let foo; async function x() { foo += await amount; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `if (1); let foo; async function x() { foo += await amount; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 39},
+				},
+			},
+
+			// ---- Inside while loop ----
+			{
+				Code: `let foo; async function x() { while (condition) { foo += await amount; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 51},
+				},
+			},
+
+			// ---- Simple assignment: read before await ----
+			{
+				Code: `let foo; async function x() { foo = foo + await amount; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Ternary in RHS ----
+			{
+				Code: `let foo; async function x() { foo = foo + (bar ? baz : await amount); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo = foo + (bar ? await amount : baz); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo = condition ? foo + await amount : somethingElse; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo = (condition ? foo : await bar) + await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Compound with extra term before await ----
+			{
+				Code: `let foo; async function x() { foo += bar + await amount; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Variable escapes to closure ----
+			{
+				Code: `async function x() { let foo; bar(() => foo); foo += await amount; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 47},
+				},
+			},
+
+			// ---- Generator with yield ----
+			{
+				Code: `let foo; function* x() { foo += yield baz }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- foo as argument before await argument ----
+			{
+				Code: `let foo; async function x() { foo = bar(foo, await something) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Member expression: static property ----
+			{
+				Code: `const foo = {}; async function x() { foo.bar += await baz }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate", Line: 1, Column: 38},
+				},
+			},
+
+			// ---- Member expression: computed property ----
+			{
+				Code: `const foo = []; async function x() { foo[bar].baz += await result;  }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate", Line: 1, Column: 38},
+				},
+			},
+
+			// ---- Member expression: private property ----
+			{
+				Code: `const foo = {}; class C { #bar; async wrap() { foo.#bar += await baz } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate", Line: 1, Column: 48},
+				},
+			},
+
+			// ---- Async generator: yield then await ----
+			{
+				Code: `let foo; async function* x() { foo = (yield foo) + await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 32},
+				},
+			},
+
+			// ---- Await call with target in args ----
+			{
+				Code: `let foo; async function x() { foo = foo + await result(foo); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Nested await with target in args ----
+			{
+				Code: `let foo; async function x() { foo = await result(foo, await somethingElse); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Inner async function in generator ----
+			{
+				Code: `function* x() { let foo; yield async function y() { foo += await bar; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 53},
+				},
+			},
+
+			// ---- Async generator: await then yield ----
+			{
+				Code: `let foo; async function* x() { foo = await foo + (yield bar); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 32},
+				},
+			},
+
+			// ---- Read inside await operand ----
+			{
+				Code: `let foo; async function x() { foo = bar + await foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Multiple errors in one expression ----
+			{
+				Code: `let foo = {}; async function x() { foo[bar].baz = await (foo.bar += await foo[bar].baz) }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate", Line: 1, Column: 58},
+					{MessageId: "nonAtomicObjectUpdate", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- String initialization ----
+			{
+				Code: `let foo = ''; async function x() { foo += await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- Nested ternary with foo in deep branch ----
+			{
+				Code: `let foo = 0; async function x() { foo = (a ? b : foo) + await bar; if (baz); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `let foo = 0; async function x() { foo = (a ? b ? c ? d ? foo : e : f : g : h) + await bar; if (baz); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- Cross-statement: property read → await → property write ----
+			{
+				Code: `
+					async function f(foo) {
+						let buz = await get(foo.id);
+						foo.bar = buz.bar;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- Property: default (no option) ----
+			{
+				Code: `
+					async function a(foo) {
+						if (foo.bar) {
+							foo.bar = await something;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			{
+				Code: `
+					function* g(foo) {
+						baz = foo.bar;
+						yield something;
+						foo.bar = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- Property: allowProperties=false ----
+			{
+				Code: `
+					async function a(foo) {
+						if (foo.bar) {
+							foo.bar = await something;
+						}
+					}`,
+				Options: map[string]interface{}{"allowProperties": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			{
+				Code: `
+					function* g(foo) {
+						baz = foo.bar;
+						yield something;
+						foo.bar = 1;
+					}`,
+				Options: map[string]interface{}{"allowProperties": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- allowProperties=true still reports variable issues ----
+			{
+				Code: `
+					let foo;
+					async function a() {
+						if (foo) {
+							foo = await something;
+						}
+					}`,
+				Options: map[string]interface{}{"allowProperties": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `
+					let foo;
+					function* g() {
+						baz = foo;
+						yield something;
+						foo = 1;
+					}`,
+				Options: map[string]interface{}{"allowProperties": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ================================================================
+			// Additional edge cases
+			// ================================================================
+
+			// ---- Arrow function (block body) ----
+			{
+				Code: `let foo; const f = async () => { foo += await bar; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Arrow function (expression body) ----
+			{
+				Code: `let foo; const f = async () => foo += await bar;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Async method in class ----
+			{
+				Code: `let foo; class C { async m() { foo += await bar; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Logical assignment operators ----
+			{
+				Code: `let foo; async function x() { foo ||= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo &&= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo ??= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Template literal: read before await ----
+			{
+				Code: "let foo; async function x() { foo = `${foo}${await bar}`; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Deeply nested member access ----
+			{
+				Code: `let foo; async function x() { foo.a.b.c += await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- Mixed bracket and dot access ----
+			{
+				Code: `let foo; async function x() { foo[0].bar += await baz; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- for loop body ----
+			{
+				Code: `let foo; async function x() { for (let i = 0; i < 10; i++) { foo += await bar; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- do-while loop body ----
+			{
+				Code: `let foo; async function x() { do { foo += await bar; } while (cond); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- for-in loop body ----
+			{
+				Code: `let foo; async function x() { for (const key in obj) { foo += await bar; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- for-of loop body ----
+			{
+				Code: `let foo; async function x() { for (const item of items) { foo += await bar; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- switch/case ----
+			{
+				Code: `let foo; async function x() { switch(x) { case 1: foo += await bar; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- try/catch: read in try, await in try, write in try ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						try {
+							foo += await bar;
+						} catch (e) {}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Cross-statement with if: read in condition, await+write in body ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						if (foo) {
+							foo = await bar;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Spread before await in array literal ----
+			{
+				Code: `let foo; async function x() { foo = [...foo, await bar]; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Await wrapped in parentheses ----
+			{
+				Code: `let foo; async function x() { foo = foo + (await bar); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Exponentiation assignment ----
+			{
+				Code: `let foo; async function x() { foo **= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Bitwise assignment ----
+			{
+				Code: `let foo; async function x() { foo &= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo |= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo ^= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Shift assignment ----
+			{
+				Code: `let foo; async function x() { foo <<= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo >>= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			{
+				Code: `let foo; async function x() { foo >>>= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- TypeScript: type assertion wrapping LHS ----
+			{
+				Code: `let foo; async function x() { (foo as any) += await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Nested property: compound on deep member ----
+			{
+				Code: `const obj = {}; async function x() { obj.a.b.c.d += await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- Variable in finally block: read before try/await, write in finally ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						if (foo > 0) {
+							try {
+								await doSomething();
+							} finally {
+								foo = 0;
+							}
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Multiple variables: only the stale one reported ----
+			{
+				Code: `let foo; let bar; async function x() { foo = foo + await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Await in condition of if, then compound assignment ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						if (await cond) {
+							foo = 1;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Block-scoped let NOT treated as function-local ----
+			// Inner `let foo` in if-block is block-scoped; outer `let foo` is non-local.
+			{
+				Code: `
+					let foo;
+					async function x() {
+						if (true) { let foo = 1; }
+						foo += await bar;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Comma expression: read before await ----
+			{
+				Code: `let foo; async function x() { foo = (foo, await bar); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Tagged template: read before await ----
+			{
+				Code: "let foo; async function x() { foo = tag`${foo}${await bar}`; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Object literal: read before await in values ----
+			{
+				Code: `let foo; async function x() { foo = {a: foo, b: await bar}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- new expression: read before await in args ----
+			{
+				Code: `let foo; async function x() { foo = new Cls(foo, await bar); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Nested async arrow inside async function ----
+			{
+				Code: `let foo; const outer = async () => { const inner = async () => { foo += await bar; }; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Async method in object literal ----
+			{
+				Code: `
+					let foo;
+					const obj = {
+						async method() { foo += await bar; }
+					};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Multiple awaits: read → first await → outdated stays through second await ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						await a;
+						await b;
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- NonNull assertion on LHS ----
+			{
+				Code: `let foo: number | null; async function x() { foo! += await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Deeply nested control flow ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						for (let i = 0; i < 10; i++) {
+							if (cond) {
+								try {
+									foo += await bar;
+								} catch (e) {}
+							}
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- void expression wrapping assignment ----
+			{
+				Code: `let foo; async function x() { void (foo += await bar); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- for-await-of: read before loop, write inside ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						for await (const item of gen) {
+							foo = item;
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Property shorthand: read before await ----
+			{
+				Code: `let foo; async function x() { foo = {foo, bar: await baz}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Computed property name: read in value before await in key ----
+			{
+				Code: `let foo; async function x() { foo = { a: foo, [await bar]: baz }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Logical OR: read-await pattern in assignment ----
+			{
+				Code: `let foo; async function x() { foo = foo || await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Logical AND: read-await pattern in assignment ----
+			{
+				Code: `let foo; async function x() { foo = foo && await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Nullish coalescing: read-await pattern in assignment ----
+			{
+				Code: `let foo; async function x() { foo = foo ?? await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Await inside parens of a call ----
+			{
+				Code: `let foo; async function x() { foo = foo.method(await bar); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Cross-statement: read in while condition, await+write in body ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						while (foo > 0) {
+							foo = await decrement();
+						}
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- yield* with outer var ----
+			{
+				Code: `let foo; function* x() { foo += yield* gen; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Subtraction assignment ----
+			{
+				Code: `let foo; async function x() { foo -= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Multiplication assignment ----
+			{
+				Code: `let foo; async function x() { foo *= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Division assignment ----
+			{
+				Code: `let foo; async function x() { foo /= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Remainder assignment ----
+			{
+				Code: `let foo; async function x() { foo %= await bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Parameter default with await: read before pause ----
+			{
+				Code: `let foo; async function x(a = foo + await bar) { foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Destructuring default with await ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						const {a = await bar} = obj;
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Nested destructuring default with await ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						const {a: {b = await bar}} = obj;
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- If-branch reads+awaits but does NOT exit → report ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						if (cond) {
+							foo;
+							await bar;
+						}
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Else-branch terminates but then-branch doesn't → then state used ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						if (cond) {
+							foo;
+							await bar;
+						} else {
+							return;
+						}
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Array destructuring default with await ----
+			{
+				Code: `
+					let foo;
+					async function x() {
+						foo;
+						const [a = await bar] = arr;
+						foo = 1;
+					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Global variable from ambient declaration (ESLint #15076) ----
+			// Mirrors ESLint's process.exitCode test: TypeChecker resolves the
+			// ambient `process` declaration, so it's tracked as a known variable.
+			{
+				Code: `
+					declare var process: { stdin: any; exitCode: number };
+					declare var opts: { spec: any };
+					declare function run(o: any): Promise<{ exit_code: number }>;
+					async () => {
+						opts.spec = process.stdin;
+						try {
+							const { exit_code } = await run(opts);
+							process.exitCode = exit_code;
+						} catch (e) {
+							process.exitCode = 1;
+						}
+					};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -263,6 +263,7 @@ export default defineConfig({
     './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-proto.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
+    './tests/eslint/rules/require-atomic-updates.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-atomic-updates.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-atomic-updates.test.ts.snap
@@ -1,0 +1,755 @@
+// Rstest Snapshot v1
+
+exports[`require-atomic-updates > invalid 1`] = `
+{
+  "code": "let foo; async function x() { foo += await amount; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 2`] = `
+{
+  "code": "if (1); let foo; async function x() { foo += await amount; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 3`] = `
+{
+  "code": "let foo; async function x() { while (condition) { foo += await amount; } }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 4`] = `
+{
+  "code": "let foo; async function x() { foo = foo + await amount; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 5`] = `
+{
+  "code": "let foo; async function x() { foo = foo + (bar ? baz : await amount); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 6`] = `
+{
+  "code": "let foo; async function x() { foo = foo + (bar ? await amount : baz); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 7`] = `
+{
+  "code": "let foo; async function x() { foo = condition ? foo + await amount : somethingElse; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 8`] = `
+{
+  "code": "let foo; async function x() { foo = (condition ? foo : await bar) + await bar; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 9`] = `
+{
+  "code": "let foo; async function x() { foo += bar + await amount; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 10`] = `
+{
+  "code": "async function x() { let foo; bar(() => foo); foo += await amount; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 11`] = `
+{
+  "code": "let foo; function* x() { foo += yield baz }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 12`] = `
+{
+  "code": "let foo; async function x() { foo = bar(foo, await something) }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 13`] = `
+{
+  "code": "const foo = {}; async function x() { foo.bar += await baz }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo.bar\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 14`] = `
+{
+  "code": "const foo = []; async function x() { foo[bar].baz += await result;  }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo[bar].baz\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 15`] = `
+{
+  "code": "const foo = {}; class C { #bar; async wrap() { foo.#bar += await baz } }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo.#bar\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 16`] = `
+{
+  "code": "let foo; async function* x() { foo = (yield foo) + await bar; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 17`] = `
+{
+  "code": "let foo; async function x() { foo = foo + await result(foo); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 18`] = `
+{
+  "code": "let foo; async function x() { foo = await result(foo, await somethingElse); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 19`] = `
+{
+  "code": "function* x() { let foo; yield async function y() { foo += await bar; } }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 20`] = `
+{
+  "code": "let foo; async function* x() { foo = await foo + (yield bar); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 21`] = `
+{
+  "code": "let foo; async function x() { foo = bar + await foo; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 22`] = `
+{
+  "code": "let foo = ''; async function x() { foo += await bar; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 23`] = `
+{
+  "code": "let foo = 0; async function x() { foo = (a ? b : foo) + await bar; if (baz); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 24`] = `
+{
+  "code": "let foo = 0; async function x() { foo = (a ? b ? c ? d ? foo : e : f : g : h) + await bar; if (baz); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 90,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 25`] = `
+{
+  "code": "
+        async function a(foo) {
+          if (foo.bar) {
+            foo.bar = await something;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo.bar\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 26`] = `
+{
+  "code": "
+        function* g(foo) {
+          baz = foo.bar;
+          yield something;
+          foo.bar = 1;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo.bar\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 5,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 27`] = `
+{
+  "code": "
+        let foo;
+        async function a() {
+          if (foo) {
+            foo = await something;
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 28`] = `
+{
+  "code": "
+        let foo;
+        function* g() {
+          baz = foo;
+          yield something;
+          foo = 1;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 6,
+        },
+        "start": {
+          "column": 11,
+          "line": 6,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/require-atomic-updates.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/require-atomic-updates.test.ts
@@ -1,0 +1,189 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-atomic-updates', {
+  valid: [
+    'let foo; async function x() { foo += bar; }',
+    'let foo; async function x() { foo = foo + bar; }',
+    'let foo; async function x() { foo = await bar + foo; }',
+    'async function x() { let foo; foo += await bar; }',
+    'let foo; async function x() { foo = (await result)(foo); }',
+    'let foo; async function x() { foo = bar(await something, foo) }',
+    'function* x() { let foo; foo += yield bar; }',
+    'const foo = {}; async function x() { foo.bar = await baz; }',
+    'const foo = []; async function x() { foo[x] += 1;  }',
+    'let foo; function* x() { foo = bar + foo; }',
+    'async function x() { let foo; bar(() => baz += 1); foo += await amount; }',
+    'let foo; async function x() { foo = condition ? foo : await bar; }',
+    'async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }',
+    'let foo; async function x() { foo = foo + 1; await bar; }',
+    'async function x() { foo += await bar; }',
+    // allowProperties
+    {
+      code: `
+        async function a(foo) {
+          if (foo.bar) {
+            foo.bar = await something;
+          }
+        }
+      `,
+      options: { allowProperties: true },
+    },
+    {
+      code: `
+        function* g(foo) {
+          baz = foo.bar;
+          yield something;
+          foo.bar = 1;
+        }
+      `,
+      options: { allowProperties: true },
+    },
+  ],
+
+  invalid: [
+    {
+      code: 'let foo; async function x() { foo += await amount; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'if (1); let foo; async function x() { foo += await amount; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { while (condition) { foo += await amount; } }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = foo + await amount; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = foo + (bar ? baz : await amount); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = foo + (bar ? await amount : baz); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = condition ? foo + await amount : somethingElse; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = (condition ? foo : await bar) + await bar; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo += bar + await amount; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'async function x() { let foo; bar(() => foo); foo += await amount; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; function* x() { foo += yield baz }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = bar(foo, await something) }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'const foo = {}; async function x() { foo.bar += await baz }',
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    {
+      code: 'const foo = []; async function x() { foo[bar].baz += await result;  }',
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    {
+      code: 'const foo = {}; class C { #bar; async wrap() { foo.#bar += await baz } }',
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    {
+      code: 'let foo; async function* x() { foo = (yield foo) + await bar; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = foo + await result(foo); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = await result(foo, await somethingElse); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'function* x() { let foo; yield async function y() { foo += await bar; } }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function* x() { foo = await foo + (yield bar); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo; async function x() { foo = bar + await foo; }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: "let foo = ''; async function x() { foo += await bar; }",
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo = 0; async function x() { foo = (a ? b : foo) + await bar; if (baz); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: 'let foo = 0; async function x() { foo = (a ? b ? c ? d ? foo : e : f : g : h) + await bar; if (baz); }',
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Property access - default (no allowProperties option)
+    {
+      code: `
+        async function a(foo) {
+          if (foo.bar) {
+            foo.bar = await something;
+          }
+        }
+      `,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    {
+      code: `
+        function* g(foo) {
+          baz = foo.bar;
+          yield something;
+          foo.bar = 1;
+        }
+      `,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // allowProperties: true still reports variable issues
+    {
+      code: `
+        let foo;
+        async function a() {
+          if (foo) {
+            foo = await something;
+          }
+        }
+      `,
+      options: { allowProperties: true },
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    {
+      code: `
+        let foo;
+        function* g() {
+          baz = foo;
+          yield something;
+          foo = 1;
+        }
+      `,
+      options: { allowProperties: true },
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `require-atomic-updates` rule from ESLint to rslint.

Disallow assignments that can lead to race conditions due to usage of `await` or `yield`. The rule detects when a variable is read, then an `await`/`yield` pauses execution, and then the variable is assigned — potentially using a stale value.

Key implementation details:
- AST-based DFS walk in evaluation order, tracking fresh/outdated variable reads relative to `await`/`yield`
- Branch-aware state forking/merging for if/else, ternary, switch, try/catch
- Termination-aware if-statement handling (return/throw in a branch excludes its state from continuation)
- TypeChecker fallback for resolving globals from type definitions (e.g., `process` from `@types/node`)
- Block-scoped variable isolation (`let`/`const` in inner blocks vs `var` hoisting)
- Closure escape detection with shadowing support
- `for await...of` implicit await handling
- Destructuring binding defaults and parameter default values with `await`
- TypeScript type assertion nodes (`as T`, `<T>`, `satisfies T`, `!`) correctly skipped

Supports `allowProperties` option.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/require-atomic-updates
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/require-atomic-updates.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).