### PR TITLE
feat: show executed rule count in CLI summary output

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -205,7 +205,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	}
 
 	// Run linter
-	lintedFilesCount, err := linter.RunLinter(
+	lintResult, err := linter.RunLinter(
 		programs,
 		false, // Don't use single-threaded mode for IPC
 		allowedFiles,
@@ -262,7 +262,7 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 	response := &api.LintResponse{
 		Diagnostics: diagnostics,
 		ErrorCount:  errorsCount,
-		FileCount:   int(lintedFilesCount),
+		FileCount:   int(lintResult.LintedFileCount),
 		RuleCount:   len(rulesWithOptions),
 	}
 	// Only include encoded source files if requested

--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -920,7 +920,7 @@ func runCMD() int {
 		}
 	}
 
-	lintedfileCount, err := linter.RunLinter(
+	lintResult, err := linter.RunLinter(
 		programs,
 		singleThreaded,
 		allowFiles,
@@ -940,6 +940,8 @@ func runCMD() int {
 		fmt.Fprintf(os.Stderr, "error running linter: %v\n", err)
 		return 1
 	}
+
+	lintedfileCount := lintResult.LintedFileCount
 
 	wg.Wait()
 
@@ -1035,7 +1037,7 @@ func runCMD() int {
 				}
 			}
 			var passDiags []rule.RuleDiagnostic
-			linter.RunLinter(
+			passResult, _ := linter.RunLinter(
 				newPrograms,
 				singleThreaded,
 				allowFiles,
@@ -1051,6 +1053,11 @@ func runCMD() int {
 				typeInfoFiles,
 				fixFileFilters,
 			)
+			if passResult != nil {
+				for name := range passResult.ExecutedRules {
+					lintResult.ExecutedRules[name] = struct{}{}
+				}
+			}
 
 			// Replace allDiags with latest post-fix diagnostics.
 			allDiags = passDiags
@@ -1115,6 +1122,8 @@ func runCMD() int {
 
 	warningsText := pluralize(warningsCount, "warning", "warnings")
 	filesText := pluralize(int(lintedfileCount), "file", "files")
+	rulesCount := len(lintResult.ExecutedRules)
+	rulesText := pluralize(rulesCount, "rule", "rules")
 	threadsCount := 1
 	if !singleThreaded {
 		threadsCount = runtime.GOMAXPROCS(0)
@@ -1141,13 +1150,15 @@ func runCMD() int {
 			fixText := pluralize(fixedCount, "issue", "issues")
 			fmt.Fprintf(
 				os.Stdout,
-				"Found %s and %s %s %s(linted %s %s in %s using %s threads, fixed %s %s)%s\n",
+				"Found %s and %s %s %s(linted %s %s with %s %s in %s using %s threads, fixed %s %s)%s\n",
 				errorsSummary,
 				warningsColorFunc("%d", warningsCount),
 				warningsText,
 				colors.DimText(""),
 				colors.BoldText("%d", lintedfileCount),
 				filesText,
+				colors.BoldText("%d", rulesCount),
+				rulesText,
 				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
 				colors.BoldText("%d", threadsCount),
 				colors.SuccessText("%d", fixedCount),
@@ -1157,13 +1168,15 @@ func runCMD() int {
 		} else {
 			fmt.Fprintf(
 				os.Stdout,
-				"Found %s and %s %s %s(linted %s %s in %s using %s threads)%s\n",
+				"Found %s and %s %s %s(linted %s %s with %s %s in %s using %s threads)%s\n",
 				errorsSummary,
 				warningsColorFunc("%d", warningsCount),
 				warningsText,
 				colors.DimText(""),
 				colors.BoldText("%d", lintedfileCount),
 				filesText,
+				colors.BoldText("%d", rulesCount),
+				rulesText,
 				colors.BoldText("%v", time.Since(timeBefore).Round(time.Millisecond)),
 				colors.BoldText("%d", threadsCount),
 				color.New().SprintFunc()(""), // Reset

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
@@ -397,6 +398,12 @@ func RunLinterInProgram(program *compiler.Program, allowFiles []string, allowDir
 type RuleHandler = func(sourceFile *ast.SourceFile) []ConfiguredRule
 type DiagnosticHandler = func(diagnostic rule.RuleDiagnostic)
 
+// LintResult holds the outcome of a RunLinter invocation.
+type LintResult struct {
+	LintedFileCount int32
+	ExecutedRules   map[string]struct{}
+}
+
 // RunLinter runs all configured rules across the given programs in parallel.
 //   - allowFiles: if non-nil, only lint files in this list; nil = all files
 //   - allowDirs: if non-nil, also lint files under these dirs (OR with allowFiles)
@@ -404,7 +411,20 @@ type DiagnosticHandler = func(diagnostic rule.RuleDiagnostic)
 //   - fileFilters: optional per-program ownership filters (parallel to programs).
 //     In multi-config mode, each filter ensures a program only lints files owned by
 //     its nearest config. nil or missing entries = no filter (process all).
-func RunLinter(programs []*compiler.Program, singleThreaded bool, allowFiles []string, allowDirs []string, excludedPaths []string, getRulesForFile RuleHandler, typeCheck bool, onDiagnostic DiagnosticHandler, typeInfoFiles map[string]struct{}, fileFilters []func(string) bool) (int32, error) {
+func RunLinter(programs []*compiler.Program, singleThreaded bool, allowFiles []string, allowDirs []string, excludedPaths []string, getRulesForFile RuleHandler, typeCheck bool, onDiagnostic DiagnosticHandler, typeInfoFiles map[string]struct{}, fileFilters []func(string) bool) (*LintResult, error) {
+
+	executedRules := make(map[string]struct{})
+	var rulesMu sync.Mutex
+
+	trackedGetRules := func(sourceFile *ast.SourceFile) []ConfiguredRule {
+		rules := getRulesForFile(sourceFile)
+		rulesMu.Lock()
+		for _, r := range rules {
+			executedRules[r.Name] = struct{}{}
+		}
+		rulesMu.Unlock()
+		return rules
+	}
 
 	wg := core.NewWorkGroup(singleThreaded)
 
@@ -432,12 +452,15 @@ func RunLinter(programs []*compiler.Program, singleThreaded bool, allowFiles []s
 		}
 
 		wg.Queue(func() {
-			fileCount := RunLinterInProgram(program, allowFiles, allowDirs, excludedPaths, getRulesForFile, typeCheck, onDiagnostic, typeInfoFiles, filter)
+			fileCount := RunLinterInProgram(program, allowFiles, allowDirs, excludedPaths, trackedGetRules, typeCheck, onDiagnostic, typeInfoFiles, filter)
 			lintedFileCount.Add(fileCount)
 		})
 	}
 	wg.RunAndWait()
-	return lintedFileCount.Load(), nil
+	return &LintResult{
+		LintedFileCount: lintedFileCount.Load(),
+		ExecutedRules:   executedRules,
+	}, nil
 }
 
 // buildOwnedFileSet returns a set of file names that this program directly owns

--- a/internal/linter/linter_allowdirs_test.go
+++ b/internal/linter/linter_allowdirs_test.go
@@ -372,7 +372,7 @@ func TestRunLinter_AllowDirsIntegration(t *testing.T) {
 	})
 
 	srcDir := tmpDirPath(t, paths, "src/a.ts")
-	lintedCount, err := RunLinter([]*compiler.Program{program}, true, nil, []string{srcDir}, utils.ExcludePaths,
+	result, err := RunLinter([]*compiler.Program{program}, true, nil, []string{srcDir}, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
@@ -381,8 +381,8 @@ func TestRunLinter_AllowDirsIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunLinter error: %v", err)
 	}
-	if lintedCount != 1 {
-		t.Errorf("Expected 1 file under src/, got %d", lintedCount)
+	if result.LintedFileCount != 1 {
+		t.Errorf("Expected 1 file under src/, got %d", result.LintedFileCount)
 	}
 }
 
@@ -396,7 +396,7 @@ func TestRunLinter_MultiplePrograms(t *testing.T) {
 	})
 
 	lintedFileNames := []string{}
-	lintedCount, err := RunLinter(
+	result, err := RunLinter(
 		[]*compiler.Program{programA, programB},
 		true,
 		[]string{pathsA["a.ts"], pathsB["b.ts"]},
@@ -413,8 +413,8 @@ func TestRunLinter_MultiplePrograms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunLinter error: %v", err)
 	}
-	if lintedCount != 2 {
-		t.Errorf("Expected 2 files across 2 programs, got %d", lintedCount)
+	if result.LintedFileCount != 2 {
+		t.Errorf("Expected 2 files across 2 programs, got %d", result.LintedFileCount)
 	}
 }
 
@@ -431,7 +431,7 @@ func TestRunLinter_MultipleProgramsWithAllowDirs(t *testing.T) {
 	srcDirA := tmpDirPath(t, pathsA, "src/a.ts")
 	srcDirB := tmpDirPath(t, pathsB, "src/b.ts")
 
-	lintedCount, err := RunLinter(
+	result, err := RunLinter(
 		[]*compiler.Program{programA, programB},
 		true,
 		nil,
@@ -446,8 +446,8 @@ func TestRunLinter_MultipleProgramsWithAllowDirs(t *testing.T) {
 		t.Fatalf("RunLinter error: %v", err)
 	}
 	// Only src/ files from each program
-	if lintedCount != 2 {
-		t.Errorf("Expected 2 files (src from each program), got %d", lintedCount)
+	if result.LintedFileCount != 2 {
+		t.Errorf("Expected 2 files (src from each program), got %d", result.LintedFileCount)
 	}
 }
 

--- a/internal/linter/linter_allowfiles_test.go
+++ b/internal/linter/linter_allowfiles_test.go
@@ -181,7 +181,7 @@ func TestRunLinter_AllowFilesIntegration(t *testing.T) {
 	})
 
 	lintedFileNames := []string{}
-	lintedCount, err := RunLinter([]*compiler.Program{program}, true, []string{paths["b.ts"]}, nil, utils.ExcludePaths,
+	result, err := RunLinter([]*compiler.Program{program}, true, []string{paths["b.ts"]}, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule {
 			lintedFileNames = append(lintedFileNames, sf.FileName())
 			return noopRule()
@@ -193,8 +193,8 @@ func TestRunLinter_AllowFilesIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunLinter error: %v", err)
 	}
-	if lintedCount != 1 {
-		t.Errorf("Expected 1 file, got %d", lintedCount)
+	if result.LintedFileCount != 1 {
+		t.Errorf("Expected 1 file, got %d", result.LintedFileCount)
 	}
 }
 
@@ -204,7 +204,7 @@ func TestRunLinter_AllowFilesNilPassthrough(t *testing.T) {
 		"b.ts": "const b = 2;",
 	})
 
-	lintedCount, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []ConfiguredRule { return noopRule() },
 		false, func(d rule.RuleDiagnostic) {}, nil,
 		nil,
@@ -213,7 +213,7 @@ func TestRunLinter_AllowFilesNilPassthrough(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunLinter error: %v", err)
 	}
-	if lintedCount < 2 {
-		t.Errorf("Expected at least 2 files, got %d", lintedCount)
+	if result.LintedFileCount < 2 {
+		t.Errorf("Expected at least 2 files, got %d", result.LintedFileCount)
 	}
 }

--- a/internal/linter/linter_test.go
+++ b/internal/linter/linter_test.go
@@ -77,3 +77,87 @@ func tmpDirPath(t *testing.T, normalizedPaths map[string]string, fileName string
 	return tspath.GetDirectoryPath(normalizedPaths[fileName])
 }
 
+func TestRunLinter_ExecutedRules(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+		"b.ts": "const b = 2;",
+	})
+
+	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []ConfiguredRule {
+			return []ConfiguredRule{
+				{Name: "rule-a", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
+				{Name: "rule-b", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
+			}
+		},
+		false, func(d rule.RuleDiagnostic) {}, nil, nil,
+	)
+
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if _, ok := result.ExecutedRules["rule-a"]; !ok {
+		t.Error("Expected rule-a in ExecutedRules")
+	}
+	if _, ok := result.ExecutedRules["rule-b"]; !ok {
+		t.Error("Expected rule-b in ExecutedRules")
+	}
+	if len(result.ExecutedRules) != 2 {
+		t.Errorf("Expected 2 executed rules, got %d", len(result.ExecutedRules))
+	}
+}
+
+func TestRunLinter_ExecutedRulesPerFile(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+		"b.ts": "const b = 2;",
+	})
+
+	// Different files get different rules — ExecutedRules should be the union.
+	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []ConfiguredRule {
+			if sf.FileName() == paths["a.ts"] {
+				return []ConfiguredRule{
+					{Name: "only-a", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
+				}
+			}
+			return []ConfiguredRule{
+				{Name: "only-b", Severity: rule.SeverityWarning, Run: func(ctx rule.RuleContext) rule.RuleListeners { return nil }},
+			}
+		},
+		false, func(d rule.RuleDiagnostic) {}, nil, nil,
+	)
+
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if len(result.ExecutedRules) != 2 {
+		t.Errorf("Expected 2 executed rules (union), got %d", len(result.ExecutedRules))
+	}
+	if _, ok := result.ExecutedRules["only-a"]; !ok {
+		t.Error("Expected only-a in ExecutedRules")
+	}
+	if _, ok := result.ExecutedRules["only-b"]; !ok {
+		t.Error("Expected only-b in ExecutedRules")
+	}
+}
+
+func TestRunLinter_ExecutedRulesEmpty(t *testing.T) {
+	program, _ := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const a = 1;",
+	})
+
+	// No rules returned → ExecutedRules should be empty.
+	result, err := RunLinter([]*compiler.Program{program}, true, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		false, func(d rule.RuleDiagnostic) {}, nil, nil,
+	)
+
+	if err != nil {
+		t.Fatalf("RunLinter error: %v", err)
+	}
+	if len(result.ExecutedRules) != 0 {
+		t.Errorf("Expected 0 executed rules, got %d", len(result.ExecutedRules))
+	}
+}
+

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -889,7 +889,7 @@ func TestTypeCheck_MultiplePrograms(t *testing.T) {
 
 	var mu sync.Mutex
 	var diagnostics []rule.RuleDiagnostic
-	count, err := RunLinter(
+	result, err := RunLinter(
 		[]*compiler.Program{program1, program2},
 		true,
 		nil, nil, utils.ExcludePaths,
@@ -906,8 +906,8 @@ func TestTypeCheck_MultiplePrograms(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunLinter error: %v", err)
 	}
-	if count < 2 {
-		t.Errorf("Expected lintedFileCount >= 2, got %d", count)
+	if result.LintedFileCount < 2 {
+		t.Errorf("Expected lintedFileCount >= 2, got %d", result.LintedFileCount)
 	}
 
 	tsCount := 0

--- a/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
+++ b/packages/rslint-test-tools/tests/cli/type-check/__snapshots__/type-check-snapshot.test.ts.snap
@@ -9,7 +9,7 @@ exports[`--type-check output snapshots (default format) > --quiet suppresses war
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 1 warning (linted 1 file in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 1 warning (linted 1 file with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -28,7 +28,7 @@ exports[`--type-check output snapshots (default format) > both lint error and ty
   │ 3 │  
   ╰────────────────────────────────
 
-Found 1 lint error, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -40,7 +40,7 @@ exports[`--type-check output snapshots (default format) > lint error only with -
   │ 2 │  console.log(a);
   ╰────────────────────────────────
 
-Found 1 lint error, 0 type errors and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 1 lint error, 0 type errors and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -52,7 +52,7 @@ exports[`--type-check output snapshots (default format) > lint error without --t
   │ 2 │  console.log(a);
   ╰────────────────────────────────
 
-Found 1 error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 1 error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -66,7 +66,7 @@ exports[`--type-check output snapshots (default format) > multi-line lint error 
   │ 6 │  console.log(fn);
   ╰────────────────────────────────
 
-Found 1 error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 1 error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -87,7 +87,7 @@ exports[`--type-check output snapshots (default format) > multi-line lint error 
   │ 7 │  
   ╰────────────────────────────────
 
-Found 1 lint error, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 1 lint error, 1 type error and 0 warnings (linted 1 file with 1 rule in <TIME> using <N> threads)
 "
 `;
 
@@ -100,7 +100,7 @@ exports[`--type-check output snapshots (default format) > multi-line: MessageCha
   │ 2 │  console.log(foo);
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -114,7 +114,7 @@ exports[`--type-check output snapshots (default format) > multi-line: RelatedInf
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -128,7 +128,7 @@ exports[`--type-check output snapshots (default format) > multi-line: RelatedInf
   │ 3 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -143,12 +143,12 @@ exports[`--type-check output snapshots (default format) > multi-line: deep Messa
   │ 4 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
 "
 `;
 
 exports[`--type-check output snapshots (default format) > no errors with --type-check 1`] = `
-"Found 0 lint errors, 0 type errors and 0 warnings (linted 1 file in <TIME> using <N> threads)
+"Found 0 lint errors, 0 type errors and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
 "
 `;
 
@@ -160,7 +160,7 @@ exports[`--type-check output snapshots (default format) > type error only (TS232
   │ 2 │  
   ╰────────────────────────────────
 
-Found 0 lint errors, 1 type error and 0 warnings (linted 1 file in <TIME> using <N> threads)
+Found 0 lint errors, 1 type error and 0 warnings (linted 1 file with 0 rules in <TIME> using <N> threads)
 "
 `;
 


### PR DESCRIPTION
## Summary

- `RunLinter` now returns `*LintResult` struct (containing `LintedFileCount` and `ExecutedRules`) instead of a bare `int32`, so the linter reports what rules it actually executed.
- The CLI "Found" summary line now includes the count of unique rules evaluated, e.g.:
  ```
  Found 0 errors and 2 warnings (linted 150 files with 45 rules in 320ms using 8 threads)
  ```
- `--fix` multi-pass merges executed rules across all passes.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).