### PR TITLE
fix: apply config ignores to type-check diagnostics and file count

### DIFF
--- a/cmd/rslint/cmd.go
+++ b/cmd/rslint/cmd.go
@@ -898,27 +898,10 @@ func runCMD() int {
 		return rslintconfig.GlobalRuleRegistry.GetActiveRulesForFile(rslintConfig, filePath, currentDirectory, enforcePlugins, typeInfoFiles)
 	}
 
-	// Build per-program file ownership filters for multi-config deduplication.
-	// Each file is owned by its nearest config (ESLint v10 aligned).
-	// Programs only lint files belonging to their own config directory.
-	var fileFilters []func(string) bool
-	if len(configMap) > 1 {
-		fileOwner := buildFileOwnerMap(programs, configMap)
-		fileFilters = make([]func(string) bool, len(programs))
-		for i := range programs {
-			if i < len(programConfigDirs) && programConfigDirs[i] != "" {
-				ownerDir := programConfigDirs[i]
-				fileFilters[i] = func(fileName string) bool {
-					owner, ok := fileOwner[fileName]
-					if !ok {
-						return true
-					}
-					return owner == ownerDir
-				}
-			}
-			// nil filter for gap file fallback program (no configDir) → process all
-		}
-	}
+	// Build per-program file filters combining:
+	//   - multi-config ownership deduplication (ESLint v10 aligned)
+	//   - config `ignores` exclusion (applies to rules, type-check, and counts)
+	fileFilters := buildFileFilters(programs, configMap, programConfigDirs, rslintConfig, currentDirectory)
 
 	lintResult, err := linter.RunLinter(
 		programs,
@@ -1018,24 +1001,8 @@ func runCMD() int {
 			}
 
 			// Re-lint: collect remaining diagnostics.
-			// Rebuild file filters for the new programs.
-			var fixFileFilters []func(string) bool
-			if len(configMap) > 1 {
-				fixOwner := buildFileOwnerMap(newPrograms, configMap)
-				fixFileFilters = make([]func(string) bool, len(newPrograms))
-				for i := range newPrograms {
-					if i < len(programConfigDirs) && programConfigDirs[i] != "" {
-						ownerDir := programConfigDirs[i]
-						fixFileFilters[i] = func(fileName string) bool {
-							owner, ok := fixOwner[fileName]
-							if !ok {
-								return true
-							}
-							return owner == ownerDir
-						}
-					}
-				}
-			}
+			// Rebuild file filters for the new programs (ownership + ignores).
+			fixFileFilters := buildFileFilters(newPrograms, configMap, programConfigDirs, rslintConfig, currentDirectory)
 			var passDiags []rule.RuleDiagnostic
 			passResult, _ := linter.RunLinter(
 				newPrograms,

--- a/cmd/rslint/programs.go
+++ b/cmd/rslint/programs.go
@@ -125,3 +125,59 @@ func buildFileOwnerMap(programs []*compiler.Program, configMap map[string]rslint
 	}
 	return fileOwner
 }
+
+// buildFileFilters returns per-program file filters combining two concerns:
+//   - multi-config ownership: a file is linted by the program belonging to its
+//     nearest config (only active when len(configMap) > 1)
+//   - config `ignores`: files matching the user's ignore patterns are excluded
+//     from ALL diagnostics (lint rules, type-check, and the linted-file count)
+//
+// The returned slice is always len(programs). Entries are never nil — ignores
+// must apply to every program, including the gap-file fallback program.
+//
+// singleConfig / singleConfigDir are used when configMap is nil (single-config
+// mode). When configMap is non-nil, the per-file nearest config is looked up.
+func buildFileFilters(
+	programs []*compiler.Program,
+	configMap map[string]rslintconfig.RslintConfig,
+	programConfigDirs []string,
+	singleConfig rslintconfig.RslintConfig,
+	singleConfigDir string,
+) []func(string) bool {
+	var fileOwner map[string]string
+	if len(configMap) > 1 {
+		fileOwner = buildFileOwnerMap(programs, configMap)
+	}
+
+	filters := make([]func(string) bool, len(programs))
+	for i := range programs {
+		var ownerDir string
+		if fileOwner != nil && i < len(programConfigDirs) {
+			ownerDir = programConfigDirs[i]
+		}
+		filters[i] = func(fileName string) bool {
+			// Ownership check: only when we have multiple configs AND this
+			// program is anchored to a configDir (gap fallback has "").
+			if fileOwner != nil && ownerDir != "" {
+				if owner, ok := fileOwner[fileName]; ok && owner != ownerDir {
+					return false
+				}
+			}
+			// Ignore check: resolve the config that governs this file and
+			// consult its global `ignores` patterns.
+			var cfg rslintconfig.RslintConfig
+			var cwd string
+			if configMap != nil {
+				cwd, cfg = rslintconfig.FindNearestConfig(fileName, configMap)
+			} else {
+				cfg = singleConfig
+				cwd = singleConfigDir
+			}
+			if cfg != nil && cfg.IsFileIgnored(fileName, cwd) {
+				return false
+			}
+			return true
+		}
+	}
+	return filters
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -727,6 +727,20 @@ type MergedConfig struct {
 	Plugins         map[string]struct{}
 }
 
+// IsFileIgnored reports whether filePath is excluded by the config's global
+// `ignores` patterns. It is distinct from GetConfigForFile returning nil,
+// which also covers "no entry matched this file" — callers that need ESLint's
+// "ignores hides the file from the linter entirely" semantics (including
+// type-check diagnostics and file counts) should use this method.
+func (config RslintConfig) IsFileIgnored(filePath string, cwd string) bool {
+	patterns := ExtractConfigIgnores(config)
+	if len(patterns) == 0 {
+		return false
+	}
+	return isDirBlockedByIgnores(filePath, patterns, cwd) ||
+		isFileIgnored(filePath, patterns, cwd)
+}
+
 // GetConfigForFile computes the merged configuration for a file following ESLint flat config semantics.
 // Returns nil if the file is globally ignored or no entry matches (should not be linted).
 //

--- a/internal/config/config_ignore_test.go
+++ b/internal/config/config_ignore_test.go
@@ -424,3 +424,59 @@ func TestGetConfigForFile_NegationSequentialOverride(t *testing.T) {
 		t.Error("Expected dist/generated/a.js to be ignored")
 	}
 }
+
+// IsFileIgnored reports only on global ignores, distinct from GetConfigForFile
+// which ALSO returns nil when no entry matched the file. This distinction
+// matters for --type-check: ignored files must be silenced, but files outside
+// rslint's `files` scope should still receive type diagnostics.
+func TestIsFileIgnored_OnlyReflectsIgnores(t *testing.T) {
+	config := RslintConfig{
+		{Ignores: []string{"**/fixtures/**", "**/*.gen.ts"}},
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+
+	tests := []struct {
+		name    string
+		path    string
+		ignored bool
+	}{
+		{"directory pattern hits", "packages/x/fixtures/a.ts", true},
+		{"file pattern hits", "src/schema.gen.ts", true},
+		{"in-scope file not ignored", "src/index.ts", false},
+		// Critical: a file that no entry matches (e.g. .js when only **/*.ts
+		// has rules) is NOT ignored — it's just out of rslint's scope.
+		// GetConfigForFile returns nil for both cases, but IsFileIgnored
+		// distinguishes them so --type-check can still report on out-of-scope files.
+		{"out-of-scope file not ignored", "src/index.js", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := config.IsFileIgnored(tt.path, ""); got != tt.ignored {
+				t.Errorf("IsFileIgnored(%q) = %v, want %v", tt.path, got, tt.ignored)
+			}
+		})
+	}
+}
+
+// Empty patterns short-circuit — no config with ignores should never flag a file.
+func TestIsFileIgnored_NoPatterns(t *testing.T) {
+	config := RslintConfig{
+		{Files: []string{"**/*.ts"}, Rules: Rules{"r": "error"}},
+	}
+	if config.IsFileIgnored("any/file.ts", "") {
+		t.Error("IsFileIgnored should return false when config has no ignore patterns")
+	}
+}
+
+// Directory-level blocking cannot be undone by `!` negation, matching
+// ESLint v10's isDirectoryIgnored. IsFileIgnored must reflect this so
+// --type-check honors the same blocking rule.
+func TestIsFileIgnored_DirectoryBlockingBeatsNegation(t *testing.T) {
+	config := RslintConfig{
+		{Ignores: []string{"blocked/**", "!blocked/keep.ts"}},
+	}
+	if !config.IsFileIgnored("blocked/keep.ts", "") {
+		t.Error("directory-level block should ignore blocked/keep.ts even with negation")
+	}
+}

--- a/internal/linter/linter.go
+++ b/internal/linter/linter.go
@@ -114,8 +114,10 @@ func flattenMessageChain(b *strings.Builder, chain *ast.Diagnostic, level int) {
 
 // RunLinterInProgram lints files in a single Program. Files are filtered through
 // skipFiles, allowFiles/allowDirs, and the optional fileFilter before rule execution.
-// fileFilter is used in multi-config mode for ownership-based deduplication: only files
-// owned by this program's config pass the filter. Pass nil to lint all files.
+// fileFilter is a caller-supplied predicate covering any reason to skip a file —
+// used for multi-config ownership-based deduplication and for config `ignores`
+// patterns. Files it rejects are excluded from rule diagnostics, type-check
+// diagnostics, and the returned linted-file count. Pass nil to lint all files.
 func RunLinterInProgram(program *compiler.Program, allowFiles []string, allowDirs []string, skipFiles []string, getRulesForFile RuleHandler, typeCheck bool, onDiagnostic DiagnosticHandler, typeInfoFiles map[string]struct{}, fileFilter func(string) bool) int32 {
 	// Pre-compute FileInfo for allowFiles once to avoid N×M stat calls in the loop.
 	var allowFileInfos []os.FileInfo
@@ -408,9 +410,10 @@ type LintResult struct {
 //   - allowFiles: if non-nil, only lint files in this list; nil = all files
 //   - allowDirs: if non-nil, also lint files under these dirs (OR with allowFiles)
 //   - typeInfoFiles: files with type info; gap files not in this set skip type-aware rules
-//   - fileFilters: optional per-program ownership filters (parallel to programs).
-//     In multi-config mode, each filter ensures a program only lints files owned by
-//     its nearest config. nil or missing entries = no filter (process all).
+//   - fileFilters: optional per-program skip predicates (parallel to programs).
+//     Each filter covers any caller-specific reason to skip a file — multi-config
+//     ownership deduplication and config `ignores` exclusion are both composed
+//     in here by the caller. nil or missing entries = no filter (process all).
 func RunLinter(programs []*compiler.Program, singleThreaded bool, allowFiles []string, allowDirs []string, excludedPaths []string, getRulesForFile RuleHandler, typeCheck bool, onDiagnostic DiagnosticHandler, typeInfoFiles map[string]struct{}, fileFilters []func(string) bool) (*LintResult, error) {
 
 	executedRules := make(map[string]struct{})

--- a/internal/linter/linter_typecheck_test.go
+++ b/internal/linter/linter_typecheck_test.go
@@ -1256,3 +1256,83 @@ func TestTypeCheck_MessageIdEmpty(t *testing.T) {
 		}
 	}
 }
+
+// fileFilter rejecting a file must suppress BOTH rule and type-check
+// diagnostics for it, and exclude it from the returned LintedFileCount.
+// This is what wires config `ignores` into the linter at the CLI/LSP layer.
+func TestTypeCheck_FileFilterSuppressesDiagnostics(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"kept.ts":    "const x: number = 'hello';",
+		"ignored.ts": "const y: number = 'world';",
+	})
+
+	ignoredPath := paths["ignored.ts"]
+	keptPath := paths["kept.ts"]
+
+	var diagnostics []rule.RuleDiagnostic
+	count := RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		true,
+		func(d rule.RuleDiagnostic) { diagnostics = append(diagnostics, d) }, nil,
+		// Reject ignored.ts — stands in for config `ignores` hitting the file.
+		func(fileName string) bool { return fileName != ignoredPath },
+	)
+
+	// Count should exclude the filtered file.
+	if count != 1 {
+		t.Errorf("LintedFileCount = %d, want 1 (ignored file should not count)", count)
+	}
+
+	// Kept file should still produce its TS error; filtered file must be silent.
+	var keptDiags, ignoredDiags int
+	for _, d := range diagnostics {
+		switch d.SourceFile.FileName() {
+		case keptPath:
+			keptDiags++
+		case ignoredPath:
+			ignoredDiags++
+		}
+	}
+	if keptDiags == 0 {
+		t.Error("expected kept.ts to produce TS diagnostics, got none")
+	}
+	if ignoredDiags != 0 {
+		t.Errorf("expected ignored.ts to produce no diagnostics, got %d", ignoredDiags)
+	}
+}
+
+// Parallel scenario: multiple programs each with their own filter.
+func TestTypeCheck_FileFilterSuppressesAcrossPrograms(t *testing.T) {
+	program, paths := createTestProgramWithFiles(t, map[string]string{
+		"a.ts": "const x: number = 'hello';",
+		"b.ts": "const y: number = 'world';",
+	})
+
+	// Filter that rejects everything — simulates all files being ignored.
+	rejectAll := func(string) bool { return false }
+
+	var diagCount int
+	var mu sync.Mutex
+	result, err := RunLinter(
+		[]*compiler.Program{program},
+		true, // singleThreaded
+		nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []ConfiguredRule { return nil },
+		true,
+		func(d rule.RuleDiagnostic) { mu.Lock(); diagCount++; mu.Unlock() },
+		nil,
+		[]func(string) bool{rejectAll},
+	)
+	if err != nil {
+		t.Fatalf("RunLinter: %v", err)
+	}
+	if result.LintedFileCount != 0 {
+		t.Errorf("LintedFileCount = %d, want 0", result.LintedFileCount)
+	}
+	if diagCount != 0 {
+		t.Errorf("diagnostic count = %d, want 0", diagCount)
+	}
+	// Reference paths so the test fails obviously if the helper changes shape.
+	_ = paths["a.ts"]
+	_ = paths["b.ts"]
+}

--- a/internal/lsp/service.go
+++ b/internal/lsp/service.go
@@ -678,6 +678,12 @@ type LintResponse struct {
 func runLintWithSession(uri lsproto.DocumentUri, session *project.Session, ctx context.Context, rslintConfig config.RslintConfig, cwd string, enforcePlugins bool, tsConfigPaths []string, fs vfs.FS) ([]rule.RuleDiagnostic, error) {
 	filename := uriToPath(uri)
 
+	// Files excluded by the config's `ignores` patterns produce no diagnostics,
+	// matching CLI behavior. Return early before spinning up the language service.
+	if rslintConfig.IsFileIgnored(filename, cwd) {
+		return []rule.RuleDiagnostic{}, nil
+	}
+
 	// GetLanguageService flushes any pending changes (from DidChangeFile) and
 	// returns a language service whose program reflects the latest overlay content.
 	languageService, err := session.GetLanguageService(ctx, uri)

--- a/internal/lsp/service_test.go
+++ b/internal/lsp/service_test.go
@@ -1438,3 +1438,62 @@ func TestRebuildTsConfigPaths_NoConfig(t *testing.T) {
 		t.Errorf("expected tsConfigPaths nil when no config, got %v", s.tsConfigPaths)
 	}
 }
+
+// ======== runLintWithSession: ignored-file short-circuit ========
+
+// runLintWithSession must early-return for files matching the config's
+// `ignores` patterns, WITHOUT touching the session. This test proves the
+// guard semantically (not just by coincidence of a no-op session):
+//
+//  1. Positive: call with session=nil AND an ignored path. The call must
+//     return empty diagnostics with no error. Passing a nil session is the
+//     key trick — if the guard is removed, the very next line dereferences
+//     session and panics, making the test fail loudly rather than silently.
+//  2. Control: call with session=nil AND a non-ignored path. The call MUST
+//     panic (runtime nil-pointer dereference). This proves the only thing
+//     keeping the positive case alive is the ignore early-return, not some
+//     accidental nil-session tolerance downstream.
+func TestRunLintWithSession_IgnoredFileShortCircuits(t *testing.T) {
+	ctx := context.Background()
+	cwd := "/project"
+	cfg := config.RslintConfig{
+		// Global ignores entry: hides everything under lib/.
+		{Ignores: []string{"lib/**"}},
+	}
+
+	ignoredURI := lsproto.DocumentUri("file:///project/lib/util.ts")
+	normalURI := lsproto.DocumentUri("file:///project/src/main.ts")
+
+	t.Run("ignored file returns empty without touching session", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("runLintWithSession panicked on ignored file (early-return missing?): %v", r)
+			}
+		}()
+
+		diags, err := runLintWithSession(ignoredURI, nil, ctx, cfg, cwd, false, nil, nil)
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if diags == nil {
+			t.Fatal("expected non-nil empty slice (LSP protocol expects [], not null)")
+		}
+		if len(diags) != 0 {
+			t.Errorf("expected 0 diagnostics for ignored file, got %d: %+v", len(diags), diags)
+		}
+	})
+
+	t.Run("non-ignored file falls through to session (nil-session → panic)", func(t *testing.T) {
+		// This control test asserts the inverse: without a matching ignore,
+		// the function proceeds to `session.GetLanguageService(...)` which
+		// must nil-dereference. If this test stops panicking, it means some
+		// other short-circuit has crept in and the positive test above may
+		// be passing for the wrong reason.
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatal("expected panic when non-ignored file is given a nil session, got none — the ignore short-circuit may be matching too broadly")
+			}
+		}()
+		_, _ = runLintWithSession(normalURI, nil, ctx, cfg, cwd, false, nil, nil)
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -24,6 +24,7 @@ export default defineConfig({
     './tests/cli/entry-point.test.ts',
     './tests/cli/type-check/type-check.test.ts',
     './tests/cli/type-check/type-check-snapshot.test.ts',
+    './tests/cli/type-check/ignores-suppression.test.ts',
 
     // eslint
     './tests/eslint/rules/default-case.test.ts',

--- a/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
+++ b/packages/rslint-test-tools/tests/cli/type-check/ignores-suppression.test.ts
@@ -1,0 +1,206 @@
+import { describe, test, expect } from '@rstest/core';
+import { runRslint, createTempDir, cleanupTempDir, TS_CONFIG } from './helpers';
+
+// `ignores` must hide files from --type-check, matching ESLint v10 semantics.
+// These tests guard the end-to-end CLI path (config → buildFileFilters →
+// RunLinter). Unit tests inside internal/linter only exercise the filter
+// callback; they cannot catch regressions in the cmd wiring that composes it.
+
+interface Diagnostic {
+  ruleName: string;
+  filePath: string;
+  severity?: string;
+}
+
+/**
+ * Run rslint --type-check twice: once with --format jsonline for exact
+ * per-file diagnostic parsing, once with the default format for the summary
+ * line ("linted N files"). The default format does not emit structured
+ * diagnostics, and jsonline suppresses the summary, so both runs are needed
+ * for precise assertions.
+ */
+async function lintTypeCheck(
+  tempDir: string,
+  extraArgs: string[] = [],
+): Promise<{
+  diagnostics: Diagnostic[];
+  lintedFileCount: number;
+  exitCode: number;
+}> {
+  const jsonRun = await runRslint(
+    ['--type-check', '--format', 'jsonline', ...extraArgs],
+    tempDir,
+  );
+  const diagnostics: Diagnostic[] = jsonRun.stdout
+    .trim()
+    .split('\n')
+    .filter((l) => l.trim().startsWith('{'))
+    .map((l) => JSON.parse(l) as Diagnostic);
+
+  const summaryRun = await runRslint(['--type-check', ...extraArgs], tempDir);
+  const combined = `${summaryRun.stdout}\n${summaryRun.stderr}`;
+  const countMatch = combined.match(/linted (\d+) files?/);
+  if (!countMatch) {
+    throw new Error(
+      `Could not parse linted-file count from summary output:\nSTDOUT:\n${summaryRun.stdout}\nSTDERR:\n${summaryRun.stderr}`,
+    );
+  }
+
+  return {
+    diagnostics,
+    lintedFileCount: parseInt(countMatch[1]!, 10),
+    exitCode: jsonRun.exitCode,
+  };
+}
+
+/**
+ * Build an rslint.config.mjs with a given `ignores` array. Keeps everything
+ * else (files glob, parserOptions, no enabled rules) constant so the only
+ * variable under test is the ignores behavior.
+ */
+function makeConfigWithIgnores(ignores: string[]): string {
+  return `export default [
+  { ignores: ${JSON.stringify(ignores)} },
+  {
+    files: ['**/*.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json'] } },
+  }
+];
+`;
+}
+
+describe('--type-check + config ignores', () => {
+  test('ignored file produces zero diagnostics; non-ignored file still does', async () => {
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigWithIgnores(['ignored/**']),
+      // Ignored file: has a TS2322 that would otherwise fire
+      'ignored/bad.ts': "const x: number = 'from-ignored';\n",
+      // Control file: same kind of error, should still fire
+      'src/bad.ts': "const y: number = 'from-src';\n",
+    });
+    try {
+      const r = await lintTypeCheck(tempDir);
+
+      // Guard against trivial pass: the non-ignored file MUST produce a TS
+      // diagnostic. If it doesn't, the test setup is broken (e.g. tsconfig
+      // not picked up) and any assertion about the ignored file is vacuous.
+      const srcDiags = r.diagnostics.filter((d) =>
+        d.filePath?.includes('src/bad.ts'),
+      );
+      expect(srcDiags.length).toBeGreaterThan(0);
+      expect(srcDiags.some((d) => d.ruleName.includes('TS'))).toBe(true);
+
+      // The actual assertion: zero diagnostics point at the ignored file.
+      const ignoredDiags = r.diagnostics.filter((d) =>
+        d.filePath?.includes('ignored/bad.ts'),
+      );
+      expect(ignoredDiags).toEqual([]);
+
+      // Counts must reflect the filter: exactly one file was linted.
+      // If ignores leaks, count would be 2 (or more if tsgolint pulled extras).
+      expect(r.lintedFileCount).toBe(1);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('ignored file stays in TS program as import context but emits no own diagnostics', async () => {
+    // Scenario: caller.ts imports from util.ts; util.ts is ignored. The TS
+    // compiler must still load util.ts to type-check caller.ts's call site,
+    // but util.ts itself must not emit diagnostics and must not count.
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': makeConfigWithIgnores(['lib/**']),
+      // Ignored file: exports a typed function. Contains its own TS error
+      // that would fire if it were not ignored.
+      'lib/util.ts': [
+        'export function greet(name: string): string {',
+        '  return `hi ${name}`;',
+        '}',
+        "const shouldBeIgnored: number = 'not a number';", // TS2322 if linted
+        '',
+      ].join('\n'),
+      // Non-ignored caller passes wrong arg type — TS must still catch this,
+      // which proves util.ts is loaded into the program as context.
+      'src/caller.ts': "import { greet } from '../lib/util';\ngreet(42);\n",
+    });
+    try {
+      const r = await lintTypeCheck(tempDir);
+
+      // Context check: caller.ts must get its TS2345 (wrong arg type). This
+      // only works if util.ts's types were resolved → proves ignored file
+      // stayed in the TS program.
+      const callerDiags = r.diagnostics.filter((d) =>
+        d.filePath?.includes('src/caller.ts'),
+      );
+      expect(callerDiags.length).toBeGreaterThan(0);
+      const callerTsDiags = callerDiags.filter((d) =>
+        d.ruleName.startsWith('TypeScript('),
+      );
+      expect(callerTsDiags.length).toBeGreaterThan(0);
+
+      // Assertion: the ignored file's own TS2322 must NOT surface.
+      const utilDiags = r.diagnostics.filter((d) =>
+        d.filePath?.includes('lib/util.ts'),
+      );
+      expect(utilDiags).toEqual([]);
+
+      // Count: only caller.ts counts as "linted".
+      expect(r.lintedFileCount).toBe(1);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+
+  test('multi-config: root ignores filter files covered by child tsconfig', async () => {
+    // Root rslint.config.mjs globally ignores packages/child/**. The child
+    // package has its own tsconfig that includes those files. The ignores
+    // must still win — this is the ESLint v10 "global ignores" semantics.
+    const tempDir = await createTempDir({
+      'tsconfig.json': TS_CONFIG,
+      'rslint.config.mjs': `export default [
+  { ignores: ['packages/child/**'] },
+  {
+    files: ['**/*.ts'],
+    languageOptions: { parserOptions: { project: ['./tsconfig.json', './packages/child/tsconfig.json'] } },
+  }
+];
+`,
+      'packages/child/tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          target: 'ES2020',
+          module: 'ESNext',
+          strict: true,
+          moduleResolution: 'node',
+        },
+        include: ['**/*.ts'],
+      }),
+      // File covered by child's tsconfig, but globally ignored
+      'packages/child/a.ts': "const x: number = 'ignored-by-root';\n",
+      // File not covered by the root ignore — must still be linted
+      'src/ok.ts': "const y: number = 'from-src';\n",
+    });
+    try {
+      const r = await lintTypeCheck(tempDir);
+
+      // Control: the non-ignored file must still produce diagnostics.
+      const srcDiags = r.diagnostics.filter((d) =>
+        d.filePath?.includes('src/ok.ts'),
+      );
+      expect(srcDiags.length).toBeGreaterThan(0);
+
+      // Assertion: no diagnostic anywhere under packages/child/.
+      const childDiags = r.diagnostics.filter((d) =>
+        d.filePath?.includes('packages/child/'),
+      );
+      expect(childDiags).toEqual([]);
+
+      // Count: only src/ok.ts, even though packages/child/a.ts is in the
+      // child's tsconfig include.
+      expect(r.lintedFileCount).toBe(1);
+    } finally {
+      await cleanupTempDir(tempDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`rslint --type-check` used to emit TypeScript semantic diagnostics for files that the user explicitly excluded via global `ignores` patterns, and the \"linted N files\" summary counted them too.

Reproducible on this repo:

```
$ npm run lint -- --type-check --quiet
Found 0 lint errors, 8 type errors and 91 warnings (linted 414 files ...)
```

The 8 type errors all came from `packages/rslint/fixtures/src/*.ts`, which `**/fixtures/**` covers in `rslint.config.ts`. The 414 count was inflated by the same set (test-tools tests, vscode extension tests, etc.) pulled into TS programs via `parserOptions.project`.

Root cause: the ignore check was hidden inside `getRulesForFile`, so the rule phase skipped ignored files, but the type-check phase (a second consumer that bypasses rule resolution) did not.

Fix: pull ignores out of rule resolution and into the linter's existing caller-supplied file filter, so all phases share a single \"should this file be processed\" answer.

- `config.IsFileIgnored(path, cwd)`: new public predicate for global `ignores` only (distinct from `GetConfigForFile` nil which also covers out-of-scope files that should still receive type diagnostics).
- `cmd/rslint`: always build a per-program file filter composing ownership dedup + `IsFileIgnored`.
- `lsp/service`: early-return empty diagnostics for ignored files, matching CLI.
- `linter`: widen the `fileFilter` doc to reflect its true contract (any caller-specific skip reason).

After the fix on this repo:

```
Found 0 lint errors, 0 type errors and 91 warnings (linted 95 files ...)
```

Same 91 lint warnings are preserved — no real source files are over-filtered. Verified on rsbuild (no ignores, identical output) and rspack (has ignores, correctly filters the explicitly-ignored `moduleFederationDefaultRuntime.js`). Performance is within ±5% noise across all three.

## Related Links

None.

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).