### PR TITLE
fix: no-unreachable false positives for TS enum/class/namespace declarations

### DIFF
--- a/internal/rules/no_unreachable/no_unreachable.go
+++ b/internal/rules/no_unreachable/no_unreachable.go
@@ -10,10 +10,23 @@ import (
 // https://eslint.org/docs/latest/rules/no-unreachable
 
 // isUnreachable checks if a statement is unreachable using the binder's flow analysis.
-// The binder sets FlowNode on each reachable statement; unreachable statements have nil FlowNode.
+// The binder assigns FlowNode only to nodes in [KindFirstStatement, KindLastStatement].
+// Declaration nodes like EnumDeclaration, ClassDeclaration, and ModuleDeclaration fall
+// outside that range and never receive a FlowNode, so a nil FlowNode alone does not imply
+// the node is unreachable. For those nodes we fall back to the NodeFlagsUnreachable flag that the
+// binder sets on all potentially-executable unreachable nodes.
 func isUnreachable(node *ast.Node) bool {
 	flowData := node.FlowNodeData()
-	return flowData == nil || flowData.FlowNode == nil
+	if flowData != nil && flowData.FlowNode != nil {
+		return false
+	}
+	// For nodes in the statement range, the binder always assigns FlowNode;
+	// a nil value reliably means unreachable.
+	if node.Kind >= ast.KindFirstStatement && node.Kind <= ast.KindLastStatement {
+		return true
+	}
+	// For nodes outside the range, use the explicit flag.
+	return node.Flags&ast.NodeFlagsUnreachable != 0
 }
 
 // isHoistedOrEmpty returns true if the statement is safe to appear

--- a/internal/rules/no_unreachable/no_unreachable_test.go
+++ b/internal/rules/no_unreachable/no_unreachable_test.go
@@ -107,6 +107,13 @@ func TestNoUnreachableRule(t *testing.T) {
 
 			// --- Generator try/yield: catch IS reachable (yield can throw) ---
 			{Code: `function* foo() { try { yield 1; return; } catch (err) { return err; } }`},
+
+			// --- TypeScript: enum/class/namespace declarations that are reachable ---
+			{Code: `export enum Foo { A, B }`},
+			{Code: `const x = 1; export enum Foo { A, B }`},
+			{Code: `const x = 1; enum Foo { A, B }`},
+			{Code: `const x = 1; class Bar {}`},
+			{Code: `const x = 1; namespace NS { export const a = 1; }`},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
@@ -324,6 +331,15 @@ func TestNoUnreachableRule(t *testing.T) {
 			// --- TypeScript: enum after return (has runtime effect) ---
 			{
 				Code:   `function foo() { return; enum Color { Red } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			// --- TypeScript: export enum / export class after throw at module level ---
+			{
+				Code:   `export const x = 1; throw new Error(); export enum Bar { A, B }`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
+			},
+			{
+				Code:   `export const x = 1; throw new Error(); export class Foo {}`,
 				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unreachableCode"}},
 			},
 


### PR DESCRIPTION
## Summary

Fix false positives in the `no-unreachable` rule for TypeScript enum, class, and namespace declarations.

**Root cause:** The binder assigns `FlowNode` only to nodes within `[KindFirstStatement, KindLastStatement]`. Declaration nodes like `EnumDeclaration`, `ClassDeclaration`, and `ModuleDeclaration` fall outside that range and never receive a `FlowNode`. The previous implementation treated a nil `FlowNode` as unreachable, which caused false positives for these declaration types.

**Fix:** 
- For nodes within the statement kind range, a nil `FlowNode` reliably means unreachable (unchanged behavior).
- For nodes outside the range (enum, class, namespace declarations), fall back to the `NodeFlagsUnreachable` flag that the binder sets on all potentially-executable unreachable nodes.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).
