### PR TITLE
feat: port rule no-restricted-imports

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,8 +59,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_require_imports"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_this_alias"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_boolean_literal_compare"
-	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_template_expression"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_condition"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_template_expression"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_arguments"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_assertion"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_argument"
@@ -110,6 +110,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/constructor_super"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case_last"
+	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
@@ -136,7 +137,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
-	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
@@ -144,6 +144,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
+	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
@@ -153,12 +154,12 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
 	"github.com/web-infra-dev/rslint/internal/rules/no_octal_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
+	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
-	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
@@ -536,6 +537,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-new-func", no_new_func.NoNewFuncRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
+	GlobalRuleRegistry.Register("no-restricted-imports", no_restricted_imports.NoRestrictedImportsRule)
 	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)

--- a/internal/rules/no_restricted_imports/no_restricted_imports.go
+++ b/internal/rules/no_restricted_imports/no_restricted_imports.go
@@ -1,0 +1,831 @@
+package no_restricted_imports
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// specifierInfo holds the node and type-only status of an import/export specifier,
+// used to report errors on the correct AST location.
+type specifierInfo struct {
+	node       *ast.Node
+	isTypeOnly bool
+}
+
+// importNameEntry is a single name→specifiers mapping, preserving insertion order.
+type importNameEntry struct {
+	name       string
+	specifiers []specifierInfo
+}
+
+// orderedImportNames preserves the insertion order of import names so that
+// errors are reported in source-code order (Go maps have non-deterministic iteration).
+type orderedImportNames struct {
+	entries []importNameEntry
+	index   map[string]int // name → index into entries
+}
+
+func newOrderedImportNames() *orderedImportNames {
+	return &orderedImportNames{index: make(map[string]int)}
+}
+
+func (o *orderedImportNames) add(name string, spec specifierInfo) {
+	if idx, ok := o.index[name]; ok {
+		o.entries[idx].specifiers = append(o.entries[idx].specifiers, spec)
+	} else {
+		o.index[name] = len(o.entries)
+		o.entries = append(o.entries, importNameEntry{name: name, specifiers: []specifierInfo{spec}})
+	}
+}
+
+// restrictedPathEntry represents one entry from the "paths" config option.
+// A single module path can have multiple entries with different importNames restrictions.
+type restrictedPathEntry struct {
+	message          string
+	importNames      []string
+	allowImportNames []string
+	allowTypeImports bool
+}
+
+// restrictedPatternGroup represents one entry from the "patterns" config option.
+// It matches import sources via either gitignore-style globs or regex.
+type restrictedPatternGroup struct {
+	matcher                *ignoreMatcher  // gitignore-style matcher (from "group")
+	regexMatcher           *regexp2.Regexp // regex matcher (from "regex"); uses regexp2 for JS-compatible lookahead/lookbehind
+	customMessage          string
+	importNames            []string
+	importNamePattern      *regexp2.Regexp
+	allowImportNames       []string
+	allowImportNamePattern *regexp2.Regexp
+	allowTypeImports       bool
+}
+
+// --- Gitignore-style Pattern Matcher ---
+//
+// Implements matching compatible with the npm `ignore` package used by ESLint.
+// Key behaviors:
+//   - Pattern without "/" matches at any depth (e.g., "bar" matches "foo/bar")
+//   - Pattern with "/" is anchored to root (e.g., "foo/bar" matches only "foo/bar")
+//   - "!" prefix negates a pattern; later patterns override earlier ones
+//   - "#" prefix is a comment (skipped)
+//   - Case-insensitive by default
+
+type ignoreMatcher struct {
+	patterns      []ignorePattern
+	caseSensitive bool
+}
+
+type ignorePattern struct {
+	negated bool
+	glob    string
+}
+
+func newIgnoreMatcher(patterns []string, caseSensitive bool) *ignoreMatcher {
+	m := &ignoreMatcher{caseSensitive: caseSensitive}
+	for _, raw := range patterns {
+		p := raw
+
+		negated := false
+		if strings.HasPrefix(p, "!") {
+			negated = true
+			p = p[1:]
+		}
+
+		if p == "" || strings.HasPrefix(p, "#") {
+			continue
+		}
+
+		// Escaped # → literal #
+		if strings.HasPrefix(p, "\\#") {
+			p = "#" + p[2:]
+		}
+
+		p = strings.TrimSuffix(p, "/")
+		if p == "" {
+			continue
+		}
+
+		// No "/" → match at any depth (gitignore: unrooted pattern)
+		if !strings.Contains(p, "/") {
+			p = "**/" + p
+		} else if strings.HasPrefix(p, "/") {
+			p = p[1:] // Leading "/" → anchored to root
+		}
+
+		m.patterns = append(m.patterns, ignorePattern{negated: negated, glob: p})
+	}
+	return m
+}
+
+// ignores returns true if path is matched (and not negated) by any pattern.
+func (m *ignoreMatcher) ignores(path string) bool {
+	ignored := false
+	for _, p := range m.patterns {
+		glob := p.glob
+		testPath := path
+		if !m.caseSensitive {
+			glob = strings.ToLower(glob)
+			testPath = strings.ToLower(testPath)
+		}
+		if matchIgnore(glob, testPath) {
+			ignored = !p.negated
+		}
+	}
+	return ignored
+}
+
+// matchIgnore checks for an exact match, then tries directory-prefix matching:
+// if any prefix of path (at a '/' boundary) matches the glob, the full path is
+// considered matched (gitignore directory semantics — matched directories include
+// all their contents). We skip empty-segment boundaries from "//" so that
+// doublestar's `*` (which matches zero chars) doesn't produce false positives.
+func matchIgnore(glob, path string) bool {
+	if matched, _ := doublestar.Match(glob, path); matched {
+		return true
+	}
+	for i := len(path) - 1; i > 0; i-- {
+		if path[i] == '/' && path[i-1] != '/' {
+			if matched, _ := doublestar.Match(glob, path[:i]); matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// --- Options Parsing ---
+//
+// The rule accepts two option formats (matching ESLint):
+//   1. Array of strings/objects: ["fs", { name: "foo", importNames: ["bar"] }]
+//   2. Single object with paths/patterns: [{ paths: [...], patterns: [...] }]
+
+func parseOptions(options any) (groupedPaths map[string][]restrictedPathEntry, patternGroups []restrictedPatternGroup) {
+	groupedPaths = make(map[string][]restrictedPathEntry)
+
+	// Handle the case where the config parser unwraps a single-element array,
+	// delivering a map directly instead of [map]. Wrap it back into an array.
+	if obj, ok := options.(map[string]interface{}); ok {
+		options = []interface{}{obj}
+	}
+
+	arr, ok := options.([]interface{})
+	if !ok || len(arr) == 0 {
+		return groupedPaths, patternGroups
+	}
+
+	// Detect format 2: first element is an object with "paths" or "patterns" key
+	isPathAndPatternsObject := false
+	if firstObj, ok := arr[0].(map[string]interface{}); ok {
+		_, hasPaths := firstObj["paths"]
+		_, hasPatterns := firstObj["patterns"]
+		if hasPaths || hasPatterns {
+			isPathAndPatternsObject = true
+		}
+	}
+
+	var restrictedPathsList []interface{}
+	var restrictedPatternsList []interface{}
+
+	if isPathAndPatternsObject {
+		obj, _ := arr[0].(map[string]interface{})
+		if paths, ok := obj["paths"]; ok {
+			if pathsArr, ok := paths.([]interface{}); ok {
+				restrictedPathsList = pathsArr
+			}
+		}
+		if patterns, ok := obj["patterns"]; ok {
+			if patternsArr, ok := patterns.([]interface{}); ok {
+				restrictedPatternsList = patternsArr
+			}
+		}
+	} else {
+		restrictedPathsList = arr
+	}
+
+	// Parse restricted paths
+	for _, item := range restrictedPathsList {
+		switch v := item.(type) {
+		case string:
+			groupedPaths[v] = append(groupedPaths[v], restrictedPathEntry{})
+		case map[string]interface{}:
+			name, _ := v["name"].(string)
+			rp := restrictedPathEntry{}
+			if msg, ok := v["message"].(string); ok {
+				rp.message = msg
+			}
+			rp.importNames = utils.ToStringSlice(v["importNames"])
+			rp.allowImportNames = utils.ToStringSlice(v["allowImportNames"])
+			if b, ok := v["allowTypeImports"].(bool); ok {
+				rp.allowTypeImports = b
+			}
+			groupedPaths[name] = append(groupedPaths[name], rp)
+		}
+	}
+
+	// Parse restricted patterns
+	if len(restrictedPatternsList) > 0 {
+		if _, isString := restrictedPatternsList[0].(string); isString {
+			// String array → single implicit group
+			var group []string
+			for _, p := range restrictedPatternsList {
+				if s, ok := p.(string); ok {
+					group = append(group, s)
+				}
+			}
+			patternGroups = append(patternGroups, restrictedPatternGroup{
+				matcher: newIgnoreMatcher(group, false),
+			})
+		} else {
+			// Object array → one group per object
+			for _, item := range restrictedPatternsList {
+				obj, ok := item.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				pg := restrictedPatternGroup{}
+				caseSensitive := false
+				if cs, ok := obj["caseSensitive"].(bool); ok {
+					caseSensitive = cs
+				}
+				if group := utils.ToStringSlice(obj["group"]); len(group) > 0 {
+					pg.matcher = newIgnoreMatcher(group, caseSensitive)
+				}
+				if regexStr, ok := obj["regex"].(string); ok {
+					opts := regexp2.RegexOptions(regexp2.IgnoreCase | regexp2.Unicode)
+					if caseSensitive {
+						opts = regexp2.Unicode
+					}
+					if re, err := regexp2.Compile(regexStr, opts); err == nil {
+						pg.regexMatcher = re
+					}
+				}
+				if msg, ok := obj["message"].(string); ok {
+					pg.customMessage = msg
+				}
+				pg.importNames = utils.ToStringSlice(obj["importNames"])
+				pg.allowImportNames = utils.ToStringSlice(obj["allowImportNames"])
+				if pattern, ok := obj["importNamePattern"].(string); ok && pattern != "" {
+					if re, err := regexp2.Compile(pattern, regexp2.Unicode); err == nil {
+						pg.importNamePattern = re
+					}
+				}
+				if pattern, ok := obj["allowImportNamePattern"].(string); ok && pattern != "" {
+					if re, err := regexp2.Compile(pattern, regexp2.Unicode); err == nil {
+						pg.allowImportNamePattern = re
+					}
+				}
+				if b, ok := obj["allowTypeImports"].(bool); ok {
+					pg.allowTypeImports = b
+				}
+				patternGroups = append(patternGroups, pg)
+			}
+		}
+	}
+	return groupedPaths, patternGroups
+}
+
+// --- Rule Definition ---
+
+var NoRestrictedImportsRule = rule.Rule{
+	Name: "no-restricted-imports",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		groupedPaths, patternGroups := parseOptions(options)
+
+		if len(groupedPaths) == 0 && len(patternGroups) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		checkNode := func(node *ast.Node, importSource string, importNames *orderedImportNames) {
+			checkRestrictedPathAndReport(&ctx, node, importSource, importNames, groupedPaths)
+			for i := range patternGroups {
+				if isRestrictedPattern(importSource, &patternGroups[i]) {
+					reportPathForPatterns(&ctx, node, &patternGroups[i], importNames, importSource)
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindImportDeclaration: func(node *ast.Node) {
+				importDecl := node.AsImportDeclaration()
+				if importDecl.ModuleSpecifier == nil {
+					return
+				}
+				importSource := strings.TrimSpace(utils.GetStaticStringValue(importDecl.ModuleSpecifier))
+				if importSource == "" {
+					return
+				}
+				checkNode(node, importSource, extractImportNames(importDecl))
+			},
+			ast.KindExportDeclaration: func(node *ast.Node) {
+				exportDecl := node.AsExportDeclaration()
+				if exportDecl.ModuleSpecifier == nil {
+					return
+				}
+				importSource := strings.TrimSpace(utils.GetStaticStringValue(exportDecl.ModuleSpecifier))
+				if importSource == "" {
+					return
+				}
+				checkNode(node, importSource, extractExportNames(exportDecl))
+			},
+			ast.KindImportEqualsDeclaration: func(node *ast.Node) {
+				ieDecl := node.AsImportEqualsDeclaration()
+				if ieDecl.ModuleReference == nil || ieDecl.ModuleReference.Kind != ast.KindExternalModuleReference {
+					return
+				}
+				extRef := ieDecl.ModuleReference.AsExternalModuleReference()
+				if extRef.Expression == nil {
+					return
+				}
+				// ESLint does NOT trim require() source — match that behavior exactly
+				importSource := utils.GetStaticStringValue(extRef.Expression)
+				if importSource == "" {
+					return
+				}
+				checkNode(node, importSource, newOrderedImportNames())
+			},
+		}
+	},
+}
+
+// --- Import/Export Name Extraction ---
+
+// extractImportNames builds a map from import name → specifier info for an ImportDeclaration.
+// - Default import → name "default"
+// - Namespace import (import * as ns) → name "*"
+// - Named imports → the source name before "as" (e.g., import { Foo as Bar } → "Foo")
+func extractImportNames(importDecl *ast.ImportDeclaration) *orderedImportNames {
+	importNames := newOrderedImportNames()
+	if importDecl.ImportClause == nil {
+		return importNames
+	}
+	ic := importDecl.ImportClause.AsImportClause()
+	if ic == nil {
+		return importNames
+	}
+	isWholeTypeOnly := ic.PhaseModifier == ast.KindTypeKeyword
+
+	// Default import: import foo from 'bar'
+	if ic.Name() != nil {
+		importNames.add("default", specifierInfo{
+			node:       importDecl.ImportClause,
+			isTypeOnly: isWholeTypeOnly,
+		})
+	}
+
+	if ic.NamedBindings == nil {
+		return importNames
+	}
+	switch ic.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		importNames.add("*", specifierInfo{
+			node:       ic.NamedBindings,
+			isTypeOnly: isWholeTypeOnly,
+		})
+	case ast.KindNamedImports:
+		ni := ic.NamedBindings.AsNamedImports()
+		if ni.Elements != nil {
+			for _, elem := range ni.Elements.Nodes {
+				spec := elem.AsImportSpecifier()
+				if spec == nil {
+					continue
+				}
+				name := specifierSourceName(spec.PropertyName, spec.Name())
+				importNames.add(name, specifierInfo{
+					node:       elem,
+					isTypeOnly: spec.IsTypeOnly || isWholeTypeOnly,
+				})
+			}
+		}
+	}
+	return importNames
+}
+
+// extractExportNames builds a map from export source name → specifier info for an ExportDeclaration.
+// - export * from 'foo' → name "*"
+// - export * as ns from 'foo' → name "*"
+// - export { Foo as Bar } from 'foo' → name "Foo" (the source module's export name)
+func extractExportNames(exportDecl *ast.ExportDeclaration) *orderedImportNames {
+	importNames := newOrderedImportNames()
+
+	if exportDecl.ExportClause == nil {
+		// export * from 'foo' — find the * token node for accurate error position
+		importNames.add("*", specifierInfo{
+			node:       findStarToken(exportDecl),
+			isTypeOnly: exportDecl.IsTypeOnly,
+		})
+		return importNames
+	}
+
+	switch exportDecl.ExportClause.Kind {
+	case ast.KindNamespaceExport:
+		// export * as ns from 'foo' — use * token for error position (matching ESLint)
+		importNames.add("*", specifierInfo{
+			node:       findStarToken(exportDecl),
+			isTypeOnly: exportDecl.IsTypeOnly,
+		})
+	case ast.KindNamedExports:
+		ne := exportDecl.ExportClause.AsNamedExports()
+		if ne.Elements != nil {
+			for _, elem := range ne.Elements.Nodes {
+				spec := elem.AsExportSpecifier()
+				if spec == nil {
+					continue
+				}
+				name := specifierSourceName(spec.PropertyName, spec.Name())
+				importNames.add(name, specifierInfo{
+					node:       elem,
+					isTypeOnly: spec.IsTypeOnly || exportDecl.IsTypeOnly,
+				})
+			}
+		}
+	}
+	return importNames
+}
+
+// specifierSourceName returns the "source" name of an import/export specifier.
+// For "import { Foo as Bar }", propertyName is Foo (the module export) and nameNode is Bar (the local binding).
+// When there is no "as" rename, propertyName is nil and nameNode is used for both.
+func specifierSourceName(propertyName *ast.Node, nameNode *ast.Node) string {
+	if propertyName != nil {
+		if name, ok := utils.GetStaticPropertyName(propertyName); ok {
+			return name
+		}
+	}
+	if nameNode != nil {
+		if name, ok := utils.GetStaticPropertyName(nameNode); ok {
+			return name
+		}
+	}
+	return ""
+}
+
+// findStarToken scans the ExportDeclaration to locate the `*` token node.
+// For `export * from 'foo'`, the `*` is a token without its own AST node; we
+// use the scanner to find it and GetOrCreateToken to materialize a node so that
+// ReportNode can highlight just the `*` (matching ESLint's behavior).
+func findStarToken(exportDecl *ast.ExportDeclaration) *ast.Node {
+	node := exportDecl.AsNode()
+	sf := ast.GetSourceFileOfNode(node)
+	if sf == nil {
+		return nil
+	}
+	s := scanner.GetScannerForSourceFile(sf, node.Pos())
+	for s.TokenStart() < node.End() {
+		if s.Token() == ast.KindAsteriskToken {
+			return sf.GetOrCreateToken(s.Token(), s.TokenFullStart(), s.TokenEnd(), node, ast.TokenFlagsNone)
+		}
+		s.Scan()
+	}
+	return nil
+}
+
+// --- Path Restriction Checking ---
+
+func checkRestrictedPathAndReport(
+	ctx *rule.RuleContext,
+	node *ast.Node,
+	importSource string,
+	importNames *orderedImportNames,
+	groupedPaths map[string][]restrictedPathEntry,
+) {
+	entries, ok := groupedPaths[importSource]
+	if !ok {
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.allowTypeImports && isTypeOnlyDeclaration(node) {
+			continue
+		}
+
+		// No importNames or allowImportNames → restrict the entire import path
+		if len(entry.importNames) == 0 && len(entry.allowImportNames) == 0 {
+			messageId := "path"
+			msg := fmt.Sprintf("'%s' import is restricted from being used.", importSource)
+			if entry.message != "" {
+				messageId = "pathWithCustomMessage"
+				msg += " " + entry.message
+			}
+			ctx.ReportNode(node, rule.RuleMessage{Id: messageId, Description: msg})
+			continue
+		}
+
+		for _, e := range importNames.entries {
+			if e.name == "*" {
+				reportStarForPath(ctx, node, e.specifiers[0], entry, importSource)
+				continue
+			}
+			if len(entry.importNames) > 0 && slices.Contains(entry.importNames, e.name) {
+				reportNameForPath(ctx, node, e.specifiers, entry, e.name, importSource, "importName", "importNameWithCustomMessage",
+					fmt.Sprintf("'%s' import from '%s' is restricted.", e.name, importSource))
+			}
+			if len(entry.allowImportNames) > 0 && !slices.Contains(entry.allowImportNames, e.name) {
+				reportNameForPath(ctx, node, e.specifiers, entry, e.name, importSource, "allowedImportName", "allowedImportNameWithCustomMessage",
+					fmt.Sprintf("'%s' import from '%s' is restricted because only %s %s allowed.",
+						e.name, importSource, formatEnglishList(entry.allowImportNames), isOrAre(entry.allowImportNames)))
+			}
+		}
+	}
+}
+
+// reportStarForPath reports an error for a namespace ("*") import against a path restriction.
+func reportStarForPath(ctx *rule.RuleContext, node *ast.Node, spec specifierInfo, entry restrictedPathEntry, importSource string) {
+	reportNode := spec.node
+	if reportNode == nil {
+		reportNode = node
+	}
+	if len(entry.importNames) > 0 {
+		messageId := "everything"
+		msg := fmt.Sprintf("* import is invalid because %s from '%s' %s restricted.",
+			formatEnglishList(entry.importNames), importSource, isOrAre(entry.importNames))
+		if entry.message != "" {
+			messageId = "everythingWithCustomMessage"
+			msg += " " + entry.message
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: messageId, Description: msg})
+	} else if len(entry.allowImportNames) > 0 {
+		messageId := "everythingWithAllowImportNames"
+		msg := fmt.Sprintf("* import is invalid because only %s from '%s' %s allowed.",
+			formatEnglishList(entry.allowImportNames), importSource, isOrAre(entry.allowImportNames))
+		if entry.message != "" {
+			messageId = "everythingWithAllowImportNamesAndCustomMessage"
+			msg += " " + entry.message
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: messageId, Description: msg})
+	}
+}
+
+// reportNameForPath reports errors for each non-type-only specifier with the given messageIds.
+func reportNameForPath(ctx *rule.RuleContext, node *ast.Node, specifiers []specifierInfo, entry restrictedPathEntry, name string, importSource string, messageId string, messageIdCustom string, baseMsg string) {
+	for _, spec := range specifiers {
+		if entry.allowTypeImports && spec.isTypeOnly {
+			continue
+		}
+		id := messageId
+		msg := baseMsg
+		if entry.message != "" {
+			id = messageIdCustom
+			msg += " " + entry.message
+		}
+		reportNode := spec.node
+		if reportNode == nil {
+			reportNode = node
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: id, Description: msg})
+	}
+}
+
+// --- Pattern Restriction Checking ---
+
+func isRestrictedPattern(importSource string, group *restrictedPatternGroup) bool {
+	if group.regexMatcher != nil {
+		matched, _ := group.regexMatcher.MatchString(importSource)
+		return matched
+	}
+	if group.matcher != nil {
+		return group.matcher.ignores(importSource)
+	}
+	return false
+}
+
+func reportPathForPatterns(
+	ctx *rule.RuleContext,
+	node *ast.Node,
+	group *restrictedPatternGroup,
+	importNames *orderedImportNames,
+	importSource string,
+) {
+	if group.allowTypeImports && isTypeOnlyDeclaration(node) {
+		return
+	}
+
+	customMessage := group.customMessage
+
+	// No specific import name restrictions → report the whole import
+	if len(group.importNames) == 0 && len(group.allowImportNames) == 0 &&
+		group.importNamePattern == nil && group.allowImportNamePattern == nil {
+		messageId := "patterns"
+		msg := fmt.Sprintf("'%s' import is restricted from being used by a pattern.", importSource)
+		if customMessage != "" {
+			messageId = "patternWithCustomMessage"
+			msg += " " + customMessage
+		}
+		ctx.ReportNode(node, rule.RuleMessage{Id: messageId, Description: msg})
+		return
+	}
+
+	for _, e := range importNames.entries {
+		if e.name == "*" {
+			reportStarForPattern(ctx, node, e.specifiers[0], group, importSource)
+			continue
+		}
+
+		// Check restricted import names (by name list or regex pattern)
+		if (len(group.importNames) > 0 && slices.Contains(group.importNames, e.name)) ||
+			(group.importNamePattern != nil && regexp2Match(group.importNamePattern, e.name)) {
+			reportSpecifiersForPattern(ctx, node, e.specifiers, group, e.name, importSource,
+				"patternAndImportName", "patternAndImportNameWithCustomMessage",
+				fmt.Sprintf("'%s' import from '%s' is restricted from being used by a pattern.", e.name, importSource))
+		}
+
+		if len(group.allowImportNames) > 0 && !slices.Contains(group.allowImportNames, e.name) {
+			reportSpecifiersForPattern(ctx, node, e.specifiers, group, e.name, importSource,
+				"allowedImportName", "allowedImportNameWithCustomMessage",
+				fmt.Sprintf("'%s' import from '%s' is restricted because only %s %s allowed.",
+					e.name, importSource, formatEnglishList(group.allowImportNames), isOrAre(group.allowImportNames)))
+		} else if group.allowImportNamePattern != nil && !regexp2Match(group.allowImportNamePattern, e.name) {
+			reportSpecifiersForPattern(ctx, node, e.specifiers, group, e.name, importSource,
+				"allowedImportNamePattern", "allowedImportNamePatternWithCustomMessage",
+				fmt.Sprintf("'%s' import from '%s' is restricted because only imports that match the pattern '%s' are allowed from '%s'.",
+					e.name, importSource, jsRegexString(group.allowImportNamePattern), importSource))
+		}
+	}
+}
+
+// reportStarForPattern reports an error for a namespace ("*") import against a pattern restriction.
+func reportStarForPattern(ctx *rule.RuleContext, node *ast.Node, spec specifierInfo, group *restrictedPatternGroup, importSource string) {
+	reportNode := spec.node
+	if reportNode == nil {
+		reportNode = node
+	}
+	customMessage := group.customMessage
+
+	if len(group.importNames) > 0 {
+		messageId := "patternAndEverything"
+		msg := fmt.Sprintf("* import is invalid because %s from '%s' %s restricted from being used by a pattern.",
+			formatEnglishList(group.importNames), importSource, isOrAre(group.importNames))
+		if customMessage != "" {
+			messageId = "patternAndEverythingWithCustomMessage"
+			msg += " " + customMessage
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: messageId, Description: msg})
+	} else if len(group.allowImportNames) > 0 {
+		messageId := "everythingWithAllowImportNames"
+		msg := fmt.Sprintf("* import is invalid because only %s from '%s' %s allowed.",
+			formatEnglishList(group.allowImportNames), importSource, isOrAre(group.allowImportNames))
+		if customMessage != "" {
+			messageId = "everythingWithAllowImportNamesAndCustomMessage"
+			msg += " " + customMessage
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: messageId, Description: msg})
+	} else if group.allowImportNamePattern != nil {
+		messageId := "everythingWithAllowedImportNamePattern"
+		msg := fmt.Sprintf("* import is invalid because only imports that match the pattern '%s' from '%s' are allowed.",
+			jsRegexString(group.allowImportNamePattern), importSource)
+		if customMessage != "" {
+			messageId = "everythingWithAllowedImportNamePatternWithCustomMessage"
+			msg += " " + customMessage
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: messageId, Description: msg})
+	} else if group.importNamePattern != nil {
+		messageId := "patternAndEverythingWithRegexImportName"
+		msg := fmt.Sprintf("* import is invalid because import name matching '%s' pattern from '%s' is restricted from being used.",
+			jsRegexString(group.importNamePattern), importSource)
+		if customMessage != "" {
+			messageId = "patternAndEverythingWithRegexImportNameAndCustomMessage"
+			msg += " " + customMessage
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: messageId, Description: msg})
+	}
+}
+
+// reportSpecifiersForPattern reports errors for each non-type-only specifier with the given messageIds.
+func reportSpecifiersForPattern(ctx *rule.RuleContext, node *ast.Node, specifiers []specifierInfo, group *restrictedPatternGroup, name string, importSource string, messageId string, messageIdCustom string, baseMsg string) {
+	for _, spec := range specifiers {
+		if group.allowTypeImports && spec.isTypeOnly {
+			continue
+		}
+		id := messageId
+		msg := baseMsg
+		if group.customMessage != "" {
+			id = messageIdCustom
+			msg += " " + group.customMessage
+		}
+		reportNode := spec.node
+		if reportNode == nil {
+			reportNode = node
+		}
+		ctx.ReportNode(reportNode, rule.RuleMessage{Id: id, Description: msg})
+	}
+}
+
+// --- Type-Only Declaration Checking ---
+
+// isTypeOnlyDeclaration checks whether an entire import/export declaration is type-only.
+// This is used for the allowTypeImports option at the declaration level.
+// For import declarations: true if "import type ..." or all specifiers have individual "type" keyword.
+// For export declarations: true if "export type ..." or all specifiers have individual "type" keyword.
+// For import equals: true if "import type x = require(...)".
+func isTypeOnlyDeclaration(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindImportDeclaration:
+		importDecl := node.AsImportDeclaration()
+		if importDecl.ImportClause == nil {
+			return false
+		}
+		ic := importDecl.ImportClause.AsImportClause()
+		if ic == nil {
+			return false
+		}
+		// "import type ..." at the clause level
+		if ic.PhaseModifier == ast.KindTypeKeyword {
+			return true
+		}
+		// All individual specifiers are "type" (e.g., import { type A, type B })
+		return allImportSpecifiersTypeOnly(ic)
+	case ast.KindExportDeclaration:
+		exportDecl := node.AsExportDeclaration()
+		if exportDecl.IsTypeOnly {
+			return true
+		}
+		return allExportSpecifiersTypeOnly(exportDecl)
+	case ast.KindImportEqualsDeclaration:
+		return node.AsImportEqualsDeclaration().IsTypeOnly
+	}
+	return false
+}
+
+func allImportSpecifiersTypeOnly(ic *ast.ImportClause) bool {
+	// Default imports cannot be individually type-only
+	if ic.Name() != nil {
+		return false
+	}
+	if ic.NamedBindings == nil || ic.NamedBindings.Kind != ast.KindNamedImports {
+		return false
+	}
+	ni := ic.NamedBindings.AsNamedImports()
+	if ni.Elements == nil || len(ni.Elements.Nodes) == 0 {
+		return false
+	}
+	for _, elem := range ni.Elements.Nodes {
+		if !elem.IsTypeOnly() {
+			return false
+		}
+	}
+	return true
+}
+
+func allExportSpecifiersTypeOnly(exportDecl *ast.ExportDeclaration) bool {
+	if exportDecl.ExportClause == nil || exportDecl.ExportClause.Kind != ast.KindNamedExports {
+		return false
+	}
+	ne := exportDecl.ExportClause.AsNamedExports()
+	if ne.Elements == nil || len(ne.Elements.Nodes) == 0 {
+		return false
+	}
+	for _, elem := range ne.Elements.Nodes {
+		if !elem.IsTypeOnly() {
+			return false
+		}
+	}
+	return true
+}
+
+// --- Utility Functions ---
+
+// formatEnglishList formats names as a single-quoted English list using Intl.ListFormat("en-US") style:
+// ["a"] → "'a'", ["a","b"] → "'a' and 'b'", ["a","b","c"] → "'a', 'b', and 'c'"
+func formatEnglishList(names []string) string {
+	quoted := make([]string, len(names))
+	for i, name := range names {
+		quoted[i] = "'" + name + "'"
+	}
+	switch len(quoted) {
+	case 0:
+		return ""
+	case 1:
+		return quoted[0]
+	case 2:
+		return quoted[0] + " and " + quoted[1]
+	default:
+		return strings.Join(quoted[:len(quoted)-1], ", ") + ", and " + quoted[len(quoted)-1]
+	}
+}
+
+// jsRegexString formats a Go regexp pattern in JavaScript RegExp.toString() notation: /pattern/u.
+// ESLint creates these patterns with `new RegExp(pattern, "u")` and interpolates them via toString().
+// jsRegexString formats a regex pattern in JavaScript RegExp.toString() notation: /pattern/u.
+func jsRegexString(re *regexp2.Regexp) string {
+	return "/" + re.String() + "/u"
+}
+
+// regexp2Match wraps regexp2.MatchString, discarding the error (timeout).
+func regexp2Match(re *regexp2.Regexp, s string) bool {
+	matched, _ := re.MatchString(s)
+	return matched
+}
+
+func isOrAre(names []string) string {
+	if len(names) == 1 {
+		return "is"
+	}
+	return "are"
+}

--- a/internal/rules/no_restricted_imports/no_restricted_imports.md
+++ b/internal/rules/no_restricted_imports/no_restricted_imports.md
@@ -1,0 +1,70 @@
+# no-restricted-imports
+
+## Rule Details
+
+Disallow specified modules when loaded by `import`. This rule allows you to specify imports that you don't want to use in your application.
+
+This can be useful if you want to restrict usage of certain modules, enforce alternatives, or prevent accidental use of deprecated APIs.
+
+Examples of **incorrect** code for this rule with `["error", "fs"]`:
+
+```javascript
+import fs from 'fs';
+export * from 'fs';
+```
+
+Examples of **correct** code for this rule with `["error", "fs"]`:
+
+```javascript
+import crypto from 'crypto';
+```
+
+## Options
+
+The rule accepts either an array of strings/objects or an object with `paths` and `patterns` properties.
+
+### String format
+
+```json
+"no-restricted-imports": ["error", "fs", "path"]
+```
+
+### Object format with paths and patterns
+
+```json
+"no-restricted-imports": ["error", {
+  "paths": [{
+    "name": "import-foo",
+    "importNames": ["Bar"],
+    "message": "Please use Bar from /import-bar/ instead."
+  }],
+  "patterns": [{
+    "group": ["import1/private/*"],
+    "message": "usage of import1 private modules not allowed."
+  }]
+}]
+```
+
+### Path options
+
+- `name` (required): The module name to restrict
+- `message`: Custom message to display
+- `importNames`: Restrict specific named exports
+- `allowImportNames`: Allow only specified named exports
+- `allowTypeImports`: Allow type-only imports (TypeScript)
+
+### Pattern options
+
+- `group`: Gitignore-style patterns
+- `regex`: Regular expression pattern
+- `message`: Custom message to display
+- `caseSensitive`: Case-sensitive matching (default: false)
+- `importNames`: Restrict specific named imports
+- `importNamePattern`: Regex pattern for import names
+- `allowImportNames`: Allow only specified named imports
+- `allowImportNamePattern`: Regex pattern for allowed import names
+- `allowTypeImports`: Allow type-only imports (TypeScript)
+
+## Original Documentation
+
+[ESLint: no-restricted-imports](https://eslint.org/docs/latest/rules/no-restricted-imports)

--- a/internal/rules/no_restricted_imports/no_restricted_imports_test.go
+++ b/internal/rules/no_restricted_imports/no_restricted_imports_test.go
@@ -1,0 +1,1290 @@
+package no_restricted_imports
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRestrictedImportsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRestrictedImportsRule,
+		// ========== Valid cases ==========
+		[]rule_tester.ValidTestCase{
+			// --- Basic: no options / non-matching ---
+			{Code: `import os from "os";`},
+			{Code: `import async from "async";`},
+			{Code: `import os from "os";`, Options: []interface{}{"osx"}},
+			{Code: `import fs from "fs";`, Options: []interface{}{"crypto"}},
+			{Code: `import path from "path";`, Options: []interface{}{"crypto", "stream", "os"}},
+			// Side-effect import not matching
+			{Code: `import "foo"`, Options: []interface{}{"crypto"}},
+			// Subpath import ≠ parent path (exact match semantics)
+			{Code: `import "foo/bar";`, Options: []interface{}{"foo"}},
+
+			// --- Paths option ---
+			{Code: `import withPaths from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{"foo", "bar"},
+			}}},
+
+			// --- Patterns option ---
+			{Code: `import withPatterns from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{"foo/c*"},
+			}}},
+
+			// --- Relative / absolute paths not matching ---
+			{Code: `import foo from 'foo';`, Options: []interface{}{"../foo"}},
+			{Code: `import foo from 'foo';`, Options: []interface{}{map[string]interface{}{"paths": []interface{}{"../foo"}}}},
+			{Code: `import foo from 'foo';`, Options: []interface{}{map[string]interface{}{"patterns": []interface{}{"../foo"}}}},
+			{Code: `import foo from 'foo';`, Options: []interface{}{"/foo"}},
+			{Code: `import relative from '../foo';`},
+			{Code: `import relative from '../foo';`, Options: []interface{}{"../notFoo"}},
+			{Code: `import absolute from '/foo';`},
+			{Code: `import absolute from '/foo';`, Options: []interface{}{"/notFoo"}},
+
+			// --- Gitignore negation ---
+			{Code: `import withGitignores from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{"foo/*", "!foo/bar"},
+			}}},
+			{Code: `import withPatterns from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group":   []interface{}{"foo/*", "!foo/bar"},
+					"message": "foo is forbidden, use bar instead",
+				}},
+			}}},
+
+			// --- Case sensitive not matching ---
+			{Code: `import x from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group":         []interface{}{"FOO"},
+					"caseSensitive": true,
+				}},
+			}}},
+
+			// --- importNames: allowed names not restricted ---
+			{Code: `import AllowedObject from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// Default import treated as "default", NOT as identifier text
+			{Code: `import DisallowedObject from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// Named import — source name differs from restricted
+			{Code: `import { AllowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// Alias: restriction checks source name (AllowedObject), not alias
+			{Code: `import { AllowedObject as DisallowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// Side-effect import with importNames → no specifiers → no error
+			{Code: `import "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// Namespace import from different module
+			{Code: `import * as DisallowedObject from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "bar", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+
+			// --- Export: non-restricted ---
+			{Code: `export * from "foo";`, Options: []interface{}{"bar"}},
+			{Code: `export * from "foo";`, Options: []interface{}{map[string]interface{}{
+				"name": "bar", "importNames": []interface{}{"DisallowedObject"},
+			}}},
+
+			// --- allowImportNames ---
+			{Code: `import { AllowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "allowImportNames": []interface{}{"AllowedObject"},
+				}},
+			}}},
+			{Code: `import { foo } from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"foo"}, "allowImportNames": []interface{}{"foo"},
+				}},
+			}}},
+			{Code: `export { bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "allowImportNames": []interface{}{"bar"},
+				}},
+			}}},
+			{Code: `export { bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"foo"}, "allowImportNames": []interface{}{"bar"},
+				}},
+			}}},
+
+			// --- Regex: non-matching ---
+			{Code: `import x from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"regex": "foo/baz"}},
+			}}},
+			{Code: `import x from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"regex": "FOO", "caseSensitive": true}},
+			}}},
+			// Regex negative lookahead: "foo/bar" NOT matched by "foo/(?!bar)"
+			{Code: `import x from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"regex": "foo/(?!bar)"}},
+			}}},
+
+			// --- importNamePattern: default import NOT matched ---
+			{Code: `import Foo from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+				}},
+			}}},
+			// importNamePattern: named import doesn't match
+			{Code: `import { Bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+				}},
+			}}},
+			// Aliased import: source name (Bar) doesn't match pattern ^Foo
+			{Code: `import { Bar as Foo } from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+				}},
+			}}},
+			// Default import NOT matched by importNames in patterns (only named "Foo" matches, not default)
+			{Code: `import Foo from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"**/my/relative-module"}, "importNames": []interface{}{"Foo"},
+				}},
+			}}},
+
+			// --- allowImportNamePattern ---
+			{Code: `import { Foo } from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"foo"}, "allowImportNamePattern": "^Foo",
+				}},
+			}}},
+
+			// --- Pattern importNames + importNamePattern together: default import ---
+			// Default import is "default", doesn't match importNames ["Foo"] or pattern "^Foo"
+			{Code: `import Foo from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"importNames": []interface{}{"Foo"}, "group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+				}},
+			}}},
+			// Default + named: only named matches pattern, default doesn't
+			{Code: `import Foo, { Baz as Bar } from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"**/my/relative-module"}, "importNamePattern": "^(Foo|Bar)",
+				}},
+			}}},
+
+			// --- TypeScript: type import allowed ---
+			{Code: `import type foo from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+			}}},
+			{Code: `import type { Bar } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+			}}},
+			{Code: `export type { Bar } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+			}}},
+			{Code: `import type { Bar } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"import-foo"}, "allowTypeImports": true,
+				}},
+			}}},
+			// import type = require() allowed
+			{Code: `import type foo = require("import-foo");`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+			}}},
+			// all specifiers individually type → whole import is type-only
+			{Code: `import { type A, type B } from "import-foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+			}}},
+			// export with all specifiers individually type
+			{Code: `export { type A, type B } from "import-foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+			}}},
+			// import Bar = Foo.Bar (namespace import, no external module → ignored)
+			{Code: `import Bar = Foo.Bar;`, Options: []interface{}{"Foo"}},
+			// export type * allowed with allowTypeImports
+			{Code: `export type * from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{"name": "foo", "allowTypeImports": true}},
+			}}},
+			// import type = require() allowed with pattern
+			{Code: `import type fs = require("fs");`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"f*"}, "allowTypeImports": true}},
+			}}},
+			// individual type specifier with importNames + allowTypeImports → allowed
+			{Code: `import { type Bar } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "import-foo", "importNames": []interface{}{"Bar"}, "allowTypeImports": true,
+				}},
+			}}},
+			{Code: `export { type Bar } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "import-foo", "importNames": []interface{}{"Bar"}, "allowTypeImports": true,
+				}},
+			}}},
+			// export { type bar, baz } where bar matches importNames + allowTypeImports: bar is type → skipped, baz doesn't match → no error
+			{Code: `export { type bar, baz } from "foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"bar"}, "allowTypeImports": true,
+				}},
+			}}},
+			// Pattern importNames + allowTypeImports: type specifier of matching name → skipped, non-matching name → no error
+			{Code: `import { Bar, type Baz } from "import/private/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"import/private/*"}, "importNames": []interface{}{"Baz"}, "allowTypeImports": true,
+				}},
+			}}},
+			// Pattern allowImportNames + allowTypeImports: Foo allowed, type Bar skipped
+			{Code: `import { Foo, type Bar } from "import/private/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"import/private/*"}, "allowImportNames": []interface{}{"Foo"}, "allowTypeImports": true,
+				}},
+			}}},
+			// Pattern allowImportNamePattern + allowTypeImports
+			{Code: `import { Foo, type Bar } from "import/private/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"import/private/*"}, "allowImportNamePattern": "^Foo", "allowTypeImports": true,
+				}},
+			}}},
+			// export { Baz, type Bar } with allowImportNames + allowTypeImports
+			{Code: `export { Baz, type Bar } from "import/private/bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"import/private/*"}, "allowImportNames": []interface{}{"Baz"}, "allowTypeImports": true,
+				}},
+			}}},
+			// export { bar, type baz } with path allowImportNames + allowTypeImports
+			{Code: `export { bar, type baz } from "import-foo";`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "import-foo", "allowImportNames": []interface{}{"bar"}, "allowTypeImports": true,
+				}},
+			}}},
+			// import = require() with path importNames: no specifiers → no importName error (valid)
+			{Code: `import foo = require('foo');`, Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"foo"},
+				}},
+			}}},
+			// @scoped package in pattern
+			{Code: `import { foo } from '@app/api/enums';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{
+					"group": []interface{}{"@app/api/*", "!@app/api/enums"},
+				}},
+			}}},
+			// String literal specifier: 'AllowedObject' (not in restriction list)
+			{Code: "import { 'AllowedObject' as bar } from \"foo\";", Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// String literal ' ' (space) is not '' (empty)
+			{Code: "import { ' ' as bar } from \"foo\";", Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{""},
+				}},
+			}}},
+			// Aliased string literal: source name 'AllowedObject' doesn't match restriction 'DisallowedObject'
+			{Code: "import { 'AllowedObject' as DisallowedObject } from \"foo\";", Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// export string literal specifier: source name 'AllowedObject' not restricted
+			{Code: "export { 'AllowedObject' } from \"foo\";", Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+			// export aliased string literal: source name 'AllowedObject' not restricted
+			{Code: "export { 'AllowedObject' as DisallowedObject } from \"foo\";", Options: []interface{}{map[string]interface{}{
+				"paths": []interface{}{map[string]interface{}{
+					"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+				}},
+			}}},
+
+			// --- Edge cases: ./ in import source (pattern matching via **/ handles . segment) ---
+			// unrooted pattern matches ./foo (** absorbs the . segment)
+			{Code: `import foo from './foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{"bar"},
+			}}},
+			// rooted pattern does NOT match ./foo/bar (npm ignore behavior: no ./ normalization)
+			{Code: `import foo from './foo/bar';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"foo/bar"}}},
+			}}},
+			// ./foo in pattern stays as-is (has /), does NOT match foo
+			{Code: `import foo from 'foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"./foo"}}},
+			}}},
+
+			// --- Edge case: consecutive slashes — foo/* does NOT match foo//bar ---
+			{Code: `import x from "foo//bar";`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"foo/*"}}},
+			}}},
+
+			// --- Edge case: whitespace in import source trimmed before matching ---
+			// 'foo ' and ' foo' are trimmed to 'foo', so they DON'T match pattern 'bar'
+			{Code: `import foo from 'foo ';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{"bar"},
+			}}},
+			{Code: `import foo from ' foo';`, Options: []interface{}{map[string]interface{}{
+				"patterns": []interface{}{"bar"},
+			}}},
+		},
+
+		// ========== Invalid cases ==========
+		[]rule_tester.InvalidTestCase{
+			// --- Basic string restriction ---
+			{
+				Code: `import "fs"`, Options: []interface{}{"fs"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import os from "os ";`, Options: []interface{}{"fs", "crypto ", "stream", "os"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import "foo/bar";`, Options: []interface{}{"foo/bar"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+
+			// --- Path option ---
+			{
+				Code: `import withPaths from "foo/bar";`, Options: []interface{}{map[string]interface{}{"paths": []interface{}{"foo/bar"}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+
+			// --- Pattern matching ---
+			{
+				Code: `import withPatterns from "foo/bar";`, Options: []interface{}{map[string]interface{}{"patterns": []interface{}{"foo"}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import withPatterns from "foo/bar";`, Options: []interface{}{map[string]interface{}{"patterns": []interface{}{"bar"}}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Pattern group with custom message ---
+			{
+				Code: `import withPatterns from "foo/baz";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo/*", "!foo/bar"}, "message": "foo is forbidden, use foo/bar instead",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternWithCustomMessage", Line: 1, Column: 1}},
+			},
+			// Pattern group exact match
+			{
+				Code: `import x from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"foo/bar"}}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Case sensitivity ---
+			{
+				Code: `import x from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"FOO"}}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Explicit caseSensitive: false
+			{
+				Code: `import x from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"FOO"}, "caseSensitive": false,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Gitignore negation: negation doesn't match → still restricted ---
+			{
+				Code: `import x from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"foo/*", "!foo/baz"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Export * ---
+			{
+				Code: `export * from "fs";`, Options: []interface{}{"fs"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// --- Export * as ns ---
+			{
+				Code: `export * as ns from "fs";`, Options: []interface{}{"fs"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// --- Export named ---
+			{
+				Code: `export {a} from "fs";`, Options: []interface{}{"fs"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// Export named with importNames + custom message
+			{
+				Code: `export {foo as b} from "fs";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "fs", "importNames": []interface{}{"foo"}, "message": "Don't import 'foo'.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 9}},
+			},
+			// Export * as ns with importNames → error on * token (column 8)
+			{
+				Code: `export * as ns from "fs";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "fs", "importNames": []interface{}{"foo"}, "message": "Don't import 'foo'.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "everythingWithCustomMessage", Line: 1, Column: 8}},
+			},
+
+			// --- Custom messages ---
+			{
+				Code: `import x from "foo";`, Options: []interface{}{map[string]interface{}{
+					"name": "foo", "message": "Please import from 'bar' instead.",
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "pathWithCustomMessage", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import x from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "message": "Please import from 'bar' instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "pathWithCustomMessage", Line: 1, Column: 1}},
+			},
+
+			// --- importNames: "default" ---
+			{
+				Code: `import DisallowedObject from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "importNames": []interface{}{"default"},
+						"message": "Please import the default import of 'foo' from /bar/ instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage"}},
+			},
+			// import foo, { bar } with importNames: ["default"] → only default reported
+			{
+				Code: `import foo, { bar } from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "mod", "importNames": []interface{}{"default"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importName"}},
+			},
+			// import foo, * as bar with importNames: ["default"] → BOTH default and * reported
+			{
+				Code: `import foo, * as bar from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "mod", "importNames": []interface{}{"default"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importName"},
+					{MessageId: "everything"},
+				},
+			},
+			// import foo, { default as bar } with importNames: ["default"] → both default and named "default" reported
+			{
+				Code: `import foo, { default as bar } from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "mod", "importNames": []interface{}{"default"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importName"},
+					{MessageId: "importName"},
+				},
+			},
+
+			// --- Star import with importNames ---
+			{
+				Code: `import * as All from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+						"message": "Please import 'DisallowedObject' from /bar/ instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "everythingWithCustomMessage"}},
+			},
+			// * import restricted as whole module (no importNames)
+			{
+				Code: `import * as bar from 'foo';`, Options: []interface{}{"foo"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+
+			// --- Named import restrictions ---
+			{
+				Code: `import { DisallowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+						"message": "Please import 'DisallowedObject' from /bar/ instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 10}},
+			},
+			// Aliased import — source name restricted
+			{
+				Code: `import { DisallowedObject as AllowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+						"message": "Please import 'DisallowedObject' from /bar/ instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 10}},
+			},
+			// Only restricted name in mixed import gets error
+			{
+				Code: `import { AllowedObject, DisallowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "importNames": []interface{}{"DisallowedObject"},
+						"message": "Please import 'DisallowedObject' from /bar/ instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 25}},
+			},
+
+			// --- Multiple restricted names → multiple errors ---
+			{
+				Code: `import { DisallowedObjectOne, DisallowedObjectTwo, AllowedObject } from "foo";`,
+				Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "importNames": []interface{}{"DisallowedObjectOne", "DisallowedObjectTwo"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importName", Line: 1, Column: 10},
+					{MessageId: "importName", Line: 1, Column: 31},
+				},
+			},
+
+			// --- Duplicate source name: import { a, a as b } → 2 errors ---
+			{
+				Code: `import { a, a as b } from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "mod", "importNames": []interface{}{"a"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importName", Line: 1, Column: 10},
+					{MessageId: "importName", Line: 1, Column: 13},
+				},
+			},
+			// export { x as y, x as z } → 2 errors on same source name
+			{
+				Code: `export { x as y, x as z } from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "mod", "importNames": []interface{}{"x"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importName", Line: 1, Column: 10},
+					{MessageId: "importName", Line: 1, Column: 18},
+				},
+			},
+
+			// --- Multiple path entries for same module ---
+			// Whole-module restriction + specific importName → 2 errors on { bar }
+			{
+				Code: `import { bar } from 'mod'`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{
+						map[string]interface{}{"name": "mod"},
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"bar"}, "message": "Import bar from qux instead."},
+					},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "path", Line: 1, Column: 1},
+					{MessageId: "importNameWithCustomMessage"},
+				},
+			},
+			// Multiple entries with different importNames → errors from each matching entry
+			{
+				Code: `import { foo, bar, baz } from 'mod'`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"foo"}, "message": "Import foo from qux instead."},
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"baz"}, "message": "Import baz from qux instead."},
+					},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importNameWithCustomMessage"},
+					{MessageId: "importNameWithCustomMessage"},
+				},
+			},
+			// * import with multiple path entries → error from each entry
+			{
+				Code: `import * as mod from 'mod'`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"foo"}, "message": "Import foo from qux instead."},
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"bar"}, "message": "Import bar from qux instead."},
+					},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "everythingWithCustomMessage"},
+					{MessageId: "everythingWithCustomMessage"},
+				},
+			},
+
+			// --- Real-world: React Native multiple restrictions ---
+			{
+				Code: `import { Image, Text, ScrollView } from 'react-native'`,
+				Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{
+						map[string]interface{}{"name": "react-native", "importNames": []interface{}{"Text"}, "message": "import Text from ui/_components instead"},
+						map[string]interface{}{"name": "react-native", "importNames": []interface{}{"ScrollView"}, "message": "import ScrollView from ui/_components instead"},
+						map[string]interface{}{"name": "react-native", "importNames": []interface{}{"Image"}, "message": "import Image from ui/_components instead"},
+					},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "importNameWithCustomMessage"},
+					{MessageId: "importNameWithCustomMessage"},
+					{MessageId: "importNameWithCustomMessage"},
+				},
+			},
+
+			// --- Relative/absolute path restrictions ---
+			{
+				Code: `import relative from '../foo';`, Options: []interface{}{"../foo"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import absolute from '/foo';`, Options: []interface{}{"/foo"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// Relative path matched by pattern
+			{
+				Code: `import x from '../foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"../foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Absolute path matched by pattern "foo" (matches /foo because "foo" component)
+			{
+				Code: `import x from '/foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Hash import with escaped # pattern
+			{
+				Code: `import x from '#foo/bar';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"\\#foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Regex ---
+			{
+				Code: `import x from "foo/baz";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"regex": "foo/baz", "message": "foo is forbidden, use bar instead",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternWithCustomMessage", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import x from "foo";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{"regex": "FOO"}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Regex case sensitive matching
+			{
+				Code: `import x from 'FOO';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"regex": "FOO", "caseSensitive": true,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Regex negative lookahead: "foo/baz" matched by "foo/(?!bar)"
+			{
+				Code: `import x from "foo/baz";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"regex": "foo/(?!bar)", "message": "foo is forbidden, use bar instead",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternWithCustomMessage", Line: 1, Column: 1}},
+			},
+			// Regex with importNamePattern
+			{
+				Code: `import { Foo } from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"regex": "my/relative-module", "importNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 10}},
+			},
+
+			// --- Pattern importNames ---
+			{
+				Code: `import { Foo } from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"**/my/relative-module"}, "importNames": []interface{}{"Foo"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 10}},
+			},
+			// Pattern importNames: multiple restricted in same import
+			{
+				Code: `import { Foo, Bar } from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"**/my/relative-module"}, "importNames": []interface{}{"Foo", "Bar"},
+						"message": "Import from @/utils instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "patternAndImportNameWithCustomMessage", Line: 1, Column: 10},
+					{MessageId: "patternAndImportNameWithCustomMessage", Line: 1, Column: 15},
+				},
+			},
+			// Pattern importNames: "default" matches default import
+			{
+				Code: `import Foo from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"mod"}, "importNames": []interface{}{"default"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName"}},
+			},
+			// Pattern importNames: default + namespace → 2 errors
+			{
+				Code: `import def, * as ns from 'mod';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"mod"}, "importNames": []interface{}{"default"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "patternAndImportName"},
+					{MessageId: "patternAndEverything"},
+				},
+			},
+
+			// --- Pattern importNamePattern ---
+			{
+				Code: `import { Foo } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 10}},
+			},
+			// Aliased: source name checked
+			{
+				Code: `import { Foo as Bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 10}},
+			},
+			// importNamePattern does not match default imports
+			{
+				Code: `import Foo, { Bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^(Foo|Bar)",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 15}},
+			},
+			// Multiple matches with importNamePattern
+			{
+				Code: `import { Foo, Bar } from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"**/my/relative-module"}, "importNamePattern": "^(Foo|Bar)",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "patternAndImportName", Line: 1, Column: 10},
+					{MessageId: "patternAndImportName", Line: 1, Column: 15},
+				},
+			},
+			// export with importNamePattern
+			{
+				Code: `export { Foo } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 10}},
+			},
+			// export * with importNamePattern → star reported at column 8 (the * token)
+			{
+				Code: `export * from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndEverythingWithRegexImportName", Line: 1, Column: 8}},
+			},
+
+			// --- importNames + importNamePattern together (OR logic) ---
+			// importNames has "Foo", importNamePattern has "^Bar" → { Foo, Bar } both match
+			{
+				Code: `import { Foo, Bar } from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"importNames": []interface{}{"Foo"}, "group": []interface{}{"**/my/relative-module"}, "importNamePattern": "^Bar",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "patternAndImportName", Line: 1, Column: 10},
+					{MessageId: "patternAndImportName", Line: 1, Column: 15},
+				},
+			},
+			// With both importNames and importNamePattern, * import uses importNames (has priority)
+			{
+				Code: `import * as All from '../../my/relative-module';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"importNames": []interface{}{"Foo"}, "group": []interface{}{"**/my/relative-module"},
+						"importNamePattern": "^Foo", "message": "Import from @/utils instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndEverythingWithCustomMessage"}},
+			},
+
+			// --- Star import with importNamePattern ---
+			{
+				Code: `import * as Foo from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndEverythingWithRegexImportName"}},
+			},
+
+			// --- Star import with pattern importNames ---
+			{
+				Code: `import * as All from 'foo-bar-baz';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"**"}, "importNames": []interface{}{"Foo", "Bar"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndEverything"}},
+			},
+
+			// --- Multiple pattern groups matching same import → separate errors ---
+			{
+				Code: `import * as All from "foo/bar";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{
+						map[string]interface{}{"group": []interface{}{"foo/*"}, "allowImportNames": []interface{}{"Foo", "Bar"}},
+						map[string]interface{}{"group": []interface{}{"*/bar"}, "allowImportNames": []interface{}{"Foo", "Bar"}, "message": "Good luck!"},
+					},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "everythingWithAllowImportNames"},
+					{MessageId: "everythingWithAllowImportNamesAndCustomMessage"},
+				},
+			},
+
+			// --- allowImportNames ---
+			{
+				Code: `import { AllowedObject, DisallowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "allowImportNames": []interface{}{"AllowedObject"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportName", Line: 1, Column: 25}},
+			},
+			// allowImportNames: multiple allowed, one not
+			{
+				Code: `import { foo, bar, baz, qux } from "foo-bar-baz";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo-bar-baz"}, "allowImportNames": []interface{}{"foo", "bar", "baz"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportName", Line: 1, Column: 25}},
+			},
+			// allowImportNames with star import
+			{
+				Code: `import * as AllowedObject from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "allowImportNames": []interface{}{"AllowedObject"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "everythingWithAllowImportNames"}},
+			},
+			// Pattern allowImportNames
+			{
+				Code: `import { AllowedObject, DisallowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "allowImportNames": []interface{}{"AllowedObject"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportName", Line: 1, Column: 25}},
+			},
+
+			// --- allowImportNamePattern ---
+			{
+				Code: `import { Bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "allowImportNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportNamePattern", Line: 1, Column: 10}},
+			},
+			{
+				Code: `export { Bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "allowImportNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportNamePattern", Line: 1, Column: 10}},
+			},
+			{
+				Code: `import * as Foo from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "allowImportNamePattern": "^Foo",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "everythingWithAllowedImportNamePattern"}},
+			},
+
+			// --- TypeScript ---
+			// Regular import fails even with allowTypeImports
+			{
+				Code: `import foo from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// import = require()
+			{
+				Code: `import foo = require('import-foo');`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{"name": "import-foo"}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// import = require() with pattern
+			{
+				Code: `import foo = require('import-foo');`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"import-foo"}}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Type import with restricted importNames still reported (no allowTypeImports)
+			{
+				Code: `import type { bar } from "mod";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "mod", "importNames": []interface{}{"bar"}, "message": "don't import 'bar' at all",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 15}},
+			},
+			// Mixed type and regular imports: only regular reported with allowTypeImports
+			{
+				Code: `import { Bar, type Baz } from "import-foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "import-foo", "importNames": []interface{}{"Bar", "Baz"}, "allowTypeImports": true,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importName", Line: 1, Column: 10}},
+			},
+			// export type * restricted (without allowTypeImports)
+			{
+				Code: `export type * from "foo";`, Options: []interface{}{"foo"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+			// Pattern with allowTypeImports: regular import fails, type import passes
+			{
+				Code: `import { Bar } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"import-foo"}, "allowTypeImports": true,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// Pattern with allowTypeImports + importNames: regular specifier reported, type specifier skipped
+			{
+				Code: `import { Foo, type Bar } from "import/private/bar";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"import/private/*"}, "importNames": []interface{}{"Foo", "Bar"}, "allowTypeImports": true,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "patternAndImportName", Line: 1, Column: 10},
+				},
+			},
+
+			// --- Side-effect import with allowTypeImports: still restricted (side-effect can't be type-only) ---
+			{
+				Code: `import 'import-foo';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{"name": "import-foo", "allowTypeImports": true}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+
+			// --- import = require() with allowTypeImports: regular require still restricted ---
+			{
+				Code: `import foo = require('import-foo');`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "import-foo", "allowTypeImports": true, "message": "Please use import-bar instead.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "pathWithCustomMessage", Line: 1, Column: 1}},
+			},
+
+			// --- export { Bar, type Baz } with allowTypeImports: only Bar reported ---
+			{
+				Code: `export { Bar, type Baz } from 'import-foo';`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "import-foo", "importNames": []interface{}{"Bar", "Baz"}, "allowTypeImports": true,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importName"}},
+			},
+
+			// --- export type { bar } with two path entries: one with allowTypeImports, one without ---
+			// First entry allows type imports of "foo" → skips. Second entry restricts "bar" without allowTypeImports → reports.
+			{
+				Code: `export type { bar } from "mod";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"foo"}, "allowTypeImports": true, "message": "import 'foo' only as type"},
+						map[string]interface{}{"name": "mod", "importNames": []interface{}{"bar"}, "message": "don't import 'bar' at all"},
+					},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage"}},
+			},
+
+			// --- export type * + export * with allowTypeImports: only regular export * reported ---
+			{
+				Code: "export type * from \"foo\";\nexport * from \"foo\";",
+				Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{"name": "foo", "allowTypeImports": true}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 2, Column: 1}},
+			},
+
+			// --- export {} from "mod" (empty named export): whole path still restricted ---
+			{
+				Code: "export { } from \"mod\";\nexport type { } from \"mod\";",
+				Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{"name": "mod", "allowTypeImports": true}},
+				}},
+				// export { } → no specifiers but not type-only → whole path restricted
+				// export type { } → type-only → allowed
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+
+			// --- allowTypeImports: false explicitly → type import still restricted ---
+			{
+				Code: "import { Foo } from 'restricted-path';\nimport type { Bar } from 'restricted-path';",
+				Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "restricted-path", "allowTypeImports": false, "message": "This import is restricted.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "pathWithCustomMessage", Line: 1, Column: 1},
+					{MessageId: "pathWithCustomMessage", Line: 2, Column: 1},
+				},
+			},
+
+			// --- import = require() with pattern ---
+			{
+				Code: `import fs = require("fs");`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{"group": []interface{}{"f*"}}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Type-only export matched by pattern (type-only but no allowTypeImports) ---
+			{
+				Code: `export type { InvalidTestCase } from '@typescript-eslint/utils/dist/ts-eslint';`,
+				Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"@typescript-eslint/utils/dist/*"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- allowImportNames + allowTypeImports: regular import of non-allowed name restricted ---
+			{
+				Code: `import { baz } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "allowImportNames": []interface{}{"bar"}, "allowTypeImports": true,
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportName", Line: 1, Column: 10}},
+			},
+
+			// --- Both paths AND patterns matching same import → errors from both ---
+			{
+				Code: `import foo from 'import1/private/foo';`, Options: []interface{}{map[string]interface{}{
+					"paths":    []interface{}{"import1/private/foo"},
+					"patterns": []interface{}{"import1/private/*"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "path", Line: 1, Column: 1},
+					{MessageId: "patterns", Line: 1, Column: 1},
+				},
+			},
+
+			// --- @scoped package matched by pattern ---
+			{
+				Code: `import { foo } from '@app/api/bar';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"@app/api/*", "!@app/api/enums"},
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- @scoped with importNamePattern ---
+			{
+				Code: `import { Foo_Enum } from '@app/api';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"regex": "@app/api$", "importNamePattern": "_Enum$",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndImportName", Line: 1, Column: 10}},
+			},
+
+			// --- String literal specifier names ---
+			// export { 'foo' as b } from "fs" with importNames: ["foo"]
+			{
+				Code: "export { 'foo' as b } from \"fs\";", Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "fs", "importNames": []interface{}{"foo"}, "message": "Don't import 'foo'.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 10}},
+			},
+			// export { 'foo' } from "fs" (no alias, StringLiteral name)
+			{
+				Code: "export { 'foo' } from \"fs\";", Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "fs", "importNames": []interface{}{"foo"}, "message": "Don't import 'foo'.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 10}},
+			},
+			// Empty string import name: export { '' } from "fs" with importNames: [""]
+			{
+				Code: "export { '' } from \"fs\";", Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "fs", "importNames": []interface{}{""}, "message": "Don't import ''.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "importNameWithCustomMessage", Line: 1, Column: 10}},
+			},
+
+			// --- Complex glob pattern ---
+			// **/*-*-baz matching foo-bar-baz
+			{
+				Code: `import * as All from 'foo-bar-baz';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"**/*-*-baz"}, "importNames": []interface{}{"Foo", "Bar"},
+						"message": "Use only 'Baz'.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndEverythingWithCustomMessage"}},
+			},
+			// pattern group with multiple exact paths
+			{
+				Code: `import x from "foo/baz";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group":   []interface{}{"foo/bar", "foo/baz"},
+						"message": "some foo sub-imports are restricted",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternWithCustomMessage", Line: 1, Column: 1}},
+			},
+
+			// --- Edge cases: ./ in import source matched by unrooted pattern ---
+			{
+				Code: `import foo from './foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import bar from './foo/bar';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"bar"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Edge case: consecutive slashes matched by unrooted pattern ---
+			{
+				Code: `import x from "foo//bar";`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			// foo/bar does NOT match foo//bar (rooted, strict)
+			{
+				Code: `import x from "foo//bar";`, Options: []interface{}{"foo//bar"},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "path", Line: 1, Column: 1}},
+			},
+
+			// --- Edge case: whitespace in source trimmed → matches pattern ---
+			{
+				Code: `import foo from 'foo ';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+			{
+				Code: `import foo from ' foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{"foo"},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patterns", Line: 1, Column: 1}},
+			},
+
+			// --- Missing messageId coverage ---
+			// allowedImportNameWithCustomMessage (path)
+			{
+				Code: `import { DisallowedObject } from "foo";`, Options: []interface{}{map[string]interface{}{
+					"paths": []interface{}{map[string]interface{}{
+						"name": "foo", "allowImportNames": []interface{}{"AllowedObject"},
+						"message": "Only 'AllowedObject' is allowed.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportNameWithCustomMessage"}},
+			},
+			// allowedImportNamePatternWithCustomMessage (pattern)
+			{
+				Code: `import { Bar } from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "allowImportNamePattern": "^Foo",
+						"message": "Only Foo* allowed.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "allowedImportNamePatternWithCustomMessage"}},
+			},
+			// everythingWithAllowedImportNamePatternWithCustomMessage
+			{
+				Code: `import * as All from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "allowImportNamePattern": "^Allow",
+						"message": "Only Allow* allowed.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "everythingWithAllowedImportNamePatternWithCustomMessage"}},
+			},
+			// patternAndEverythingWithRegexImportNameAndCustomMessage
+			{
+				Code: `import * as All from 'foo';`, Options: []interface{}{map[string]interface{}{
+					"patterns": []interface{}{map[string]interface{}{
+						"group": []interface{}{"foo"}, "importNamePattern": "^Foo",
+						"message": "Don't import Foo*.",
+					}},
+				}},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "patternAndEverythingWithRegexImportNameAndCustomMessage"}},
+			},
+		},
+	)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -265,6 +265,29 @@ func GetOptionsString(opts any) string {
 	return ""
 }
 
+// ToStringSlice converts a weakly-typed JSON array ([]interface{}) to []string,
+// extracting only the string elements. Returns nil if the input is nil, not an array,
+// or contains no strings. Useful for parsing rule options from JSON config.
+func ToStringSlice(val interface{}) []string {
+	if val == nil {
+		return nil
+	}
+	arr, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+	result := make([]string, 0, len(arr))
+	for _, item := range arr {
+		if s, ok := item.(string); ok {
+			result = append(result, s)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
 // NaturalCompare compares two strings using natural sort order,
 // where embedded numeric segments are compared by their numeric value
 // (e.g., "a2" < "a10" instead of "a10" < "a2").

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -245,6 +245,7 @@ export default defineConfig({
     './tests/eslint/rules/no-fallthrough.test.ts',
     './tests/eslint/rules/no-invalid-regexp.test.ts',
     './tests/eslint/rules/no-new-symbol.test.ts',
+    './tests/eslint/rules/no-restricted-imports.test.ts',
     './tests/eslint/rules/no-obj-calls.test.ts',
     './tests/eslint/rules/no-setter-return.test.ts',
     './tests/eslint/rules/no-unreachable.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-restricted-imports.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-restricted-imports.test.ts.snap
@@ -1,0 +1,1505 @@
+// Rstest Snapshot v1
+
+exports[`no-restricted-imports > invalid 1`] = `
+{
+  "code": "import "fs"",
+  "diagnostics": [
+    {
+      "message": "'fs' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 2`] = `
+{
+  "code": "import os from "os ";",
+  "diagnostics": [
+    {
+      "message": "'os' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 3`] = `
+{
+  "code": "import "foo/bar";",
+  "diagnostics": [
+    {
+      "message": "'foo/bar' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 4`] = `
+{
+  "code": "import withPaths from "foo/bar";",
+  "diagnostics": [
+    {
+      "message": "'foo/bar' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 5`] = `
+{
+  "code": "import withPatterns from "foo/bar";",
+  "diagnostics": [
+    {
+      "message": "'foo/bar' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 6`] = `
+{
+  "code": "import withPatterns from "foo/bar";",
+  "diagnostics": [
+    {
+      "message": "'foo/bar' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 7`] = `
+{
+  "code": "import withPatterns from "foo/baz";",
+  "diagnostics": [
+    {
+      "message": "'foo/baz' import is restricted from being used by a pattern. foo is forbidden, use foo/bar instead",
+      "messageId": "patternWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 8`] = `
+{
+  "code": "import x from 'foo';",
+  "diagnostics": [
+    {
+      "message": "'foo' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 9`] = `
+{
+  "code": "import x from "foo/bar";",
+  "diagnostics": [
+    {
+      "message": "'foo/bar' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 10`] = `
+{
+  "code": "export * from "fs";",
+  "diagnostics": [
+    {
+      "message": "'fs' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 11`] = `
+{
+  "code": "export * as ns from "fs";",
+  "diagnostics": [
+    {
+      "message": "'fs' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 12`] = `
+{
+  "code": "export {a} from "fs";",
+  "diagnostics": [
+    {
+      "message": "'fs' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 13`] = `
+{
+  "code": "export {foo as b} from "fs";",
+  "diagnostics": [
+    {
+      "message": "'foo' import from 'fs' is restricted. Don't import 'foo'.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 14`] = `
+{
+  "code": "import x from "foo";",
+  "diagnostics": [
+    {
+      "message": "'foo' import is restricted from being used. Please import from 'bar' instead.",
+      "messageId": "pathWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 15`] = `
+{
+  "code": "import DisallowedObject from "foo";",
+  "diagnostics": [
+    {
+      "message": "'default' import from 'foo' is restricted. Please import the default import of 'foo' from /bar/ instead.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 16`] = `
+{
+  "code": "import * as All from "foo";",
+  "diagnostics": [
+    {
+      "message": "* import is invalid because 'DisallowedObject' from 'foo' is restricted. Please import 'DisallowedObject' from /bar/ instead.",
+      "messageId": "everythingWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 17`] = `
+{
+  "code": "import { DisallowedObject } from "foo";",
+  "diagnostics": [
+    {
+      "message": "'DisallowedObject' import from 'foo' is restricted. Please import 'DisallowedObject' from /bar/ instead.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 18`] = `
+{
+  "code": "import { DisallowedObject as AllowedObject } from "foo";",
+  "diagnostics": [
+    {
+      "message": "'DisallowedObject' import from 'foo' is restricted. Please import 'DisallowedObject' from /bar/ instead.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 19`] = `
+{
+  "code": "import { DisallowedObjectOne, DisallowedObjectTwo, AllowedObject } from "foo";",
+  "diagnostics": [
+    {
+      "message": "'DisallowedObjectOne' import from 'foo' is restricted.",
+      "messageId": "importName",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+    {
+      "message": "'DisallowedObjectTwo' import from 'foo' is restricted.",
+      "messageId": "importName",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 20`] = `
+{
+  "code": "import relative from '../foo';",
+  "diagnostics": [
+    {
+      "message": "'../foo' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 21`] = `
+{
+  "code": "import x from "foo/baz";",
+  "diagnostics": [
+    {
+      "message": "'foo/baz' import is restricted from being used by a pattern. foo is forbidden, use bar instead",
+      "messageId": "patternWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 22`] = `
+{
+  "code": "import x from "foo";",
+  "diagnostics": [
+    {
+      "message": "'foo' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 23`] = `
+{
+  "code": "import x from "foo/baz";",
+  "diagnostics": [
+    {
+      "message": "'foo/baz' import is restricted from being used by a pattern. foo is forbidden, use bar instead",
+      "messageId": "patternWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 24`] = `
+{
+  "code": "import { Foo } from '../../my/relative-module';",
+  "diagnostics": [
+    {
+      "message": "'Foo' import from '../../my/relative-module' is restricted from being used by a pattern.",
+      "messageId": "patternAndImportName",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 25`] = `
+{
+  "code": "import { Foo } from 'foo';",
+  "diagnostics": [
+    {
+      "message": "'Foo' import from 'foo' is restricted from being used by a pattern.",
+      "messageId": "patternAndImportName",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 26`] = `
+{
+  "code": "import * as All from 'foo-bar-baz';",
+  "diagnostics": [
+    {
+      "message": "* import is invalid because 'Foo' and 'Bar' from 'foo-bar-baz' are restricted from being used by a pattern.",
+      "messageId": "patternAndEverything",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 27`] = `
+{
+  "code": "import { AllowedObject, DisallowedObject } from "foo";",
+  "diagnostics": [
+    {
+      "message": "'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' is allowed.",
+      "messageId": "allowedImportName",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 28`] = `
+{
+  "code": "import * as AllowedObject from "foo";",
+  "diagnostics": [
+    {
+      "message": "* import is invalid because only 'AllowedObject' from 'foo' is allowed.",
+      "messageId": "everythingWithAllowImportNames",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 29`] = `
+{
+  "code": "import { AllowedObject, DisallowedObject } from "foo";",
+  "diagnostics": [
+    {
+      "message": "'DisallowedObject' import from 'foo' is restricted because only 'AllowedObject' is allowed.",
+      "messageId": "allowedImportName",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 30`] = `
+{
+  "code": "import { Bar } from 'foo';",
+  "diagnostics": [
+    {
+      "message": "'Bar' import from 'foo' is restricted because only imports that match the pattern '/^Foo/u' are allowed from 'foo'.",
+      "messageId": "allowedImportNamePattern",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 31`] = `
+{
+  "code": "export { Bar } from 'foo';",
+  "diagnostics": [
+    {
+      "message": "'Bar' import from 'foo' is restricted because only imports that match the pattern '/^Foo/u' are allowed from 'foo'.",
+      "messageId": "allowedImportNamePattern",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 32`] = `
+{
+  "code": "import * as Foo from 'foo';",
+  "diagnostics": [
+    {
+      "message": "* import is invalid because only imports that match the pattern '/^Foo/u' from 'foo' are allowed.",
+      "messageId": "everythingWithAllowedImportNamePattern",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 33`] = `
+{
+  "code": "import * as Foo from 'foo';",
+  "diagnostics": [
+    {
+      "message": "* import is invalid because import name matching '/^Foo/u' pattern from 'foo' is restricted from being used.",
+      "messageId": "patternAndEverythingWithRegexImportName",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 34`] = `
+{
+  "code": "import foo from 'import-foo';",
+  "diagnostics": [
+    {
+      "message": "'import-foo' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 35`] = `
+{
+  "code": "import foo = require('import-foo');",
+  "diagnostics": [
+    {
+      "message": "'import-foo' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 36`] = `
+{
+  "code": "import type { bar } from "mod";",
+  "diagnostics": [
+    {
+      "message": "'bar' import from 'mod' is restricted. don't import 'bar' at all",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 37`] = `
+{
+  "code": "import { Bar, type Baz } from "import-foo";",
+  "diagnostics": [
+    {
+      "message": "'Bar' import from 'import-foo' is restricted.",
+      "messageId": "importName",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 38`] = `
+{
+  "code": "import 'import-foo';",
+  "diagnostics": [
+    {
+      "message": "'import-foo' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 39`] = `
+{
+  "code": "import foo = require('import-foo');",
+  "diagnostics": [
+    {
+      "message": "'import-foo' import is restricted from being used. Please use import-bar instead.",
+      "messageId": "pathWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 40`] = `
+{
+  "code": "export { Bar, type Baz } from 'import-foo';",
+  "diagnostics": [
+    {
+      "message": "'Bar' import from 'import-foo' is restricted.",
+      "messageId": "importName",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 41`] = `
+{
+  "code": "export type * from "foo";
+export * from "foo";",
+  "diagnostics": [
+    {
+      "message": "'foo' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 42`] = `
+{
+  "code": "export { } from "mod";
+export type { } from "mod";",
+  "diagnostics": [
+    {
+      "message": "'mod' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 43`] = `
+{
+  "code": "import { Foo } from 'restricted-path';
+import type { Bar } from 'restricted-path';",
+  "diagnostics": [
+    {
+      "message": "'restricted-path' import is restricted from being used. This import is restricted.",
+      "messageId": "pathWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+    {
+      "message": "'restricted-path' import is restricted from being used. This import is restricted.",
+      "messageId": "pathWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 44`] = `
+{
+  "code": "import fs = require("fs");",
+  "diagnostics": [
+    {
+      "message": "'fs' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 45`] = `
+{
+  "code": "export type { InvalidTestCase } from '@typescript-eslint/utils/dist/ts-eslint';",
+  "diagnostics": [
+    {
+      "message": "'@typescript-eslint/utils/dist/ts-eslint' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 46`] = `
+{
+  "code": "import { baz } from "foo";",
+  "diagnostics": [
+    {
+      "message": "'baz' import from 'foo' is restricted because only 'bar' is allowed.",
+      "messageId": "allowedImportName",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 47`] = `
+{
+  "code": "import { Foo, type Bar } from "import/private/bar";",
+  "diagnostics": [
+    {
+      "message": "'Foo' import from 'import/private/bar' is restricted from being used by a pattern.",
+      "messageId": "patternAndImportName",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 48`] = `
+{
+  "code": "export type { bar } from "mod";",
+  "diagnostics": [
+    {
+      "message": "'bar' import from 'mod' is restricted. don't import 'bar' at all",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 49`] = `
+{
+  "code": "import foo from 'import1/private/foo';",
+  "diagnostics": [
+    {
+      "message": "'import1/private/foo' import is restricted from being used.",
+      "messageId": "path",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+    {
+      "message": "'import1/private/foo' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 50`] = `
+{
+  "code": "import { foo } from '@app/api/bar';",
+  "diagnostics": [
+    {
+      "message": "'@app/api/bar' import is restricted from being used by a pattern.",
+      "messageId": "patterns",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 51`] = `
+{
+  "code": "import { Foo_Enum } from '@app/api';",
+  "diagnostics": [
+    {
+      "message": "'Foo_Enum' import from '@app/api' is restricted from being used by a pattern.",
+      "messageId": "patternAndImportName",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 52`] = `
+{
+  "code": "export { 'foo' as b } from "fs";",
+  "diagnostics": [
+    {
+      "message": "'foo' import from 'fs' is restricted. Don't import 'foo'.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 53`] = `
+{
+  "code": "export { 'foo' } from "fs";",
+  "diagnostics": [
+    {
+      "message": "'foo' import from 'fs' is restricted. Don't import 'foo'.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 54`] = `
+{
+  "code": "export { '' } from "fs";",
+  "diagnostics": [
+    {
+      "message": "'' import from 'fs' is restricted. Don't import ''.",
+      "messageId": "importNameWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 55`] = `
+{
+  "code": "import * as All from 'foo-bar-baz';",
+  "diagnostics": [
+    {
+      "message": "* import is invalid because 'Foo' and 'Bar' from 'foo-bar-baz' are restricted from being used by a pattern. Use only 'Baz'.",
+      "messageId": "patternAndEverythingWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-restricted-imports > invalid 56`] = `
+{
+  "code": "import x from "foo/baz";",
+  "diagnostics": [
+    {
+      "message": "'foo/baz' import is restricted from being used by a pattern. some foo subimports are restricted",
+      "messageId": "patternWithCustomMessage",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-restricted-imports",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-restricted-imports.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-restricted-imports.test.ts
@@ -1,0 +1,764 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-restricted-imports', {
+  valid: [
+    // No options
+    'import os from "os";',
+    // String option — different module
+    { code: 'import os from "os";', options: ['osx'] as any },
+    { code: 'import fs from "fs";', options: ['crypto'] as any },
+    {
+      code: 'import path from "path";',
+      options: ['crypto', 'stream', 'os'] as any,
+    },
+    // Side-effect import not matching
+    { code: 'import "foo"', options: ['crypto'] as any },
+    // Subpath not matching parent
+    { code: 'import "foo/bar";', options: ['foo'] as any },
+    // Paths option
+    {
+      code: 'import withPaths from "foo/bar";',
+      options: { paths: ['foo', 'bar'] },
+    },
+    // Patterns option
+    {
+      code: 'import withPatterns from "foo/bar";',
+      options: { patterns: ['foo/c*'] },
+    },
+    // Relative path not matching
+    { code: "import foo from 'foo';", options: ['../foo'] as any },
+    // Gitignore negation
+    {
+      code: 'import withGitignores from "foo/bar";',
+      options: { patterns: ['foo/*', '!foo/bar'] },
+    },
+    // Pattern group with negation
+    {
+      code: 'import withPatterns from "foo/bar";',
+      options: {
+        patterns: [
+          { group: ['foo/*', '!foo/bar'], message: 'foo is forbidden' },
+        ],
+      },
+    },
+    // Case sensitive not matching
+    {
+      code: "import x from 'foo';",
+      options: { patterns: [{ group: ['FOO'], caseSensitive: true }] },
+    },
+    // importNames — allowed name
+    {
+      code: 'import { AllowedObject } from "foo";',
+      options: { paths: [{ name: 'foo', importNames: ['DisallowedObject'] }] },
+    },
+    // Default import not restricted by named importNames
+    {
+      code: 'import DisallowedObject from "foo";',
+      options: { paths: [{ name: 'foo', importNames: ['DisallowedObject'] }] },
+    },
+    // Aliased import — alias matches restriction name, but source name doesn't
+    {
+      code: 'import { AllowedObject as DisallowedObject } from "foo";',
+      options: { paths: [{ name: 'foo', importNames: ['DisallowedObject'] }] },
+    },
+    // Side-effect import with importNames
+    {
+      code: 'import "foo";',
+      options: { paths: [{ name: 'foo', importNames: ['DisallowedObject'] }] },
+    },
+    // Export * from non-restricted
+    { code: 'export * from "foo";', options: ['bar'] as any },
+    // allowImportNames
+    {
+      code: 'import { AllowedObject } from "foo";',
+      options: {
+        paths: [{ name: 'foo', allowImportNames: ['AllowedObject'] }],
+      },
+    },
+    // allowImportNames in patterns
+    {
+      code: "import { foo } from 'foo';",
+      options: { patterns: [{ group: ['foo'], allowImportNames: ['foo'] }] },
+    },
+    // Export allowImportNames
+    {
+      code: "export { bar } from 'foo';",
+      options: { paths: [{ name: 'foo', allowImportNames: ['bar'] }] },
+    },
+    // Regex not matching
+    {
+      code: 'import x from "foo/bar";',
+      options: { patterns: [{ regex: 'foo/baz' }] },
+    },
+    // Regex case sensitive not matching
+    {
+      code: "import x from 'foo';",
+      options: { patterns: [{ regex: 'FOO', caseSensitive: true }] },
+    },
+    // Regex negative lookahead: "foo/bar" NOT matched by "foo/(?!bar)"
+    {
+      code: 'import x from "foo/bar";',
+      options: { patterns: [{ regex: 'foo/(?!bar)' }] },
+    },
+    // Default import not reported by importNamePattern
+    {
+      code: "import Foo from 'foo';",
+      options: { patterns: [{ group: ['foo'], importNamePattern: '^Foo' }] },
+    },
+    // Named import not matching importNamePattern
+    {
+      code: "import { Bar } from 'foo';",
+      options: { patterns: [{ group: ['foo'], importNamePattern: '^Foo' }] },
+    },
+    // allowImportNamePattern matching
+    {
+      code: "import { Foo } from 'foo';",
+      options: {
+        patterns: [{ group: ['foo'], allowImportNamePattern: '^Foo' }],
+      },
+    },
+    // Pattern importNames — different name
+    {
+      code: "import { Bar } from '../../my/relative-module';",
+      options: {
+        patterns: [{ group: ['**/my/relative-module'], importNames: ['Foo'] }],
+      },
+    },
+    // TypeScript: type import allowed
+    {
+      code: "import type foo from 'import-foo';",
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+    },
+    {
+      code: "import type { Bar } from 'import-foo';",
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+    },
+    {
+      code: "export type { Bar } from 'import-foo';",
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+    },
+    // TypeScript: type-only pattern allowed
+    {
+      code: "import type { Bar } from 'import-foo';",
+      options: {
+        patterns: [{ group: ['import-foo'], allowTypeImports: true }],
+      },
+    },
+    // export type * allowed with allowTypeImports
+    {
+      code: 'export type * from "foo";',
+      options: { paths: [{ name: 'foo', allowTypeImports: true }] },
+    },
+    // import type = require() allowed with pattern
+    {
+      code: 'import type fs = require("fs");',
+      options: { patterns: [{ group: ['f*'], allowTypeImports: true }] },
+    },
+    // individual type specifier with importNames + allowTypeImports
+    {
+      code: "import { type Bar } from 'import-foo';",
+      options: {
+        paths: [
+          { name: 'import-foo', importNames: ['Bar'], allowTypeImports: true },
+        ],
+      },
+    },
+    {
+      code: "export { type Bar } from 'import-foo';",
+      options: {
+        paths: [
+          { name: 'import-foo', importNames: ['Bar'], allowTypeImports: true },
+        ],
+      },
+    },
+    // all specifiers individually type → whole import is type-only
+    {
+      code: 'import { type A, type B } from "import-foo";',
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+    },
+    // export with all specifiers individually type
+    {
+      code: 'export { type A, type B } from "import-foo";',
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+    },
+    // Pattern importNames + allowTypeImports: type specifier skipped
+    {
+      code: 'import { Bar, type Baz } from "import/private/bar";',
+      options: {
+        patterns: [
+          {
+            group: ['import/private/*'],
+            importNames: ['Baz'],
+            allowTypeImports: true,
+          },
+        ],
+      },
+    },
+    // Pattern allowImportNames + allowTypeImports
+    {
+      code: 'import { Foo, type Bar } from "import/private/bar";',
+      options: {
+        patterns: [
+          {
+            group: ['import/private/*'],
+            allowImportNames: ['Foo'],
+            allowTypeImports: true,
+          },
+        ],
+      },
+    },
+    // export { bar, type baz } with path allowImportNames + allowTypeImports
+    {
+      code: 'export { bar, type baz } from "import-foo";',
+      options: {
+        paths: [
+          {
+            name: 'import-foo',
+            allowImportNames: ['bar'],
+            allowTypeImports: true,
+          },
+        ],
+      },
+    },
+    // import = require() with importNames: no specifiers → no importName error
+    {
+      code: "import foo = require('foo');",
+      options: { paths: [{ name: 'foo', importNames: ['foo'] }] },
+    },
+    // @scoped package in pattern with negation
+    {
+      code: "import { foo } from '@app/api/enums';",
+      options: { patterns: [{ group: ['@app/api/*', '!@app/api/enums'] }] },
+    },
+    // String literal specifier: 'AllowedObject' not in restriction list
+    {
+      code: 'import { \'AllowedObject\' as bar } from "foo";',
+      options: { paths: [{ name: 'foo', importNames: ['DisallowedObject'] }] },
+    },
+    // String literal ' ' (space) is not '' (empty)
+    {
+      code: 'import { \' \' as bar } from "foo";',
+      options: { paths: [{ name: 'foo', importNames: [''] }] },
+    },
+    // export with string literal alias: source 'AllowedObject' not restricted
+    {
+      code: 'export { \'AllowedObject\' as DisallowedObject } from "foo";',
+      options: { paths: [{ name: 'foo', importNames: ['DisallowedObject'] }] },
+    },
+  ],
+  invalid: [
+    // Basic string restriction
+    {
+      code: 'import "fs"',
+      options: ['fs'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    {
+      code: 'import os from "os ";',
+      options: ['fs', 'crypto ', 'stream', 'os'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    // Subpath restriction
+    {
+      code: 'import "foo/bar";',
+      options: ['foo/bar'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    // Path option
+    {
+      code: 'import withPaths from "foo/bar";',
+      options: { paths: ['foo/bar'] },
+      errors: [{ messageId: 'path' }],
+    },
+    // Pattern matching
+    {
+      code: 'import withPatterns from "foo/bar";',
+      options: { patterns: ['foo'] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    {
+      code: 'import withPatterns from "foo/bar";',
+      options: { patterns: ['bar'] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // Pattern group with custom message
+    {
+      code: 'import withPatterns from "foo/baz";',
+      options: {
+        patterns: [
+          {
+            group: ['foo/*', '!foo/bar'],
+            message: 'foo is forbidden, use foo/bar instead',
+          },
+        ],
+      },
+      errors: [{ messageId: 'patternWithCustomMessage' }],
+    },
+    // Case insensitive pattern (default)
+    {
+      code: "import x from 'foo';",
+      options: { patterns: [{ group: ['FOO'] }] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // Gitignore negation: not negated → matches
+    {
+      code: 'import x from "foo/bar";',
+      options: { patterns: ['foo/*', '!foo/baz'] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // Export * restriction
+    {
+      code: 'export * from "fs";',
+      options: ['fs'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    // Export * as ns restriction
+    {
+      code: 'export * as ns from "fs";',
+      options: ['fs'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    // Export named restriction
+    {
+      code: 'export {a} from "fs";',
+      options: ['fs'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    // Export named with importNames
+    {
+      code: 'export {foo as b} from "fs";',
+      options: {
+        paths: [
+          { name: 'fs', importNames: ['foo'], message: "Don't import 'foo'." },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Custom message on path
+    {
+      code: 'import x from "foo";',
+      options: {
+        paths: [{ name: 'foo', message: "Please import from 'bar' instead." }],
+      },
+      errors: [{ messageId: 'pathWithCustomMessage' }],
+    },
+    // Default import restriction via importNames: ["default"]
+    {
+      code: 'import DisallowedObject from "foo";',
+      options: {
+        paths: [
+          {
+            name: 'foo',
+            importNames: ['default'],
+            message:
+              "Please import the default import of 'foo' from /bar/ instead.",
+          },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Star import with importNames
+    {
+      code: 'import * as All from "foo";',
+      options: {
+        paths: [
+          {
+            name: 'foo',
+            importNames: ['DisallowedObject'],
+            message: "Please import 'DisallowedObject' from /bar/ instead.",
+          },
+        ],
+      },
+      errors: [{ messageId: 'everythingWithCustomMessage' }],
+    },
+    // Named import — restricted name
+    {
+      code: 'import { DisallowedObject } from "foo";',
+      options: {
+        paths: [
+          {
+            name: 'foo',
+            importNames: ['DisallowedObject'],
+            message: "Please import 'DisallowedObject' from /bar/ instead.",
+          },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Aliased import — source name restricted
+    {
+      code: 'import { DisallowedObject as AllowedObject } from "foo";',
+      options: {
+        paths: [
+          {
+            name: 'foo',
+            importNames: ['DisallowedObject'],
+            message: "Please import 'DisallowedObject' from /bar/ instead.",
+          },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Multiple restricted names — two errors
+    {
+      code: 'import { DisallowedObjectOne, DisallowedObjectTwo, AllowedObject } from "foo";',
+      options: {
+        paths: [
+          {
+            name: 'foo',
+            importNames: ['DisallowedObjectOne', 'DisallowedObjectTwo'],
+          },
+        ],
+      },
+      errors: [{ messageId: 'importName' }, { messageId: 'importName' }],
+    },
+    // Relative path
+    {
+      code: "import relative from '../foo';",
+      options: ['../foo'] as any,
+      errors: [{ messageId: 'path' }],
+    },
+    // Regex pattern matching
+    {
+      code: 'import x from "foo/baz";',
+      options: {
+        patterns: [
+          { regex: 'foo/baz', message: 'foo is forbidden, use bar instead' },
+        ],
+      },
+      errors: [{ messageId: 'patternWithCustomMessage' }],
+    },
+    // Regex case insensitive (default)
+    {
+      code: 'import x from "foo";',
+      options: { patterns: [{ regex: 'FOO' }] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // Regex negative lookahead: "foo/baz" matched by "foo/(?!bar)"
+    {
+      code: 'import x from "foo/baz";',
+      options: {
+        patterns: [
+          {
+            regex: 'foo/(?!bar)',
+            message: 'foo is forbidden, use bar instead',
+          },
+        ],
+      },
+      errors: [{ messageId: 'patternWithCustomMessage' }],
+    },
+    // Pattern importNames
+    {
+      code: "import { Foo } from '../../my/relative-module';",
+      options: {
+        patterns: [{ group: ['**/my/relative-module'], importNames: ['Foo'] }],
+      },
+      errors: [{ messageId: 'patternAndImportName' }],
+    },
+    // Pattern importNamePattern
+    {
+      code: "import { Foo } from 'foo';",
+      options: { patterns: [{ group: ['foo'], importNamePattern: '^Foo' }] },
+      errors: [{ messageId: 'patternAndImportName' }],
+    },
+    // Star import with pattern importNames
+    {
+      code: "import * as All from 'foo-bar-baz';",
+      options: { patterns: [{ group: ['**'], importNames: ['Foo', 'Bar'] }] },
+      errors: [{ messageId: 'patternAndEverything' }],
+    },
+    // allowImportNames — disallowed name
+    {
+      code: 'import { AllowedObject, DisallowedObject } from "foo";',
+      options: {
+        paths: [{ name: 'foo', allowImportNames: ['AllowedObject'] }],
+      },
+      errors: [{ messageId: 'allowedImportName' }],
+    },
+    // allowImportNames with star import
+    {
+      code: 'import * as AllowedObject from "foo";',
+      options: {
+        paths: [{ name: 'foo', allowImportNames: ['AllowedObject'] }],
+      },
+      errors: [{ messageId: 'everythingWithAllowImportNames' }],
+    },
+    // Pattern allowImportNames — disallowed name
+    {
+      code: 'import { AllowedObject, DisallowedObject } from "foo";',
+      options: {
+        patterns: [{ group: ['foo'], allowImportNames: ['AllowedObject'] }],
+      },
+      errors: [{ messageId: 'allowedImportName' }],
+    },
+    // Pattern allowImportNamePattern — non-matching name
+    {
+      code: "import { Bar } from 'foo';",
+      options: {
+        patterns: [{ group: ['foo'], allowImportNamePattern: '^Foo' }],
+      },
+      errors: [{ messageId: 'allowedImportNamePattern' }],
+    },
+    // Export with allowImportNamePattern
+    {
+      code: "export { Bar } from 'foo';",
+      options: {
+        patterns: [{ group: ['foo'], allowImportNamePattern: '^Foo' }],
+      },
+      errors: [{ messageId: 'allowedImportNamePattern' }],
+    },
+    // Star with allowImportNamePattern
+    {
+      code: "import * as Foo from 'foo';",
+      options: {
+        patterns: [{ group: ['foo'], allowImportNamePattern: '^Foo' }],
+      },
+      errors: [{ messageId: 'everythingWithAllowedImportNamePattern' }],
+    },
+    // Star with importNamePattern
+    {
+      code: "import * as Foo from 'foo';",
+      options: { patterns: [{ group: ['foo'], importNamePattern: '^Foo' }] },
+      errors: [{ messageId: 'patternAndEverythingWithRegexImportName' }],
+    },
+    // TypeScript: regular import fails even with allowTypeImports
+    {
+      code: "import foo from 'import-foo';",
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+      errors: [{ messageId: 'path' }],
+    },
+    // TypeScript: import equals with external module reference
+    {
+      code: "import foo = require('import-foo');",
+      options: { paths: [{ name: 'import-foo' }] },
+      errors: [{ messageId: 'path' }],
+    },
+    // TypeScript: type import with restricted importNames still reported
+    {
+      code: 'import type { bar } from "mod";',
+      options: {
+        paths: [
+          {
+            name: 'mod',
+            importNames: ['bar'],
+            message: "don't import 'bar' at all",
+          },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // TypeScript: mixed type and regular imports with allowTypeImports
+    {
+      code: 'import { Bar, type Baz } from "import-foo";',
+      options: {
+        paths: [
+          {
+            name: 'import-foo',
+            importNames: ['Bar', 'Baz'],
+            allowTypeImports: true,
+          },
+        ],
+      },
+      errors: [{ messageId: 'importName' }],
+    },
+    // Side-effect import with allowTypeImports: still restricted
+    {
+      code: "import 'import-foo';",
+      options: { paths: [{ name: 'import-foo', allowTypeImports: true }] },
+      errors: [{ messageId: 'path' }],
+    },
+    // import = require() with allowTypeImports: regular require restricted
+    {
+      code: "import foo = require('import-foo');",
+      options: {
+        paths: [
+          {
+            name: 'import-foo',
+            allowTypeImports: true,
+            message: 'Please use import-bar instead.',
+          },
+        ],
+      },
+      errors: [{ messageId: 'pathWithCustomMessage' }],
+    },
+    // export { Bar, type Baz } with allowTypeImports: only Bar reported
+    {
+      code: "export { Bar, type Baz } from 'import-foo';",
+      options: {
+        paths: [
+          {
+            name: 'import-foo',
+            importNames: ['Bar', 'Baz'],
+            allowTypeImports: true,
+          },
+        ],
+      },
+      errors: [{ messageId: 'importName' }],
+    },
+    // export type * + export * with allowTypeImports: only regular export * reported
+    {
+      code: 'export type * from "foo";\nexport * from "foo";',
+      options: { paths: [{ name: 'foo', allowTypeImports: true }] },
+      errors: [{ messageId: 'path' }],
+    },
+    // empty export {} with allowTypeImports: non-type export restricted
+    {
+      code: 'export { } from "mod";\nexport type { } from "mod";',
+      options: { paths: [{ name: 'mod', allowTypeImports: true }] },
+      errors: [{ messageId: 'path' }],
+    },
+    // allowTypeImports: false explicitly → type import restricted too
+    {
+      code: "import { Foo } from 'restricted-path';\nimport type { Bar } from 'restricted-path';",
+      options: {
+        paths: [
+          {
+            name: 'restricted-path',
+            allowTypeImports: false,
+            message: 'This import is restricted.',
+          },
+        ],
+      },
+      errors: [
+        { messageId: 'pathWithCustomMessage' },
+        { messageId: 'pathWithCustomMessage' },
+      ],
+    },
+    // import = require() with pattern
+    {
+      code: 'import fs = require("fs");',
+      options: { patterns: [{ group: ['f*'] }] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // type-only export matched by pattern (no allowTypeImports)
+    {
+      code: "export type { InvalidTestCase } from '@typescript-eslint/utils/dist/ts-eslint';",
+      options: { patterns: ['@typescript-eslint/utils/dist/*'] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // allowImportNames + allowTypeImports: non-allowed name restricted
+    {
+      code: 'import { baz } from "foo";',
+      options: {
+        paths: [
+          { name: 'foo', allowImportNames: ['bar'], allowTypeImports: true },
+        ],
+      },
+      errors: [{ messageId: 'allowedImportName' }],
+    },
+    // Pattern with allowTypeImports + importNames: regular specifier reported
+    {
+      code: 'import { Foo, type Bar } from "import/private/bar";',
+      options: {
+        patterns: [
+          {
+            group: ['import/private/*'],
+            importNames: ['Foo', 'Bar'],
+            allowTypeImports: true,
+          },
+        ],
+      },
+      errors: [{ messageId: 'patternAndImportName' }],
+    },
+    // export type { bar } with two entries: one allowTypeImports, one not
+    {
+      code: 'export type { bar } from "mod";',
+      options: {
+        paths: [
+          {
+            name: 'mod',
+            importNames: ['foo'],
+            allowTypeImports: true,
+            message: "import 'foo' only as type",
+          },
+          {
+            name: 'mod',
+            importNames: ['bar'],
+            message: "don't import 'bar' at all",
+          },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Both paths AND patterns matching same import → errors from both
+    {
+      code: "import foo from 'import1/private/foo';",
+      options: {
+        paths: ['import1/private/foo'],
+        patterns: ['import1/private/*'],
+      },
+      errors: [{ messageId: 'path' }, { messageId: 'patterns' }],
+    },
+    // @scoped package matched by pattern
+    {
+      code: "import { foo } from '@app/api/bar';",
+      options: { patterns: [{ group: ['@app/api/*', '!@app/api/enums'] }] },
+      errors: [{ messageId: 'patterns' }],
+    },
+    // @scoped with regex + importNamePattern
+    {
+      code: "import { Foo_Enum } from '@app/api';",
+      options: {
+        patterns: [{ regex: '@app/api$', importNamePattern: '_Enum$' }],
+      },
+      errors: [{ messageId: 'patternAndImportName' }],
+    },
+    // String literal specifier: export { 'foo' as b } from "fs"
+    {
+      code: 'export { \'foo\' as b } from "fs";',
+      options: {
+        paths: [
+          { name: 'fs', importNames: ['foo'], message: "Don't import 'foo'." },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // String literal specifier: export { 'foo' } from "fs" (no alias)
+    {
+      code: 'export { \'foo\' } from "fs";',
+      options: {
+        paths: [
+          { name: 'fs', importNames: ['foo'], message: "Don't import 'foo'." },
+        ],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Empty string import name: export { '' } from "fs"
+    {
+      code: 'export { \'\' } from "fs";',
+      options: {
+        paths: [{ name: 'fs', importNames: [''], message: "Don't import ''." }],
+      },
+      errors: [{ messageId: 'importNameWithCustomMessage' }],
+    },
+    // Complex glob: **/*-*-baz matching foo-bar-baz
+    {
+      code: "import * as All from 'foo-bar-baz';",
+      options: {
+        patterns: [
+          {
+            group: ['**/*-*-baz'],
+            importNames: ['Foo', 'Bar'],
+            message: "Use only 'Baz'.",
+          },
+        ],
+      },
+      errors: [{ messageId: 'patternAndEverythingWithCustomMessage' }],
+    },
+    // Pattern group with multiple exact paths
+    {
+      code: 'import x from "foo/baz";',
+      options: {
+        patterns: [
+          {
+            group: ['foo/bar', 'foo/baz'],
+            message: 'some foo subimports are restricted',
+          },
+        ],
+      },
+      errors: [{ messageId: 'patternWithCustomMessage' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-restricted-imports` rule from ESLint to rslint.

This rule disallows specified modules when loaded by `import`, supporting both exact path restrictions and gitignore-style/regex pattern matching. Full feature parity with the ESLint rule including:

- **Path restrictions**: string or object format with `importNames`, `allowImportNames`, custom messages
- **Pattern restrictions**: gitignore-style `group` patterns, `regex` patterns (with JS-compatible lookahead/lookbehind via `regexp2`), `importNamePattern`, `allowImportNamePattern`, `caseSensitive`
- **TypeScript support**: `allowTypeImports` for `import type`, `export type`, individual `type` specifiers, `import type = require()`
- **All 22 ESLint messageIds** with identical message text formatting

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-restricted-imports
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-restricted-imports.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).