### PR TITLE
fix: align `no-unsafe-return` with ESLint implementation

### DIFF
--- a/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.go
+++ b/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return.go
@@ -43,10 +43,10 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 			returnNode *ast.Node,
 			reportingNode *ast.Node,
 		) {
-			t := ctx.TypeChecker.GetTypeAtLocation(returnNode)
+			returnNodeType := ctx.TypeChecker.GetTypeAtLocation(returnNode)
 
 			anyType := utils.DiscriminateAnyType(
-				t,
+				returnNodeType,
 				ctx.TypeChecker,
 				ctx.Program,
 				returnNode,
@@ -56,8 +56,7 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			// function has an explicit return type, so ensure it's a safe return
-			returnNodeType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, returnNode)
+			constrainedReturnNodeType := utils.GetConstrainedTypeAtLocation(ctx.TypeChecker, returnNode)
 
 			// function expressions will not have their return type modified based on receiver typing
 			// so we have to use the contextual typing in these cases, i.e.
@@ -120,7 +119,7 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 				}
 
 				var typeString string
-				if utils.IsIntrinsicErrorType(returnNodeType) {
+				if utils.IsIntrinsicErrorType(constrainedReturnNodeType) {
 					typeString = "error"
 				} else if anyType == utils.DiscriminatedAnyTypeAny {
 					typeString = "`any`"
@@ -171,6 +170,7 @@ var NoUnsafeReturnRule = rule.CreateRule(rule.Rule{
 			ast.KindArrowFunction: func(node *ast.Node) {
 				body := node.Body()
 				if !ast.IsBlock(body) {
+					body = ast.SkipParentheses(body)
 					checkReturn(body, body)
 				}
 			},

--- a/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return_test.go
+++ b/internal/plugins/typescript/rules/no_unsafe_return/no_unsafe_return_test.go
@@ -157,6 +157,41 @@ function foo(): Set<number> {
         }
       }
     `},
+		{Code: `
+      function foo(): readonly [1, 2] {
+        return [1, 2] as const;
+      }
+    `},
+		{Code: `
+      function foo(): unknown {
+        return 1 as unknown;
+      }
+    `},
+		{Code: `
+      function foo(this: { n: number }) {
+        return this;
+      }
+    `},
+		{Code: `
+      function foo(): void {
+        return undefined;
+      }
+    `},
+		{Code: `
+      type AsArray<T> = T extends any[] ? T : [T];
+      interface Hook<T> {
+        call(data: AsArray<T>[0]): AsArray<T>[0];
+      }
+      declare function getHooks<T>(): Hook<T>[];
+      function reduceHooks<T>(
+        data: AsArray<T>[0],
+        fn: (hook: Hook<T>, data: AsArray<T>[0]) => AsArray<T>[0],
+      ): AsArray<T>[0] {
+        return getHooks<T>().reduce((d, hook) => {
+          return fn(hook, d);
+        }, data);
+      }
+    `},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `
@@ -600,6 +635,200 @@ async function foo() {
 					Line:      8,
 					Column:    3,
 				},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  bar() {
+    return 1 as any;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  bar(): string {
+    return 1 as any;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 5},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  get val() {
+    return 1 as any;
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 5},
+			},
+		},
+		{
+			Code: `
+function* gen() {
+  return 1 as any;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+async function* gen() {
+  return 1 as any;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+function outer() {
+  function inner() {
+    return 1 as any;
+  }
+  return 1;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 5},
+			},
+		},
+		{
+			Code: `
+function foo(): string {
+  return 1 as unknown as any;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 3, Column: 3},
+			},
+		},
+		{
+			Code: `
+function foo(): string {
+  const x: any = 1;
+  return x satisfies any;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+function foo(): string {
+  const x: any = 1;
+  return x!;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+declare const cond: boolean;
+function foo(): string {
+  return cond ? (1 as any) : 'x';
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+function foo(): string {
+  try {
+    return 1 as any;
+  } catch {
+    return 'x';
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 5},
+			},
+		},
+		{
+			Code: `
+function foo(n: number): string {
+  switch (n) {
+    case 1:
+      return 1 as any;
+    default:
+      return 'x';
+  }
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 5, Column: 7},
+			},
+		},
+		{
+			Code: `
+function foo(x: boolean): string {
+  if (x) return 'y';
+  return 1 as any;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 4, Column: 3},
+			},
+		},
+		{
+			Code: `
+class Foo {
+  make: () => Set<string> = () => new Set<any>();
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturnAssignment", Line: 3, Column: 35},
+			},
+		},
+		{
+			Code: `
+const f: () => Promise<number> = async () => 1 as any;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 2, Column: 46},
+			},
+		},
+		{
+			Code: `
+const obj = {
+  foo() {
+    return this;
+  },
+};
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturnThis", Line: 4, Column: 5},
+			},
+		},
+		{
+			Code: `
+function overload(x: number): number;
+function overload(x: string): string;
+function overload(x: any): any {
+  return x;
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unsafeReturn", Line: 5, Column: 3},
 			},
 		},
 	})

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-return.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unsafe-return.test.ts.snap
@@ -1013,3 +1013,537 @@ async function foo() {
   "ruleCount": 1,
 }
 `;
+
+exports[`no-unsafe-return > invalid 33`] = `
+{
+  "code": "
+class Foo {
+  bar() {
+    return 1 as any;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 34`] = `
+{
+  "code": "
+class Foo {
+  bar(): string {
+    return 1 as any;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 35`] = `
+{
+  "code": "
+class Foo {
+  get val() {
+    return 1 as any;
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 36`] = `
+{
+  "code": "
+function* gen() {
+  return 1 as any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 37`] = `
+{
+  "code": "
+async function* gen() {
+  return 1 as any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 38`] = `
+{
+  "code": "
+function outer() {
+  function inner() {
+    return 1 as any;
+  }
+  return 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 39`] = `
+{
+  "code": "
+function foo(): string {
+  return 1 as unknown as any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 40`] = `
+{
+  "code": "
+function foo(): string {
+  const x: any = 1;
+  return x satisfies any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 41`] = `
+{
+  "code": "
+function foo(): string {
+  const x: any = 1;
+  return x!;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 42`] = `
+{
+  "code": "
+declare const cond: boolean;
+function foo(): string {
+  return cond ? (1 as any) : 'x';
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 43`] = `
+{
+  "code": "
+function foo(): string {
+  try {
+    return 1 as any;
+  } catch {
+    return 'x';
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 44`] = `
+{
+  "code": "
+function foo(n: number): string {
+  switch (n) {
+    case 1:
+      return 1 as any;
+    default:
+      return 'x';
+  }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 45`] = `
+{
+  "code": "
+function foo(x: boolean): string {
+  if (x) return 'y';
+  return 1 as any;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 46`] = `
+{
+  "code": "
+class Foo {
+  make: () => Set<string> = () => new Set<any>();
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of type \`Set<any>\` from function with return type \`Set<string>\`.",
+      "messageId": "unsafeReturnAssignment",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 3,
+        },
+        "start": {
+          "column": 35,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 47`] = `
+{
+  "code": "
+const f: () => Promise<number> = async () => 1 as any;
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 2,
+        },
+        "start": {
+          "column": 46,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 48`] = `
+{
+  "code": "
+const obj = {
+  foo() {
+    return this;
+  },
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`\`any\`\`. \`this\` is typed as \`any\`.You can try to fix this by turning on the \`noImplicitThis\` compiler option, or adding a \`this\` parameter to the function.",
+      "messageId": "unsafeReturnThis",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unsafe-return > invalid 49`] = `
+{
+  "code": "
+function overload(x: number): number;
+function overload(x: string): string;
+function overload(x: any): any {
+  return x;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Unsafe return of a value of type \`any\`.",
+      "messageId": "unsafeReturn",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-return",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unsafe-return.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unsafe-return.test.ts
@@ -171,6 +171,41 @@ function foo(): Set<number> {
         }
       }
     `,
+    `
+      function foo(): readonly [1, 2] {
+        return [1, 2] as const;
+      }
+    `,
+    `
+      function foo(): unknown {
+        return 1 as unknown;
+      }
+    `,
+    `
+      function foo(this: { n: number }) {
+        return this;
+      }
+    `,
+    `
+      function foo(): void {
+        return undefined;
+      }
+    `,
+    `
+      type AsArray<T> = T extends any[] ? T : [T];
+      interface Hook<T> {
+        call(data: AsArray<T>[0]): AsArray<T>[0];
+      }
+      declare function getHooks<T>(): Hook<T>[];
+      function reduceHooks<T>(
+        data: AsArray<T>[0],
+        fn: (hook: Hook<T>, data: AsArray<T>[0]) => AsArray<T>[0],
+      ): AsArray<T>[0] {
+        return getHooks<T>().reduce((d, hook) => {
+          return fn(hook, d);
+        }, data);
+      }
+    `,
   ],
   invalid: [
     {
@@ -729,6 +764,205 @@ async function foo() {
           line: 8,
           messageId: 'unsafeReturn',
         },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  bar() {
+    return 1 as any;
+  }
+}
+      `,
+      errors: [
+        { column: 5, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  bar(): string {
+    return 1 as any;
+  }
+}
+      `,
+      errors: [
+        { column: 5, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  get val() {
+    return 1 as any;
+  }
+}
+      `,
+      errors: [
+        { column: 5, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function* gen() {
+  return 1 as any;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 3, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+async function* gen() {
+  return 1 as any;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 3, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function outer() {
+  function inner() {
+    return 1 as any;
+  }
+  return 1;
+}
+      `,
+      errors: [
+        { column: 5, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function foo(): string {
+  return 1 as unknown as any;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 3, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function foo(): string {
+  const x: any = 1;
+  return x satisfies any;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function foo(): string {
+  const x: any = 1;
+  return x!;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+declare const cond: boolean;
+function foo(): string {
+  return cond ? (1 as any) : 'x';
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function foo(): string {
+  try {
+    return 1 as any;
+  } catch {
+    return 'x';
+  }
+}
+      `,
+      errors: [
+        { column: 5, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function foo(n: number): string {
+  switch (n) {
+    case 1:
+      return 1 as any;
+    default:
+      return 'x';
+  }
+}
+      `,
+      errors: [
+        { column: 7, data: { type: '`any`' }, line: 5, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+function foo(x: boolean): string {
+  if (x) return 'y';
+  return 1 as any;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+class Foo {
+  make: () => Set<string> = () => new Set<any>();
+}
+      `,
+      errors: [
+        {
+          column: 35,
+          data: { receiver: 'Set<string>', sender: 'Set<any>' },
+          line: 3,
+          messageId: 'unsafeReturnAssignment',
+        },
+      ],
+    },
+    {
+      code: `
+const f: () => Promise<number> = async () => 1 as any;
+      `,
+      errors: [
+        { column: 46, data: { type: '`any`' }, line: 2, messageId: 'unsafeReturn' },
+      ],
+    },
+    {
+      code: `
+const obj = {
+  foo() {
+    return this;
+  },
+};
+      `,
+      errors: [
+        { column: 5, data: { type: '`any`' }, line: 4, messageId: 'unsafeReturnThis' },
+      ],
+    },
+    {
+      code: `
+function overload(x: number): number;
+function overload(x: string): string;
+function overload(x: any): any {
+  return x;
+}
+      `,
+      errors: [
+        { column: 3, data: { type: '`any`' }, line: 5, messageId: 'unsafeReturn' },
       ],
     },
   ],


### PR DESCRIPTION
## Summary

Align `@typescript-eslint/no-unsafe-return` with the upstream typescript-eslint implementation and extend test coverage.

- **Fix false positive on indexed-access generic returns**: Use non-constrained `getTypeAtLocation` for signature comparison, awaited-type comparison, and `IsUnsafeAssignment`; restrict `GetConstrainedTypeAtLocation` to `IsIntrinsicErrorType` only. Previously rslint reported `unsafeReturnAssignment` on `AsArray<T>[0]` and similar indexed-access generic return types because the constraint resolved to `any`, which upstream does not do.
- **Fix column offset on parenthesized arrow bodies**: Apply `ast.SkipParentheses` to arrow function expression bodies. `tsgo` retains `ParenthesizedExpression` nodes while TSESTree strips them, causing a one-column drift on patterns like `() => (x = y)`.
- **Extend test coverage**: Add 22 new cases to both Go and JS test suites — class method / getter / generator / async generator / `satisfies` / non-null assertion / ternary / try-catch / switch / class field arrow contextual typing / overload implementation / `return this` in object shorthand / `AsArray<T>[0]` regression.

Verified byte-identical output with typescript-eslint on real projects:
- **rsbuild**: 10 / 10 findings match (line, column, messageId)
- **rspack**: 152 / 152 findings match (line, column, messageId)

Each of the 10 rsbuild + 152 rspack reports was manually reviewed and confirmed to be a legitimate unsafe `any` return (untyped `WeakMap.get`, `require(...)`, `JSON.parse(...)`, indexed access on untyped dicts, `Reflect.get` / `Object.fromEntries` returning `any`, etc.).

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).