### PR TITLE
feat: port rule method-signature-style

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/dot_notation"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/explicit_function_return_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/member_ordering"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/method_signature_style"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/naming_convention"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_delete"
@@ -414,6 +415,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/dot-notation", dot_notation.DotNotationRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/explicit-function-return-type", explicit_function_return_type.ExplicitFunctionReturnTypeRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/member-ordering", member_ordering.MemberOrderingRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/method-signature-style", method_signature_style.MethodSignatureStyleRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/naming-convention", naming_convention.NamingConventionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-constructor", no_array_constructor.NoArrayConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-delete", no_array_delete.NoArrayDeleteRule)

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.go
@@ -1,0 +1,267 @@
+package method_signature_style
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type mode string
+
+const (
+	modeProperty mode = "property"
+	modeMethod   mode = "method"
+)
+
+func messageErrorMethod() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "errorMethod",
+		Description: "Shorthand method signature is forbidden. Use a function property instead.",
+	}
+}
+
+func messageErrorProperty() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "errorProperty",
+		Description: "Function property signature is forbidden. Use a method shorthand instead.",
+	}
+}
+
+var MethodSignatureStyleRule = rule.CreateRule(rule.Rule{
+	Name: "method-signature-style",
+	Run:  run,
+})
+
+// containsThisType recursively checks whether the given type node (or any of
+// its descendants) is a `this` type reference.
+func containsThisType(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindThisType {
+		return true
+	}
+	found := false
+	node.ForEachChild(func(child *ast.Node) bool {
+		if containsThisType(child) {
+			found = true
+		}
+		return found
+	})
+	return found
+}
+
+func run(ctx rule.RuleContext, options any) rule.RuleListeners {
+	opt := mode(utils.GetOptionsString(options))
+	if opt == "" {
+		opt = modeProperty
+	}
+
+	sourceText := ctx.SourceFile.Text()
+
+	// safeSlice returns sourceText[start:end] with bounds clamping.
+	safeSlice := func(start, end int) string {
+		if start < 0 {
+			start = 0
+		}
+		if end > len(sourceText) {
+			end = len(sourceText)
+		}
+		return sourceText[start:end]
+	}
+
+	// getMethodKey returns the key text for a method or property signature,
+	// including optional marker and readonly prefix.
+	getMethodKey := func(node *ast.Node) string {
+		var nameNode *ast.Node
+		switch node.Kind {
+		case ast.KindMethodSignature:
+			nameNode = node.AsMethodSignatureDeclaration().Name()
+		case ast.KindPropertySignature:
+			nameNode = node.AsPropertySignatureDeclaration().Name()
+		default:
+			return ""
+		}
+
+		// TrimmedNodeText handles computed property names correctly —
+		// ComputedPropertyName nodes already include the surrounding brackets.
+		key := utils.TrimmedNodeText(ctx.SourceFile, nameNode)
+
+		if ast.HasQuestionToken(node) {
+			key += "?"
+		}
+		if ast.HasSyntacticModifier(node, ast.ModifierFlagsReadonly) {
+			key = "readonly " + key
+		}
+		return key
+	}
+
+	// getMethodParams returns the type parameters + parameters text.
+	// E.g. "<T>(a: T, b: T)" or "()" for no params.
+	getMethodParams := func(node *ast.Node) string {
+		var params *ast.NodeList
+		var typeParams *ast.NodeList
+
+		switch node.Kind {
+		case ast.KindMethodSignature:
+			sig := node.AsMethodSignatureDeclaration()
+			params = sig.Parameters
+			typeParams = sig.TypeParameters
+		case ast.KindFunctionType:
+			ft := node.AsFunctionTypeNode()
+			params = ft.Parameters
+			typeParams = ft.TypeParameters
+		default:
+			return "()"
+		}
+
+		paramsText := "()"
+		if params != nil && len(params.Nodes) > 0 {
+			firstRange := utils.TrimNodeTextRange(ctx.SourceFile, params.Nodes[0])
+			lastRange := utils.TrimNodeTextRange(ctx.SourceFile, params.Nodes[len(params.Nodes)-1])
+			// Scan backward to find '(' before first param
+			openParen := firstRange.Pos() - 1
+			for openParen > 0 && sourceText[openParen] != '(' {
+				openParen--
+			}
+			// Scan forward to find ')' after last param
+			closeParen := lastRange.End()
+			for closeParen < len(sourceText) && sourceText[closeParen] != ')' {
+				closeParen++
+			}
+			paramsText = safeSlice(openParen, closeParen+1)
+		}
+
+		if typeParams != nil && len(typeParams.Nodes) > 0 {
+			firstRange := utils.TrimNodeTextRange(ctx.SourceFile, typeParams.Nodes[0])
+			lastRange := utils.TrimNodeTextRange(ctx.SourceFile, typeParams.Nodes[len(typeParams.Nodes)-1])
+			// Scan backward/forward to find '<'/'>' (comments may sit between the bracket and the first/last param)
+			start := firstRange.Pos() - 1
+			for start > 0 && sourceText[start] != '<' {
+				start--
+			}
+			end := lastRange.End()
+			for end < len(sourceText) && sourceText[end] != '>' {
+				end++
+			}
+			paramsText = safeSlice(start, end+1) + paramsText
+		}
+
+		return paramsText
+	}
+
+	// getMethodReturnType returns the return type text, or "any" if omitted.
+	getMethodReturnType := func(node *ast.Node) string {
+		var typeNode *ast.Node
+		switch node.Kind {
+		case ast.KindMethodSignature:
+			typeNode = node.AsMethodSignatureDeclaration().Type
+		case ast.KindFunctionType:
+			typeNode = node.AsFunctionTypeNode().Type
+		}
+		if typeNode == nil {
+			return "any"
+		}
+		return utils.TrimmedNodeText(ctx.SourceFile, typeNode)
+	}
+
+	// getDelimiter returns the trailing ';' or ',' of a member node, or "".
+	getDelimiter := func(node *ast.Node) string {
+		end := utils.TrimNodeTextRange(ctx.SourceFile, node).End()
+		if end > 0 && end <= len(sourceText) {
+			if ch := sourceText[end-1]; ch == ';' || ch == ',' {
+				return string(ch)
+			}
+		}
+		return ""
+	}
+
+	listeners := rule.RuleListeners{}
+
+	if opt == modeProperty {
+		listeners[ast.KindMethodSignature] = func(node *ast.Node) {
+			// In typescript-go AST, get/set accessors use KindGetAccessor/KindSetAccessor,
+			// so KindMethodSignature always represents an actual method — no kind check needed.
+
+			skipFix := containsThisType(node.AsMethodSignatureDeclaration().Type)
+			isParentModule := ast.FindAncestorKind(node, ast.KindModuleDeclaration) != nil
+			thisKey := getMethodKey(node)
+			members := node.Parent.Members()
+
+			// Find overloaded method signatures with the same key
+			var duplicates []*ast.Node
+			for _, member := range members {
+				if member.Kind == ast.KindMethodSignature && member != node && getMethodKey(member) == thisKey {
+					duplicates = append(duplicates, member)
+				}
+			}
+
+			if len(duplicates) > 0 {
+				if isParentModule || skipFix {
+					ctx.ReportNode(node, messageErrorMethod())
+					return
+				}
+
+				// Sort all overloads by position; only the first provides the fix
+				allNodes := append([]*ast.Node{node}, duplicates...)
+				sort.Slice(allNodes, func(i, j int) bool {
+					return allNodes[i].Pos() < allNodes[j].Pos()
+				})
+				if allNodes[0] != node {
+					ctx.ReportNode(node, messageErrorMethod())
+					return
+				}
+
+				// Merge overloads into an intersection of function types
+				var typeParts []string
+				for _, n := range allNodes {
+					typeParts = append(typeParts, "("+getMethodParams(n)+" => "+getMethodReturnType(n)+")")
+				}
+				typeString := strings.Join(typeParts, " & ")
+				replacement := getMethodKey(node) + ": " + typeString + getDelimiter(node)
+
+				var fixes []rule.RuleFix
+				fixes = append(fixes, rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+
+				// Remove each duplicate and its preceding whitespace
+				for _, dup := range duplicates {
+					dupRange := utils.TrimNodeTextRange(ctx.SourceFile, dup)
+					start := dupRange.Pos()
+					// Consume leading whitespace/newlines back to the previous member's delimiter
+					for start > 0 && (sourceText[start-1] == ' ' || sourceText[start-1] == '\t' || sourceText[start-1] == '\n' || sourceText[start-1] == '\r') {
+						start--
+					}
+					fixes = append(fixes, rule.RuleFixRemoveRange(dupRange.WithPos(start).WithEnd(dupRange.End())))
+				}
+
+				ctx.ReportNodeWithFixes(node, messageErrorMethod(), fixes...)
+				return
+			}
+
+			// Single method signature (no overloads)
+			if isParentModule || skipFix {
+				ctx.ReportNode(node, messageErrorMethod())
+			} else {
+				replacement := getMethodKey(node) + ": " + getMethodParams(node) + " => " + getMethodReturnType(node) + getDelimiter(node)
+				ctx.ReportNodeWithFixes(node, messageErrorMethod(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+			}
+		}
+	}
+
+	if opt == modeMethod {
+		listeners[ast.KindPropertySignature] = func(node *ast.Node) {
+			propSig := node.AsPropertySignatureDeclaration()
+			if propSig == nil || propSig.Type == nil || propSig.Type.Kind != ast.KindFunctionType {
+				return
+			}
+
+			replacement := getMethodKey(node) + getMethodParams(propSig.Type) + ": " + getMethodReturnType(propSig.Type) + getDelimiter(node)
+			ctx.ReportNodeWithFixes(node, messageErrorProperty(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+		}
+	}
+
+	return listeners
+}

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style.md
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style.md
@@ -1,0 +1,57 @@
+# method-signature-style
+
+## Rule Details
+
+Enforces using a particular method signature syntax in interfaces and type literals.
+
+There are two styles for declaring method signatures in TypeScript:
+
+- **Method shorthand**: `func(arg: string): number;`
+- **Property**: `func: (arg: string) => number;`
+
+The key difference: with `strictFunctionTypes` enabled, method parameters are checked less strictly, while function property parameters are checked more strictly. This makes function properties more type-safe.
+
+### Options
+
+- `"property"` (default): Enforces function property signature syntax.
+- `"method"`: Enforces method shorthand signature syntax.
+
+### `"property"` (default)
+
+Examples of **incorrect** code:
+
+```typescript
+interface T1 {
+  func(arg: string): number;
+}
+```
+
+Examples of **correct** code:
+
+```typescript
+interface T1 {
+  func: (arg: string) => number;
+}
+```
+
+### `"method"`
+
+Examples of **incorrect** code:
+
+```typescript
+interface T1 {
+  func: (arg: string) => number;
+}
+```
+
+Examples of **correct** code:
+
+```typescript
+interface T1 {
+  func(arg: string): number;
+}
+```
+
+## Original Documentation
+
+https://typescript-eslint.io/rules/method-signature-style

--- a/internal/plugins/typescript/rules/method_signature_style/method_signature_style_test.go
+++ b/internal/plugins/typescript/rules/method_signature_style/method_signature_style_test.go
@@ -1,0 +1,814 @@
+package method_signature_style
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestMethodSignatureStyleRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &MethodSignatureStyleRule, []rule_tester.ValidTestCase{
+		// =============================================
+		// Property mode (default) — valid
+		// =============================================
+		{Code: `interface Test { f: (a: string) => number; }`},
+		{Code: "interface Test { ['f']: (a: boolean) => void; }"},
+		{Code: `interface Test { f: <T>(a: T) => T; }`},
+		{Code: "interface Test { ['f']: <T extends {}>(a: T, b: T) => T; }"},
+		{Code: `interface Test { get f(): number; }`},
+		{Code: `interface Test { set f(value: number): void; }`},
+		{Code: `type Test = { readonly f: (a: string) => number };`},
+		{Code: "type Test = { ['f']?: (a: boolean) => void };"},
+		{Code: `type Test = { readonly f?: <T>(a?: T) => T };`},
+		{Code: "type Test = { readonly ['f']?: <T>(a: T, b: T) => T };"},
+		{Code: `type Test = { get f(): number };`},
+		{Code: `type Test = { set f(value: number): void };`},
+
+		// Non-method members should be ignored in property mode
+		{Code: `interface Test { (): void; }`},                    // call signature
+		{Code: `interface Test { new (): Test; }`},                // construct signature
+		{Code: `interface Test { [key: string]: any; }`},          // index signature
+		{Code: `interface Test { x: number; y: string; }`},        // regular properties
+		{Code: `interface Test { f: (a: string) => number; g: number; }`}, // mix
+
+		// =============================================
+		// Method mode — valid
+		// =============================================
+		{Code: `interface Test { f(a: string): number; }`, Options: []interface{}{"method"}},
+		{Code: "interface Test { ['f'](a: boolean): void; }", Options: []interface{}{"method"}},
+		{Code: `interface Test { f<T>(a: T): T; }`, Options: []interface{}{"method"}},
+		{Code: "interface Test { ['f']<T extends {}>(a: T, b: T): T; }", Options: []interface{}{"method"}},
+		{Code: `type Test = { f(a: string): number };`, Options: []interface{}{"method"}},
+		{Code: "type Test = { ['f']?(a: boolean): void };", Options: []interface{}{"method"}},
+		{Code: `type Test = { f?<T>(a?: T): T };`, Options: []interface{}{"method"}},
+		{Code: "type Test = { ['f']?<T>(a: T, b: T): T };", Options: []interface{}{"method"}},
+		{Code: `interface Test { get f(): number; }`, Options: []interface{}{"method"}},
+		{Code: `interface Test { set f(value: number): void; }`, Options: []interface{}{"method"}},
+		{Code: `type Test = { get f(): number };`, Options: []interface{}{"method"}},
+		{Code: `type Test = { set f(value: number): void };`, Options: []interface{}{"method"}},
+
+		// Non-function-type properties should be ignored in method mode
+		{Code: `interface Test { f: string; }`, Options: []interface{}{"method"}},
+		{Code: `interface Test { f: number; }`, Options: []interface{}{"method"}},
+		{Code: `interface Test { f: string | number; }`, Options: []interface{}{"method"}},
+		// Union/intersection containing function types — not a bare FunctionType, should be ignored
+		{Code: `interface Test { f: (() => void) | string; }`, Options: []interface{}{"method"}},
+		{Code: `interface Test { f: (() => void) & (() => string); }`, Options: []interface{}{"method"}},
+		// Array of functions — not a bare FunctionType
+		{Code: `interface Test { f: (() => void)[]; }`, Options: []interface{}{"method"}},
+		// Parenthesized function type — not a bare FunctionType
+		{Code: `interface Test { f: ((a: string) => void); }`, Options: []interface{}{"method"}},
+	}, []rule_tester.InvalidTestCase{
+		// =============================================
+		// Property mode: method → property (basic)
+		// =============================================
+		{
+			Code:   `interface Test { f(a: string): number; }`,
+			Output: []string{`interface Test { f: (a: string) => number; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:   "interface Test { ['f'](a: boolean): void; }",
+			Output: []string{"interface Test { ['f']: (a: boolean) => void; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:   `interface Test { f<T>(a: T): T; }`,
+			Output: []string{`interface Test { f: <T>(a: T) => T; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:   "interface Test { ['f']<T extends {}>(a: T, b: T): T; }",
+			Output: []string{"interface Test { ['f']: <T extends {}>(a: T, b: T) => T; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:   `type Test = { f(a: string): number };`,
+			Output: []string{`type Test = { f: (a: string) => number };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:   "type Test = { ['f']?(a: boolean): void };",
+			Output: []string{"type Test = { ['f']?: (a: boolean) => void };"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:   `type Test = { f?<T>(a?: T): T };`,
+			Output: []string{`type Test = { f?: <T>(a?: T) => T };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:   "type Test = { ['f']?<T>(a: T, b: T): T };",
+			Output: []string{"type Test = { ['f']?: <T>(a: T, b: T) => T };"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 15},
+			},
+		},
+		// Implicit return type → any
+		{
+			Code:   `interface MyInterface { methodReturningImplicitAny(); }`,
+			Output: []string{`interface MyInterface { methodReturningImplicitAny: () => any; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 25},
+			},
+		},
+		// Comments preserved in type params and params
+		{
+			Code:   "interface Test { 'f!'</* a */ T>(/* b */ x: any /* c */): void; }",
+			Output: []string{"interface Test { 'f!': </* a */ T>(/* b */ x: any /* c */) => void; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		// NOTE: `readonly` on method signatures is invalid TypeScript (parse error
+		// in ESLint parser), so no readonly-method test case here.
+
+		// =============================================
+		// Delimiters: semicolon, comma, none
+		// =============================================
+		{
+			Code: "interface Foo {\n  semi(arg: string): void;\n  comma(arg: string): void,\n  none(arg: string): void\n}",
+			Output: []string{"interface Foo {\n  semi: (arg: string) => void;\n  comma: (arg: string) => void,\n  none: (arg: string) => void\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+
+		// =============================================
+		// Multi-line parameters
+		// =============================================
+		{
+			Code: "interface Foo {\n  x(\n    args: Pick<\n      Bar,\n      'one' | 'two' | 'three'\n    >,\n  ): Baz;\n  y(\n    foo: string,\n    bar: number,\n  ): void;\n}",
+			Output: []string{"interface Foo {\n  x: (\n    args: Pick<\n      Bar,\n      'one' | 'two' | 'three'\n    >,\n  ) => Baz;\n  y: (\n    foo: string,\n    bar: number,\n  ) => void;\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 8},
+			},
+		},
+
+		// =============================================
+		// Method mode: property → method (basic)
+		// =============================================
+		{
+			Code:    `interface Test { f: (a: string) => number; }`,
+			Options: []interface{}{"method"},
+			Output:  []string{`interface Test { f(a: string): number; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    "interface Test { ['f']: (a: boolean) => void; }",
+			Options: []interface{}{"method"},
+			Output:  []string{"interface Test { ['f'](a: boolean): void; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    `interface Test { f: <T>(a: T) => T; }`,
+			Options: []interface{}{"method"},
+			Output:  []string{`interface Test { f<T>(a: T): T; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    "interface Test { ['f']: <T extends {}>(a: T, b: T) => T; }",
+			Options: []interface{}{"method"},
+			Output:  []string{"interface Test { ['f']<T extends {}>(a: T, b: T): T; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code:    `type Test = { f: (a: string) => number };`,
+			Options: []interface{}{"method"},
+			Output:  []string{`type Test = { f(a: string): number };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:    "type Test = { ['f']?: (a: boolean) => void };",
+			Options: []interface{}{"method"},
+			Output:  []string{"type Test = { ['f']?(a: boolean): void };"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:    `type Test = { f?: <T>(a?: T) => T };`,
+			Options: []interface{}{"method"},
+			Output:  []string{`type Test = { f?<T>(a?: T): T };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 15},
+			},
+		},
+		{
+			Code:    "type Test = { ['f']?: <T>(a: T, b: T) => T };",
+			Options: []interface{}{"method"},
+			Output:  []string{"type Test = { ['f']?<T>(a: T, b: T): T };"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 15},
+			},
+		},
+		// Readonly property with function type → method
+		{
+			Code:    `type Test = { readonly f: (a: string) => number };`,
+			Options: []interface{}{"method"},
+			Output:  []string{`type Test = { readonly f(a: string): number };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 15},
+			},
+		},
+		// Delimiter preservation in method mode
+		{
+			Code:    "interface Foo {\n  semi: (arg: string) => void;\n  comma: (arg: string) => void,\n  none: (arg: string) => void\n}",
+			Options: []interface{}{"method"},
+			Output:  []string{"interface Foo {\n  semi(arg: string): void;\n  comma(arg: string): void,\n  none(arg: string): void\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 2},
+				{MessageId: "errorProperty", Line: 3},
+				{MessageId: "errorProperty", Line: 4},
+			},
+		},
+		// Comments preserved in method mode
+		{
+			Code:    "interface Test { 'f!': </* a */ T>(/* b */ x: any /* c */) => void; }",
+			Options: []interface{}{"method"},
+			Output:  []string{"interface Test { 'f!'</* a */ T>(/* b */ x: any /* c */): void; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// this return type — no autofix
+		// =============================================
+		{
+			Code: `interface Test { f(): this; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code: `interface Test { f(): this | undefined; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code: `interface Test { f(): Promise<this>; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code: `interface Test { f(value: number): Promise<this | undefined>; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		// Overloaded methods returning this — both should report, no fix
+		{
+			Code: "interface Test {\n  foo(): this;\n  foo(): Promise<this>;\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// Overloads — merge into intersection type
+		// =============================================
+		// 3 overloads, same params
+		{
+			Code: "interface Test {\n  foo(): one;\n  foo(): two;\n  foo(): three;\n}",
+			Output: []string{"interface Test {\n  foo: (() => one) & (() => two) & (() => three);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+		// Overloads with different parameters
+		{
+			Code: "interface Test {\n  foo(bar: string): one;\n  foo(bar: number, baz: string): two;\n  foo(): three;\n}",
+			Output: []string{"interface Test {\n  foo: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+		// Overloads with computed property names
+		{
+			Code: "interface Foo {\n  [foo](bar: string): one;\n  [foo](bar: number, baz: string): two;\n  [foo](): three;\n}",
+			Output: []string{"interface Foo {\n  [foo]: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+		// Two independent overload groups in one interface
+		{
+			Code: "interface Foo {\n  [foo](bar: string): one;\n  [foo](bar: number, baz: string): two;\n  [foo](): three;\n  bar(arg: string): void;\n  bar(baz: number): Foo;\n}",
+			Output: []string{"interface Foo {\n  [foo]: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);\n  bar: ((arg: string) => void) & ((baz: number) => Foo);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+				{MessageId: "errorMethod", Line: 5},
+				{MessageId: "errorMethod", Line: 6},
+			},
+		},
+		// Overloads in type literal
+		{
+			Code: "type Foo = {\n  foo(): one;\n  foo(): two;\n  foo(): three;\n}",
+			Output: []string{"type Foo = {\n  foo: (() => one) & (() => two) & (() => three);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+		// Overloads in declare const
+		{
+			Code: "declare const Foo: {\n  foo(): one;\n  foo(): two;\n  foo(): three;\n}",
+			Output: []string{"declare const Foo: {\n  foo: (() => one) & (() => two) & (() => three);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+
+		// =============================================
+		// Module/namespace declaration — no autofix
+		// =============================================
+		{
+			Code: "declare global {\n  namespace jest {\n    interface Matchers<R> {\n      toHaveProperties(): R;\n    }\n  }\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+		// Nested namespace — multiple methods, all unfixable
+		{
+			Code: "declare global {\n  namespace jest {\n    interface Matchers<R, T> {\n      toHaveProp<K extends keyof T>(name: K, value?: T[K]): R;\n      toHaveProps(props: Partial<T>): R;\n    }\n  }\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 4},
+				{MessageId: "errorMethod", Line: 5},
+			},
+		},
+
+		// =============================================
+		// Rest parameters
+		// =============================================
+		{
+			Code:   `interface Test { f(...args: any[]): void; }`,
+			Output: []string{`interface Test { f: (...args: any[]) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Multiple type parameters
+		// =============================================
+		{
+			Code:   `interface Test { f<T, U>(a: T, b: U): [T, U]; }`,
+			Output: []string{`interface Test { f: <T, U>(a: T, b: U) => [T, U]; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// No parameters, explicit void return
+		// =============================================
+		{
+			Code:   `interface Test { f(): void; }`,
+			Output: []string{`interface Test { f: () => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Numeric literal key
+		// =============================================
+		{
+			Code:   `interface Test { 0(a: string): void; }`,
+			Output: []string{`interface Test { 0: (a: string) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Nested type literal (inner method should also be flagged)
+		// =============================================
+		{
+			Code:   `type Outer = { inner: { method(): void } };`,
+			Output: []string{`type Outer = { inner: { method: () => void } };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 25},
+			},
+		},
+
+		// =============================================
+		// Method in generic constraint
+		// =============================================
+		{
+			Code:   `interface Foo<T extends { bar(): void }> { baz(): T; }`,
+			Output: []string{`interface Foo<T extends { bar: () => void }> { baz: () => T; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 27},
+				{MessageId: "errorMethod", Line: 1, Column: 44},
+			},
+		},
+
+		// =============================================
+		// Complex return types
+		// =============================================
+		// Conditional type return
+		{
+			Code:   `interface Test { f<T>(a: T): T extends string ? number : boolean; }`,
+			Output: []string{`interface Test { f: <T>(a: T) => T extends string ? number : boolean; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		// Tuple return
+		{
+			Code:   `interface Test { f(a: number): [string, number]; }`,
+			Output: []string{`interface Test { f: (a: number) => [string, number]; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Method mode: no-param function property → method
+		// =============================================
+		{
+			Code:    `interface Test { f: () => void; }`,
+			Options: []interface{}{"method"},
+			Output:  []string{`interface Test { f(): void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Multiple members — only methods are flagged
+		// =============================================
+		{
+			Code:   `interface Test { x: number; f(a: string): void; y: string; }`,
+			Output: []string{`interface Test { x: number; f: (a: string) => void; y: string; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 29},
+			},
+		},
+
+		// =============================================
+		// Non-adjacent overloads (interspersed with other members)
+		// Two fix rounds: round 1 merges foo overloads (removal spans past bar),
+		// round 2 converts bar.
+		// =============================================
+		{
+			Code: "interface Test {\n  foo(): one;\n  bar(): void;\n  foo(): two;\n}",
+			Output: []string{
+				"interface Test {\n  foo: (() => one) & (() => two);\n  bar(): void;\n}",
+				"interface Test {\n  foo: (() => one) & (() => two);\n  bar: () => void;\n}",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+				{MessageId: "errorMethod", Line: 4},
+			},
+		},
+
+		// =============================================
+		// Minimum overload: exactly 2
+		// =============================================
+		{
+			Code:   "interface Test {\n  f(a: string): void;\n  f(a: number): void;\n}",
+			Output: []string{"interface Test {\n  f: ((a: string) => void) & ((a: number) => void);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// Overload: first returns this → all skip fix
+		// =============================================
+		{
+			Code: "interface Test {\n  foo(): this;\n  foo(a: string): string;\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// `this` as parameter (NOT return type) — should fix normally
+		// =============================================
+		{
+			Code:   `interface Test { f(this: Foo, a: string): void; }`,
+			Output: []string{`interface Test { f: (this: Foo, a: string) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// No params but has type params
+		// =============================================
+		{
+			Code:   `interface Test { f<T>(): T; }`,
+			Output: []string{`interface Test { f: <T>() => T; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Default type parameter
+		// =============================================
+		{
+			Code:   `interface Test { f<T = string>(): T; }`,
+			Output: []string{`interface Test { f: <T = string>() => T; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Method in intersection type's type literal
+		// =============================================
+		{
+			Code:   `type Test = A & { method(): void };`,
+			Output: []string{`type Test = A & { method: () => void };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 19},
+			},
+		},
+
+		// =============================================
+		// declare module (not declare global) — still a module, no fix
+		// =============================================
+		{
+			Code: "declare module 'foo' {\n  interface Bar {\n    baz(): void;\n  }\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// Deeply nested type literals
+		// =============================================
+		{
+			Code:   `type T = { a: { b: { c(): void } } };`,
+			Output: []string{`type T = { a: { b: { c: () => void } } };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+
+		// =============================================
+		// String key with special characters
+		// =============================================
+		{
+			Code:   "interface Test { 'foo-bar'(x: number): void; }",
+			Output: []string{"interface Test { 'foo-bar': (x: number) => void; }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Method mode: generic no-param function property
+		// =============================================
+		{
+			Code:    `interface Test { f: <T>() => T; }`,
+			Options: []interface{}{"method"},
+			Output:  []string{`interface Test { f<T>(): T; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Parameter with function type (nested parens in param type)
+		// The ')' scan must find the correct outer paren.
+		// =============================================
+		{
+			Code:   `interface Test { f(callback: (x: number) => void): void; }`,
+			Output: []string{`interface Test { f: (callback: (x: number) => void) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		// Multiple params, last param has function type
+		{
+			Code:   `interface Test { f(a: string, callback: (x: number) => void): void; }`,
+			Output: []string{`interface Test { f: (a: string, callback: (x: number) => void) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+		// Method mode: property with function type param
+		{
+			Code:    `interface Test { f: (callback: (x: number) => void) => void; }`,
+			Options: []interface{}{"method"},
+			Output:  []string{`interface Test { f(callback: (x: number) => void): void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorProperty", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Overloads with different generic type params
+		// =============================================
+		{
+			Code:   "interface Test {\n  f<T>(a: T): T;\n  f<T, U>(a: T, b: U): [T, U];\n}",
+			Output: []string{"interface Test {\n  f: (<T>(a: T) => T) & (<T, U>(a: T, b: U) => [T, U]);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// Optional method overloads
+		// =============================================
+		{
+			Code:   "interface Test {\n  f?(): void;\n  f?(a: string): string;\n}",
+			Output: []string{"interface Test {\n  f?: (() => void) & ((a: string) => string);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// TypeLiteral in various contexts
+		// =============================================
+		// In function parameter type
+		{
+			Code:   `function foo(x: { method(): void }) {}`,
+			Output: []string{`function foo(x: { method: () => void }) {}`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+		// In type assertion
+		{
+			Code:   `const x = {} as { method(): void };`,
+			Output: []string{`const x = {} as { method: () => void };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+		// In return type
+		{
+			Code:   `function foo(): { method(): void } { return {} as any; }`,
+			Output: []string{`function foo(): { method: () => void } { return {} as any; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+		// In variable type annotation
+		{
+			Code:   `let x: { method(): void };`,
+			Output: []string{`let x: { method: () => void };`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+		// In conditional type branch
+		{
+			Code:   `type T = true extends true ? { method(): void } : never;`,
+			Output: []string{`type T = true extends true ? { method: () => void } : never;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+		// In tuple element
+		{
+			Code:   `type T = [{ method(): void }];`,
+			Output: []string{`type T = [{ method: () => void }];`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+		// In mapped type value
+		{
+			Code:   "type T = { [K in string]: { method(): void } };",
+			Output: []string{"type T = { [K in string]: { method: () => void } };"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+
+		// =============================================
+		// Single-line overloads
+		// =============================================
+		{
+			Code:   `interface Test { f(): one; f(): two; }`,
+			Output: []string{`interface Test { f: (() => one) & (() => two); }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+
+		// =============================================
+		// Overload: only second returns this → first generates fix (includes this)
+		// Matches ESLint behavior: skipFix is per-node, not per-group.
+		// =============================================
+		{
+			Code: "interface Test {\n  foo(a: string): string;\n  foo(): this;\n}",
+			Output: []string{"interface Test {\n  foo: ((a: string) => string) & (() => this);\n}"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 2},
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// Destructured parameter
+		// =============================================
+		{
+			Code:   `interface Test { f({ a, b }: Options): void; }`,
+			Output: []string{`interface Test { f: ({ a, b }: Options) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Trailing comma in parameter list
+		// =============================================
+		{
+			Code:   `interface Test { f(a: string,): void; }`,
+			Output: []string{`interface Test { f: (a: string,) => void; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1, Column: 18},
+			},
+		},
+
+		// =============================================
+		// Non-declare namespace (still a ModuleDeclaration — no fix)
+		// =============================================
+		{
+			Code: "namespace Foo {\n  interface Bar {\n    method(): void;\n  }\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 3},
+			},
+		},
+
+		// =============================================
+		// Type predicate return type
+		// =============================================
+		{
+			Code:   `interface Guard { check(x: unknown): x is string; }`,
+			Output: []string{`interface Guard { check: (x: unknown) => x is string; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+
+		// =============================================
+		// Asserts return type
+		// =============================================
+		{
+			Code:   `interface Guard { assert(x: unknown): asserts x is string; }`,
+			Output: []string{`interface Guard { assert: (x: unknown) => asserts x is string; }`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "errorMethod", Line: 1},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -108,7 +108,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/member-ordering/member-ordering-natural-case-insensitive-order.test.ts',
     './tests/typescript-eslint/rules/member-ordering/member-ordering-natural-order.test.ts',
     './tests/typescript-eslint/rules/member-ordering/member-ordering-optionalMembers.test.ts',
-    // './tests/typescript-eslint/rules/method-signature-style.test.ts',
+    './tests/typescript-eslint/rules/method-signature-style.test.ts',
     // './tests/typescript-eslint/rules/naming-convention/cases/accessor.test.ts',
     // './tests/typescript-eslint/rules/naming-convention/cases/autoAccessor.test.ts',
     // './tests/typescript-eslint/rules/naming-convention/cases/class.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/method-signature-style.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/method-signature-style.test.ts.snap
@@ -1,0 +1,1498 @@
+// Rstest Snapshot v1
+
+exports[`method-signature-style > invalid 1`] = `
+{
+  "code": "
+        interface Test {
+          f(a: string): number;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          f: (a: string) => number;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 2`] = `
+{
+  "code": "
+        interface Test {
+          ['f'](a: boolean): void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          ['f']: (a: boolean) => void;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 3`] = `
+{
+  "code": "
+        interface Test {
+          f<T>(a: T): T;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          f: <T>(a: T) => T;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 4`] = `
+{
+  "code": "
+        interface Test {
+          ['f']<T extends {}>(a: T, b: T): T;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          ['f']: <T extends {}>(a: T, b: T) => T;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 5`] = `
+{
+  "code": "
+        interface Test {
+          'f!'</* a */>(/* b */ x: any /* c */): void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          'f!': </* a */>(/* b */ x: any /* c */) => void;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 6`] = `
+{
+  "code": "
+        type Test = { f(a: string): number };
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { f: (a: string) => number };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 7`] = `
+{
+  "code": "
+        type Test = { ['f']?(a: boolean): void };
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { ['f']?: (a: boolean) => void };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 8`] = `
+{
+  "code": "
+        type Test = { f?<T>(a?: T): T };
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { f?: <T>(a?: T) => T };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 9`] = `
+{
+  "code": "
+        type Test = { ['f']?<T>(a: T, b: T): T };
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { ['f']?: <T>(a: T, b: T) => T };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 10`] = `
+{
+  "code": "
+        interface Test {
+          f: (a: string) => number;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          f(a: string): number;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 11`] = `
+{
+  "code": "
+        interface Test {
+          ['f']: (a: boolean) => void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          ['f'](a: boolean): void;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 12`] = `
+{
+  "code": "
+        interface Test {
+          f: <T>(a: T) => T;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          f<T>(a: T): T;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 13`] = `
+{
+  "code": "
+        interface Test {
+          ['f']: <T extends {}>(a: T, b: T) => T;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          ['f']<T extends {}>(a: T, b: T): T;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 14`] = `
+{
+  "code": "
+        interface Test {
+          'f!': </* a */>(/* b */ x: any /* c */) => void;
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        interface Test {
+          'f!'</* a */>(/* b */ x: any /* c */): void;
+        }
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 15`] = `
+{
+  "code": "
+        type Test = { f: (a: string) => number };
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { f(a: string): number };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 16`] = `
+{
+  "code": "
+        type Test = { ['f']?: (a: boolean) => void };
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { ['f']?(a: boolean): void };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 17`] = `
+{
+  "code": "
+        type Test = { f?: <T>(a?: T) => T };
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { f?<T>(a?: T): T };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 18`] = `
+{
+  "code": "
+        type Test = { ['f']?: <T>(a: T, b: T) => T };
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 2,
+        },
+        "start": {
+          "column": 23,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        type Test = { ['f']?<T>(a: T, b: T): T };
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 19`] = `
+{
+  "code": "
+interface Foo {
+  semi(arg: string): void;
+  comma(arg: string): void,
+  none(arg: string): void
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  semi: (arg: string) => void;
+  comma: (arg: string) => void,
+  none: (arg: string) => void
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 20`] = `
+{
+  "code": "
+interface Foo {
+  semi: (arg: string) => void;
+  comma: (arg: string) => void,
+  none: (arg: string) => void
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Function property signature is forbidden. Use a method shorthand instead.",
+      "messageId": "errorProperty",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  semi(arg: string): void;
+  comma(arg: string): void,
+  none(arg: string): void
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 21`] = `
+{
+  "code": "
+interface Foo {
+  x(
+    args: Pick<
+      Bar,
+      'one' | 'two' | 'three'
+    >,
+  ): Baz;
+  y(
+    foo: string,
+    bar: number,
+  ): void;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 8,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 12,
+        },
+        "start": {
+          "column": 3,
+          "line": 9,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  x: (
+    args: Pick<
+      Bar,
+      'one' | 'two' | 'three'
+    >,
+  ) => Baz;
+  y: (
+    foo: string,
+    bar: number,
+  ) => void;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 22`] = `
+{
+  "code": "
+interface Foo {
+  foo(): one;
+  foo(): two;
+  foo(): three;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  foo: (() => one) & (() => two) & (() => three);
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 23`] = `
+{
+  "code": "
+interface Foo {
+  foo(bar: string): one;
+  foo(bar: number, baz: string): two;
+  foo(): three;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  foo: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 24`] = `
+{
+  "code": "
+interface Foo {
+  [foo](bar: string): one;
+  [foo](bar: number, baz: string): two;
+  [foo](): three;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  [foo]: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 25`] = `
+{
+  "code": "
+interface Foo {
+  [foo](bar: string): one;
+  [foo](bar: number, baz: string): two;
+  [foo](): three;
+  bar(arg: string): void;
+  bar(baz: number): Foo;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 6,
+        },
+        "start": {
+          "column": 3,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 7,
+        },
+        "start": {
+          "column": 3,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 1,
+  "output": "
+interface Foo {
+  [foo]: ((bar: string) => one) & ((bar: number, baz: string) => two) & (() => three);
+  bar: ((arg: string) => void) & ((baz: number) => Foo);
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 26`] = `
+{
+  "code": "
+        declare global {
+          namespace jest {
+            interface Matchers<R, T> {
+              // Add overloads specific to the DOM
+              toHaveProp<K extends keyof DomPropsOf<T>>(name: K, value?: DomPropsOf<T>[K]): R;
+              toHaveProps(props: Partial<DomPropsOf<T>>): R;
+            }
+          }
+        }
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 95,
+          "line": 6,
+        },
+        "start": {
+          "column": 15,
+          "line": 6,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 7,
+        },
+        "start": {
+          "column": 15,
+          "line": 7,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 27`] = `
+{
+  "code": "
+type Foo = {
+  foo(): one;
+  foo(): two;
+  foo(): three;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+type Foo = {
+  foo: (() => one) & (() => two) & (() => three);
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 28`] = `
+{
+  "code": "
+declare const Foo: {
+  foo(): one;
+  foo(): two;
+  foo(): three;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "output": "
+declare const Foo: {
+  foo: (() => one) & (() => two) & (() => three);
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 29`] = `
+{
+  "code": "
+interface MyInterface {
+  methodReturningImplicitAny();
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface MyInterface {
+  methodReturningImplicitAny: () => any;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 30`] = `
+{
+  "code": "
+interface Test {
+  f(value: number): this;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 31`] = `
+{
+  "code": "
+interface Test {
+  foo(): this;
+  foo(): Promise<this>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 32`] = `
+{
+  "code": "
+interface Test {
+  f(value: number): this | undefined;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 33`] = `
+{
+  "code": "
+interface Test {
+  f(value: number): Promise<this>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`method-signature-style > invalid 34`] = `
+{
+  "code": "
+interface Test {
+  f(value: number): Promise<this | undefined>;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Shorthand method signature is forbidden. Use a function property instead.",
+      "messageId": "errorMethod",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/method-signature-style",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/method-signature-style.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/method-signature-style.test.ts
@@ -670,5 +670,81 @@ interface MyInterface {
 }
       `,
     },
+    // this return type — no autofix
+    {
+      code: `
+interface Test {
+  f(value: number): this;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'errorMethod',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+interface Test {
+  foo(): this;
+  foo(): Promise<this>;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'errorMethod',
+        },
+        {
+          line: 4,
+          messageId: 'errorMethod',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+interface Test {
+  f(value: number): this | undefined;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'errorMethod',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+interface Test {
+  f(value: number): Promise<this>;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'errorMethod',
+        },
+      ],
+      output: null,
+    },
+    {
+      code: `
+interface Test {
+  f(value: number): Promise<this | undefined>;
+}
+      `,
+      errors: [
+        {
+          line: 3,
+          messageId: 'errorMethod',
+        },
+      ],
+      output: null,
+    },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/method-signature-style` rule from typescript-eslint to rslint.

This rule enforces consistent method signature syntax in TypeScript interfaces and type literals, choosing between method shorthand (`func(arg: string): number`) and property syntax (`func: (arg: string) => number`).

Key features:
- Default `"property"` mode and optional `"method"` mode
- Autofix for converting between both styles
- Overload merging (method overloads → intersection function types)
- `this` return type detection (skips autofix)
- Module/namespace declaration detection (reports without autofix)

## Related Links

- typescript-eslint rule: https://typescript-eslint.io/rules/method-signature-style
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/method-signature-style.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).