### PR TITLE
fix(lsp): scope tsConfigPaths per-config to prevent type-aware rule leak (fixes #671)

### DIFF
--- a/internal/lsp/server.go
+++ b/internal/lsp/server.go
@@ -160,10 +160,16 @@ type Server struct {
 	compilerOptionsForInferredProjects *core.CompilerOptions
 
 	// rslint config
-	jsConfigs        map[string]config.RslintConfig                // configDirectory -> config entries (from JS/TS configs)
+	jsConfigs        map[string]config.RslintConfig                // configDirectory URI -> config entries (from JS/TS configs)
 	jsonConfig       config.RslintConfig                           // fallback JSON config (rslint.json/rslint.jsonc)
 	rslintConfigPath string                                        // path to rslint.json/rslint.jsonc, empty if not found
-	tsConfigPaths    []string                                       // resolved parserOptions.project tsconfig paths
+	// tsConfigPaths holds resolved parserOptions.project tsconfig paths.
+	// For the JSON-config path this is a single global list.
+	// For the JS-config path (multi-config monorepo) use tsConfigPathsByConfig
+	// which keys per-config-directory so a nested config with no tsconfig
+	// does not disable filtering for files under other configs.
+	tsConfigPaths         []string
+	tsConfigPathsByConfig map[string][]string // configDirectory URI -> resolved tsconfig paths (nil value = allow-all for that config's files)
 	documents        map[lsproto.DocumentUri]string                // URI -> content
 	diagnostics      map[lsproto.DocumentUri][]rule.RuleDiagnostic // URI -> diagnostics
 

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -268,33 +268,28 @@ func (s *Server) resolveTsConfigPaths(cfg config.RslintConfig, cwd string) []str
 // rebuildTsConfigPaths resolves parserOptions.project from the current config.
 // Called when a tsconfig or rslint config changes so that type-aware rule
 // filtering stays in sync.
+//
+// For JS/TS configs we resolve per-config directory into tsConfigPathsByConfig.
+// A config whose parserOptions.project is empty and has no auto-detected
+// tsconfig resolves to nil — this disables type-aware-rule filtering only for
+// files governed by that config, not globally across the workspace. A nested
+// template / fixture config without a tsconfig must not relax filtering for
+// other configs' files.
 func (s *Server) rebuildTsConfigPaths() {
 	if len(s.jsConfigs) > 0 {
-		var merged []string
-		seen := make(map[string]struct{})
+		byConfig := make(map[string][]string, len(s.jsConfigs))
 		for dir, entries := range s.jsConfigs {
 			configDir := uriToPath(lsproto.DocumentUri(dir))
-			paths := s.resolveTsConfigPaths(entries, configDir)
-			if paths == nil {
-				// At least one config has no parserOptions.project and no
-				// auto-detected tsconfig. Cannot determine which files should
-				// have type-aware rules without per-file config resolution.
-				// Disable filtering entirely (conservative: allow all).
-				s.tsConfigPaths = nil
-				return
-			}
-			for _, p := range paths {
-				if _, ok := seen[p]; !ok {
-					seen[p] = struct{}{}
-					merged = append(merged, p)
-				}
-			}
+			byConfig[dir] = s.resolveTsConfigPaths(entries, configDir)
 		}
-		s.tsConfigPaths = merged
+		s.tsConfigPathsByConfig = byConfig
+		s.tsConfigPaths = nil
 	} else if s.rslintConfigPath != "" {
 		s.tsConfigPaths = s.resolveTsConfigPaths(s.jsonConfig, s.cwd)
+		s.tsConfigPathsByConfig = nil
 	} else {
 		s.tsConfigPaths = nil
+		s.tsConfigPathsByConfig = nil
 	}
 }
 
@@ -524,6 +519,7 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 	}
 
 	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
+	tsConfigPaths := s.tsConfigPathsForURI(uri)
 	originalContent := s.documents[uri]
 	currentContent := originalContent
 
@@ -536,7 +532,7 @@ func (s *Server) handleFixAllCodeAction(ctx context.Context, uri lsproto.Documen
 			})
 		}
 
-		ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, s.tsConfigPaths, s.fs)
+		ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths, s.fs)
 		if err != nil {
 			log.Printf("Error running lint for fixAll pass %d: %v", pass, err)
 			break
@@ -920,6 +916,31 @@ func (s *Server) getConfigForURI(uri lsproto.DocumentUri) (config.RslintConfig, 
 	return s.jsonConfig, s.cwd, false
 }
 
+// tsConfigPathsForURI returns the resolved parserOptions.project tsconfig
+// paths for the rslint config that governs the given URI. It walks parents
+// the same way getConfigForURI does so a nested config with no tsconfig
+// does not leak its "allow-all" fallback into sibling configs.
+//
+// A nil return means the governing config has no resolved tsconfig; callers
+// should treat this as "disable type-aware filtering for this file only".
+func (s *Server) tsConfigPathsForURI(uri lsproto.DocumentUri) []string {
+	if len(s.jsConfigs) > 0 {
+		dir := uriDirname(string(uri))
+		for {
+			if _, ok := s.jsConfigs[dir]; ok {
+				return s.tsConfigPathsByConfig[dir]
+			}
+			parent := uriDirname(dir)
+			if parent == dir {
+				break
+			}
+			dir = parent
+		}
+		return nil
+	}
+	return s.tsConfigPaths
+}
+
 // uriDirname returns the parent directory of a URI string.
 // e.g. "file:///project/src/index.ts" → "file:///project/src"
 func uriDirname(uri string) string {
@@ -950,7 +971,8 @@ func (s *Server) pushDiagnostics(uri lsproto.DocumentUri) {
 	}
 
 	rslintConfig, configCwd, isJSConfig := s.getConfigForURI(uri)
-	ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, s.tsConfigPaths, s.fs)
+	tsConfigPaths := s.tsConfigPathsForURI(uri)
+	ruleDiags, err := runLintWithSession(uri, s.session, ctx, rslintConfig, configCwd, isJSConfig, tsConfigPaths, s.fs)
 	if err != nil {
 		log.Printf("Error running lint for push diagnostics: %v", err)
 		return

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -1301,11 +1301,12 @@ func TestHandleConfigUpdate_RebuildsTsConfigPaths(t *testing.T) {
 	s.fs = &mockFS{files: map[string]bool{}}
 	ctx := context.Background()
 
-	// Set stale tsConfigPaths
-	s.tsConfigPaths = []string{"/old/tsconfig.json"}
+	// Set stale state
+	s.tsConfigPathsByConfig = map[string][]string{"file:///old": {"/old/tsconfig.json"}}
 
 	// Config update with no parserOptions.project and no tsconfig.json (mockFS has no files)
-	// → ResolveTsConfigPaths returns nil → rebuildTsConfigPaths clears tsConfigPaths
+	// → ResolveTsConfigPaths returns nil → per-config entry should be nil, and
+	// stale entries should be dropped.
 	err := s.handleConfigUpdate(ctx, map[string]any{
 		"configs": []any{
 			map[string]any{
@@ -1322,9 +1323,15 @@ func TestHandleConfigUpdate_RebuildsTsConfigPaths(t *testing.T) {
 		t.Fatalf("handleConfigUpdate failed: %v", err)
 	}
 
-	// tsConfigPaths should be nil (mockFS has no tsconfig.json to auto-detect)
-	if s.tsConfigPaths != nil {
-		t.Errorf("expected tsConfigPaths nil after config update with no project, got %v", s.tsConfigPaths)
+	if _, stale := s.tsConfigPathsByConfig["file:///old"]; stale {
+		t.Errorf("expected stale config entry to be dropped, still present in %v", s.tsConfigPathsByConfig)
+	}
+	entry, ok := s.tsConfigPathsByConfig["file:///project"]
+	if !ok {
+		t.Fatalf("expected per-config entry for file:///project, got %v", s.tsConfigPathsByConfig)
+	}
+	if entry != nil {
+		t.Errorf("expected nil tsconfig paths for config with no project/auto-detect, got %v", entry)
 	}
 }
 
@@ -1333,7 +1340,7 @@ func TestHandleConfigUpdate_EmptyConfigs_ClearsTsConfigPaths(t *testing.T) {
 	s.fs = &mockFS{files: map[string]bool{}}
 	ctx := context.Background()
 
-	s.tsConfigPaths = []string{"/project/tsconfig.json"}
+	s.tsConfigPathsByConfig = map[string][]string{"file:///project": {"/project/tsconfig.json"}}
 
 	err := s.handleConfigUpdate(ctx, map[string]any{
 		"configs": []any{},
@@ -1342,6 +1349,9 @@ func TestHandleConfigUpdate_EmptyConfigs_ClearsTsConfigPaths(t *testing.T) {
 		t.Fatalf("handleConfigUpdate failed: %v", err)
 	}
 
+	if len(s.tsConfigPathsByConfig) != 0 {
+		t.Errorf("expected tsConfigPathsByConfig empty after clearing configs, got %v", s.tsConfigPathsByConfig)
+	}
 	if s.tsConfigPaths != nil {
 		t.Errorf("expected tsConfigPaths nil after empty config update, got %v", s.tsConfigPaths)
 	}
@@ -1349,10 +1359,11 @@ func TestHandleConfigUpdate_EmptyConfigs_ClearsTsConfigPaths(t *testing.T) {
 
 func TestRebuildTsConfigPaths_MixedConfigsWithAndWithoutProject(t *testing.T) {
 	s := newTestServer()
-	s.fs = &mockFS{files: map[string]bool{}}
+	s.fs = &mockFS{files: map[string]bool{"/project-a/tsconfig.json": true}}
 
-	// Config A has project, Config B doesn't (and no tsconfig.json to auto-detect)
-	// → ResolveTsConfigPaths returns nil for B → rebuildTsConfigPaths should set nil (allow all)
+	// Config A has a project that resolves; Config B has neither a project
+	// nor an auto-detectable tsconfig. The two must be tracked independently
+	// so B's missing tsconfig does not disable filtering for A's files.
 	s.jsConfigs = map[string]config.RslintConfig{
 		"file:///project-a": {
 			{
@@ -1372,9 +1383,15 @@ func TestRebuildTsConfigPaths_MixedConfigsWithAndWithoutProject(t *testing.T) {
 
 	s.rebuildTsConfigPaths()
 
-	// Should be nil because config B has no project and no auto-detected tsconfig
+	entryA := s.tsConfigPathsByConfig["file:///project-a"]
+	if len(entryA) != 1 || entryA[0] != "/project-a/tsconfig.json" {
+		t.Errorf("expected project-a to resolve to its tsconfig, got %v", entryA)
+	}
+	if entry, ok := s.tsConfigPathsByConfig["file:///project-b"]; !ok || entry != nil {
+		t.Errorf("expected project-b entry present and nil (no tsconfig), got present=%v value=%v", ok, entry)
+	}
 	if s.tsConfigPaths != nil {
-		t.Errorf("expected tsConfigPaths nil for mixed configs (some without project), got %v", s.tsConfigPaths)
+		t.Errorf("expected legacy tsConfigPaths nil in JS-config mode, got %v", s.tsConfigPaths)
 	}
 }
 
@@ -1408,22 +1425,57 @@ func TestRebuildTsConfigPaths_AllConfigsHaveProject(t *testing.T) {
 
 	s.rebuildTsConfigPaths()
 
-	if s.tsConfigPaths == nil {
-		t.Fatal("expected tsConfigPaths non-nil when all configs have project")
+	entryA := s.tsConfigPathsByConfig["file:///project-a"]
+	if len(entryA) != 1 || entryA[0] != "/project-a/tsconfig.json" {
+		t.Errorf("expected project-a → /project-a/tsconfig.json, got %v", entryA)
 	}
-	if len(s.tsConfigPaths) != 2 {
-		t.Fatalf("expected 2 tsconfig paths, got %d: %v", len(s.tsConfigPaths), s.tsConfigPaths)
+	entryB := s.tsConfigPathsByConfig["file:///project-b"]
+	if len(entryB) != 1 || entryB[0] != "/project-b/tsconfig.json" {
+		t.Errorf("expected project-b → /project-b/tsconfig.json, got %v", entryB)
 	}
-	// Verify actual paths contain the expected tsconfig locations
-	pathSet := make(map[string]bool)
-	for _, p := range s.tsConfigPaths {
-		pathSet[p] = true
+}
+
+// Regression test: a nested config without any resolvable tsconfig must not
+// cascade its "allow-all" fallback onto files under OTHER configs.
+// See https://github.com/web-infra-dev/rslint/issues/671 — the create-rstack
+// workspace ships a `template-rslint/` starter directory with its own
+// rslint.config.ts but no tsconfig.json, which used to flip the whole
+// workspace into allow-all and incorrectly run type-aware rules on files
+// under the root config.
+func TestTsConfigPathsForURI_NestedConfigWithoutTsconfigDoesNotLeak(t *testing.T) {
+	s := newTestServer()
+	s.fs = &mockFS{files: map[string]bool{"/project/tsconfig.json": true}}
+
+	s.jsConfigs = map[string]config.RslintConfig{
+		"file:///project": {
+			{
+				LanguageOptions: &config.LanguageOptions{
+					ParserOptions: &config.ParserOptions{
+						Project: []string{"./tsconfig.json"},
+					},
+				},
+			},
+		},
+		"file:///project/template-rslint": {
+			{
+				Rules: config.Rules{"no-console": "error"},
+			},
+		},
 	}
-	if !pathSet["/project-a/tsconfig.json"] {
-		t.Errorf("expected /project-a/tsconfig.json in paths, got %v", s.tsConfigPaths)
+
+	s.rebuildTsConfigPaths()
+
+	// File under root config → root's resolved tsconfig.
+	rootPaths := s.tsConfigPathsForURI("file:///project/test/skills.test.ts")
+	if len(rootPaths) != 1 || rootPaths[0] != "/project/tsconfig.json" {
+		t.Errorf("expected root-config file to see [/project/tsconfig.json], got %v", rootPaths)
 	}
-	if !pathSet["/project-b/tsconfig.json"] {
-		t.Errorf("expected /project-b/tsconfig.json in paths, got %v", s.tsConfigPaths)
+
+	// File under nested template config → nil (allow-all) but scoped to this
+	// config only; the root config's list above must remain unaffected.
+	nestedPaths := s.tsConfigPathsForURI("file:///project/template-rslint/foo.ts")
+	if nestedPaths != nil {
+		t.Errorf("expected nested-config file to see nil tsconfig paths (allow-all), got %v", nestedPaths)
 	}
 }
 

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/rslint.config.js
@@ -1,0 +1,18 @@
+// Matches the shape of `ts.configs.recommended`: parserOptions only sets
+// `projectService: true`, with no explicit `project`. tsconfig.json's
+// `include` covers `src` only.
+export default [
+  { ignores: ['**/dist/**'] },
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    plugins: ['@typescript-eslint'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/rslint.config.js
@@ -13,6 +13,10 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-unused-vars': 'error',
+      // Non-type-aware marker rule. The suite relies on its diagnostic as a
+      // "rslint has finished linting this file" signal, so the negative
+      // assertion does not need a fixed-duration sleep.
+      'no-console': 'error',
     },
   },
 ];

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/src/covered.ts
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/src/covered.ts
@@ -1,0 +1,4 @@
+// File IN tsconfig.include (`src`). Type-aware rules should fire.
+export const covered = ((command: string, args: string[], options: unknown) => {
+  return { stdout: '', stderr: '', exitCode: 0 };
+}) as unknown;

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/orphan.ts
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/orphan.ts
@@ -1,0 +1,9 @@
+// This file lives under a config directory that has NO tsconfig.json.
+// The nearest rslint config says `projectService: true` + no explicit
+// `project`, so rslint can't resolve a tsconfig for it.
+//
+// CLI and LSP must agree on whether `@typescript-eslint/no-unused-vars`
+// (a type-aware rule) runs here.
+export const orphan = ((command: string, args: string[], options: unknown) => {
+  return { stdout: '', stderr: '', exitCode: 0 };
+}) as unknown;

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/rslint.config.js
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/rslint.config.js
@@ -1,0 +1,22 @@
+// Nested rslint config inside a template-style subdirectory that does NOT
+// ship a tsconfig.json. Mirrors the create-rstack layout where the
+// `template-rslint/` starter directory carries a rslint.config.ts but no
+// tsconfig. Previously this caused the LSP to fall back to a global
+// "allow-all" mode, incorrectly enabling type-aware rules on files under
+// OTHER configs (e.g. root-level test files outside the root tsconfig's
+// include). The fix scopes tsConfigPaths per-config so this only disables
+// filtering for files under THIS config's directory.
+export default [
+  {
+    files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    plugins: ['@typescript-eslint'],
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+];

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/test/skills.test.ts
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/test/skills.test.ts
@@ -1,4 +1,9 @@
 // File NOT in tsconfig.include (test/ outside src/).
+// The `console.log` below triggers the non-type-aware `no-console` rule,
+// acting as a marker so tests can wait for rslint to finalize diagnostics
+// on this file without resorting to a fixed-duration sleep.
+console.log('skills.test fixture loaded');
+
 export const uncovered = ((
   command: string,
   args: string[],

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/test/skills.test.ts
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/test/skills.test.ts
@@ -1,0 +1,8 @@
+// File NOT in tsconfig.include (test/ outside src/).
+export const uncovered = ((
+  command: string,
+  args: string[],
+  options: unknown,
+) => {
+  return { stdout: '', stderr: '', exitCode: 0 };
+}) as unknown;

--- a/packages/vscode-extension/__tests__/fixtures-project-service-scope/tsconfig.json
+++ b/packages/vscode-extension/__tests__/fixtures-project-service-scope/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "compilerOptions": { "strict": true, "noEmit": true },
+  "include": ["src"]
+}

--- a/packages/vscode-extension/__tests__/runTest.ts
+++ b/packages/vscode-extension/__tests__/runTest.ts
@@ -109,6 +109,28 @@ async function main() {
     failed = true;
   }
 
+  // --- projectService type-aware scope tests ---
+  const projectServiceScopeWorkspace = path.resolve(
+    testsSourceDir,
+    'fixtures-project-service-scope',
+  );
+  const projectServiceScopeTestsPath = path.resolve(
+    __dirname,
+    './suite-project-service-scope',
+  );
+
+  try {
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath: projectServiceScopeTestsPath,
+      launchArgs: ['--disable-extensions', projectServiceScopeWorkspace],
+      version: 'stable',
+    });
+  } catch (err) {
+    console.error('projectService scope tests failed:', err);
+    failed = true;
+  }
+
   if (failed) {
     console.error('Some test suites failed');
     process.exit(1);

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/index.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/index.ts
@@ -1,0 +1,27 @@
+import fastGlob from 'fast-glob';
+import path from 'node:path';
+import Mocha from 'mocha';
+
+export function run(
+  testPath: string,
+  callback: (error: unknown, failures?: number) => void,
+) {
+  const files = fastGlob.sync('**/*.test.js', {
+    cwd: testPath,
+  });
+  const mocha = new Mocha({
+    ui: 'tdd',
+  });
+
+  files.forEach((file) => {
+    mocha.addFile(path.join(testPath, file));
+  });
+
+  try {
+    mocha.run((failures) => {
+      callback(null, failures);
+    });
+  } catch (error) {
+    callback(error);
+  }
+}

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
@@ -27,16 +27,15 @@ suite('rslint projectService type-aware scope', function () {
       const current = vscode.languages.getDiagnostics(doc.uri);
       if (predicate(current)) return current;
       await new Promise((resolve) => {
+        let timer: ReturnType<typeof setTimeout>;
         const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
-          for (const uri of e.uris) {
-            if (uri.toString() === doc.uri.toString()) {
-              disposable.dispose();
-              resolve(void 0);
-              return;
-            }
+          if (e.uris.some((uri) => uri.toString() === doc.uri.toString())) {
+            clearTimeout(timer);
+            disposable.dispose();
+            resolve(void 0);
           }
         });
-        setTimeout(() => {
+        timer = setTimeout(() => {
           disposable.dispose();
           resolve(void 0);
         }, 1500);

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
@@ -1,0 +1,93 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import path from 'node:path';
+
+// Type-aware rule scope when parserOptions uses `projectService: true`
+// (the shape `ts.configs.recommended` exports) without an explicit
+// `project`. The LSP and CLI must agree: only files covered by the
+// fallback tsconfig's `include` get type-aware rules.
+//
+// Fixture: fixtures-project-service-scope
+//   - rslint.config.js  — parserOptions.projectService: true (no explicit project)
+//   - tsconfig.json     — include: ["src"]
+//   - src/covered.ts    — IN tsconfig: no-unused-vars SHOULD fire
+//   - test/skills.test.ts — NOT IN tsconfig: no-unused-vars should NOT fire
+suite('rslint projectService type-aware scope', function () {
+  this.timeout(60000);
+
+  function workspaceRoot(): string {
+    return vscode.workspace.workspaceFolders![0].uri.fsPath;
+  }
+
+  async function waitForDiagnostics(
+    doc: vscode.TextDocument,
+    predicate: (diags: vscode.Diagnostic[]) => boolean,
+  ): Promise<vscode.Diagnostic[]> {
+    for (let i = 0; i < 20; i++) {
+      const current = vscode.languages.getDiagnostics(doc.uri);
+      if (predicate(current)) return current;
+      await new Promise((resolve) => {
+        const disposable = vscode.languages.onDidChangeDiagnostics((e) => {
+          for (const uri of e.uris) {
+            if (uri.toString() === doc.uri.toString()) {
+              disposable.dispose();
+              resolve(void 0);
+              return;
+            }
+          }
+        });
+        setTimeout(() => {
+          disposable.dispose();
+          resolve(void 0);
+        }, 1500);
+      });
+    }
+    return vscode.languages.getDiagnostics(doc.uri);
+  }
+
+  // Only inspect rslint-originated diagnostics — TS's own 6133 ("declared but
+  // never read") is also emitted on the same lines and would otherwise confuse
+  // the assertion.
+  function rslintDiagnostics(diags: vscode.Diagnostic[]): vscode.Diagnostic[] {
+    return diags.filter((d) => d.source === 'rslint');
+  }
+
+  test('src/covered.ts (in tsconfig include) — no-unused-vars SHOULD fire', async () => {
+    const doc = await vscode.workspace.openTextDocument(
+      path.join(workspaceRoot(), 'src/covered.ts'),
+    );
+    await vscode.window.showTextDocument(doc);
+
+    const diagnostics = await waitForDiagnostics(doc, (diags) =>
+      rslintDiagnostics(diags).some((d) =>
+        d.message.includes('no-unused-vars'),
+      ),
+    );
+
+    const rslintDiags = rslintDiagnostics(diagnostics);
+    assert.ok(
+      rslintDiags.some((d) => d.message.includes('no-unused-vars')),
+      `Expected no-unused-vars on src/covered.ts. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,
+    );
+  });
+
+  test('test/skills.test.ts (outside tsconfig include) — no-unused-vars should NOT fire', async () => {
+    const doc = await vscode.workspace.openTextDocument(
+      path.join(workspaceRoot(), 'test/skills.test.ts'),
+    );
+    await vscode.window.showTextDocument(doc);
+
+    // Give the server time to publish diagnostics. Waiting for a specific
+    // predicate is unreliable here because the correct outcome is "no rslint
+    // diagnostics" — we instead wait a bounded amount of time.
+    await new Promise((r) => setTimeout(r, 5000));
+    const rslintDiags = rslintDiagnostics(
+      vscode.languages.getDiagnostics(doc.uri),
+    );
+
+    assert.ok(
+      !rslintDiags.some((d) => d.message.includes('no-unused-vars')),
+      `no-unused-vars should NOT fire on a file outside tsconfig.include. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,
+    );
+  });
+});

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
@@ -10,10 +10,14 @@ import path from 'node:path';
 // configs' files.
 //
 // Fixture: fixtures-project-service-scope
-//   - rslint.config.js            — parserOptions.projectService: true (no explicit project)
+//   - rslint.config.js            — parserOptions.projectService: true (no explicit project).
+//                                    Also enables `no-console` as a non-type-aware marker
+//                                    rule so the negative test case can wait for rslint to
+//                                    finish linting a file without a fixed-duration sleep.
 //   - tsconfig.json               — include: ["src"]
 //   - src/covered.ts              — IN tsconfig: no-unused-vars SHOULD fire
-//   - test/skills.test.ts         — NOT IN tsconfig: no-unused-vars should NOT fire
+//   - test/skills.test.ts         — NOT IN tsconfig: no-unused-vars should NOT fire.
+//                                    Contains a `console.log` so the marker rule triggers.
 //   - template-nested/rslint.config.js — nested config, also projectService: true,
 //                                    but the dir has NO tsconfig.json.
 //   - template-nested/orphan.ts   — under the nested config. Both CLI and LSP
@@ -85,14 +89,19 @@ suite('rslint projectService type-aware scope', function () {
     );
     await vscode.window.showTextDocument(doc);
 
-    // Give the server time to publish diagnostics. Waiting for a specific
-    // predicate is unreliable here because the correct outcome is "no rslint
-    // diagnostics" — we instead wait a bounded amount of time.
-    await new Promise((r) => setTimeout(r, 5000));
-    const rslintDiags = rslintDiagnostics(
-      vscode.languages.getDiagnostics(doc.uri),
+    // Wait for `no-console` (non-type-aware, must fire on the fixture's
+    // console.log) — its presence proves rslint has finalized this file's
+    // diagnostics, so the negative assertion below can run synchronously
+    // instead of waiting on a fixed-duration sleep.
+    const diagnostics = await waitForDiagnostics(doc, (diags) =>
+      rslintDiagnostics(diags).some((d) => d.message.includes('no-console')),
     );
 
+    const rslintDiags = rslintDiagnostics(diagnostics);
+    assert.ok(
+      rslintDiags.some((d) => d.message.includes('no-console')),
+      `Expected no-console marker to appear on test/skills.test.ts. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,
+    );
     assert.ok(
       !rslintDiags.some((d) => d.message.includes('no-unused-vars')),
       `no-unused-vars should NOT fire on a file outside tsconfig.include. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,

--- a/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
+++ b/packages/vscode-extension/__tests__/suite-project-service-scope/project-service-scope.test.ts
@@ -5,13 +5,22 @@ import path from 'node:path';
 // Type-aware rule scope when parserOptions uses `projectService: true`
 // (the shape `ts.configs.recommended` exports) without an explicit
 // `project`. The LSP and CLI must agree: only files covered by the
-// fallback tsconfig's `include` get type-aware rules.
+// fallback tsconfig's `include` get type-aware rules, AND a nested
+// config that has no tsconfig must not leak allow-all onto sibling
+// configs' files.
 //
 // Fixture: fixtures-project-service-scope
-//   - rslint.config.js  — parserOptions.projectService: true (no explicit project)
-//   - tsconfig.json     — include: ["src"]
-//   - src/covered.ts    — IN tsconfig: no-unused-vars SHOULD fire
-//   - test/skills.test.ts — NOT IN tsconfig: no-unused-vars should NOT fire
+//   - rslint.config.js            — parserOptions.projectService: true (no explicit project)
+//   - tsconfig.json               — include: ["src"]
+//   - src/covered.ts              — IN tsconfig: no-unused-vars SHOULD fire
+//   - test/skills.test.ts         — NOT IN tsconfig: no-unused-vars should NOT fire
+//   - template-nested/rslint.config.js — nested config, also projectService: true,
+//                                    but the dir has NO tsconfig.json.
+//   - template-nested/orphan.ts   — under the nested config. Both CLI and LSP
+//                                    treat this as "has type info" (CLI via the
+//                                    scan-directory fallback Program, LSP via
+//                                    allow-all for the nested config's scope),
+//                                    so no-unused-vars SHOULD fire.
 suite('rslint projectService type-aware scope', function () {
   this.timeout(60000);
 
@@ -87,6 +96,34 @@ suite('rslint projectService type-aware scope', function () {
     assert.ok(
       !rslintDiags.some((d) => d.message.includes('no-unused-vars')),
       `no-unused-vars should NOT fire on a file outside tsconfig.include. Got: ${rslintDiags.map((d) => d.message).join(' | ')}`,
+    );
+  });
+
+  test('template-nested/orphan.ts (nested config without tsconfig) — no-unused-vars SHOULD fire, matching CLI', async () => {
+    // Alignment check with CLI: when the nearest rslint config has no
+    // resolvable tsconfig, the CLI builds a scan-directory AllowJs Program
+    // and runs type-aware rules; the LSP falls through to allow-all scoped
+    // to that config. Both engines must produce the same no-unused-vars
+    // diagnostics on this file.
+    const doc = await vscode.workspace.openTextDocument(
+      path.join(workspaceRoot(), 'template-nested/orphan.ts'),
+    );
+    await vscode.window.showTextDocument(doc);
+
+    const diagnostics = await waitForDiagnostics(doc, (diags) =>
+      rslintDiagnostics(diags).some((d) =>
+        d.message.includes('no-unused-vars'),
+      ),
+    );
+
+    const rslintDiags = rslintDiagnostics(diagnostics);
+    const unusedVarDiags = rslintDiags.filter((d) =>
+      d.message.includes('no-unused-vars'),
+    );
+    assert.strictEqual(
+      unusedVarDiags.length,
+      3,
+      `Expected 3 no-unused-vars diagnostics (command/args/options) to match CLI output. Got ${unusedVarDiags.length}: ${unusedVarDiags.map((d) => d.message).join(' | ')}`,
     );
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: `rebuildTsConfigPaths` (`internal/lsp/service.go`) stored a single global `tsConfigPaths`. If any rslint config in the workspace couldn't resolve a tsconfig (no explicit `parserOptions.project` and no auto-detectable `tsconfig.json` under that config's directory), the code set `s.tsConfigPaths = nil` and flipped the type-aware-rule filter into conservative "allow-all" for **every** file in the workspace — including files governed by sibling configs that had perfectly resolvable tsconfigs.
- **Concrete trigger (issue #671)**: [create-rstack](https://github.com/rstackjs/create-rstack) ships a nested `template-rslint/` starter directory that carries its own `rslint.config.ts` but no `tsconfig.json`. Opening any .ts file in VSCode tripped the global fallback, so type-aware rules like `@typescript-eslint/no-unused-vars` ran on `test/skills.test.ts` (outside the root `tsconfig.json`'s `include: ["src"]`) and produced 3 diagnostics that the CLI correctly suppressed.
- **Fix**: track the resolved tsconfig list **per-config-directory** in `tsConfigPathsByConfig`. At lint time pick the nearest config's list via the new `tsConfigPathsForURI`. A config with no resolved tsconfig still disables filtering — but only for files under that config's own scope.
- **Reproduction matrix** (same create-rstack fixture, same probe flow):
  - pre-fix + two configs (root + `template-rslint/`) → **3** `no-unused-vars` diagnostics on `test/skills.test.ts`
  - post-fix + same two configs → **0** diagnostics
- Added regression coverage:
  - `internal/lsp/service_test.go`: updated existing `TestRebuildTsConfigPaths_*` / `TestHandleConfigUpdate_*` cases for per-config shape, plus a dedicated `TestTsConfigPathsForURI_NestedConfigWithoutTsconfigDoesNotLeak`.
  - `packages/vscode-extension/__tests__/fixtures-project-service-scope/template-nested/rslint.config.js`: nested config without tsconfig so the existing E2E asserts the multi-config path end-to-end.

## Related Links

- Fixes https://github.com/web-infra-dev/rslint/issues/671

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).