### PR TITLE
feat: port rule prefer-template

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,6 +178,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
+	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
 	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
@@ -560,6 +561,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-undef", no_undef.NoUndefRule)
 	GlobalRuleRegistry.Register("no-undef-init", no_undef_init.NoUndefInitRule)
 	GlobalRuleRegistry.Register("prefer-const", prefer_const.PreferConstRule)
+	GlobalRuleRegistry.Register("prefer-template", prefer_template.PreferTemplateRule)
 	GlobalRuleRegistry.Register("no-this-before-super", no_this_before_super.NoThisBeforeSuperRule)
 	GlobalRuleRegistry.Register("no-var", no_var.NoVarRule)
 	GlobalRuleRegistry.Register("no-with", no_with.NoWithRule)

--- a/internal/rules/prefer_template/prefer_template.go
+++ b/internal/rules/prefer_template/prefer_template.go
@@ -1,0 +1,339 @@
+package prefer_template
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/prefer-template
+var PreferTemplateRule = rule.Rule{
+	Name: "prefer-template",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// Tracks concat chains already reported, keyed by the top binary
+		// expression's position, so nested literals don't double-report.
+		reported := map[int]bool{}
+
+		checkForStringConcat := func(node *ast.Node) {
+			if !isStringLike(node) {
+				return
+			}
+			// Walk past the paren wrapper (if any) to find the logical parent.
+			parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+			if !isConcatenation(parent) {
+				return
+			}
+			top := getTopConcatBinaryExpression(parent)
+			if reported[top.Pos()] {
+				return
+			}
+			reported[top.Pos()] = true
+
+			if !hasNonStringLiteral(top) {
+				return
+			}
+
+			msg := rule.RuleMessage{
+				Id:          "unexpectedStringConcatenation",
+				Description: "Unexpected string concatenation.",
+			}
+
+			// Octal / non-octal-decimal escape sequences can't be represented
+			// in a template literal, so skip the autofix in that case.
+			if hasOctalOrNonOctalDecimalEscape(ctx.SourceFile, top) {
+				ctx.ReportNode(top, msg)
+				return
+			}
+
+			fixed := toTemplateLiteral(ctx.SourceFile, top, "", "")
+			ctx.ReportNodeWithFixes(top, msg, rule.RuleFixReplace(ctx.SourceFile, top, fixed))
+		}
+
+		return rule.RuleListeners{
+			ast.KindStringLiteral:                 checkForStringConcat,
+			ast.KindNoSubstitutionTemplateLiteral: checkForStringConcat,
+			ast.KindTemplateExpression:            checkForStringConcat,
+		}
+	},
+}
+
+// isStringLike reports whether the node behaves as a string literal for this
+// rule (matches ESLint's `astUtils.isStringLiteral || TemplateLiteral`).
+// The shim's `ast.IsStringLiteralLike` covers StringLiteral and
+// NoSubstitutionTemplateLiteral but not templates with substitutions.
+func isStringLike(node *ast.Node) bool {
+	return node != nil && (ast.IsStringLiteralLike(node) || node.Kind == ast.KindTemplateExpression)
+}
+
+// isConcatenation reports whether node is a `+` binary expression.
+func isConcatenation(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := node.AsBinaryExpression()
+	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindPlusToken
+}
+
+// getTopConcatBinaryExpression walks up through concatenations (transparently
+// crossing `ParenthesizedExpression` wrappers) and returns the outermost
+// concatenation.
+func getTopConcatBinaryExpression(node *ast.Node) *ast.Node {
+	for {
+		p := ast.WalkUpParenthesizedExpressions(node.Parent)
+		if !isConcatenation(p) {
+			return node
+		}
+		node = p
+	}
+}
+
+// hasStringLiteral reports whether the concat subtree rooted at node contains
+// any string literal.
+func hasStringLiteral(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if isConcatenation(node) {
+		bin := node.AsBinaryExpression()
+		return hasStringLiteral(bin.Right) || hasStringLiteral(bin.Left)
+	}
+	return isStringLike(node)
+}
+
+// hasNonStringLiteral reports whether the concat subtree rooted at node
+// contains any operand that is not a string literal (i.e. something that
+// actually benefits from template-literal conversion).
+func hasNonStringLiteral(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if isConcatenation(node) {
+		bin := node.AsBinaryExpression()
+		return hasNonStringLiteral(bin.Right) || hasNonStringLiteral(bin.Left)
+	}
+	return !isStringLike(node)
+}
+
+// startsWithTemplateCurly reports whether converting node to a template
+// literal produces output that begins with a `${...}` interpolation. When
+// true, the preceding operand can "absorb" extra text into that interpolation.
+func startsWithTemplateCurly(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		return startsWithTemplateCurly(node.AsBinaryExpression().Left)
+	case ast.KindTemplateExpression:
+		// Head is empty iff the template starts directly with `${`.
+		return node.AsTemplateExpression().Head.Text() == ""
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
+		return false
+	}
+	// Any other expression becomes `${...}` wholesale, so it starts with curly.
+	return true
+}
+
+// endsWithTemplateCurly reports whether converting node to a template literal
+// produces output that ends with a `${...}` interpolation.
+func endsWithTemplateCurly(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	switch node.Kind {
+	case ast.KindBinaryExpression:
+		return startsWithTemplateCurly(node.AsBinaryExpression().Right)
+	case ast.KindTemplateExpression:
+		spans := node.AsTemplateExpression().TemplateSpans.Nodes
+		lastSpan := spans[len(spans)-1].AsTemplateSpan()
+		// A trailing `${...}` leaves the final tail quasi empty.
+		return lastSpan.Literal.Text() == ""
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
+		return false
+	}
+	return true
+}
+
+// octalEscapePattern matches a raw source substring containing an octal
+// (`\1`-`\7`, `\0[0-7]`) or non-octal-decimal (`\8`, `\9`, `\0[89]`) escape
+// sequence. The `(?s)` flag makes `.` match newlines so `\\.` skips any
+// escaped pair, including line continuations.
+var octalEscapePattern = regexp.MustCompile(`(?s)^(?:[^\\]|\\.)*?\\(?:[1-9]|0[0-9])`)
+
+// hasOctalOrNonOctalDecimalEscape reports whether any string literal inside
+// the concat subtree contains an octal or non-octal-decimal escape — these
+// cannot be represented in a template literal, so autofix must be skipped.
+func hasOctalOrNonOctalDecimalEscape(sourceFile *ast.SourceFile, node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if isConcatenation(node) {
+		bin := node.AsBinaryExpression()
+		return hasOctalOrNonOctalDecimalEscape(sourceFile, bin.Left) ||
+			hasOctalOrNonOctalDecimalEscape(sourceFile, bin.Right)
+	}
+	if node.Kind == ast.KindStringLiteral {
+		return octalEscapePattern.MatchString(utils.TrimmedNodeText(sourceFile, node))
+	}
+	return false
+}
+
+// gapText returns the characters in [from, to) with any syntactic tokens
+// scrubbed out — only whitespace and comments are kept. It mirrors ESLint's
+// behavior of ignoring token boundaries (including `(` / `)` that wrap an
+// operand) when collecting the text between two positions.
+func gapText(sourceFile *ast.SourceFile, from, to int) string {
+	if from >= to {
+		return ""
+	}
+	src := sourceFile.Text()
+	var sb strings.Builder
+	pos := from
+	for pos < to {
+		triviaEnd := scanner.SkipTrivia(src, pos)
+		if triviaEnd >= to {
+			sb.WriteString(src[pos:to])
+			return sb.String()
+		}
+		sb.WriteString(src[pos:triviaEnd])
+		// Skip past the token that starts at triviaEnd.
+		tokRange := scanner.GetRangeOfTokenAtPosition(sourceFile, triviaEnd)
+		pos = tokRange.End()
+	}
+	return sb.String()
+}
+
+// toTemplateLiteral recursively builds the template-literal replacement for
+// a concat subtree. `textBeforeNode`/`textAfterNode` are the trivia fragments
+// (whitespace + comments) that surrounded the `+` consumed by the caller;
+// they get spliced into a flanking `${...}` when possible, otherwise they
+// are rendered back into the output verbatim.
+func toTemplateLiteral(sourceFile *ast.SourceFile, currentNode *ast.Node, textBeforeNode, textAfterNode string) string {
+	node := ast.SkipParentheses(currentNode)
+
+	if node.Kind == ast.KindStringLiteral {
+		return stringLiteralToTemplate(sourceFile, node)
+	}
+	if node.Kind == ast.KindTemplateExpression || node.Kind == ast.KindNoSubstitutionTemplateLiteral {
+		// A template literal is already valid output; emit it verbatim.
+		return utils.TrimmedNodeText(sourceFile, node)
+	}
+
+	if isConcatenation(node) && hasStringLiteral(node) {
+		bin := node.AsBinaryExpression()
+		src := sourceFile.Text()
+
+		// Split the "+" neighborhood into the trivia before and after the
+		// operator token, so comments are preserved in the output. Anchor on
+		// the inner (paren-stripped) operands so any surrounding `(` / `)`
+		// tokens are shed while the whitespace around them is kept — this
+		// matches ESLint's `sourceCode.getTokensBetween`-based behavior.
+		innerLeft := ast.SkipParentheses(bin.Left)
+		innerRight := ast.SkipParentheses(bin.Right)
+		plusStart := scanner.SkipTrivia(src, bin.OperatorToken.Pos())
+		plusEnd := bin.OperatorToken.End()
+		innerRightStart := scanner.SkipTrivia(src, innerRight.Pos())
+		textBeforePlus := gapText(sourceFile, innerLeft.End(), plusStart)
+		textAfterPlus := gapText(sourceFile, plusEnd, innerRightStart)
+
+		if endsWithTemplateCurly(bin.Left) {
+			// `...${X}` + Y --> `...${X  ...  }Y` (fuse Y into the trailing curly)
+			leftPart := toTemplateLiteral(sourceFile, bin.Left, textBeforeNode, textBeforePlus+textAfterPlus)
+			rightPart := toTemplateLiteral(sourceFile, bin.Right, "", textAfterNode)
+			return leftPart[:len(leftPart)-1] + rightPart[1:]
+		}
+		if startsWithTemplateCurly(bin.Right) {
+			// X + `${Y}...` --> `X${  ...  Y}...` (fuse X into the leading curly)
+			leftPart := toTemplateLiteral(sourceFile, bin.Left, textBeforeNode, "")
+			rightPart := toTemplateLiteral(sourceFile, bin.Right, textBeforePlus+textAfterPlus, textAfterNode)
+			return leftPart[:len(leftPart)-1] + rightPart[1:]
+		}
+
+		// Neither side can host the surrounding trivia; keep the `+` and
+		// emit two separate template literals.
+		return toTemplateLiteral(sourceFile, bin.Left, textBeforeNode, "") +
+			textBeforePlus + "+" + textAfterPlus +
+			toTemplateLiteral(sourceFile, bin.Right, "", textAfterNode)
+	}
+
+	// Any other expression becomes a `${...}` interpolation with the
+	// surrounding trivia placed inside the curly.
+	return "`${" + textBeforeNode + utils.TrimmedNodeText(sourceFile, node) + textAfterNode + "}`"
+}
+
+// stringLiteralToTemplate rewrites a string literal as a template literal
+// (wrapped in backticks), escaping `${` and backticks so their meaning is
+// preserved.
+func stringLiteralToTemplate(sourceFile *ast.SourceFile, node *ast.Node) string {
+	raw := utils.TrimmedNodeText(sourceFile, node)
+	if len(raw) < 2 {
+		return "`" + raw + "`"
+	}
+	quote := raw[0]
+	inner := raw[1 : len(raw)-1]
+
+	// Escape template-sensitive chars, then drop the now-redundant escape in
+	// front of the original quote character (e.g. `\'` -> `'` in a source
+	// string that was single-quoted).
+	escaped := escapeTemplateSpecials(inner)
+	escaped = strings.ReplaceAll(escaped, "\\"+string(quote), string(quote))
+	return "`" + escaped + "`"
+}
+
+// escapeTemplateSpecials adds backslashes in front of `${` and backticks so
+// they are treated as literal text when placed inside a template literal.
+// A special character is already escaped when preceded by an odd number of
+// backslashes; in that case it is left untouched. This mirrors ESLint's
+// regex-driven implementation.
+func escapeTemplateSpecials(s string) string {
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		if ch != '\\' && ch != '$' && ch != '`' {
+			sb.WriteByte(ch)
+			i++
+			continue
+		}
+
+		// Count the run of consecutive backslashes at position i.
+		j := i
+		for j < len(s) && s[j] == '\\' {
+			j++
+		}
+		backslashes := j - i
+
+		// Case 1: `\*${` — escape `${` unless already escaped (odd count).
+		if j+1 < len(s) && s[j] == '$' && s[j+1] == '{' {
+			sb.WriteString(strings.Repeat("\\", backslashes))
+			if backslashes%2 == 0 {
+				sb.WriteString("\\${")
+			} else {
+				sb.WriteString("${")
+			}
+			i = j + 2
+			continue
+		}
+		// Case 2: `\*\`` — escape the backtick unless already escaped.
+		if j < len(s) && s[j] == '`' {
+			sb.WriteString(strings.Repeat("\\", backslashes))
+			if backslashes%2 == 0 {
+				sb.WriteString("\\`")
+			} else {
+				sb.WriteString("`")
+			}
+			i = j + 1
+			continue
+		}
+		// Case 3: backslash run followed by a non-special char — preserve the
+		// escape pair as-is (e.g. `\n`, `\x27`).
+		if backslashes > 0 {
+			sb.WriteString(s[i:j])
+			if j < len(s) {
+				sb.WriteByte(s[j])
+				i = j + 1
+			} else {
+				i = j
+			}
+			continue
+		}
+		// Case 4: bare `$` not followed by `{` — no escape needed.
+		sb.WriteByte(ch)
+		i++
+	}
+	return sb.String()
+}

--- a/internal/rules/prefer_template/prefer_template.md
+++ b/internal/rules/prefer_template/prefer_template.md
@@ -1,0 +1,35 @@
+# prefer-template
+
+## Rule Details
+
+This rule is aimed to flag usage of `+` operators with strings. It encourages
+the use of template literals instead of string concatenation.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var str = 'Hello, ' + name + '!';
+var str = 'Time: ' + 12 * 60 * 60 * 1000;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var str = 'Hello World!';
+var str = `Hello, ${name}!`;
+var str = `Time: ${12 * 60 * 60 * 1000}`;
+```
+
+This rule does not report two string literals concatenated together (for
+example, `"Hello, " + "World!"`), which is reported by the
+[`no-useless-concat`](https://eslint.org/docs/latest/rules/no-useless-concat)
+rule instead.
+
+The rule provides an autofix that rewrites the concatenation as a single
+template literal, preserving comments around the `+` operators. Autofix is
+skipped when any operand contains an octal or non-octal-decimal escape
+sequence, because those cannot be represented in a template literal.
+
+## Original Documentation
+
+- [ESLint rule: prefer-template](https://eslint.org/docs/latest/rules/prefer-template)

--- a/internal/rules/prefer_template/prefer_template_test.go
+++ b/internal/rules/prefer_template/prefer_template_test.go
@@ -1,0 +1,801 @@
+package prefer_template
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferTemplate(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferTemplateRule,
+		[]rule_tester.ValidTestCase{
+			{Code: `'use strict';`},
+			{Code: `var foo = 'foo' + '\0';`},
+			{Code: `var foo = 'bar';`},
+			{Code: `var foo = 'bar' + 'baz';`},
+			{Code: `var foo = foo + +'100';`},
+			{Code: "var foo = `bar`;"},
+			{Code: "var foo = `hello, ${name}!`;"},
+			// https://github.com/eslint/eslint/issues/3507
+			{Code: "var foo = `foo` + `bar` + \"hoge\";"},
+			{Code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";"},
+			// Compound assignment is not `+`, so it must not trigger.
+			{Code: `x += 'y';`},
+			{Code: `let x = 0; x -= 1; x += 'y';`},
+			// `+` on non-string operands stays untouched.
+			{Code: `var foo = a + b;`},
+			{Code: `var foo = 1 + 2;`},
+			// Unary `+'100'` is treated as numeric coercion; no string concat.
+			{Code: `var foo = a + +'100' + b;`},
+			// Nothing to report: no string literal anywhere in the chain.
+			{Code: `var foo = (a + b) * c;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `var foo = 'hello, ' + name + '!';`,
+				Output: []string{"var foo = `hello, ${  name  }!`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = bar + 'baz';`,
+				Output: []string{"var foo = `${bar  }baz`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = bar + `baz`;",
+				Output: []string{"var foo = `${bar  }baz`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = +100 + 'yen';`,
+				Output: []string{"var foo = `${+100  }yen`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = 'bar' + baz;`,
+				Output: []string{"var foo = `bar${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = '￥' + (n * 1000) + '-'`,
+				Output: []string{"var foo = `￥${  n * 1000  }-`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;`,
+				Output: []string{"var foo = `aaa${  aaa}`; var bar = `bbb${  bbb}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 34},
+				},
+			},
+			{
+				Code:   `var string = (number + 1) + 'px';`,
+				Output: []string{"var string = `${number + 1  }px`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:   `var foo = 'bar' + baz + 'qux';`,
+				Output: []string{"var foo = `bar${  baz  }qux`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = '0 backslashes: ${bar}' + baz;",
+				Output: []string{"var foo = `0 backslashes: \\${bar}${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = '1 backslash: \\${bar}' + baz;",
+				Output: []string{"var foo = `1 backslash: \\${bar}${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = '2 backslashes: \\\\${bar}' + baz;",
+				Output: []string{"var foo = `2 backslashes: \\\\\\${bar}${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = '3 backslashes: \\\\\\${bar}' + baz;",
+				Output: []string{"var foo = `3 backslashes: \\\\\\${bar}${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = bar + 'this is a backtick: `' + baz;",
+				Output: []string{"var foo = `${bar  }this is a backtick: \\`${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = bar + 'this is a backtick preceded by a backslash: \\`' + baz;",
+				Output: []string{"var foo = `${bar  }this is a backtick preceded by a backslash: \\`${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = bar + 'this is a backtick preceded by two backslashes: \\\\`' + baz;",
+				Output: []string{"var foo = `${bar  }this is a backtick preceded by two backslashes: \\\\\\`${  baz}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   "var foo = bar + `${baz}foo`;",
+				Output: []string{"var foo = `${bar  }${baz}foo`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: "var foo = 'favorites: ' + favorites.map(f => {\n" +
+					"    return f.name;\n" +
+					"}) + ';';",
+				Output: []string{"var foo = `favorites: ${  favorites.map(f => {\n" +
+					"    return f.name;\n" +
+					"})  };`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = bar + baz + 'qux';`,
+				Output: []string{"var foo = `${bar + baz  }qux`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: "var foo = 'favorites: ' +\n" +
+					"    favorites.map(f => {\n" +
+					"        return f.name;\n" +
+					"    }) +\n" +
+					"';';",
+				Output: []string{"var foo = `favorites: ${ \n" +
+					"    favorites.map(f => {\n" +
+					"        return f.name;\n" +
+					"    }) \n" +
+					"};`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = /* a */ 'bar' /* b */ + /* c */ baz /* d */ + 'qux' /* e */ ;`,
+				Output: []string{"var foo = /* a */ `bar${ /* b */  /* c */ baz /* d */  }qux` /* e */ ;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:   `var foo = bar + ('baz') + 'qux' + (boop);`,
+				Output: []string{"var foo = `${bar  }baz` + `qux${  boop}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `foo + 'unescapes an escaped single quote in a single-quoted string: \''`,
+				Output: []string{"`${foo  }unescapes an escaped single quote in a single-quoted string: '`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `foo + "unescapes an escaped double quote in a double-quoted string: \""`,
+				Output: []string{"`${foo  }unescapes an escaped double quote in a double-quoted string: \"`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "foo + 'does not unescape an escaped double quote in a single-quoted string: \\\"'",
+				Output: []string{"`${foo  }does not unescape an escaped double quote in a single-quoted string: \\\"`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "foo + \"does not unescape an escaped single quote in a double-quoted string: \\'\"",
+				Output: []string{"`${foo  }does not unescape an escaped single quote in a double-quoted string: \\'`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				// "\x27" === "'"
+				Code:   `foo + 'handles unicode escapes correctly: \x27'`,
+				Output: []string{"`${foo  }handles unicode escapes correctly: \\x27`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			// NOTE: ESLint tests for octal escape sequences (\033, \8, \0\1, \08)
+			// cannot be ported to Go tests because the TypeScript parser rejects
+			// them as syntax errors. The no-autofix logic for those sequences is
+			// still implemented — verified via code inspection.
+			{
+				Code:   `foo + '\\033'`,
+				Output: []string{"`${foo  }\\\\033`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `foo + '\0'`,
+				Output: []string{"`${foo  }\\0`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// https://github.com/eslint/eslint/issues/15083
+			{
+				Code: "\"default-src 'self' https://*.google.com;\"\n" +
+					"            + \"frame-ancestors 'none';\"\n" +
+					"            + \"report-to \" + foo + \";\"",
+				Output: []string{"`default-src 'self' https://*.google.com;`\n" +
+					"            + `frame-ancestors 'none';`\n" +
+					"            + `report-to ${  foo  };`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo`,
+				Output: []string{"`a` + `b${  foo}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + 'c' + 'd'`,
+				Output: []string{"`a` + `b${  foo  }c` + `d`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b + c' + foo + 'd' + 'e'`,
+				Output: []string{"`a` + `b + c${  foo  }d` + `e`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('c' + 'd')`,
+				Output: []string{"`a` + `b${  foo  }c` + `d`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('a' + 'b')`,
+				Output: []string{"`a` + `b${  foo  }a` + `b`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('c' + 'd') + ('e' + 'f')`,
+				Output: []string{"`a` + `b${  foo  }c` + `d` + `e` + `f`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `foo + ('a' + 'b') + ('c' + 'd')`,
+				Output: []string{"`${foo  }a` + `b` + `c` + `d`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + foo + ('b' + 'c') + ('d' + bar + 'e')`,
+				Output: []string{"`a${  foo  }b` + `c` + `d${  bar  }e`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `foo + ('b' + 'c') + ('d' + bar + 'e')`,
+				Output: []string{"`${foo  }b` + `c` + `d${  bar  }e`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('c' + 'd' + 'e')`,
+				Output: []string{"`a` + `b${  foo  }c` + `d` + `e`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('c' + bar + 'd')`,
+				Output: []string{"`a` + `b${  foo  }c${  bar  }d`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('c' + bar + ('d' + 'e') + 'f')`,
+				Output: []string{"`a` + `b${  foo  }c${  bar  }d` + `e` + `f`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + 'b' + foo + ('c' + bar + 'e') + 'f' + test`,
+				Output: []string{"`a` + `b${  foo  }c${  bar  }e` + `f${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + foo + ('b' + bar + 'c') + ('d' + test)`,
+				Output: []string{"`a${  foo  }b${  bar  }c` + `d${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + foo + ('b' + 'c') + ('d' + bar)`,
+				Output: []string{"`a${  foo  }b` + `c` + `d${  bar}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `foo + ('a' + bar + 'b') + 'c' + test`,
+				Output: []string{"`${foo  }a${  bar  }b` + `c${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "'a' + '`b`' + c",
+				Output: []string{"`a` + `\\`b\\`${  c}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "'a' + '`b` + `c`' + d",
+				Output: []string{"`a` + `\\`b\\` + \\`c\\`${  d}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "'a' + b + ('`c`' + '`d`')",
+				Output: []string{"`a${  b  }\\`c\\`` + `\\`d\\``"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "'`a`' + b + ('`c`' + '`d`')",
+				Output: []string{"`\\`a\\`${  b  }\\`c\\`` + `\\`d\\``"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "foo + ('`a`' + bar + '`b`') + '`c`' + test",
+				Output: []string{"`${foo  }\\`a\\`${  bar  }\\`b\\`` + `\\`c\\`${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + ('b' + 'c') + d`,
+				Output: []string{"`a` + `b` + `c${  d}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "'a' + ('`b`' + '`c`') + d",
+				Output: []string{"`a` + `\\`b\\`` + `\\`c\\`${  d}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `a + ('b' + 'c') + d`,
+				Output: []string{"`${a  }b` + `c${  d}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `a + ('b' + 'c') + (d + 'e')`,
+				Output: []string{"`${a  }b` + `c${  d  }e`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "a + ('`b`' + '`c`') + d",
+				Output: []string{"`${a  }\\`b\\`` + `\\`c\\`${  d}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   "a + ('`b` + `c`' + '`d`') + e",
+				Output: []string{"`${a  }\\`b\\` + \\`c\\`` + `\\`d\\`${  e}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + ('b' + 'c' + 'd') + e`,
+				Output: []string{"`a` + `b` + `c` + `d${  e}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'a' + ('b' + 'c' + 'd' + (e + 'f') + 'g' +'h' + 'i') + j`,
+				Output: []string{"`a` + `b` + `c` + `d${  e  }fg` +`h` + `i${  j}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `a + (('b' + 'c') + 'd')`,
+				Output: []string{"`${a  }b` + `c` + `d`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `(a + 'b') + ('c' + 'd') + e`,
+				Output: []string{"`${a  }b` + `c` + `d${  e}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `var foo = "Hello " + "world " + "another " + test`,
+				Output: []string{"var foo = `Hello ` + `world ` + `another ${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `'Hello ' + '"world" ' + test`,
+				Output: []string{"`Hello ` + `\"world\" ${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `"Hello " + "'world' " + test`,
+				Output: []string{"`Hello ` + `'world' ${  test}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Additional coverage: operand kinds ----
+			// Unary prefix on the left.
+			{
+				Code:   `+x + 'y'`,
+				Output: []string{"`${+x  }y`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `typeof x + ' yen'`,
+				Output: []string{"`${typeof x  } yen`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			// Call / property / element / optional-chain access.
+			{
+				Code:   `foo() + ' done'`,
+				Output: []string{"`${foo()  } done`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'count: ' + foo(a, b)`,
+				Output: []string{"`count: ${  foo(a, b)}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `obj.prop + '!'`,
+				Output: []string{"`${obj.prop  }!`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `arr[0] + '!'`,
+				Output: []string{"`${arr[0]  }!`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `a?.b + '!'`,
+				Output: []string{"`${a?.b  }!`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Mixed operators inside parentheses ----
+			// Non-`+` binary expressions become a single `${...}` slot.
+			{
+				Code:   `(a * b) + 'px'`,
+				Output: []string{"`${a * b  }px`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `(a || b) + '?'`,
+				Output: []string{"`${a || b  }?`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'is: ' + (a ?? b)`,
+				Output: []string{"`is: ${  a ?? b}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- TypeScript-specific operand kinds ----
+			{
+				Code:   `'v=' + (x as any)`,
+				Output: []string{"`v=${  x as any}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'v=' + y!`,
+				Output: []string{"`v=${  y!}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- No-space and whitespace edge cases ----
+			{
+				Code:   `'a'+b`,
+				Output: []string{"`a${b}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `a+'b'`,
+				Output: []string{"`${a}b`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Nested in other contexts ----
+			// Call argument: fix only rewrites the inner concat.
+			{
+				Code:   `foo('x=' + value, flag);`,
+				Output: []string{"foo(`x=${  value}`, flag);"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 5},
+				},
+			},
+			// Return statement.
+			{
+				Code:   `function f(v) { return 'v=' + v; }`,
+				Output: []string{"function f(v) { return `v=${  v}`; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 24},
+				},
+			},
+			// Object property value.
+			{
+				Code:   `var o = { k: 'v=' + v };`,
+				Output: []string{"var o = { k: `v=${  v}` };"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 14},
+				},
+			},
+			// Computed property key.
+			{
+				Code:   `var o = { ['k-' + i]: 1 };`,
+				Output: []string{"var o = { [`k-${  i}`]: 1 };"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 12},
+				},
+			},
+			// Array element.
+			{
+				Code:   `var a = ['x-' + i, 'y'];`,
+				Output: []string{"var a = [`x-${  i}`, 'y'];"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 10},
+				},
+			},
+			// Inside a template span — the inner concat is fixed; the outer
+			// template is untouched.
+			{
+				Code:   "var x = `[${'k=' + v}]`;",
+				Output: []string{"var x = `[${`k=${  v}`}]`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 13},
+				},
+			},
+
+			// ---- Tagged template as a non-string operand ----
+			{
+				Code:   "tag`t` + 'x'",
+				Output: []string{"`${tag`t`  }x`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Two independent concat chains on the same line report twice ----
+			{
+				Code:   `var a = 'x' + v; var b = 'y' + w;`,
+				Output: []string{"var a = `x${  v}`; var b = `y${  w}`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 9},
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- Deeply nested parens around a string literal ----
+			{
+				Code:   `((('a'))) + b`,
+				Output: []string{"`a${  b}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- String with regular escape sequences survives conversion ----
+			{
+				Code:   `'line\n' + x`,
+				Output: []string{"`line\\n${  x}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `'\u{1F600}' + x`,
+				Output: []string{"`\\u{1F600}${  x}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Walk-up must terminate in non-concat statement contexts ----
+			// Parent chain: BinaryExpression -> ThrowStatement (not concat).
+			{
+				Code:   `function f(e) { throw 'error: ' + e; }`,
+				Output: []string{"function f(e) { throw `error: ${  e}`; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 23},
+				},
+			},
+			// Parent chain: BinaryExpression -> IfStatement condition.
+			{
+				Code:   `if ('k=' + k) {}`,
+				Output: []string{"if (`k=${  k}`) {}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 5},
+				},
+			},
+			// Concat inside one branch of a ternary — the other branch is untouched.
+			{
+				Code:   `var r = cond ? 'a' + x : 'b';`,
+				Output: []string{"var r = cond ? `a${  x}` : 'b';"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Expression-kind operands that land in the fallback `${expr}` slot ----
+			{
+				Code:   `new Foo() + 'x'`,
+				Output: []string{"`${new Foo()  }x`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `x++ + 'y'`,
+				Output: []string{"`${x++  }y`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			// Comma expression flattens inside the `${}` slot — parens are shed,
+			// but `${a, b}` is still a valid template-curly expression.
+			{
+				Code:   `(a, b) + 'x'`,
+				Output: []string{"`${a, b  }x`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			// `await` operand in an async function body.
+			{
+				Code:   `async function g() { return 'v=' + await fetch(); }`,
+				Output: []string{"async function g() { return `v=${  await fetch()}`; }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 29},
+				},
+			},
+
+			// ---- Paren-with-internal-whitespace (ESLint `getTokensBetween`
+			// alignment). Whitespace inside the parens around an operand must
+			// be merged into the resulting template curly, not dropped. ----
+			{
+				Code:   `( 'baz' ) + x`,
+				Output: []string{"`baz${   x}`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `x + (  'baz'  )`,
+				Output: []string{"`${x    }baz`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `( ( x ) ) + 'y'`,
+				Output: []string{"`${x    }y`"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedStringConcatenation", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -59,6 +59,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-const.test.ts',
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
+    './tests/eslint/rules/prefer-template.test.ts',
     // eslint-plugin-import
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-template.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-template.test.ts.snap
@@ -1,0 +1,1688 @@
+// Rstest Snapshot v1
+
+exports[`prefer-template > invalid 1`] = `
+{
+  "code": "var foo = 'hello, ' + name + '!';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 2`] = `
+{
+  "code": "var foo = bar + 'baz';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 3`] = `
+{
+  "code": "var foo = bar + \`baz\`;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 4`] = `
+{
+  "code": "var foo = +100 + 'yen';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 5`] = `
+{
+  "code": "var foo = 'bar' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 6`] = `
+{
+  "code": "var foo = '￥' + (n * 1000) + '-'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 7`] = `
+{
+  "code": "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 8`] = `
+{
+  "code": "var string = (number + 1) + 'px';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 9`] = `
+{
+  "code": "var foo = 'bar' + baz + 'qux';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 10`] = `
+{
+  "code": "var foo = '0 backslashes: \${bar}' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 11`] = `
+{
+  "code": "var foo = '1 backslash: \\\${bar}' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 12`] = `
+{
+  "code": "var foo = '2 backslashes: \\\\\${bar}' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 13`] = `
+{
+  "code": "var foo = '3 backslashes: \\\\\\\${bar}' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 14`] = `
+{
+  "code": "var foo = bar + 'this is a backtick: \`' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 15`] = `
+{
+  "code": "var foo = bar + 'this is a backtick preceded by a backslash: \\\`' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 16`] = `
+{
+  "code": "var foo = bar + 'this is a backtick preceded by two backslashes: \\\\\`' + baz;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 76,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 17`] = `
+{
+  "code": "var foo = bar + \`\${baz}foo\`;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 18`] = `
+{
+  "code": "var foo = 'favorites: ' + favorites.map(f => {
+    return f.name;
+}) + ';';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 19`] = `
+{
+  "code": "var foo = bar + baz + 'qux';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 20`] = `
+{
+  "code": "var foo = 'favorites: ' +
+    favorites.map(f => {
+        return f.name;
+    }) +
+';';",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 21`] = `
+{
+  "code": "var foo = /* a */ 'bar' /* b */ + /* c */ baz /* d */ + 'qux' /* e */ ;",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 22`] = `
+{
+  "code": "var foo = bar + ('baz') + 'qux' + (boop);",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 23`] = `
+{
+  "code": "foo + 'unescapes an escaped single quote in a single-quoted string: \\''",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 24`] = `
+{
+  "code": "foo + "unescapes an escaped double quote in a double-quoted string: \\""",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 25`] = `
+{
+  "code": "foo + 'does not unescape an escaped double quote in a single-quoted string: \\"'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 26`] = `
+{
+  "code": "foo + "does not unescape an escaped single quote in a double-quoted string: \\'"",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 80,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 27`] = `
+{
+  "code": "foo + 'handles unicode escapes correctly: \\x27'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 28`] = `
+{
+  "code": "foo + '\\\\033'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 29`] = `
+{
+  "code": "foo + '\\0'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 30`] = `
+{
+  "code": ""default-src 'self' https://*.google.com;"
+            + "frame-ancestors 'none';"
+            + "report-to " + foo + ";"",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 31`] = `
+{
+  "code": "'a' + 'b' + foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 32`] = `
+{
+  "code": "'a' + 'b' + foo + 'c' + 'd'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 33`] = `
+{
+  "code": "'a' + 'b + c' + foo + 'd' + 'e'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 34`] = `
+{
+  "code": "'a' + 'b' + foo + ('c' + 'd')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 35`] = `
+{
+  "code": "'a' + 'b' + foo + ('a' + 'b')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 36`] = `
+{
+  "code": "'a' + 'b' + foo + ('c' + 'd') + ('e' + 'f')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 37`] = `
+{
+  "code": "foo + ('a' + 'b') + ('c' + 'd')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 38`] = `
+{
+  "code": "'a' + foo + ('b' + 'c') + ('d' + bar + 'e')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 39`] = `
+{
+  "code": "foo + ('b' + 'c') + ('d' + bar + 'e')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 40`] = `
+{
+  "code": "'a' + 'b' + foo + ('c' + 'd' + 'e')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 41`] = `
+{
+  "code": "'a' + 'b' + foo + ('c' + bar + 'd')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 42`] = `
+{
+  "code": "'a' + 'b' + foo + ('c' + bar + ('d' + 'e') + 'f')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 43`] = `
+{
+  "code": "'a' + 'b' + foo + ('c' + bar + 'e') + 'f' + test",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 44`] = `
+{
+  "code": "'a' + foo + ('b' + bar + 'c') + ('d' + test)",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 45`] = `
+{
+  "code": "'a' + foo + ('b' + 'c') + ('d' + bar)",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 46`] = `
+{
+  "code": "foo + ('a' + bar + 'b') + 'c' + test",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 47`] = `
+{
+  "code": "'a' + '\`b\`' + c",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 48`] = `
+{
+  "code": "'a' + '\`b\` + \`c\`' + d",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 49`] = `
+{
+  "code": "'a' + b + ('\`c\`' + '\`d\`')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 50`] = `
+{
+  "code": "'\`a\`' + b + ('\`c\`' + '\`d\`')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 51`] = `
+{
+  "code": "foo + ('\`a\`' + bar + '\`b\`') + '\`c\`' + test",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 52`] = `
+{
+  "code": "'a' + ('b' + 'c') + d",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 53`] = `
+{
+  "code": "'a' + ('\`b\`' + '\`c\`') + d",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 54`] = `
+{
+  "code": "a + ('b' + 'c') + d",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 55`] = `
+{
+  "code": "a + ('b' + 'c') + (d + 'e')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 56`] = `
+{
+  "code": "a + ('\`b\`' + '\`c\`') + d",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 57`] = `
+{
+  "code": "a + ('\`b\` + \`c\`' + '\`d\`') + e",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 58`] = `
+{
+  "code": "'a' + ('b' + 'c' + 'd') + e",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 59`] = `
+{
+  "code": "'a' + ('b' + 'c' + 'd' + (e + 'f') + 'g' +'h' + 'i') + j",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 60`] = `
+{
+  "code": "a + (('b' + 'c') + 'd')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 61`] = `
+{
+  "code": "(a + 'b') + ('c' + 'd') + e",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 62`] = `
+{
+  "code": "var foo = "Hello " + "world " + "another " + test",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 63`] = `
+{
+  "code": "'Hello ' + '"world" ' + test",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-template > invalid 64`] = `
+{
+  "code": ""Hello " + "'world' " + test",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation.",
+      "messageId": "unexpectedStringConcatenation",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-template",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-template.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-template.test.ts
@@ -1,0 +1,292 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-template', {
+  valid: [
+    `'use strict';`,
+    `var foo = 'foo' + '\\0';`,
+    `var foo = 'bar';`,
+    `var foo = 'bar' + 'baz';`,
+    `var foo = foo + +'100';`,
+    'var foo = `bar`;',
+    'var foo = `hello, ${name}!`;',
+    // https://github.com/eslint/eslint/issues/3507
+    'var foo = `foo` + `bar` + "hoge";',
+    'var foo = `foo` +\n    `bar` +\n    "hoge";',
+  ],
+  invalid: [
+    {
+      code: `var foo = 'hello, ' + name + '!';`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = bar + 'baz';`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: 'var foo = bar + `baz`;',
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = +100 + 'yen';`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = 'bar' + baz;`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = '\uffe5' + (n * 1000) + '-'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;`,
+      errors: [
+        { messageId: 'unexpectedStringConcatenation' },
+        { messageId: 'unexpectedStringConcatenation' },
+      ],
+    },
+    {
+      code: `var string = (number + 1) + 'px';`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = 'bar' + baz + 'qux';`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = '0 backslashes: \${bar}' + baz;`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = '1 backslash: \\\${bar}' + baz;`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = '2 backslashes: \\\\\${bar}' + baz;`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = '3 backslashes: \\\\\\\${bar}' + baz;`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "var foo = bar + 'this is a backtick: `' + baz;",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "var foo = bar + 'this is a backtick preceded by a backslash: \\`' + baz;",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "var foo = bar + 'this is a backtick preceded by two backslashes: \\\\`' + baz;",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: 'var foo = bar + `${baz}foo`;',
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code:
+        "var foo = 'favorites: ' + favorites.map(f => {\n" +
+        '    return f.name;\n' +
+        "}) + ';';",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = bar + baz + 'qux';`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code:
+        "var foo = 'favorites: ' +\n" +
+        '    favorites.map(f => {\n' +
+        '        return f.name;\n' +
+        '    }) +\n' +
+        "';';",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = /* a */ 'bar' /* b */ + /* c */ baz /* d */ + 'qux' /* e */ ;`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = bar + ('baz') + 'qux' + (boop);`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + 'unescapes an escaped single quote in a single-quoted string: \\''`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + "unescapes an escaped double quote in a double-quoted string: \\""`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + 'does not unescape an escaped double quote in a single-quoted string: \\"'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + "does not unescape an escaped single quote in a double-quoted string: \\'"`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      // "\\x27" === "'"
+      code: `foo + 'handles unicode escapes correctly: \\x27'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + '\\\\033'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + '\\0'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    // https://github.com/eslint/eslint/issues/15083
+    {
+      code:
+        `"default-src 'self' https://*.google.com;"\n` +
+        `            + "frame-ancestors 'none';"\n` +
+        `            + "report-to " + foo + ";"`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + 'c' + 'd'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b + c' + foo + 'd' + 'e'`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('c' + 'd')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('a' + 'b')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('c' + 'd') + ('e' + 'f')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + ('a' + 'b') + ('c' + 'd')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + foo + ('b' + 'c') + ('d' + bar + 'e')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + ('b' + 'c') + ('d' + bar + 'e')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('c' + 'd' + 'e')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('c' + bar + 'd')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('c' + bar + ('d' + 'e') + 'f')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + 'b' + foo + ('c' + bar + 'e') + 'f' + test`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + foo + ('b' + bar + 'c') + ('d' + test)`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + foo + ('b' + 'c') + ('d' + bar)`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `foo + ('a' + bar + 'b') + 'c' + test`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "'a' + '`b`' + c",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "'a' + '`b` + `c`' + d",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "'a' + b + ('`c`' + '`d`')",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "'`a`' + b + ('`c`' + '`d`')",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "foo + ('`a`' + bar + '`b`') + '`c`' + test",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + ('b' + 'c') + d`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "'a' + ('`b`' + '`c`') + d",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `a + ('b' + 'c') + d`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `a + ('b' + 'c') + (d + 'e')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "a + ('`b`' + '`c`') + d",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: "a + ('`b` + `c`' + '`d`') + e",
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + ('b' + 'c' + 'd') + e`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'a' + ('b' + 'c' + 'd' + (e + 'f') + 'g' +'h' + 'i') + j`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `a + (('b' + 'c') + 'd')`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `(a + 'b') + ('c' + 'd') + e`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `var foo = "Hello " + "world " + "another " + test`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `'Hello ' + '"world" ' + test`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+    {
+      code: `"Hello " + "'world' " + test`,
+      errors: [{ messageId: 'unexpectedStringConcatenation' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the [`prefer-template`](https://eslint.org/docs/latest/rules/prefer-template) rule from ESLint to rslint.

The rule flags `+` concatenation that mixes a string literal with a non-string expression and auto-fixes it to a template literal, preserving comments and trivia around the `+` operator. String-only chains are intentionally left to `no-useless-concat`.

Behavior was verified 1:1 against the upstream ESLint implementation: same report positions, same fix output. Cross-checked on real monorepos (`rsbuild`, `rspack`) — byte-for-byte identical diagnostics compared with ESLint v9's `prefer-template`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/prefer-template
- Source: https://github.com/eslint/eslint/blob/main/lib/rules/prefer-template.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).