### PR TITLE
ci: increase vscode-extension test timeouts to reduce flaky failures

### DIFF
--- a/packages/vscode-extension/__tests__/suite/extension.test.ts
+++ b/packages/vscode-extension/__tests__/suite/extension.test.ts
@@ -3,23 +3,23 @@ import * as vscode from 'vscode';
 import path from 'node:path';
 
 suite('rslint extension', function () {
-  this.timeout(50000);
+  this.timeout(90000);
 
-  // Helper function to wait for diagnostics
+  // Helper function to wait for diagnostics.
+  // On CI (especially Windows), the LSP server may take longer to start up,
+  // load config, type-check, and push initial diagnostics. Use generous
+  // iteration count (15) and per-iteration timeout (2s) to avoid flaky failures.
   async function waitForDiagnostics(
     doc: vscode.TextDocument,
   ): Promise<vscode.Diagnostic[]> {
-    // Try multiple times to get diagnostics
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < 15; i++) {
       const diagnostics = vscode.languages.getDiagnostics(doc.uri);
       if (diagnostics.length > 0) {
         return diagnostics;
       }
 
-      // Wait for diagnostics change event or timeout
       await new Promise((resolve) => {
         const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          // Check if this event is for our document
           for (const uri of e.uris) {
             if (uri.toString() === doc.uri.toString()) {
               disposable.dispose();
@@ -28,22 +28,20 @@ suite('rslint extension', function () {
             }
           }
         });
-        // Wait 1 second then check again
         setTimeout(() => {
           disposable.dispose();
           resolve(void 0);
-        }, 1000);
+        }, 2000);
       });
     }
 
     return vscode.languages.getDiagnostics(doc.uri);
   }
 
-  // Helper function to wait for diagnostics to change from a previous state
   async function waitForDiagnosticsToChange(
     doc: vscode.TextDocument,
     previousCount: number,
-    timeoutMs = 15000,
+    timeoutMs = 30000,
   ): Promise<vscode.Diagnostic[]> {
     const startTime = Date.now();
 
@@ -74,11 +72,10 @@ suite('rslint extension', function () {
     return vscode.languages.getDiagnostics(doc.uri);
   }
 
-  // Helper function to wait for diagnostics to reach a specific count
   async function waitForDiagnosticsCount(
     doc: vscode.TextDocument,
     expectedCount: number,
-    timeoutMs = 15000,
+    timeoutMs = 30000,
   ): Promise<vscode.Diagnostic[]> {
     const startTime = Date.now();
 
@@ -108,11 +105,10 @@ suite('rslint extension', function () {
     return vscode.languages.getDiagnostics(doc.uri);
   }
 
-  // Helper function to wait for diagnostics containing a specific message
   async function waitForDiagnosticsWithMessage(
     doc: vscode.TextDocument,
     messageSubstring: string,
-    timeoutMs = 15000,
+    timeoutMs = 30000,
   ): Promise<vscode.Diagnostic[]> {
     const startTime = Date.now();
 

--- a/packages/vscode-extension/__tests__/suite/fixall-cascade.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-cascade.test.ts
@@ -10,7 +10,7 @@ import {
 } from './fixall-helpers';
 
 suite('rslint fixAll - cascade (multi-pass)', function () {
-  this.timeout(50000);
+  this.timeout(90000);
 
   test('ban-types triggers no-inferrable-types in second pass', async () => {
     const cascadeContent = [
@@ -67,7 +67,7 @@ suite('rslint fixAll - cascade (multi-pass)', function () {
       while (
         (doc.getText().includes(': String') ||
           doc.getText().includes(': string')) &&
-        Date.now() - startTime < 15000
+        Date.now() - startTime < 30000
       ) {
         await new Promise((r) => setTimeout(r, 500));
       }

--- a/packages/vscode-extension/__tests__/suite/fixall-error.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-error.test.ts
@@ -10,7 +10,7 @@ import {
 } from './fixall-helpers';
 
 suite('rslint fixAll - error flows', function () {
-  this.timeout(50000);
+  this.timeout(90000);
 
   test('fixAll on file with syntax errors does not crash', async () => {
     const brokenContent = 'const x: string = \nfunction (\nexport { \n';
@@ -65,7 +65,7 @@ suite('rslint fixAll - error flows', function () {
       const probeStart = Date.now();
       while (
         doc.getText().includes('pVal as string') &&
-        Date.now() - probeStart < 10000
+        Date.now() - probeStart < 20000
       ) {
         await new Promise((r) => setTimeout(r, 500));
       }

--- a/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-helpers.ts
@@ -18,7 +18,10 @@ export async function openFixture(
 export async function waitForDiagnostics(
   doc: vscode.TextDocument,
 ): Promise<vscode.Diagnostic[]> {
-  for (let i = 0; i < 10; i++) {
+  // On CI (especially Windows), the LSP server may take longer to start up,
+  // load config, type-check, and push initial diagnostics. Use generous
+  // iteration count (15) and per-iteration timeout (2s) to avoid flaky failures.
+  for (let i = 0; i < 15; i++) {
     const diagnostics = vscode.languages.getDiagnostics(doc.uri);
     if (diagnostics.length > 0) {
       return diagnostics;
@@ -36,7 +39,7 @@ export async function waitForDiagnostics(
       setTimeout(() => {
         disposable.dispose();
         resolve(void 0);
-      }, 1000);
+      }, 2000);
     });
   }
   return vscode.languages.getDiagnostics(doc.uri);
@@ -45,7 +48,7 @@ export async function waitForDiagnostics(
 export async function waitForDiagnosticsToChange(
   doc: vscode.TextDocument,
   previousCount: number,
-  timeoutMs = 15000,
+  timeoutMs = 30000,
 ): Promise<vscode.Diagnostic[]> {
   const startTime = Date.now();
   while (Date.now() - startTime < timeoutMs) {
@@ -75,7 +78,7 @@ export async function waitForDiagnosticsToChange(
 export async function waitForDiagnosticsCount(
   doc: vscode.TextDocument,
   expectedCount: number,
-  timeoutMs = 15000,
+  timeoutMs = 30000,
 ): Promise<vscode.Diagnostic[]> {
   const startTime = Date.now();
   while (Date.now() - startTime < timeoutMs) {

--- a/packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall-onsave.test.ts
@@ -11,7 +11,7 @@ import {
 } from './fixall-helpers';
 
 suite('rslint fixAll - on-save', function () {
-  this.timeout(50000);
+  this.timeout(90000);
 
   test('generic source.fixAll triggers rslint via on-save', async () => {
     const fixturesDir = getFixturesDir();
@@ -54,7 +54,7 @@ suite('rslint fixAll - on-save', function () {
         const startTime = Date.now();
         while (
           doc.getText().includes('gfVal as string') &&
-          Date.now() - startTime < 10000
+          Date.now() - startTime < 20000
         ) {
           await new Promise((r) => setTimeout(r, 500));
         }
@@ -97,7 +97,7 @@ suite('rslint fixAll - on-save', function () {
       const startTime = Date.now();
       while (
         doc.getText().includes('saveVal as string') &&
-        Date.now() - startTime < 10000
+        Date.now() - startTime < 20000
       ) {
         await new Promise((r) => setTimeout(r, 500));
       }
@@ -222,7 +222,7 @@ suite('rslint fixAll - on-save', function () {
       const startTime = Date.now();
       while (
         doc.getText().includes('quickVal as string') &&
-        Date.now() - startTime < 10000
+        Date.now() - startTime < 20000
       ) {
         await new Promise((r) => setTimeout(r, 500));
       }

--- a/packages/vscode-extension/__tests__/suite/fixall.test.ts
+++ b/packages/vscode-extension/__tests__/suite/fixall.test.ts
@@ -11,7 +11,7 @@ import {
 } from './fixall-helpers';
 
 suite('rslint fixAll - code actions', function () {
-  this.timeout(50000);
+  this.timeout(90000);
 
   // ======== Basic fixAll behavior (read-only, safe to use fixtures) ========
 


### PR DESCRIPTION
## Summary

Increase timeouts in VS Code extension integration tests to reduce flaky failures on CI, especially on Windows.

The LSP server startup chain (spawn Go binary → initialize → load config → type-check → push diagnostics) can be slow on CI runners. The existing timeouts were too tight, causing intermittent failures:
- `Expected diagnostics but got 0`
- `Single save should fix both cascade passes`
- `On-save fixAll should work even when debounce has not fired`

### Changes

| Setting | Before | After |
|---------|--------|-------|
| `waitForDiagnostics` iterations | 10 × 1s | 15 × 2s |
| `waitForDiagnosticsToChange` / `Count` default | 15s | 30s |
| Save-then-poll loops | 10–15s | 20–30s |
| Suite-level Mocha timeout | 50s | 90s |

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).