### PR TITLE
feat: port rule no-param-reassign

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
 	"github.com/web-infra-dev/rslint/internal/rules/no_octal_escape"
+	"github.com/web-infra-dev/rslint/internal/rules/no_param_reassign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
@@ -546,6 +547,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-restricted-imports", no_restricted_imports.NoRestrictedImportsRule)
 	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)
+	GlobalRuleRegistry.Register("no-param-reassign", no_param_reassign.NoParamReassignRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)

--- a/internal/rules/no_class_assign/no_class_assign.go
+++ b/internal/rules/no_class_assign/no_class_assign.go
@@ -247,41 +247,9 @@ func isNameShadowed(node *ast.Node, className string, classNode *ast.Node, ctx *
 		return symbol != classSymbol
 	}
 
-	// Fallback: check if the identifier is within a scope that shadows the class name
-	return isInShadowingScope(node, className, classNode)
-}
-
-// isInShadowingScope checks if a node is within a scope that shadows the class name.
-// Unlike utils.IsShadowed, this walks only up to classNode (not to SourceFile).
-func isInShadowingScope(node *ast.Node, className string, classNode *ast.Node) bool {
-	current := node.Parent
-	for current != nil && current != classNode {
-		if ast.IsFunctionLikeDeclaration(current) {
-			if utils.HasShadowingParameter(current, className) {
-				return true
-			}
-		}
-
-		if current.Kind == ast.KindBlock {
-			if utils.HasShadowingDeclaration(current, className) {
-				return true
-			}
-		}
-
-		if current.Kind == ast.KindCatchClause {
-			catchClause := current.AsCatchClause()
-			if catchClause != nil && catchClause.VariableDeclaration != nil {
-				varDecl := catchClause.VariableDeclaration.AsVariableDeclaration()
-				if varDecl != nil && varDecl.Name() != nil {
-					if utils.HasNameInBindingPattern(varDecl.Name(), className) {
-						return true
-					}
-				}
-			}
-		}
-		current = current.Parent
-	}
-	return false
+	// Fallback: check if the identifier is within a scope that shadows the
+	// class name. Walks only up to classNode (not to SourceFile).
+	return utils.IsNameShadowedBetween(node, classNode, className)
 }
 
 // checkClassReassignments finds all reassignments to the class name

--- a/internal/rules/no_ex_assign/no_ex_assign.go
+++ b/internal/rules/no_ex_assign/no_ex_assign.go
@@ -202,30 +202,12 @@ func isWriteReference(node *ast.Node) bool {
 	return false
 }
 
-func getReferenceSymbol(node *ast.Node, ctx rule.RuleContext) *ast.Symbol {
-	if node == nil || ctx.TypeChecker == nil {
-		return nil
-	}
-
-	parent := node.Parent
-	if parent != nil && parent.Kind == ast.KindShorthandPropertyAssignment {
-		shorthand := parent.AsShorthandPropertyAssignment()
-		if shorthand != nil && shorthand.Name() == node {
-			if symbol := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(parent); symbol != nil {
-				return symbol
-			}
-		}
-	}
-
-	return ctx.TypeChecker.GetSymbolAtLocation(node)
-}
-
 func isNameShadowed(node *ast.Node, symbols []*ast.Symbol, ctx rule.RuleContext) bool {
 	if node == nil || ctx.TypeChecker == nil || len(symbols) == 0 {
 		return false
 	}
 
-	symbol := getReferenceSymbol(node, ctx)
+	symbol := utils.GetReferenceSymbol(node, ctx.TypeChecker)
 	if symbol == nil {
 		return false
 	}

--- a/internal/rules/no_func_assign/no_func_assign.go
+++ b/internal/rules/no_func_assign/no_func_assign.go
@@ -53,36 +53,14 @@ func isNameShadowed(node *ast.Node, name string, declNode *ast.Node, ctx *rule.R
 }
 
 // isInShadowingScope walks from `node` up to (but not including) `declNode`,
-// returning true if any intermediate scope introduces a binding with the given name.
+// returning true if any intermediate scope introduces a binding with the given
+// name. Also treats `declNode`'s own parameters as shadowing
+// (e.g. `function foo(foo) { foo = bar; }`).
 func isInShadowingScope(node *ast.Node, name string, declNode *ast.Node) bool {
-	for current := node.Parent; current != nil && current != declNode; current = current.Parent {
-		if ast.IsFunctionLikeDeclaration(current) {
-			if utils.HasShadowingParameter(current, name) {
-				return true
-			}
-		}
-
-		if current.Kind == ast.KindBlock {
-			if utils.HasShadowingDeclaration(current, name) {
-				return true
-			}
-		}
-
-		if current.Kind == ast.KindCatchClause {
-			cc := current.AsCatchClause()
-			if cc != nil && cc.VariableDeclaration != nil {
-				vd := cc.VariableDeclaration.AsVariableDeclaration()
-				if vd != nil && vd.Name() != nil && vd.Name().Kind == ast.KindIdentifier && vd.Name().Text() == name {
-					return true
-				}
-			}
-		}
-	}
-	// Also check declNode's own parameters (e.g. function foo(foo) { foo = bar; }).
-	if declNode != nil && utils.HasShadowingParameter(declNode, name) {
+	if utils.IsNameShadowedBetween(node, declNode, name) {
 		return true
 	}
-	return false
+	return declNode != nil && utils.HasShadowingParameter(declNode, name)
 }
 
 // checkReassignments walks `searchRoot` and reports every write-reference to `name`

--- a/internal/rules/no_param_reassign/no_param_reassign.go
+++ b/internal/rules/no_param_reassign/no_param_reassign.go
@@ -1,0 +1,308 @@
+package no_param_reassign
+
+import (
+	"regexp"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type Options struct {
+	Props                               bool
+	IgnorePropertyModificationsFor      []string
+	IgnorePropertyModificationsForRegex []*regexp.Regexp
+}
+
+func parseOptions(options any) Options {
+	opts := Options{Props: false}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+	if props, ok := optsMap["props"].(bool); ok {
+		opts.Props = props
+	}
+	if arr, ok := optsMap["ignorePropertyModificationsFor"].([]interface{}); ok {
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				opts.IgnorePropertyModificationsFor = append(opts.IgnorePropertyModificationsFor, s)
+			}
+		}
+	}
+	if arr, ok := optsMap["ignorePropertyModificationsForRegex"].([]interface{}); ok {
+		for _, v := range arr {
+			if s, ok := v.(string); ok {
+				// ESLint uses the "u" flag; Go's regexp is UTF-8 by default.
+				if re, err := regexp.Compile(s); err == nil {
+					opts.IgnorePropertyModificationsForRegex = append(opts.IgnorePropertyModificationsForRegex, re)
+				}
+			}
+		}
+	}
+	return opts
+}
+
+func buildAssignmentMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "assignmentToFunctionParam",
+		Description: "Assignment to function parameter '" + name + "'.",
+	}
+}
+
+func buildPropAssignmentMessage(name string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "assignmentToFunctionParamProp",
+		Description: "Assignment to property of function parameter '" + name + "'.",
+	}
+}
+
+// isPropWalkStopNode marks the edge of the expression context around a
+// parameter reference. The walk in isModifyingProp continues upward through
+// expressions and halts once it hits a statement, declaration, or function
+// boundary — mirroring ESLint's stopNodePattern. ForIn/ForOf are intentionally
+// excluded so the walk can still inspect their initializer position.
+func isPropWalkStopNode(node *ast.Node) bool {
+	if node == nil {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		return false
+	case ast.KindSourceFile, ast.KindModuleBlock:
+		return true
+	case ast.KindVariableDeclaration,
+		ast.KindParameter,
+		ast.KindPropertyDeclaration,
+		ast.KindBindingElement,
+		ast.KindClassStaticBlockDeclaration:
+		return true
+	}
+	if ast.IsFunctionLikeDeclaration(node) {
+		return true
+	}
+	return ast.IsStatement(node)
+}
+
+// isModifyingProp walks up from a parameter reference to decide whether the
+// reference participates in a property modification (assignment, update,
+// delete, or for-in/of target). Ported from ESLint's isModifyingProp.
+func isModifyingProp(ident *ast.Node) bool {
+	node := ident
+	parent := node.Parent
+	for parent != nil && !isPropWalkStopNode(parent) {
+		switch parent.Kind {
+		case ast.KindBinaryExpression:
+			binary := parent.AsBinaryExpression()
+			if binary != nil && binary.OperatorToken != nil && ast.IsAssignmentOperator(binary.OperatorToken.Kind) {
+				return binary.Left == node
+			}
+
+		case ast.KindPrefixUnaryExpression:
+			pf := parent.AsPrefixUnaryExpression()
+			if pf != nil && (pf.Operator == ast.KindPlusPlusToken || pf.Operator == ast.KindMinusMinusToken) {
+				return true
+			}
+
+		case ast.KindPostfixUnaryExpression:
+			pf := parent.AsPostfixUnaryExpression()
+			if pf != nil && (pf.Operator == ast.KindPlusPlusToken || pf.Operator == ast.KindMinusMinusToken) {
+				return true
+			}
+
+		case ast.KindDeleteExpression:
+			return true
+
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			stmt := parent.AsForInOrOfStatement()
+			if stmt != nil && stmt.Initializer == node {
+				return true
+			}
+			// Initializer is somewhere else: this statement bounds the walk.
+			return false
+
+		case ast.KindCallExpression:
+			// `foo(bar.x).y = 0` — bar is an argument, not the callee.
+			call := parent.AsCallExpression()
+			if call != nil && call.Expression != node {
+				return false
+			}
+
+		case ast.KindPropertyAccessExpression:
+			// `obj[bar].x = 0` — bar cannot appear as the Name side of a
+			// property access; if it did (private identifier case), stop.
+			pa := parent.AsPropertyAccessExpression()
+			if pa != nil && pa.Name() == node {
+				return false
+			}
+
+		case ast.KindElementAccessExpression:
+			// `cache[bar] = 0` — bar is the computed key, not the target.
+			ea := parent.AsElementAccessExpression()
+			if ea != nil && ea.ArgumentExpression == node {
+				return false
+			}
+
+		case ast.KindPropertyAssignment:
+			// `({bar: ...})` — bar is the key position, not a write.
+			pa := parent.AsPropertyAssignment()
+			if pa != nil && pa.Name() == node {
+				return false
+			}
+
+		case ast.KindShorthandPropertyAssignment:
+			// `({bar} = ...)` is a direct reassignment, already handled by
+			// IsWriteReference; never treat it as a property modification.
+			return false
+
+		case ast.KindConditionalExpression:
+			// `(bar ? a : b).x = 0` — bar in the test position is only read.
+			ce := parent.AsConditionalExpression()
+			if ce != nil && ce.Condition == node {
+				return false
+			}
+		}
+
+		node = parent
+		parent = node.Parent
+	}
+	return false
+}
+
+// isSameBinding returns true when the given identifier resolves to the same
+// binding as one of the given parameter declarations.
+//
+// With TypeChecker: compares symbols by ValueDeclaration rather than by
+// pointer — TypeScript creates two distinct symbols for `public`/`private`
+// parameter properties (one for the local parameter, one for the class
+// field), and both symbols share the same Parameter declaration. Pointer
+// comparison would miss that.
+//
+// Without TypeChecker: falls back to a scope walk — the reference refers to
+// the parameter unless an intermediate scope introduces its own binding with
+// the same name.
+func isSameBinding(ident *ast.Node, name string, paramDecl *ast.Node, paramSymbol *ast.Symbol, fn *ast.Node, ctx rule.RuleContext) bool {
+	if ctx.TypeChecker != nil && paramSymbol != nil {
+		refSym := utils.GetReferenceSymbol(ident, ctx.TypeChecker)
+		if refSym == nil {
+			return false
+		}
+		if refSym == paramSymbol {
+			return true
+		}
+		// Parameter properties: two symbols share a Parameter decl.
+		return paramDecl != nil && refSym.ValueDeclaration == paramDecl
+	}
+	return !utils.IsNameShadowedBetween(ident, fn, name)
+}
+
+func isIgnoredPropertyAssignment(opts Options, name string) bool {
+	if slices.Contains(opts.IgnorePropertyModificationsFor, name) {
+		return true
+	}
+	for _, re := range opts.IgnorePropertyModificationsForRegex {
+		if re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// paramBinding holds the bits needed to decide whether an identifier elsewhere
+// in the function refers to this parameter — both the symbol (when a
+// TypeChecker is available) and the declaration node (Parameter or
+// BindingElement) as a fallback discriminator.
+type paramBinding struct {
+	ident  *ast.Node
+	name   string
+	decl   *ast.Node // `ident.Parent` — Parameter or BindingElement
+	symbol *ast.Symbol
+}
+
+// checkFunction walks every identifier inside `fn` and reports reassignments
+// or property modifications that target one of its parameters.
+func checkFunction(fn *ast.Node, opts Options, ctx rule.RuleContext) {
+	// Collect all parameter bindings, flattening nested destructuring so that
+	// `function foo({a, b: [c]})` yields three entries.
+	var bindings []paramBinding
+	for _, param := range fn.Parameters() {
+		if param == nil || param.Name() == nil {
+			continue
+		}
+		utils.CollectBindingNames(param.Name(), func(ident *ast.Node, n string) {
+			b := paramBinding{ident: ident, name: n, decl: ident.Parent}
+			if ctx.TypeChecker != nil {
+				b.symbol = ctx.TypeChecker.GetSymbolAtLocation(ident)
+			}
+			bindings = append(bindings, b)
+		})
+	}
+	if len(bindings) == 0 {
+		return
+	}
+
+	// Skip the declaration identifiers themselves when walking.
+	skipSet := make(map[*ast.Node]struct{}, len(bindings))
+	// Quick name lookup for the slices.Contains hot path.
+	byName := make(map[string]*paramBinding, len(bindings))
+	for i := range bindings {
+		skipSet[bindings[i].ident] = struct{}{}
+		byName[bindings[i].name] = &bindings[i]
+	}
+
+	// Guard against reporting the same identifier twice.
+	reported := make(map[*ast.Node]struct{})
+
+	var walk func(*ast.Node)
+	walk = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		if node.Kind == ast.KindIdentifier {
+			if _, skip := skipSet[node]; !skip {
+				name := node.AsIdentifier().Text
+				if b := byName[name]; b != nil && isSameBinding(node, name, b.decl, b.symbol, fn, ctx) {
+					if _, already := reported[node]; !already {
+						if utils.IsWriteReference(node) {
+							reported[node] = struct{}{}
+							ctx.ReportNode(node, buildAssignmentMessage(name))
+						} else if opts.Props && !isIgnoredPropertyAssignment(opts, name) && isModifyingProp(node) {
+							reported[node] = struct{}{}
+							ctx.ReportNode(node, buildPropAssignmentMessage(name))
+						}
+					}
+				}
+			}
+		}
+		node.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+
+	walk(fn)
+}
+
+var NoParamReassignRule = rule.Rule{
+	Name: "no-param-reassign",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		handler := func(node *ast.Node) {
+			checkFunction(node, opts, ctx)
+		}
+		// Cover every function-like declaration kind — plain/arrow/async/
+		// generator functions, class methods, constructors, and accessors.
+		// Signature-only kinds (MethodSignature, CallSignature, etc.) have
+		// no body and are intentionally omitted.
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: handler,
+			ast.KindFunctionExpression:  handler,
+			ast.KindArrowFunction:       handler,
+			ast.KindMethodDeclaration:   handler,
+			ast.KindConstructor:         handler,
+			ast.KindGetAccessor:         handler,
+			ast.KindSetAccessor:         handler,
+		}
+	},
+}

--- a/internal/rules/no_param_reassign/no_param_reassign.md
+++ b/internal/rules/no_param_reassign/no_param_reassign.md
@@ -1,0 +1,85 @@
+# no-param-reassign
+
+## Rule Details
+
+Disallow reassigning function parameters. Reassigning a parameter mutates the caller-visible `arguments` object in non-strict code and can hide bugs caused by unintentional overwrites. With the `props` option, the rule also forbids modifying properties on parameters.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function foo(bar) {
+  bar = 13;
+}
+
+function foo(bar) {
+  bar++;
+}
+
+function foo(bar) {
+  for (bar in baz) {
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function foo(bar) {
+  var baz = bar;
+}
+```
+
+## Options
+
+```json
+{
+  "no-param-reassign": ["error", { "props": false }]
+}
+```
+
+```json
+{
+  "no-param-reassign": [
+    "error",
+    {
+      "props": true,
+      "ignorePropertyModificationsFor": ["acc", "e"],
+      "ignorePropertyModificationsForRegex": ["^ctx"]
+    }
+  ]
+}
+```
+
+- `props` (default `false`) — when `true`, assignments to properties of a parameter (e.g. `bar.x = 0`, `delete bar.x`, `++bar.x`) are also reported.
+- `ignorePropertyModificationsFor` (requires `props: true`) — parameter names for which property modifications are allowed.
+- `ignorePropertyModificationsForRegex` (requires `props: true`) — regular expressions matching parameter names for which property modifications are allowed.
+
+Examples of **incorrect** code with `{ "props": true }`:
+
+```javascript
+/*eslint no-param-reassign: ["error", { "props": true }]*/
+function foo(bar) {
+  bar.prop = 'value';
+}
+
+function foo(bar) {
+  delete bar.aaa;
+}
+
+function foo(bar) {
+  bar.aaa++;
+}
+```
+
+Examples of **correct** code with `{ "props": true, "ignorePropertyModificationsFor": ["bar"] }`:
+
+```javascript
+/*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["bar"] }]*/
+function foo(bar) {
+  bar.prop = 'value';
+}
+```
+
+## Original Documentation
+
+- [ESLint no-param-reassign](https://eslint.org/docs/latest/rules/no-param-reassign)

--- a/internal/rules/no_param_reassign/no_param_reassign_test.go
+++ b/internal/rules/no_param_reassign/no_param_reassign_test.go
@@ -1,0 +1,863 @@
+package no_param_reassign
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoParamReassignRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoParamReassignRule,
+		[]rule_tester.ValidTestCase{
+			// === Ported from ESLint ===
+
+			// No reassignment
+			{Code: `function foo(a) { var b = a; }`},
+			{Code: `function foo(a) { for (b in a); }`},
+			{Code: `function foo(a) { for (b of a); }`},
+
+			// Property modifications (props: false, default)
+			{Code: `function foo(a) { a.prop = 'value'; }`},
+			{Code: `function foo(a) { for (a.prop in obj); }`},
+			{Code: `function foo(a) { for (a.prop of arr); }`},
+			{Code: `function foo(a) { a.b = 0; }`},
+			{Code: `function foo(a) { delete a.b; }`},
+			{Code: `function foo(a) { ++a.b; }`},
+
+			// Shadowing and globals
+			{Code: `function foo(a) { (function() { var a = 12; a++; })(); }`},
+			{Code: `function foo() { someGlobal = 13; }`},
+
+			// With props: true - does not flag non-property reads
+			{
+				Code:    `function foo(a) { bar(a.b).c = 0; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { data[a.b] = 0; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { +a.b; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { (a ? [] : [])[0] = 1; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { (a.b ? [] : [])[0] = 1; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+
+			// ignorePropertyModificationsFor
+			{
+				Code: `function foo(a) { a.b = 0; }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+			},
+			{
+				Code: `function foo(a) { ++a.b; }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+			},
+			{
+				Code: `function foo(a) { delete a.b; }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+			},
+			{
+				Code: `function foo(a) { for (a.b in obj); }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+			},
+			{
+				Code: `function foo(a) { for (a.b of arr); }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+			},
+			{
+				Code: `function foo(a) { a.b.c = 0; }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+			},
+
+			// ignorePropertyModificationsForRegex
+			{
+				Code: `function foo(aFoo) { aFoo.b = 0; }`,
+				Options: map[string]interface{}{
+					"props":                               true,
+					"ignorePropertyModificationsForRegex": []interface{}{"^a.*$"},
+				},
+			},
+			{
+				Code: `function foo(aFoo) { ++aFoo.b; }`,
+				Options: map[string]interface{}{
+					"props":                               true,
+					"ignorePropertyModificationsForRegex": []interface{}{"^a.*$"},
+				},
+			},
+			{
+				Code: `function foo(aFoo) { delete aFoo.b; }`,
+				Options: map[string]interface{}{
+					"props":                               true,
+					"ignorePropertyModificationsForRegex": []interface{}{"^a.*$"},
+				},
+			},
+			{
+				Code: `function foo(aFoo) { aFoo.b.c = 0; }`,
+				Options: map[string]interface{}{
+					"props":                               true,
+					"ignorePropertyModificationsForRegex": []interface{}{"^a.*$"},
+				},
+			},
+
+			// Destructuring / loop patterns that do not reassign params
+			{
+				Code:    `function foo(a) { ({ [a]: variable } = value) }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{Code: `function foo(a) { ([...a.b] = obj); }`},
+			{Code: `function foo(a) { ({...a.b} = obj); }`},
+			{
+				Code:    `function foo(a) { for (obj[a.b] in obj); }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { for (obj[a.b] of arr); }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { for (bar in a.b); }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { for (bar of a.b); }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { for (bar in baz) a.b; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { for (bar of baz) a.b; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+
+			// === Edge cases: function-like kinds (all 7) reading their params ===
+
+			{Code: `const f = (a) => a + 1;`},
+			{Code: `function* gen(a) { yield a; }`},
+			{Code: `async function asyncF(a) { return a; }`},
+			{Code: `async function* ag(a) { yield a; }`},
+			{Code: `class C { m(a: number) { return a; } }`},
+			{Code: `class C { static m(a: number) { return a; } }`},
+			{Code: `class C { get x() { return 1; } }`},
+			{Code: `class C { set x(v: number) { this._x = v; } }`},
+			{Code: `class C { constructor(a: number) { this.a = a; } }`},
+			{Code: `const o = { m(a: number) { return a; } };`},
+			{Code: `class C { async m(a: number) { return a; } }`},
+
+			// === Edge cases: shadowing — outer param unaffected ===
+
+			// Inner arrow's own param shadows; arrow just reads its own.
+			{Code: `function foo(a) { ((a: number) => a + 1)(2); }`},
+			// Inner function body reads outer closure.
+			{Code: `function foo(a) { function inner() { return a; } }`},
+			// IIFE with its own param reads its own param.
+			{Code: `function foo(a) { (function(a) { return a; })(a); }`},
+			// Class method's own param shadows; just reads it.
+			{Code: `function foo(a) { class C { m(a: number) { return a; } } }`},
+			// Inner let binding shadows — only reads after let.
+			{Code: `function foo(a) { { let a = 1; console.log(a); } }`},
+			// Catch clause param shadows; write is to catch binding.
+			{Code: `function foo(a) { try {} catch (a) { a; } }`},
+			// Catch clause destructured name shadows the param.
+			{Code: `function foo(a) { try {} catch ({a}) { a; } }`},
+			// for-let creates its own scope.
+			{Code: `function foo(a) { for (let a = 0; a < 1; a++) {} }`},
+			// Class declaration name shadows.
+			{Code: `function foo(A) { class A {} }`},
+
+			// === Edge cases: default values (reads are fine) ===
+
+			{Code: `function foo(a, b = a) { return b; }`},
+			{Code: `const x = 1; function foo({a = x}) { return a; }`},
+			{Code: `function foo({a, b = a}) { return b; }`},
+			{Code: `function foo({a: {b: [c]}}) { return c; }`},
+
+			// === Edge cases: TypeScript syntax ===
+
+			{Code: `function foo<T>(a: T) { return a; }`},
+			{Code: `function foo(a?: number) { return a; }`},
+			{Code: `function foo(...a: number[]) { return a; }`},
+			{Code: `function foo(this: number, a: number) { return a; }`},
+			{Code: `class C { constructor(public a: number) { console.log(this.a); } }`},
+
+			// === Edge cases: loop bodies reading param ===
+
+			{Code: `function foo(a) { for (const x of a) { console.log(x); } }`},
+			{Code: `function foo(a) { for (const k in a) { console.log(k); } }`},
+
+			// === Edge cases: props: true — non-modifying patterns ===
+
+			{
+				Code:    `function foo(a) { a.map(x => x); }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { const o = { [a]: 1 }; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+			{
+				Code:    `function foo(a) { return a?.x; }`,
+				Options: map[string]interface{}{"props": true},
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// === Ported from ESLint ===
+
+			// Direct reassignment
+			{
+				Code: `function foo(bar) { bar = 13; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `function foo(bar) { bar += 13; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `function foo(bar) { (function() { bar = 13; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `function foo(bar) { ++bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `function foo(bar) { bar++; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `function foo(bar) { --bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `function foo(bar) { bar--; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 21},
+				},
+			},
+
+			// Destructured parameters
+			{
+				Code: `function foo({bar}) { bar = 13; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `function foo([, {bar}]) { bar = 13; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `function foo(bar) { ({bar} = {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `function foo(bar) { ({x: [, bar = 0]} = {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 29},
+				},
+			},
+
+			// Loop assignment
+			{
+				Code: `function foo(bar) { for (bar in baz); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `function foo(bar) { for (bar of baz); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+
+			// Property modification with props: true
+			{
+				Code:    `function foo(bar) { bar.a = 0; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:    `function foo(bar) { bar.get(0).a = 0; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:    `function foo(bar) { delete bar.a; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code:    `function foo(bar) { ++bar.a; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `function foo(bar) { for (bar.a in {}); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:    `function foo(bar) { for (bar.a of []); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:    `function foo(bar) { (bar ? bar : [])[0] = 1; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code:    `function foo(bar) { [bar.a] = []; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 22},
+				},
+			},
+
+			// Parameter reassignment in destructuring
+			{
+				Code:    `function foo(a) { ({a} = obj); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `function foo(a) { ([...a] = obj); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `function foo(a) { ({...a} = obj); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 24},
+				},
+			},
+
+			// Spread/rest with property access
+			{
+				Code:    `function foo(a) { ([...a.b] = obj); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:    `function foo(a) { ({...a.b} = obj); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:    `function foo(a) { for ([a.b] of []); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 25},
+				},
+			},
+
+			// Logical assignment operators
+			{
+				Code: `function foo(a) { a &&= b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `function foo(a) { a ||= b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `function foo(a) { a ??= b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    `function foo(a) { a.b &&= c; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    `function foo(a) { a.b.c ||= d; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    `function foo(a) { a[b] ??= c; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 19},
+				},
+			},
+
+			// ignorePropertyModificationsFor bypass (property not whitelisted)
+			{
+				Code: `function foo(bar) { [bar.a] = []; }`,
+				Options: map[string]interface{}{
+					"props":                          true,
+					"ignorePropertyModificationsFor": []interface{}{"a"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `function foo(bar) { [bar.a] = []; }`,
+				Options: map[string]interface{}{
+					"props":                               true,
+					"ignorePropertyModificationsForRegex": []interface{}{"^B.*$"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 22},
+				},
+			},
+
+			// === Edge cases: function-like kinds — each flags its own param ===
+
+			// Arrow with expression body
+			{
+				Code: `const f = (a) => (a = 1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 19},
+				},
+			},
+			// Generator
+			{
+				Code: `function* gen(a) { a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 20},
+				},
+			},
+			// Async function
+			{
+				Code: `async function af(a) { a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 24},
+				},
+			},
+			// Class method
+			{
+				Code: `class C { m(a: number) { a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+			// Class setter
+			{
+				Code: `class C { set x(v: number) { v = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 30},
+				},
+			},
+			// Constructor
+			{
+				Code: `class C { constructor(a: number) { a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 36},
+				},
+			},
+			// Object shorthand method
+			{
+				Code: `const o = { m(a: number) { a = 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 28},
+				},
+			},
+			// TS parameter property — two symbols share the Parameter decl;
+			// rule must still flag via decl comparison.
+			{
+				Code: `class C { constructor(public a: number) { a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 43},
+				},
+			},
+			// Private method
+			{
+				Code: `class C { #m(a: number) { a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 27},
+				},
+			},
+
+			// === Edge cases: nested scope — outer param written from inside
+			// an inner scope that does NOT shadow ===
+
+			// Arrow closure writes outer param
+			{
+				Code: `function foo(a) { const f = () => { a = 1; }; f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 37},
+				},
+			},
+			// Inner fn (no shadow) writes outer param
+			{
+				Code: `function foo(a) { function inner() { a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 38},
+				},
+			},
+			// Class method writes outer closure param
+			{
+				Code: `function foo(a) { class C { m() { a = 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 35},
+				},
+			},
+			// Deeply nested, no shadowing intermediate
+			{
+				Code: `function foo(a) { (function() { (() => { a = 1; })(); })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 42},
+				},
+			},
+
+			// === Edge cases: shadowed inner params — reported once, by
+			// the inner function's listener, never by the outer one ===
+
+			// Nested function's own param written (bar listener reports)
+			{
+				Code: `function foo(a) { function bar(a) { a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 37},
+				},
+			},
+			// Arrow's own param written (arrow listener reports)
+			{
+				Code: `function foo(a) { ((a: number) => { a = 1; })(2); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 37},
+				},
+			},
+			// Method's own param written (method listener reports)
+			{
+				Code: `function foo(a) { class C { m(a: number) { a = 1; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 44},
+				},
+			},
+			// `var a` in same scope as param — same binding
+			{
+				Code: `function foo(a) { var a; a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+
+			// === Edge cases: multiple reassignments reported independently ===
+
+			{
+				Code: `function foo(a) { a = 1; a = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 19},
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `function foo(a, b) { ({a, b} = {}); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 24},
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 27},
+				},
+			},
+			// Two separate inner scopes each write once
+			{
+				Code: `function foo(a) { (() => { a = 1; })(); (() => { a = 2; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 28},
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 50},
+				},
+			},
+
+			// === Edge cases: parens / type assertions wrapping target ===
+
+			{
+				Code: `function foo(a) { (a) = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `function foo(a: unknown) { (a as any) = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `function foo(a: number | undefined) { a! = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 39},
+				},
+			},
+
+			// === Edge cases: destructured param reassignment ===
+
+			// Rename destructure: binding is `x`
+			{
+				Code: `function foo({a: x}) { x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 24},
+				},
+			},
+			// Rest destructure
+			{
+				Code: `function foo(...rest) { rest = []; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 25},
+				},
+			},
+			// Nested destructure write
+			{
+				Code: `function foo({a: {b}}) { b = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+
+			// === Edge cases: default value containing reassignment ===
+
+			// Reassign earlier param in later default
+			{
+				Code: `function foo(a, b = (a = 1)) { return b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 22},
+				},
+			},
+			// Inner function in a default value writes outer param
+			{
+				Code: `function foo(a, b = function() { a = 1; }) { return b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 34},
+				},
+			},
+			// Inner arrow in a later default writes an earlier param
+			{
+				Code: `function foo(a, b = () => (a = 1)) { return b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 28},
+				},
+			},
+
+			// === Edge cases: property modification (props: true) ===
+
+			// Property modification in nested arrow
+			{
+				Code:    `function foo(a) { const f = () => { a.x = 1; }; f(); }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 37},
+				},
+			},
+			// Compound on property in method
+			{
+				Code:    `class C { m(a: any) { a.x += 1; } }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 23},
+				},
+			},
+			// Setter property modification
+			{
+				Code:    `class C { set x(v: any) { v.prop = 1; } }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 27},
+				},
+			},
+			// Deep property write
+			{
+				Code:    `function foo(a: any) { a.b.c.d = 1; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 24},
+				},
+			},
+			// Destructured binding — property write via destructuring target
+			{
+				Code:    `function foo({a}: any) { a.x = 1; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 26},
+				},
+			},
+			// Rest param property write
+			{
+				Code:    `function foo(...rest: any[]) { rest[0] = 1; }`,
+				Options: map[string]interface{}{"props": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 32},
+				},
+			},
+
+			// === Edge cases: ignore lists combined ===
+
+			// `bar` ignored, `baz` not — flag only baz.
+			{
+				Code: `function foo(bar, baz) { bar.a = 1; baz.b = 2; }`,
+				Options: map[string]interface{}{
+					"props":                               true,
+					"ignorePropertyModificationsFor":      []interface{}{"bar"},
+					"ignorePropertyModificationsForRegex": []interface{}{"^qux"},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParamProp", Line: 1, Column: 37},
+				},
+			},
+
+			// === Edge cases: expression hosts the walker must descend into ===
+
+			// Template literal interpolation
+			{
+				Code: "function foo(a) { `${a = 1}`; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 22},
+				},
+			},
+			// Tagged template interpolation
+			{
+				Code: "function foo(a) { String.raw`${a = 1}`; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 32},
+				},
+			},
+			// Comma expression — left side writes
+			{
+				Code: `function foo(a) { (a = 1, a); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 20},
+				},
+			},
+			// Return statement
+			{
+				Code: `function foo(a) { return (a = 1); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 27},
+				},
+			},
+			// Throw statement
+			{
+				Code: `function foo(a) { throw (a = 1); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+			// Switch case body
+			{
+				Code: `function foo(a, x) { switch (x) { case 1: a = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 43},
+				},
+			},
+			// Labeled statement
+			{
+				Code: `function foo(a) { outer: a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 26},
+				},
+			},
+			// Await operand
+			{
+				Code: `async function foo(a: any) { await (a = 1); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 37},
+				},
+			},
+			// Yielded assignment
+			{
+				Code: `function* foo(a) { yield (a = 1); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 27},
+				},
+			},
+			// JSX attribute handler
+			{
+				Code: `function Comp(a: any) { return <div onClick={() => { a = 1; }} />; }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 1, Column: 54},
+				},
+			},
+
+			// === Edge cases: TS overloaded function declarations ===
+			// Only the implementation signature (with the body) flags.
+			{
+				Code: `function foo(a: number): void;
+function foo(a: string): void;
+function foo(a: any) { a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "assignmentToFunctionParam", Line: 3, Column: 24},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -2,7 +2,87 @@ package utils
 
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
 )
+
+// IsNameShadowedBetween walks from `node` up to (but not including) `boundary`,
+// returning true if any intermediate scope introduces a binding for `name`.
+//
+// Scopes examined:
+//   - Function-like parameter lists (covers all 7 function-like kinds).
+//   - Block-scoped declarations (var/let/const/function/class inside a Block).
+//   - Catch-clause variable bindings (including destructured patterns).
+//   - For-statement `let`/`const` init (scoped to the loop).
+//   - For-in / for-of `let`/`const` init (scoped to the loop).
+//   - Class declaration/expression names (scoped to the class body).
+//
+// Use this when a rule tracks a specific declaration (e.g. a parameter, class,
+// or function name) and needs to ignore references that were shadowed before
+// they reached the declaration site. For scope walks that should also examine
+// the SourceFile or module boundary, use `IsShadowed` instead.
+func IsNameShadowedBetween(node *ast.Node, boundary *ast.Node, name string) bool {
+	for current := node.Parent; current != nil && current != boundary; current = current.Parent {
+		if ast.IsFunctionLikeDeclaration(current) {
+			if HasShadowingParameter(current, name) {
+				return true
+			}
+		}
+		switch current.Kind {
+		case ast.KindBlock:
+			if HasShadowingDeclaration(current, name) {
+				return true
+			}
+		case ast.KindCatchClause:
+			cc := current.AsCatchClause()
+			if cc != nil && cc.VariableDeclaration != nil {
+				vd := cc.VariableDeclaration.AsVariableDeclaration()
+				if vd != nil && vd.Name() != nil && HasNameInBindingPattern(vd.Name(), name) {
+					return true
+				}
+			}
+		case ast.KindForStatement:
+			forStmt := current.AsForStatement()
+			if forStmt != nil && forStmt.Initializer != nil &&
+				forStmt.Initializer.Kind == ast.KindVariableDeclarationList &&
+				HasVarDeclListWithName(forStmt.Initializer, name) {
+				return true
+			}
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			stmt := current.AsForInOrOfStatement()
+			if stmt != nil && stmt.Initializer != nil &&
+				stmt.Initializer.Kind == ast.KindVariableDeclarationList &&
+				HasVarDeclListWithName(stmt.Initializer, name) {
+				return true
+			}
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if n := current.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// GetReferenceSymbol returns the variable symbol for the given identifier.
+// When the identifier is the key of a shorthand property assignment in a
+// destructuring pattern (e.g., `({foo} = bar)`), it returns the value-binding
+// symbol rather than the property symbol that `GetSymbolAtLocation` would
+// otherwise produce.
+func GetReferenceSymbol(node *ast.Node, typeChecker *checker.Checker) *ast.Symbol {
+	if node == nil || typeChecker == nil {
+		return nil
+	}
+	parent := node.Parent
+	if parent != nil && parent.Kind == ast.KindShorthandPropertyAssignment {
+		shorthand := parent.AsShorthandPropertyAssignment()
+		if shorthand != nil && shorthand.Name() == node {
+			if symbol := typeChecker.GetShorthandAssignmentValueSymbol(parent); symbol != nil {
+				return symbol
+			}
+		}
+	}
+	return typeChecker.GetSymbolAtLocation(node)
+}
 
 // IsShadowed checks whether the given identifier name is shadowed by a local
 // declaration at the usage site. It walks from node up to the SourceFile,

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -51,6 +51,7 @@ export default defineConfig({
     './tests/eslint/rules/no-new-func.test.ts',
     './tests/eslint/rules/no-new-object.test.ts',
     './tests/eslint/rules/no-new-wrappers.test.ts',
+    './tests/eslint/rules/no-param-reassign.test.ts',
     './tests/eslint/rules/no-self-assign.test.ts',
     './tests/eslint/rules/no-undef.test.ts',
     './tests/eslint/rules/no-undef-init.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-param-reassign.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-param-reassign.test.ts.snap
@@ -1,0 +1,911 @@
+// Rstest Snapshot v1
+
+exports[`no-param-reassign > invalid 1`] = `
+{
+  "code": "function foo(bar) { bar = 13; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 2`] = `
+{
+  "code": "function foo(bar) { bar += 13; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 3`] = `
+{
+  "code": "function foo(bar) { (function() { bar = 13; })(); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 4`] = `
+{
+  "code": "function foo(bar) { ++bar; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 5`] = `
+{
+  "code": "function foo(bar) { bar++; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 6`] = `
+{
+  "code": "function foo(bar) { --bar; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 7`] = `
+{
+  "code": "function foo(bar) { bar--; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 8`] = `
+{
+  "code": "function foo({bar}) { bar = 13; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 9`] = `
+{
+  "code": "function foo([, {bar}]) { bar = 13; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 10`] = `
+{
+  "code": "function foo(bar) { ({bar} = {}); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 11`] = `
+{
+  "code": "function foo(bar) { ({x: [, bar = 0]} = {}); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 12`] = `
+{
+  "code": "function foo(bar) { for (bar in baz); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 13`] = `
+{
+  "code": "function foo(bar) { for (bar of baz); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 14`] = `
+{
+  "code": "function foo(bar) { bar.a = 0; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 15`] = `
+{
+  "code": "function foo(bar) { bar.get(0).a = 0; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 16`] = `
+{
+  "code": "function foo(bar) { delete bar.a; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 17`] = `
+{
+  "code": "function foo(bar) { ++bar.a; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 18`] = `
+{
+  "code": "function foo(bar) { for (bar.a in {}); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 19`] = `
+{
+  "code": "function foo(bar) { for (bar.a of []); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 20`] = `
+{
+  "code": "function foo(bar) { (bar ? bar : [])[0] = 1; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 21`] = `
+{
+  "code": "function foo(bar) { [bar.a] = []; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 22`] = `
+{
+  "code": "function foo(a) { ({a} = obj); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'a'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 23`] = `
+{
+  "code": "function foo(a) { ([...a] = obj); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'a'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 24`] = `
+{
+  "code": "function foo(a) { ({...a} = obj); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'a'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 25`] = `
+{
+  "code": "function foo(a) { ([...a.b] = obj); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'a'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 26`] = `
+{
+  "code": "function foo(a) { ({...a.b} = obj); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'a'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 27`] = `
+{
+  "code": "function foo(a) { for ([a.b] of []); }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'a'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 28`] = `
+{
+  "code": "function foo(a) { a &&= b; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'a'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 29`] = `
+{
+  "code": "function foo(a) { a ||= b; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'a'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 30`] = `
+{
+  "code": "function foo(a) { a ??= b; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to function parameter 'a'.",
+      "messageId": "assignmentToFunctionParam",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 31`] = `
+{
+  "code": "function foo(a) { a.b &&= c; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'a'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 32`] = `
+{
+  "code": "function foo(a) { a.b.c ||= d; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'a'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 33`] = `
+{
+  "code": "function foo(a) { a[b] ??= c; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'a'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 34`] = `
+{
+  "code": "function foo(bar) { [bar.a] = []; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-param-reassign > invalid 35`] = `
+{
+  "code": "function foo(bar) { [bar.a] = []; }",
+  "diagnostics": [
+    {
+      "message": "Assignment to property of function parameter 'bar'.",
+      "messageId": "assignmentToFunctionParamProp",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-param-reassign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-param-reassign.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-param-reassign.test.ts
@@ -1,0 +1,296 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-param-reassign', {
+  valid: [
+    // No reassignment
+    'function foo(a) { var b = a; }',
+    'function foo(a) { for (b in a); }',
+    'function foo(a) { for (b of a); }',
+
+    // Property modifications (props: false, default)
+    "function foo(a) { a.prop = 'value'; }",
+    'function foo(a) { for (a.prop in obj); }',
+    'function foo(a) { for (a.prop of arr); }',
+    'function foo(a) { a.b = 0; }',
+    'function foo(a) { delete a.b; }',
+    'function foo(a) { ++a.b; }',
+
+    // Shadowing and globals
+    'function foo(a) { (function() { var a = 12; a++; })(); }',
+    'function foo() { someGlobal = 13; }',
+
+    // With props: true - does not flag non-property reads
+    {
+      code: 'function foo(a) { bar(a.b).c = 0; }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { data[a.b] = 0; }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { +a.b; }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { (a ? [] : [])[0] = 1; }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { (a.b ? [] : [])[0] = 1; }',
+      options: { props: true },
+    },
+
+    // ignorePropertyModificationsFor
+    {
+      code: 'function foo(a) { a.b = 0; }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+    },
+    {
+      code: 'function foo(a) { ++a.b; }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+    },
+    {
+      code: 'function foo(a) { delete a.b; }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+    },
+    {
+      code: 'function foo(a) { for (a.b in obj); }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+    },
+    {
+      code: 'function foo(a) { for (a.b of arr); }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+    },
+    {
+      code: 'function foo(a) { a.b.c = 0; }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+    },
+
+    // ignorePropertyModificationsForRegex
+    {
+      code: 'function foo(aFoo) { aFoo.b = 0; }',
+      options: { props: true, ignorePropertyModificationsForRegex: ['^a.*$'] },
+    },
+    {
+      code: 'function foo(aFoo) { ++aFoo.b; }',
+      options: { props: true, ignorePropertyModificationsForRegex: ['^a.*$'] },
+    },
+    {
+      code: 'function foo(aFoo) { delete aFoo.b; }',
+      options: { props: true, ignorePropertyModificationsForRegex: ['^a.*$'] },
+    },
+    {
+      code: 'function foo(aFoo) { aFoo.b.c = 0; }',
+      options: { props: true, ignorePropertyModificationsForRegex: ['^a.*$'] },
+    },
+
+    // Destructuring / loop patterns that do not reassign params
+    {
+      code: 'function foo(a) { ({ [a]: variable } = value) }',
+      options: { props: true },
+    },
+    'function foo(a) { ([...a.b] = obj); }',
+    'function foo(a) { ({...a.b} = obj); }',
+    {
+      code: 'function foo(a) { for (obj[a.b] in obj); }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { for (obj[a.b] of arr); }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { for (bar in a.b); }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { for (bar of a.b); }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { for (bar in baz) a.b; }',
+      options: { props: true },
+    },
+    {
+      code: 'function foo(a) { for (bar of baz) a.b; }',
+      options: { props: true },
+    },
+  ],
+  invalid: [
+    // Direct reassignment
+    {
+      code: 'function foo(bar) { bar = 13; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { bar += 13; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { (function() { bar = 13; })(); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { ++bar; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { bar++; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { --bar; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { bar--; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+
+    // Destructured parameters
+    {
+      code: 'function foo({bar}) { bar = 13; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo([, {bar}]) { bar = 13; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { ({bar} = {}); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { ({x: [, bar = 0]} = {}); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+
+    // Loop assignment
+    {
+      code: 'function foo(bar) { for (bar in baz); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(bar) { for (bar of baz); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+
+    // Property modification with props: true
+    {
+      code: 'function foo(bar) { bar.a = 0; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { bar.get(0).a = 0; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { delete bar.a; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { ++bar.a; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { for (bar.a in {}); }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { for (bar.a of []); }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { (bar ? bar : [])[0] = 1; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { [bar.a] = []; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+
+    // Parameter reassignment in destructuring
+    {
+      code: 'function foo(a) { ({a} = obj); }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(a) { ([...a] = obj); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(a) { ({...a} = obj); }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+
+    // Spread/rest with property access
+    {
+      code: 'function foo(a) { ([...a.b] = obj); }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(a) { ({...a.b} = obj); }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(a) { for ([a.b] of []); }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+
+    // Logical assignment operators
+    {
+      code: 'function foo(a) { a &&= b; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(a) { a ||= b; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(a) { a ??= b; }',
+      errors: [{ messageId: 'assignmentToFunctionParam' }],
+    },
+    {
+      code: 'function foo(a) { a.b &&= c; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(a) { a.b.c ||= d; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(a) { a[b] ??= c; }',
+      options: { props: true },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+
+    // ignorePropertyModificationsFor bypass
+    {
+      code: 'function foo(bar) { [bar.a] = []; }',
+      options: { props: true, ignorePropertyModificationsFor: ['a'] },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+    {
+      code: 'function foo(bar) { [bar.a] = []; }',
+      options: { props: true, ignorePropertyModificationsForRegex: ['^B.*$'] },
+      errors: [{ messageId: 'assignmentToFunctionParamProp' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-param-reassign` rule from ESLint to rslint.

Disallow reassigning function parameters. Reassigning a parameter mutates the caller-visible `arguments` object in non-strict code and frequently hides bugs. With the `props` option, the rule additionally reports property modifications on parameters (`bar.x = 1`, `delete bar.x`, `++bar.x`, etc.), with `ignorePropertyModificationsFor` / `ignorePropertyModificationsForRegex` escape hatches.

Supports every function-like declaration kind (`function`/`function*`/`async`, arrow, class methods/constructors/accessors, object shorthand methods, private methods) and TypeScript-specific forms including parameter properties (`public`/`private a`), type assertions as write targets, and destructured/rest parameters.

Also refactored three sibling rules (`no-class-assign`, `no-ex-assign`, `no-func-assign`) to reuse two newly extracted helpers in `internal/utils/shadowing.go`:

- `IsNameShadowedBetween(node, boundary, name)` — walk scope chain up to a boundary.
- `GetReferenceSymbol(node, checker)` — resolve the variable symbol, handling shorthand destructuring.

Verified on real-world projects: 7 hits on `rsbuild`, 18 hits on `rspack`; all spot-checked are genuine reassignments. Rule adds ~2-4% CPU overhead on top of the baseline lint pass.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-param-reassign
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-param-reassign.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).