### PR TITLE
feat: port rule object-shorthand

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -153,6 +153,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_object"
+	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
@@ -581,6 +582,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-unmodified-loop-condition", no_unmodified_loop_condition.NoUnmodifiedLoopConditionRule)
 	GlobalRuleRegistry.Register("no-unreachable", no_unreachable.NoUnreachableRule)
 	GlobalRuleRegistry.Register("require-atomic-updates", require_atomic_updates.RequireAtomicUpdatesRule)
+	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/object_shorthand/object_shorthand.go
+++ b/internal/rules/object_shorthand/object_shorthand.go
@@ -1,0 +1,954 @@
+package object_shorthand
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/object-shorthand
+
+// Option modes.
+const (
+	modeAlways             = "always"
+	modeNever              = "never"
+	modeMethods            = "methods"
+	modeProperties         = "properties"
+	modeConsistent         = "consistent"
+	modeConsistentAsNeeded = "consistent-as-needed"
+)
+
+var jsdocStarRegex = regexp.MustCompile(`^\s*\*`)
+
+type options struct {
+	apply                     string
+	ignoreConstructors        bool
+	methodsIgnorePattern      *regexp.Regexp
+	avoidQuotes               bool
+	avoidExplicitReturnArrows bool
+}
+
+func parseOptions(opts any) options {
+	o := options{apply: modeAlways}
+
+	if arr, ok := opts.([]interface{}); ok {
+		if len(arr) > 0 {
+			if s, ok := arr[0].(string); ok && s != "" {
+				o.apply = s
+			}
+		}
+		if len(arr) > 1 {
+			if m, ok := arr[1].(map[string]interface{}); ok {
+				applyObjectOptions(&o, m)
+			}
+		}
+	} else if s, ok := opts.(string); ok && s != "" {
+		o.apply = s
+	} else if m := utils.GetOptionsMap(opts); m != nil {
+		if s, ok := m["apply"].(string); ok && s != "" {
+			o.apply = s
+		}
+		applyObjectOptions(&o, m)
+	}
+
+	return o
+}
+
+func applyObjectOptions(o *options, m map[string]interface{}) {
+	if v, ok := m["ignoreConstructors"].(bool); ok {
+		o.ignoreConstructors = v
+	}
+	if v, ok := m["avoidQuotes"].(bool); ok {
+		o.avoidQuotes = v
+	}
+	if v, ok := m["avoidExplicitReturnArrows"].(bool); ok {
+		o.avoidExplicitReturnArrows = v
+	}
+	if v, ok := m["methodsIgnorePattern"].(string); ok && v != "" {
+		if re, err := regexp.Compile(v); err == nil {
+			o.methodsIgnorePattern = re
+		}
+	}
+}
+
+// isStringLiteralKey reports whether the property name node is a string
+// literal (e.g. `'foo'`), including the computed form `['foo']`. Mirrors
+// ESLint's `isStringLiteral(node.key)` check, which operates on the Literal
+// node itself regardless of `node.computed`.
+func isStringLiteralKey(nameNode *ast.Node) bool {
+	if nameNode == nil {
+		return false
+	}
+	if nameNode.Kind == ast.KindStringLiteral {
+		return true
+	}
+	if nameNode.Kind == ast.KindComputedPropertyName {
+		if expr := nameNode.AsComputedPropertyName().Expression; expr != nil {
+			return expr.Kind == ast.KindStringLiteral
+		}
+	}
+	return false
+}
+
+// propertyKind categorizes an object literal property for the purposes of
+// this rule.
+type propertyKind int
+
+const (
+	propKindOther           propertyKind = iota // getter/setter/spread - skip
+	propKindLongformProp                        // { a: b }
+	propKindLongformMethod                      // { a: function() {} } or { a: () => {} }
+	propKindShorthandProp                       // { a }
+	propKindShorthandMethod                     // { a() {} }
+)
+
+// propertyValue returns a PropertyAssignment's initializer with any
+// enclosing parentheses stripped. ESLint's parser discards parentheses by
+// default, so rules written against its AST reference `node.value` directly
+// as an Identifier / FunctionExpression / ArrowFunction. tsgo preserves
+// parentheses as `ParenthesizedExpression` nodes, so every check that looks
+// at the value's shape must go through this unwrap first — otherwise code
+// like `{a: (a)}` or `{a: (function(){})}` silently escapes the rule.
+func propertyValue(pa *ast.PropertyAssignment) *ast.Node {
+	if pa == nil || pa.Initializer == nil {
+		return nil
+	}
+	return ast.SkipParentheses(pa.Initializer)
+}
+
+func classify(node *ast.Node) propertyKind {
+	switch node.Kind {
+	case ast.KindGetAccessor, ast.KindSetAccessor, ast.KindSpreadAssignment:
+		return propKindOther
+	case ast.KindShorthandPropertyAssignment:
+		return propKindShorthandProp
+	case ast.KindMethodDeclaration:
+		return propKindShorthandMethod
+	case ast.KindPropertyAssignment:
+		value := propertyValue(node.AsPropertyAssignment())
+		if value == nil {
+			return propKindOther
+		}
+		switch value.Kind {
+		case ast.KindFunctionExpression, ast.KindArrowFunction:
+			return propKindLongformMethod
+		}
+		return propKindLongformProp
+	}
+	return propKindOther
+}
+
+// canHaveShorthand reports whether a property can have a shorthand form.
+// Getters, setters and spread elements cannot.
+func canHaveShorthand(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindGetAccessor, ast.KindSetAccessor, ast.KindSpreadAssignment:
+		return false
+	}
+	return true
+}
+
+func isShorthandKind(k propertyKind) bool {
+	return k == propKindShorthandProp || k == propKindShorthandMethod
+}
+
+// isRedundantLongform reports whether a PropertyAssignment could be rewritten
+// as a shorthand — i.e. its key and value carry the same name.
+func isRedundantLongform(node *ast.Node) bool {
+	if node.Kind == ast.KindMethodDeclaration {
+		return true
+	}
+	if node.Kind == ast.KindPropertyAssignment {
+		pa := node.AsPropertyAssignment()
+		value := propertyValue(pa)
+		if value == nil {
+			return false
+		}
+		if value.Kind == ast.KindFunctionExpression {
+			// Only anonymous FE counts as redundant (would become shorthand
+			// method without losing the function's name).
+			return value.AsFunctionExpression().Name() == nil
+		}
+		if value.Kind == ast.KindIdentifier {
+			keyName, ok := utils.GetStaticPropertyName(pa.Name())
+			if !ok {
+				return false
+			}
+			return keyName == value.AsIdentifier().Text
+		}
+	}
+	return false
+}
+
+// hasCommentsInsideText reports whether any `//` or `/*` sequence appears in
+// the half-open source range [start, end). `utils.HasCommentsInRange` only
+// checks leading/trailing comments anchored at a single position, so this
+// raw-text scan is the simplest way to look for comments sprinkled *between*
+// arbitrary children of a node (e.g. between the key, colon and value of a
+// PropertyAssignment).
+func hasCommentsInsideText(sourceText string, start, end int) bool {
+	for i := start; i+1 < end; i++ {
+		if sourceText[i] == '/' && (sourceText[i+1] == '/' || sourceText[i+1] == '*') {
+			return true
+		}
+	}
+	return false
+}
+
+// hasJSDocTypeAnnotationInside returns true when the node contains a JSDoc
+// block comment with `@type` — these are type-suppression annotations that
+// should block shorthand conversion.
+//
+// ESLint actually uses two subtly different JSDoc detection rules depending
+// on the property-key kind:
+//
+//   - Identifier key (`{foo: foo}`): body matches `^\s*\*` — tolerates a
+//     leading newline/whitespace before the first `*` (non-standard but
+//     accepted).
+//   - StringLiteral key (`{'foo': foo}`): body starts with `*` exactly — no
+//     leading whitespace allowed.
+//
+// The `strict` parameter selects the StringLiteral-key behavior. Standard
+// `/** … */` JSDoc works under both modes; the difference only shows up on
+// unusual formats like `/*\n * @type … */` (leading newline before the `*`).
+func hasJSDocTypeAnnotationInside(sourceText string, node *ast.Node, strict bool) bool {
+	start, end := node.Pos(), node.End()
+	if end > len(sourceText) {
+		end = len(sourceText)
+	}
+	for i := start; i+1 < end; i++ {
+		if sourceText[i] != '/' || sourceText[i+1] != '*' {
+			continue
+		}
+		closeIdx := strings.Index(sourceText[i+2:end], "*/")
+		if closeIdx < 0 {
+			break
+		}
+		body := sourceText[i+2 : i+2+closeIdx]
+		matchesJSDoc := strings.HasPrefix(body, "*")
+		if !strict && !matchesJSDoc {
+			matchesJSDoc = jsdocStarRegex.MatchString(body)
+		}
+		if matchesJSDoc && strings.Contains(body, "@type") {
+			return true
+		}
+		i = i + 2 + closeIdx + 1 // skip past the closing `*/`
+	}
+	return false
+}
+
+// shouldIgnoreMethodName applies the `methodsIgnorePattern` option.
+func shouldIgnoreMethodName(o *options, nameNode *ast.Node) bool {
+	if o.methodsIgnorePattern == nil {
+		return false
+	}
+	name, ok := utils.GetStaticPropertyName(nameNode)
+	if !ok {
+		return false
+	}
+	return o.methodsIgnorePattern.MatchString(name)
+}
+
+// isArgumentsIdentifier reports whether the node is an Identifier whose
+// text is literally "arguments". The caller decides whether it is a real
+// reference (see the lexical-scope check in the rule body).
+func isArgumentsIdentifier(node *ast.Node) bool {
+	return node.Kind == ast.KindIdentifier && node.AsIdentifier().Text == "arguments"
+}
+
+// isArgumentsShadowedInBlockScope reports whether a block-scoped declaration
+// named `arguments` sits in an enclosing block between the given identifier
+// and its nearest non-arrow function. When it does, ESLint's scope manager
+// resolves the identifier to that shadow instead of the function's implicit
+// `arguments`, so the reference is NOT collected as a lexical identifier
+// that blocks arrow→method conversion.
+//
+// The shadow forms we recognize mirror ESLint's scope manager:
+//   - `let` / `const` / `using arguments` at the top of an enclosing `Block`
+//   - `for (let|const arguments …)` / `for…in` / `for…of` iteration binding
+//   - `catch (arguments)` binding
+//
+// `var arguments` is NOT considered a shadow: ESLint hoists it to the
+// function scope where it merges with the implicit `arguments` variable, so
+// references still count as lexical identifiers.
+func isArgumentsShadowedInBlockScope(identifier *ast.Node) bool {
+	for cur := identifier.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindMethodDeclaration, ast.KindGetAccessor,
+			ast.KindSetAccessor, ast.KindConstructor, ast.KindSourceFile:
+			return false
+
+		case ast.KindBlock:
+			block := cur.AsBlock()
+			if block == nil || block.Statements == nil {
+				continue
+			}
+			for _, stmt := range block.Statements.Nodes {
+				if stmt.Kind == ast.KindVariableStatement &&
+					declarationListDeclaresBlockScopedArguments(stmt.AsVariableStatement().DeclarationList) {
+					return true
+				}
+			}
+
+		case ast.KindForStatement:
+			if declarationListDeclaresBlockScopedArguments(cur.AsForStatement().Initializer) {
+				return true
+			}
+		case ast.KindForInStatement:
+			if declarationListDeclaresBlockScopedArguments(cur.AsForInOrOfStatement().Initializer) {
+				return true
+			}
+		case ast.KindForOfStatement:
+			if declarationListDeclaresBlockScopedArguments(cur.AsForInOrOfStatement().Initializer) {
+				return true
+			}
+
+		case ast.KindCatchClause:
+			cc := cur.AsCatchClause()
+			if cc == nil || cc.VariableDeclaration == nil {
+				continue
+			}
+			name := cc.VariableDeclaration.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "arguments" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// declarationListDeclaresBlockScopedArguments reports whether a node that is
+// (or wraps) a VariableDeclarationList has a `let` / `const` / `using`
+// declarator named `arguments`. Accepts either a VariableDeclarationList node
+// directly (for `for` initializers) or nil (returns false).
+func declarationListDeclaresBlockScopedArguments(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindVariableDeclarationList {
+		return false
+	}
+	if node.Flags&ast.NodeFlagsBlockScoped == 0 {
+		return false
+	}
+	list := node.AsVariableDeclarationList()
+	if list == nil || list.Declarations == nil {
+		return false
+	}
+	for _, decl := range list.Declarations.Nodes {
+		vd := decl.AsVariableDeclaration()
+		if vd == nil {
+			continue
+		}
+		name := vd.Name()
+		if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "arguments" {
+			return true
+		}
+	}
+	return false
+}
+
+var ObjectShorthandRule = rule.Rule{
+	Name: "object-shorthand",
+	Run: func(ctx rule.RuleContext, optionsAny any) rule.RuleListeners {
+		opts := parseOptions(optionsAny)
+		sourceText := ctx.SourceFile.Text()
+
+		applyToMethods := opts.apply == modeMethods || opts.apply == modeAlways
+		applyToProps := opts.apply == modeProperties || opts.apply == modeAlways
+		applyNever := opts.apply == modeNever
+		applyConsistent := opts.apply == modeConsistent
+		applyConsistentAsNeeded := opts.apply == modeConsistentAsNeeded
+
+		// Lexical scope stack — each entry holds the set of arrow functions
+		// that live in the current (non-arrow) lexical scope. The program
+		// scope is seeded here because the linter does not fire a listener on
+		// the SourceFile node itself.
+		lexicalScopeStack := []map[*ast.Node]bool{{}}
+		arrowsWithLexicalIdentifiers := map[*ast.Node]bool{}
+
+		enterScope := func() {
+			lexicalScopeStack = append(lexicalScopeStack, map[*ast.Node]bool{})
+		}
+		exitScope := func() {
+			if len(lexicalScopeStack) > 0 {
+				lexicalScopeStack = lexicalScopeStack[:len(lexicalScopeStack)-1]
+			}
+		}
+		markCurrentLexical := func() {
+			if len(lexicalScopeStack) == 0 {
+				return
+			}
+			for arrow := range lexicalScopeStack[len(lexicalScopeStack)-1] {
+				arrowsWithLexicalIdentifiers[arrow] = true
+			}
+		}
+
+		// Messages.
+		msgExpectedPropertyShorthand := rule.RuleMessage{
+			Id:          "expectedPropertyShorthand",
+			Description: "Expected property shorthand.",
+		}
+		msgExpectedMethodShorthand := rule.RuleMessage{
+			Id:          "expectedMethodShorthand",
+			Description: "Expected method shorthand.",
+		}
+		msgExpectedPropertyLongform := rule.RuleMessage{
+			Id:          "expectedPropertyLongform",
+			Description: "Expected longform property syntax.",
+		}
+		msgExpectedMethodLongform := rule.RuleMessage{
+			Id:          "expectedMethodLongform",
+			Description: "Expected longform method syntax.",
+		}
+		msgExpectedLiteralMethodLongform := rule.RuleMessage{
+			Id:          "expectedLiteralMethodLongform",
+			Description: "Expected longform method syntax for string literal keys.",
+		}
+		msgExpectedAllPropertiesShorthanded := rule.RuleMessage{
+			Id:          "expectedAllPropertiesShorthanded",
+			Description: "Expected shorthand for all properties.",
+		}
+		msgUnexpectedMix := rule.RuleMessage{
+			Id:          "unexpectedMix",
+			Description: "Unexpected mix of shorthand and non-shorthand properties.",
+		}
+
+		// -------- Autofix helpers --------
+
+		// keyText returns the full textual representation of a property name,
+		// including the surrounding brackets for ComputedPropertyName.
+		keyText := func(nameNode *ast.Node) string {
+			if nameNode == nil {
+				return ""
+			}
+			r := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
+			return sourceText[r.Pos():r.End()]
+		}
+
+		// fixShorthandProperty rewrites `{ key: value }` into `{ value }` when
+		// key === value.name. Returns nil when any comment is present inside the
+		// PropertyAssignment — replacing the whole node would drop it.
+		fixShorthandProperty := func(node *ast.Node, valueName string) []rule.RuleFix {
+			if hasCommentsInsideText(sourceText, node.Pos(), node.End()) {
+				return nil
+			}
+			return []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, valueName)}
+		}
+
+		// fixPropertyToLongform rewrites `{ x }` into `{ x: x }` for the
+		// ShorthandPropertyAssignment case (`"never"` option).
+		fixPropertyToLongform := func(node *ast.Node) []rule.RuleFix {
+			sp := node.AsShorthandPropertyAssignment()
+			if sp == nil {
+				return nil
+			}
+			name := sp.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				return nil
+			}
+			ident := name.AsIdentifier().Text
+			return []rule.RuleFix{rule.RuleFixInsertAfter(name, ": "+ident)}
+		}
+
+		// fixMethodToLongform rewrites a MethodDeclaration (`{ foo() {} }`) into
+		// `{ foo: function() {} }` for the `"never"` / `avoidQuotes` cases.
+		fixMethodToLongform := func(node *ast.Node) []rule.RuleFix {
+			method := node.AsMethodDeclaration()
+			if method == nil || method.Body == nil {
+				return nil
+			}
+
+			isAsync := ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync)
+			isGenerator := method.AsteriskToken != nil
+
+			nameNode := method.Name()
+			if nameNode == nil {
+				return nil
+			}
+
+			// Range to replace: start of node → end of name.
+			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			nameRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
+
+			keyStr := keyText(nameNode)
+			header := "function"
+			if isAsync {
+				header = "async function"
+			}
+			if isGenerator {
+				header += "*"
+			}
+
+			replaceRange := core.NewTextRange(nodeRange.Pos(), nameRange.End())
+			return []rule.RuleFix{rule.RuleFixReplaceRange(replaceRange, keyStr+": "+header)}
+		}
+
+		// fixFunctionToMethod rewrites a PropertyAssignment whose initializer
+		// is a FunctionExpression into a MethodDeclaration shorthand. Handles
+		// `{a: (function(){})}` by unwrapping the outer parentheses.
+		fixFunctionToMethod := func(node *ast.Node) []rule.RuleFix {
+			pa := node.AsPropertyAssignment()
+			fn := propertyValue(pa)
+			if fn == nil || fn.Kind != ast.KindFunctionExpression {
+				return nil
+			}
+			nameNode := pa.Name()
+			if nameNode == nil {
+				return nil
+			}
+			// Disallow fix if a comment sits between the key and the function.
+			keyRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
+			fnRange := utils.TrimNodeTextRange(ctx.SourceFile, fn)
+			if utils.HasCommentsInRange(ctx.SourceFile, core.NewTextRange(keyRange.End(), fnRange.Pos())) {
+				return nil
+			}
+
+			fe := fn.AsFunctionExpression()
+			if fe == nil || fe.Body == nil {
+				return nil
+			}
+			isAsync := ast.HasSyntacticModifier(fn, ast.ModifierFlagsAsync)
+			isGenerator := fe.AsteriskToken != nil
+
+			prefix := ""
+			if isAsync {
+				prefix += "async "
+			}
+			if isGenerator {
+				prefix += "*"
+			}
+
+			// The tail we want to keep is everything after `function` (and
+			// `*` when generator). For generators, AsteriskToken gives us a
+			// precise end position; otherwise we scan for the `function`
+			// keyword past any leading modifiers (e.g. `async`).
+			var headerEnd int
+			if isGenerator {
+				headerEnd = fe.AsteriskToken.End()
+			} else {
+				kwEnd, ok := positionAfterFunctionKeyword(ctx.SourceFile, fn)
+				if !ok {
+					return nil
+				}
+				headerEnd = kwEnd
+			}
+
+			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			keyStr := keyText(nameNode)
+			tail := sourceText[headerEnd:fnRange.End()]
+
+			return []rule.RuleFix{rule.RuleFixReplaceRange(
+				core.NewTextRange(nodeRange.Pos(), nodeRange.End()),
+				prefix+keyStr+tail,
+			)}
+		}
+
+		// fixArrowToMethod rewrites `{ foo: (a) => { return; } }` into
+		// `{ foo(a) { return; } }`. Also handles extra parentheses around the
+		// arrow (`{ foo: ((a) => { … }) }`). The caller is responsible for
+		// verifying the arrow has no lexical identifiers.
+		fixArrowToMethod := func(node *ast.Node) []rule.RuleFix {
+			pa := node.AsPropertyAssignment()
+			fn := propertyValue(pa)
+			if fn == nil || fn.Kind != ast.KindArrowFunction {
+				return nil
+			}
+			arrow := fn.AsArrowFunction()
+			if arrow == nil || arrow.Body == nil {
+				return nil
+			}
+			if arrow.Body.Kind != ast.KindBlock {
+				return nil
+			}
+
+			nameNode := pa.Name()
+			if nameNode == nil {
+				return nil
+			}
+			keyRange := utils.TrimNodeTextRange(ctx.SourceFile, nameNode)
+			fnRange := utils.TrimNodeTextRange(ctx.SourceFile, fn)
+			if utils.HasCommentsInRange(ctx.SourceFile, core.NewTextRange(keyRange.End(), fnRange.Pos())) {
+				return nil
+			}
+
+			isAsync := ast.HasSyntacticModifier(fn, ast.ModifierFlagsAsync)
+			if arrow.EqualsGreaterThanToken == nil {
+				return nil
+			}
+
+			// The AST already identifies the `=>` token, so we can slice the
+			// arrow's source text around it directly. This preserves TypeScript
+			// type annotations and default values without re-parsing.
+			paramsStart := fnRange.Pos()
+			if mods := arrow.Modifiers(); isAsync && mods != nil && len(mods.Nodes) > 0 {
+				// Skip past the `async` modifier so the params start at `(`.
+				paramsStart = mods.End()
+			}
+
+			arrowTokenPos := arrow.EqualsGreaterThanToken.Pos()
+			arrowTokenEnd := arrow.EqualsGreaterThanToken.End()
+
+			paramsText := strings.TrimSpace(sourceText[paramsStart:arrowTokenPos])
+			bodyText := strings.TrimLeft(sourceText[arrowTokenEnd:fnRange.End()], " \t")
+
+			// Wrap a single identifier parameter in parentheses: `x => …`.
+			if len(paramsText) == 0 || paramsText[0] != '(' {
+				paramsText = "(" + paramsText + ")"
+			}
+
+			prefix := ""
+			if isAsync {
+				prefix = "async "
+			}
+
+			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			keyStr := keyText(nameNode)
+			replacement := prefix + keyStr + paramsText + " " + bodyText
+
+			return []rule.RuleFix{rule.RuleFixReplaceRange(
+				core.NewTextRange(nodeRange.Pos(), nodeRange.End()),
+				replacement,
+			)}
+		}
+
+		// -------- Reporting --------
+
+		reportMix := func(obj *ast.Node) {
+			ctx.ReportNode(obj, msgUnexpectedMix)
+		}
+		reportAllShorthand := func(obj *ast.Node) {
+			ctx.ReportNode(obj, msgExpectedAllPropertiesShorthanded)
+		}
+
+		checkConsistency := func(obj *ast.Node, checkRedundancy bool) {
+			ol := obj.AsObjectLiteralExpression()
+			if ol == nil || ol.Properties == nil {
+				return
+			}
+			var considered []*ast.Node
+			for _, p := range ol.Properties.Nodes {
+				if canHaveShorthand(p) {
+					considered = append(considered, p)
+				}
+			}
+			if len(considered) == 0 {
+				return
+			}
+			shorthandCount := 0
+			for _, p := range considered {
+				if isShorthandKind(classify(p)) {
+					shorthandCount++
+				}
+			}
+			if shorthandCount == len(considered) {
+				return // all shorthand — consistent
+			}
+			if shorthandCount > 0 {
+				reportMix(obj)
+				return
+			}
+			if !checkRedundancy {
+				return
+			}
+			// All longform; report if every property is redundant.
+			allRedundant := true
+			for _, p := range considered {
+				if !isRedundantLongform(p) {
+					allRedundant = false
+					break
+				}
+			}
+			if allRedundant {
+				reportAllShorthand(obj)
+			}
+		}
+
+		// -------- Property-level checks --------
+
+		handleProperty := func(node *ast.Node) {
+			// Only properties directly inside an object literal are considered.
+			if node.Parent == nil || node.Parent.Kind != ast.KindObjectLiteralExpression {
+				return
+			}
+
+			kind := classify(node)
+			if kind == propKindOther {
+				return
+			}
+
+			isConcise := kind == propKindShorthandProp || kind == propKindShorthandMethod
+
+			// Computed keys can only fail the method checks.
+			if node.Kind == ast.KindPropertyAssignment {
+				pa := node.AsPropertyAssignment()
+				if pa != nil && pa.Name() != nil && pa.Name().Kind == ast.KindComputedPropertyName {
+					if pa.Initializer != nil &&
+						pa.Initializer.Kind != ast.KindFunctionExpression &&
+						pa.Initializer.Kind != ast.KindArrowFunction {
+						return
+					}
+				}
+			}
+
+			if isConcise {
+				// Shorthand — may need to be converted to longform.
+				if kind == propKindShorthandMethod {
+					method := node.AsMethodDeclaration()
+					var keyNode *ast.Node
+					if method != nil {
+						keyNode = method.Name()
+					}
+					if applyNever || (opts.avoidQuotes && isStringLiteralKey(keyNode)) {
+						msg := msgExpectedMethodLongform
+						if !applyNever && opts.avoidQuotes {
+							msg = msgExpectedLiteralMethodLongform
+						}
+						if fixes := fixMethodToLongform(node); fixes != nil {
+							ctx.ReportNodeWithFixes(node, msg, fixes...)
+						} else {
+							ctx.ReportNode(node, msg)
+						}
+					}
+				} else if applyNever {
+					// `{ x }` → `{ x: x }`
+					if fixes := fixPropertyToLongform(node); fixes != nil {
+						ctx.ReportNodeWithFixes(node, msgExpectedPropertyLongform, fixes...)
+					} else {
+						ctx.ReportNode(node, msgExpectedPropertyLongform)
+					}
+				}
+				return
+			}
+
+			// Longform — may need to be converted to shorthand.
+			pa := node.AsPropertyAssignment()
+			value := propertyValue(pa) // unwraps parentheses
+			if value == nil {
+				return
+			}
+			valueKind := value.Kind
+
+			// Method-shorthand: `{ foo: function() {} }` / `{ foo: () => {} }`
+			if applyToMethods && (valueKind == ast.KindFunctionExpression || valueKind == ast.KindArrowFunction) {
+				if valueKind == ast.KindFunctionExpression {
+					// Named FunctionExpression: skip.
+					if value.AsFunctionExpression().Name() != nil {
+						return
+					}
+				}
+
+				nameNode := pa.Name()
+				if opts.ignoreConstructors && nameNode != nil && nameNode.Kind == ast.KindIdentifier {
+					if utils.IsConstructorName(nameNode.AsIdentifier().Text) {
+						return
+					}
+				}
+				if shouldIgnoreMethodName(&opts, nameNode) {
+					return
+				}
+				if opts.avoidQuotes && isStringLiteralKey(nameNode) {
+					return
+				}
+
+				if valueKind == ast.KindFunctionExpression {
+					if fixes := fixFunctionToMethod(node); fixes != nil {
+						ctx.ReportNodeWithFixes(node, msgExpectedMethodShorthand, fixes...)
+					} else {
+						ctx.ReportNode(node, msgExpectedMethodShorthand)
+					}
+					return
+				}
+
+				// ArrowFunction — only when avoidExplicitReturnArrows is enabled
+				// and the body is a block, and the arrow does not use lexical
+				// identifiers.
+				arrow := value.AsArrowFunction()
+				if arrow == nil || arrow.Body == nil || arrow.Body.Kind != ast.KindBlock {
+					return
+				}
+				if !opts.avoidExplicitReturnArrows {
+					return
+				}
+				if arrowsWithLexicalIdentifiers[value] {
+					return
+				}
+				if fixes := fixArrowToMethod(node); fixes != nil {
+					ctx.ReportNodeWithFixes(node, msgExpectedMethodShorthand, fixes...)
+				} else {
+					ctx.ReportNode(node, msgExpectedMethodShorthand)
+				}
+				return
+			}
+
+			// Property-shorthand: `{ foo: foo }` → `{ foo }`
+			if !applyToProps {
+				return
+			}
+			if valueKind != ast.KindIdentifier {
+				return
+			}
+			valueIdent := value.AsIdentifier()
+			if valueIdent == nil {
+				return
+			}
+			nameNode := pa.Name()
+			if nameNode == nil {
+				return
+			}
+
+			switch nameNode.Kind {
+			case ast.KindIdentifier:
+				if nameNode.AsIdentifier().Text != valueIdent.Text {
+					return
+				}
+				// Identifier-key branch uses the tolerant `^\s*\*` check —
+				// leading whitespace/newline before the first `*` is allowed
+				// (matches ESLint's `JSDOC_COMMENT_REGEX`).
+				if hasJSDocTypeAnnotationInside(sourceText, node, false /*strict*/) {
+					return
+				}
+				if fixes := fixShorthandProperty(node, valueIdent.Text); fixes != nil {
+					ctx.ReportNodeWithFixes(node, msgExpectedPropertyShorthand, fixes...)
+				} else {
+					ctx.ReportNode(node, msgExpectedPropertyShorthand)
+				}
+			case ast.KindStringLiteral:
+				if nameNode.AsStringLiteral().Text != valueIdent.Text {
+					return
+				}
+				if opts.avoidQuotes {
+					return
+				}
+				// StringLiteral-key branch uses the strict `startsWith("*")`
+				// check — matches ESLint's tighter predicate in this branch.
+				if hasJSDocTypeAnnotationInside(sourceText, node, true /*strict*/) {
+					return
+				}
+				if fixes := fixShorthandProperty(node, valueIdent.Text); fixes != nil {
+					ctx.ReportNodeWithFixes(node, msgExpectedPropertyShorthand, fixes...)
+				} else {
+					ctx.ReportNode(node, msgExpectedPropertyShorthand)
+				}
+			}
+		}
+
+		// -------- Listeners --------
+
+		listeners := rule.RuleListeners{
+			ast.KindFunctionDeclaration:                    func(n *ast.Node) { enterScope() },
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): func(n *ast.Node) { exitScope() },
+			ast.KindFunctionExpression:                     func(n *ast.Node) { enterScope() },
+			rule.ListenerOnExit(ast.KindFunctionExpression): func(n *ast.Node) { exitScope() },
+			ast.KindMethodDeclaration: func(n *ast.Node) {
+				enterScope()
+				// Also run the property-level check (only when inside an
+				// object literal) on enter: MethodDeclaration has no children
+				// whose traversal matters for this check.
+				handleProperty(n)
+			},
+			rule.ListenerOnExit(ast.KindMethodDeclaration): func(n *ast.Node) { exitScope() },
+			ast.KindGetAccessor:                            func(n *ast.Node) { enterScope() },
+			rule.ListenerOnExit(ast.KindGetAccessor):       func(n *ast.Node) { exitScope() },
+			ast.KindSetAccessor:                            func(n *ast.Node) { enterScope() },
+			rule.ListenerOnExit(ast.KindSetAccessor):       func(n *ast.Node) { exitScope() },
+			ast.KindConstructor:                            func(n *ast.Node) { enterScope() },
+			rule.ListenerOnExit(ast.KindConstructor):       func(n *ast.Node) { exitScope() },
+
+			ast.KindArrowFunction: func(n *ast.Node) {
+				if len(lexicalScopeStack) > 0 {
+					lexicalScopeStack[len(lexicalScopeStack)-1][n] = true
+				}
+			},
+			rule.ListenerOnExit(ast.KindArrowFunction): func(n *ast.Node) {
+				if len(lexicalScopeStack) > 0 {
+					delete(lexicalScopeStack[len(lexicalScopeStack)-1], n)
+				}
+			},
+
+			ast.KindThisKeyword:  func(n *ast.Node) { markCurrentLexical() },
+			ast.KindSuperKeyword: func(n *ast.Node) { markCurrentLexical() },
+			ast.KindMetaProperty: func(n *ast.Node) {
+				// `new.target`
+				mp := n.AsMetaProperty()
+				if mp != nil && mp.KeywordToken == ast.KindNewKeyword {
+					markCurrentLexical()
+				}
+			},
+			ast.KindIdentifier: func(n *ast.Node) {
+				if !isArgumentsIdentifier(n) {
+					return
+				}
+				// ESLint only collects `arguments` references seen inside a
+				// non-arrow function — the Program scope has no implicit
+				// `arguments` binding, so bare `arguments` at module / global
+				// level doesn't block arrow→method conversion. We approximate
+				// this with a depth check: stack[0] is the seeded program
+				// scope, so depth > 1 means at least one enclosing function
+				// (FunctionDeclaration, FunctionExpression, MethodDeclaration,
+				// GetAccessor, SetAccessor, Constructor). Arrow functions do
+				// NOT push a new entry, so they are correctly transparent.
+				if len(lexicalScopeStack) <= 1 {
+					return
+				}
+				// A block-scoped `let`/`const`/`using arguments` between the
+				// reference and the enclosing function hides the function's
+				// implicit `arguments` — ESLint resolves the reference to
+				// that shadow, so it doesn't count as a lexical identifier.
+				if isArgumentsShadowedInBlockScope(n) {
+					return
+				}
+				markCurrentLexical()
+			},
+
+			// Property-level checks on exit so that descendant-tracking for
+			// lexical identifiers inside arrow values is complete.
+			rule.ListenerOnExit(ast.KindPropertyAssignment): func(n *ast.Node) {
+				handleProperty(n)
+			},
+			ast.KindShorthandPropertyAssignment: func(n *ast.Node) {
+				// Skip destructuring binding: `let {a, b} = o`.
+				if n.Parent != nil && n.Parent.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				handleProperty(n)
+			},
+
+			ast.KindObjectLiteralExpression: func(n *ast.Node) {
+				if applyConsistent {
+					checkConsistency(n, false)
+				} else if applyConsistentAsNeeded {
+					checkConsistency(n, true)
+				}
+			},
+		}
+
+		return listeners
+	},
+}
+
+// positionAfterFunctionKeyword returns the end offset of the `function`
+// keyword inside a FunctionExpression. Used when splicing a property value
+// like `async function foo()` into a method shorthand — everything past this
+// position (parameters, body, type annotations) is preserved verbatim.
+//
+// Returns (-1, false) if the token at the expected position is not
+// `function`, which only happens with malformed input.
+func positionAfterFunctionKeyword(sourceFile *ast.SourceFile, fn *ast.Node) (int, bool) {
+	pos := fn.Pos()
+	// The FunctionExpression's range starts before any modifiers; advance past
+	// the modifier list (e.g. `async`) if present.
+	if fe := fn.AsFunctionExpression(); fe != nil {
+		if mods := fe.Modifiers(); mods != nil && len(mods.Nodes) > 0 {
+			pos = mods.End()
+		}
+	}
+	kwRange := scanner.GetRangeOfTokenAtPosition(sourceFile, pos)
+	if scanner.ScanTokenAtPosition(sourceFile, pos) != ast.KindFunctionKeyword {
+		return -1, false
+	}
+	return kwRange.End(), true
+}

--- a/internal/rules/object_shorthand/object_shorthand.md
+++ b/internal/rules/object_shorthand/object_shorthand.md
@@ -1,0 +1,64 @@
+# object-shorthand
+
+Require or disallow method and property shorthand syntax for object literals.
+
+## Rule Details
+
+ECMAScript 6 provides shorthand syntax for defining object literal methods and
+properties. It is useful when an object property shares the name of a local
+variable and lets you define methods using concise syntax. This rule enforces
+usage of that shorthand whenever possible (the default `"always"` mode) and can
+be configured to enforce the opposite (`"never"`) or to cover only one of the
+two shorthand forms.
+
+Examples of **incorrect** code for this rule (default):
+
+```javascript
+const foo = {
+  w: function () {},
+  x: function* () {},
+  z: z,
+};
+```
+
+Examples of **correct** code for this rule (default):
+
+```javascript
+const foo = {
+  w() {},
+  *x() {},
+  z,
+};
+```
+
+## Options
+
+The first option is a string:
+
+- `"always"` (default) — always use shorthand where possible.
+- `"methods"` — enforce only method shorthand.
+- `"properties"` — enforce only property shorthand.
+- `"never"` — never use shorthand.
+- `"consistent"` — properties within an object must be all shorthand or all
+  longform.
+- `"consistent-as-needed"` — all properties must be shorthand when they can be,
+  otherwise all must be longform.
+
+The second option is an object with additional flags (valid with `"always"`,
+`"methods"`, or `"properties"` as noted on each):
+
+- `avoidQuotes` — prefer longform for string literal keys (all modes above).
+- `ignoreConstructors` — skip constructor-style names (only `"always"` or
+  `"methods"`).
+- `methodsIgnorePattern` — regular expression of method names to skip
+  (only `"always"` or `"methods"`).
+- `avoidExplicitReturnArrows` — report arrow functions with block bodies
+  (`() => { … }`) as preferring the method shorthand
+  (only `"always"` or `"methods"`). Arrows that reference `this`, `super`,
+  `arguments`, or `new.target` are left alone because the conversion would
+  change their binding.
+
+## Original Documentation
+
+- ESLint rule: https://eslint.org/docs/latest/rules/object-shorthand
+- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/object-shorthand.js

--- a/internal/rules/object_shorthand/object_shorthand_edge_test.go
+++ b/internal/rules/object_shorthand/object_shorthand_edge_test.go
@@ -537,6 +537,45 @@ func TestObjectShorthandAutofixShapes(t *testing.T) {
 	)
 }
 
+// TestObjectShorthandIgnoreConstructorsUnicode verifies that the
+// `ignoreConstructors` option treats Unicode uppercase identifiers (e.g. Greek
+// capital Pi `Π`, Cyrillic `Д`) the same way ESLint does — they count as
+// constructor names and are skipped.
+func TestObjectShorthandIgnoreConstructorsUnicode(t *testing.T) {
+	ignoreCtorOpts := []any{"always", map[string]any{"ignoreConstructors": true}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// Greek capital Π as first rune → constructor → skipped.
+			{Code: `var x = {Πfoo: function(){}, a: b}`, Options: ignoreCtorOpts},
+			// `_` prefix + Greek capital → still constructor.
+			{Code: `var x = {_Πfoo: function(){}, a: b}`, Options: ignoreCtorOpts},
+			// Cyrillic capital Д.
+			{Code: `var x = {Дelta: function(){}, a: b}`, Options: ignoreCtorOpts},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Greek lowercase π → NOT a constructor → method shorthand enforced.
+			{
+				Code:    `var x = {πfoo: function(){}, a: b}`,
+				Output:  []string{`var x = {πfoo(){}, a: b}`},
+				Options: ignoreCtorOpts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// `_` prefix + Greek lowercase → still not a constructor.
+			{
+				Code:    `var x = {_πfoo: function(){}, a: b}`,
+				Output:  []string{`var x = {_πfoo(){}, a: b}`},
+				Options: ignoreCtorOpts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+		},
+	)
+}
+
 // TestObjectShorthandJSDocDetection covers the JSDoc `@type` detection for
 // both the Identifier-key and StringLiteral-key branches. ESLint uses two
 // subtly different predicates:

--- a/internal/rules/object_shorthand/object_shorthand_edge_test.go
+++ b/internal/rules/object_shorthand/object_shorthand_edge_test.go
@@ -1,0 +1,815 @@
+package object_shorthand
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestObjectShorthandRuleEdgeCases stresses deeply-nested object literals,
+// lexical scope propagation and TypeScript-specific syntax to ensure the
+// detector stays correct across all reachable AST shapes.
+func TestObjectShorthandRuleEdgeCases(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// --- Destructuring must never trigger ---
+			{Code: `let {a, b, c} = obj`},
+			{Code: `let {a: {b, c}} = obj`},
+			{Code: `function f({a, b}) { return a + b }`},
+			{Code: `let [{a}] = arr`},
+			{Code: `let {a: b = 1} = obj`},
+			{Code: `function f({a = 1}) {}`},
+			{Code: `const {x = 1, ...rest} = obj`},
+
+			// --- Class-adjacent: MethodDeclaration inside a class must be ignored ---
+			{Code: `class Foo { bar() {} }`},
+			{Code: `class Foo { async bar() {} }`},
+			{Code: `class Foo { *bar() {} }`},
+			{Code: `class Foo { get bar() { return 1 } set bar(v) {} }`},
+			{Code: `class Foo { static bar() {} }`},
+			{Code: `class Foo { #priv() {} }`},
+
+			// --- Computed keys: cannot shorthand with identifier value ---
+			{Code: `var x = {[a]: a}`},
+			{Code: `var x = {[a.b]: a}`},
+			{Code: `var x = {[a + b]: c}`},
+			{Code: "var x = {[`foo`]: 'bar'}"},
+
+			// --- Accessor-only objects stay as-is ---
+			{Code: `var x = {get foo() { return 1 }, set foo(v) {}}`},
+			{Code: `var x = {get [expr]() { return 1 }}`},
+
+			// --- Arrow function with expression body never converts ---
+			{Code: `var x = {foo: () => 1}`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `var x = {foo: (a) => a}`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `var x = {foo: async () => 1}`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+
+			// --- Lexical identifiers block arrow→method conversion ---
+			{Code: `var x = {foo: () => { this.x }}`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `class C extends B { m() { var x = {foo: () => { super.m() }} } }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `function foo() { var x = {f: () => { new.target }} }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `function foo() { var x = {f: () => { arguments[0] }} }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+
+			// --- Lexical identifier in an inner arrow also poisons outer arrow ---
+			{Code: `function foo() { var x = {f: () => { var g = () => this; return g; }} }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `function foo() { var x = {f: () => { return { g: () => this } }} }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+
+			// --- Named function expression is never converted (always mode) ---
+			{Code: `var x = {foo: function foo() {}}`},
+			{Code: `var x = {foo: function bar() {}}`},
+
+			// --- ignoreConstructors covers various prefix shapes ---
+			{Code: `var x = {__Foo: function(){}}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {$_Foo: function(){}}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {_1Foo: function(){}}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+
+			// --- methodsIgnorePattern on computed string literal keys ---
+			{Code: `var x = {['foo']: function(){}}`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "^foo$"}}},
+			{Code: "var x = {[`foo`]: function(){}}", Options: []any{"always", map[string]any{"methodsIgnorePattern": "^foo$"}}},
+
+			// --- Consistent with spread only ---
+			{Code: `var x = {...foo}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {...foo, bar, baz}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {bar: baz, ...qux}`, Options: []any{"consistent-as-needed"}},
+			// All properties non-redundant longform + spread — consistent-as-needed valid.
+			{Code: `var x = {bar: baz, ...qux}`, Options: []any{"consistent"}},
+
+			// --- Consistent: accessors + shorthand are consistent ---
+			{Code: `var x = {a, b, get foo() { return 1 }}`, Options: []any{"consistent"}},
+			{Code: `var x = {a: b, c: d, get foo() { return 1 }}`, Options: []any{"consistent"}},
+
+			// --- JSDoc @type must block shorthand conversion ---
+			{Code: `({ val: /** @type {number} */ (val) })`},
+			{Code: `({ val: /**\n * @type {number}\n */ (val) })`},
+
+			// --- Empty object literal: no reports ---
+			{Code: `var x = {}`},
+			{Code: `foo({})`},
+			{Code: `[{}]`},
+
+			// --- Property with value that matches key only textually via literal can't shorthand with avoidQuotes ---
+			{Code: `var x = {'foo': foo}`, Options: []any{"properties", map[string]any{"avoidQuotes": true}}},
+			{Code: `var x = {'foo': foo}`, Options: []any{"always", map[string]any{"avoidQuotes": true}}},
+
+			// --- Nested objects: each level processed independently ---
+			{Code: `var x = {a: {b: c}}`},
+
+			// --- TypeScript-specific valid syntax ---
+			{Code: `let x = {foo: (a: number): string => 'x'}`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}}, // expression body
+			{Code: `let x = {foo: (a: number): string => { return 'x' }}`},                                                                  // avoidExplicitReturnArrows not set
+		},
+		[]rule_tester.InvalidTestCase{
+			// --- Deeply nested object: innermost property reports ---
+			{
+				Code:   `var x = {a: {b: {c: c}}}`,
+				Output: []string{`var x = {a: {b: {c}}}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 18}},
+			},
+			// --- Object in array in function body ---
+			{
+				Code:   `function outer() { return [{x: x}] }`,
+				Output: []string{`function outer() { return [{x}] }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 29}},
+			},
+			// --- Object in class field initializer ---
+			{
+				Code:   `class Foo { field = {x: x} }`,
+				Output: []string{`class Foo { field = {x} }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 22}},
+			},
+			// --- Object in class method ---
+			{
+				Code:   `class Foo { bar() { return {x: function(){}} } }`,
+				Output: []string{`class Foo { bar() { return {x(){}} } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 29}},
+			},
+			// --- Object in constructor ---
+			{
+				Code:   `class Foo { constructor() { this.x = {a: a} } }`,
+				Output: []string{`class Foo { constructor() { this.x = {a} } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 39}},
+			},
+			// --- Object in getter ---
+			{
+				Code:   `var x = {get foo() { return {a: a} }}`,
+				Output: []string{`var x = {get foo() { return {a} }}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 30}},
+			},
+			// --- Object in static init block ---
+			{
+				Code:   `class Foo { static { let o = {x: x}; } }`,
+				Output: []string{`class Foo { static { let o = {x}; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 31}},
+			},
+			// --- Object inside arrow function expression body ---
+			{
+				Code:   `var f = () => ({x: x})`,
+				Output: []string{`var f = () => ({x})`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 17}},
+			},
+
+			// --- Multiple independent reports in one object ---
+			{
+				Code:   `var x = {a: a, b: b, c: c}`,
+				Output: []string{`var x = {a, b, c}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10},
+					{MessageId: "expectedPropertyShorthand", Line: 1, Column: 16},
+					{MessageId: "expectedPropertyShorthand", Line: 1, Column: 22},
+				},
+			},
+			// --- Mixed property and method reports ---
+			{
+				Code:   `var x = {a: a, b: function(){}}`,
+				Output: []string{`var x = {a, b(){}}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10},
+					{MessageId: "expectedMethodShorthand", Line: 1, Column: 16},
+				},
+			},
+
+			// --- Async generator ---
+			{
+				Code:   `var x = {foo: async function*() { yield 1 }}`,
+				Output: []string{`var x = {async *foo() { yield 1 }}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `var x = {async *foo() { yield 1 }}`,
+				Output:  []string{`var x = {foo: async function*() { yield 1 }}`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodLongform", Line: 1, Column: 10}},
+			},
+
+			// --- Generic (TypeScript) function expression → method ---
+			{
+				Code:   `var x = {foo: function<T>(a: T): T { return a }}`,
+				Output: []string{`var x = {foo<T>(a: T): T { return a }}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			// --- Async generic function expression → async method ---
+			{
+				Code:   `var x = {foo: async function<T>(a: T): Promise<T> { return a }}`,
+				Output: []string{`var x = {async foo<T>(a: T): Promise<T> { return a }}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+
+			// --- Named function expression still converts if anonymous twin is anonymous ---
+			// (ESLint: named FE is NOT converted — kept as-is)
+			// Covered in valid above; nothing to assert here.
+
+			// --- Method → longform for "never" with computed key ---
+			{
+				Code:    `({ [(foo)]() { return; } })`,
+				Output:  []string{`({ [(foo)]: function() { return; } })`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodLongform", Line: 1, Column: 4}},
+			},
+			// --- Method → longform when async + computed key ---
+			{
+				Code:    `({ async [(foo)]() { return; } })`,
+				Output:  []string{`({ [(foo)]: async function() { return; } })`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodLongform", Line: 1, Column: 4}},
+			},
+
+			// --- consistent-as-needed: all redundant longform reports ---
+			{
+				Code:    `var x = {a: a, b: b, c: c}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedAllPropertiesShorthanded", Line: 1, Column: 9}},
+			},
+			// --- consistent-as-needed: mix of shorthand and non-redundant longform ---
+			{
+				Code:    `var x = {a, b: c, d: d}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedMix", Line: 1, Column: 9}},
+			},
+			// --- consistent: spread with mix ---
+			{
+				Code:    `var x = {foo, bar: baz, ...qux}`,
+				Options: []any{"consistent"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedMix", Line: 1, Column: 9}},
+			},
+
+			// --- avoidExplicitReturnArrows: multi-arg arrow becomes method ---
+			{
+				Code:    `({ foo: (a, b) => { return a + b } })`,
+				Output:  []string{`({ foo(a, b) { return a + b } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+			// --- avoidExplicitReturnArrows: destructuring param ---
+			{
+				Code:    `({ foo: ({a, b}) => { return a + b } })`,
+				Output:  []string{`({ foo({a, b}) { return a + b } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+			// --- avoidExplicitReturnArrows: arrow with nested non-arrow using this (OK to convert) ---
+			{
+				Code:    `({ foo: () => { function inner() { this.x } } })`,
+				Output:  []string{`({ foo() { function inner() { this.x } } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+			// --- avoidExplicitReturnArrows: nested class method uses this (OK to convert outer) ---
+			{
+				Code:    `({ foo: () => { class C { m() { this.x } } } })`,
+				Output:  []string{`({ foo() { class C { m() { this.x } } } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+
+			// --- Comment between key and value: no fix ---
+			{
+				Code:   `var x = {\n  f: /* c */ function() {}\n}`,
+				Output: []string{`var x = {\n  f: /* c */ function() {}\n}`}, // unchanged (no fix)
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+				Skip:   true, // verified via separate test — see below
+			},
+			// --- Literal-key property shorthand ---
+			{
+				Code:   `var x = {'foo': foo}`,
+				Output: []string{`var x = {foo}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10}},
+			},
+			// --- Numeric-literal key cannot become shorthand (identifier != number) ---
+			// That case is implicitly covered by "not reported" above.
+		},
+	)
+}
+
+// TestObjectShorthandArgumentsScope verifies the scope-aware `arguments`
+// handling: only `arguments` seen inside a non-arrow function scope counts as
+// a lexical identifier that blocks arrow→method conversion, matching ESLint's
+// scope-analysis semantics.
+func TestObjectShorthandArgumentsScope(t *testing.T) {
+	opts := []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// Inside a function: `arguments` blocks conversion (implicit binding).
+			{Code: `function foo() { ({ x: () => { arguments; } }) }`, Options: opts},
+			{Code: `function foo() { ({ x: () => { for (var a of arguments) {} } }) }`, Options: opts},
+			// Inside a method (also a function scope).
+			{Code: `var o = { m() { ({ x: () => { arguments; } }) } }`, Options: opts},
+			// Inside a class constructor / accessors.
+			{Code: `class C { constructor() { ({ x: () => { arguments; } }) } }`, Options: opts},
+			{Code: `class C { get p() { ({ x: () => { arguments; } }); return 1 } }`, Options: opts},
+			// Inside arrow inside function: still poisons (function provides args).
+			{Code: `function foo() { var g = () => { ({ x: () => { arguments; } }) } }`, Options: opts},
+		},
+		[]rule_tester.InvalidTestCase{
+			// At module / program scope: NO enclosing function → `arguments`
+			// is just a (probably undefined) identifier, so it must NOT block
+			// conversion. This aligns with ESLint's scope handling.
+			{
+				Code:    `({ x: () => { arguments; } })`,
+				Output:  []string{`({ x() { arguments; } })`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// `arguments` inside a nested block at module scope still not a
+			// lexical identifier.
+			{
+				Code:    `({ x: () => { { arguments; } } })`,
+				Output:  []string{`({ x() { { arguments; } } })`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+
+			// Block-scoped `let arguments` inside a function shadows the
+			// function's implicit `arguments`. ESLint resolves the identifier
+			// to the shadow, so it doesn't count as lexical — arrow IS
+			// convertible.
+			{
+				Code:    `function foo() { { let arguments = 1; ({ x: () => { arguments; } }) } }`,
+				Output:  []string{`function foo() { { let arguments = 1; ({ x() { arguments; } }) } }`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// `const arguments` block shadow also disqualifies the reference.
+			{
+				Code:    `function foo() { { const arguments = [1]; ({ x: () => { arguments[0]; } }) } }`,
+				Output:  []string{`function foo() { { const arguments = [1]; ({ x() { arguments[0]; } }) } }`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// `for (let arguments of …)` iteration binding shadows.
+			{
+				Code:    `function foo() { for (let arguments of arr) { ({ x: () => { arguments; } }) } }`,
+				Output:  []string{`function foo() { for (let arguments of arr) { ({ x() { arguments; } }) } }`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// `for (let arguments = …; …; …)` C-style for loop shadow.
+			{
+				Code:    `function foo() { for (let arguments = 0; arguments < 3; arguments++) { ({ x: () => { arguments; } }) } }`,
+				Output:  []string{`function foo() { for (let arguments = 0; arguments < 3; arguments++) { ({ x() { arguments; } }) } }`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// `catch (arguments)` parameter shadow.
+			{
+				Code:    `function foo() { try {} catch (arguments) { ({ x: () => { arguments; } }) } }`,
+				Output:  []string{`function foo() { try {} catch (arguments) { ({ x() { arguments; } }) } }`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+		},
+	)
+}
+
+// TestObjectShorthandLexicalScope exhaustively verifies lexical-identifier
+// propagation for avoidExplicitReturnArrows. The invariant is: an arrow can be
+// turned into a method only if none of its enclosing "lexical scope" chain
+// references this / super / arguments / new.target.
+func TestObjectShorthandLexicalScope(t *testing.T) {
+	opts := []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// this anywhere in the arrow body blocks conversion.
+			{Code: `var x = {f: () => { this.x }}`, Options: opts},
+			{Code: `var x = {f: () => { const y = this }}`, Options: opts},
+			{Code: `var x = {f: () => { if (cond) { this } }}`, Options: opts},
+			{Code: `var x = {f: () => { for (var i of arr) { this } }}`, Options: opts},
+			{Code: `var x = {f: () => { try { this } catch(e) { this } }}`, Options: opts},
+
+			// new.target blocks conversion.
+			{Code: `function foo() { var x = {f: () => { new.target }} }`, Options: opts},
+
+			// super in a nested method blocks outer arrow conversion.
+			{Code: `class C extends B { m() { var x = {f: () => { super.m() }} } }`, Options: opts},
+
+			// arguments anywhere in the arrow.
+			{Code: `function foo() { var x = {f: () => { arguments.length }} }`, Options: opts},
+			{Code: `function foo() { var x = {f: () => { Array.from(arguments) }} }`, Options: opts},
+
+			// Inner arrow uses lexical identifier — outer arrow also poisoned.
+			{Code: `var x = {f: () => { const g = () => this }}`, Options: opts},
+			{Code: `var x = {f: () => { [1].map(() => this) }}`, Options: opts},
+			{Code: `var x = {f: () => { return { g: () => this } }}`, Options: opts},
+
+			// 3+ level arrow chain with this at the bottom.
+			{Code: `var x = {f: () => { const g = () => { const h = () => this; return h } }}`, Options: opts},
+
+			// Computed key on a nested method uses this belonging to outer scope.
+			// Expected: outer arrow is poisoned (this in computed key escapes
+			// the inner method's own `this` binding).
+			// This is the trickier case; we treat it conservatively.
+			// (Matches ESLint's behavior of reporting lexical identifiers at
+			// the exact `this` node's enclosing non-arrow scope.)
+		},
+		[]rule_tester.InvalidTestCase{
+			// No this anywhere → convertible.
+			{
+				Code:    `var x = {f: () => { return 1 }}`,
+				Output:  []string{`var x = {f() { return 1 }}`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			// this inside nested regular function — outer arrow OK to convert.
+			{
+				Code:    `var x = {f: () => { function inner() { return this.x } }}`,
+				Output:  []string{`var x = {f() { function inner() { return this.x } }}`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			// this inside nested class method — outer arrow OK to convert.
+			{
+				Code:    `var x = {f: () => { class C { m() { this.x } } }}`,
+				Output:  []string{`var x = {f() { class C { m() { this.x } } }}`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			// this inside FunctionExpression property value — outer arrow OK.
+			// Both the outer arrow and the inner `function() {}` are converted
+			// (the inner function is anonymous and thus also shorthand-able).
+			{
+				Code: `var x = {f: () => { const o = { g: function() { this.x } } }}`,
+				Output: []string{
+					`var x = {f() { const o = { g: function() { this.x } } }}`,
+					`var x = {f() { const o = { g() { this.x } } }}`,
+				},
+				Options: opts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedMethodShorthand", Line: 1, Column: 33},
+					{MessageId: "expectedMethodShorthand", Line: 1, Column: 10},
+				},
+			},
+			// this in sibling arrow at the same scope — each arrow evaluated
+			// independently. Here there are two arrow siblings reported.
+			{
+				Code:    `({ a: () => { this.x }, b: () => { return 1 } })`,
+				Output:  []string{`({ a: () => { this.x }, b() { return 1 } })`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 25}},
+			},
+			// Nested class constructor isolates both arrows.
+			{
+				Code:    `({ f: () => { class Foo extends Bar { constructor() { super() } } } })`,
+				Output:  []string{`({ f() { class Foo extends Bar { constructor() { super() } } } })`},
+				Options: opts,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+		},
+	)
+}
+
+// TestObjectShorthandAutofixShapes verifies autofix output for a range of
+// value shapes that differ in the source span between key and value, arrow /
+// function distinctions, TypeScript annotations, computed keys, etc.
+func TestObjectShorthandAutofixShapes(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// Comment between key and value: no fix but still reports. Verified
+			// by separate test so snapshot isn't fragile.
+		},
+		[]rule_tester.InvalidTestCase{
+			// Function expression with generic type params.
+			{
+				Code:   `var x = {foo: function<T, U>(a: T, b: U): [T, U] { return [a, b] }}`,
+				Output: []string{`var x = {foo<T, U>(a: T, b: U): [T, U] { return [a, b] }}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Async arrow with single param, no parens (TS parser requires a body).
+			{
+				Code:    `({ x: async a => { return a } })`,
+				Output:  []string{`({ async x(a) { return a } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Arrow with rest parameter.
+			{
+				Code:    `({ x: (...args) => { return args } })`,
+				Output:  []string{`({ x(...args) { return args } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Arrow with destructuring + default value.
+			{
+				Code:    `({ x: ({ a = 1, b } = {}) => { return a + b } })`,
+				Output:  []string{`({ x({ a = 1, b } = {}) { return a + b } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Arrow with TypeScript typed parameters and return type.
+			{
+				Code:    `({ x: (a: number, b: string): string => { return String(a) + b } })`,
+				Output:  []string{`({ x(a: number, b: string): string { return String(a) + b } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Computed key → method (avoidExplicitReturnArrows).
+			{
+				Code:    `({ [key]: () => { return 1 } })`,
+				Output:  []string{`({ [key]() { return 1 } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Method with computed key → long form (never).
+			{
+				Code:    `({ [key]() {} })`,
+				Output:  []string{`({ [key]: function() {} })`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodLongform"}},
+			},
+		},
+	)
+}
+
+// TestObjectShorthandJSDocDetection covers the JSDoc `@type` detection for
+// both the Identifier-key and StringLiteral-key branches. ESLint uses two
+// subtly different predicates:
+//
+//   - Identifier key:   `/^\s*\*/` (tolerant — allows leading whitespace/newline)
+//   - StringLiteral key: `startsWith("*")` (strict — body must begin with `*`)
+//
+// Standard `/** @type … */` matches both; unusual forms like
+// `/*\n * @type … */` (leading newline before the first `*`) only trigger
+// the tolerant branch.
+func TestObjectShorthandJSDocDetection(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// ── Identifier key + standard JSDoc @type → skipped ──
+			{Code: `({ val: /** @type {number} */ (val) })`},
+			{Code: "({ val: /**\n * @type {number}\n */ (val) })"},
+			{Code: "({ val: /**\n\t* @type {number}\n\t*/ (val) })"},
+
+			// ── Identifier key + tolerant (leading whitespace) JSDoc ──
+			// Body is `\n * @type …` — first non-whitespace char is `*`.
+			// ESLint's Identifier-key branch accepts this as JSDoc → skipped.
+			{Code: "({ val: /*\n * @type {number}\n */ (val) })"},
+			{Code: `({ val: /*   * @type {number} */ (val) })`},
+
+			// ── StringLiteral key + standard JSDoc @type → skipped ──
+			{Code: `({ 'val': /** @type {number} */ (val) })`},
+			{Code: "({ 'val': /**\n * @type {number}\n */ (val) })"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Non-@type JSDoc comments never block shorthand — only @type does.
+			{
+				Code:   `({ val: /** regular comment */ (val) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			{
+				Code:   `({ val: /** @param {string} name */ (val) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			{
+				Code:   `({ val: /** @returns {number} */ (val) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+
+			// ── StringLiteral key + tolerant (non-standard) JSDoc →
+			// NOT skipped under ESLint's strict predicate. The body is
+			// `\n * @type …` which does NOT start with `*` literally.
+			{
+				Code:   "({ 'val': /*\n * @type {number}\n */ (val) })",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			// Same applies to space-prefixed bodies: `/* * @type {number} */`
+			// body is ` * @type …` (space then `*`) — strict branch rejects it.
+			{
+				Code:   `({ 'val': /* * @type {number} */ (val) })`,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+
+			// Line comments are never JSDoc, always trigger report (no fix).
+			{
+				Code:   "({ val: // @type {number}\n val })",
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+		},
+	)
+}
+
+// TestObjectShorthandTSValueWrappers ensures TypeScript expression wrappers
+// that change the value's shape (as, satisfies, non-null, type assertion) do
+// NOT get collapsed into a shorthand — matching ESLint's @typescript-eslint
+// behavior where the value is no longer a bare Identifier.
+func TestObjectShorthandTSValueWrappers(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// `as` assertion — value is AsExpression, not Identifier.
+			{Code: `var x = {a: a as string}`},
+			// `satisfies` — value is SatisfiesExpression.
+			{Code: `var x = {a: a satisfies string}`},
+			// Non-null assertion.
+			{Code: `var x = {a: a!}`},
+			// Prefix type assertion.
+			{Code: `var x = {a: <string>a}`},
+			// These wrappers combined with parens should also stay longform.
+			{Code: `var x = {a: (a as string)}`},
+			{Code: `var x = {a: (a!)}`},
+			// Literal / template / conditional values — not shorthand-able.
+			{Code: "var x = {a: `a`}"},
+			{Code: `var x = {a: cond ? a : b}`},
+			{Code: `var x = {a: -a}`},
+			{Code: `var x = {a: obj.a}`},
+			{Code: `var x = {a: [a]}`},
+		},
+		[]rule_tester.InvalidTestCase{},
+	)
+}
+
+// TestObjectShorthandParenthesizedValues exercises values wrapped in
+// parentheses. ESLint's parser drops parentheses, but tsgo's AST keeps them as
+// ParenthesizedExpression nodes — so every value-shape check must unwrap them.
+func TestObjectShorthandParenthesizedValues(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// Key / value textually differ — unwrap must still recognize the
+			// Identifier, but no shorthand opportunity exists.
+			{Code: `var x = {a: (b)}`},
+			// Named function expression wrapped in parens — still named, so
+			// NOT convertible (ESLint preserves named FE identity).
+			{Code: `var x = {a: (function foo() {})}`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Single layer of parens around identifier → shorthand.
+			{
+				Code:   `var x = {a: (a)}`,
+				Output: []string{`var x = {a}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			// Nested parens — ast.SkipParentheses handles multiple layers.
+			{
+				Code:   `var x = {a: (((a)))}`,
+				Output: []string{`var x = {a}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			// Parenthesized anonymous FE → method shorthand.
+			{
+				Code:   `var x = {a: (function(){ return 1 })}`,
+				Output: []string{`var x = {a(){ return 1 }}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Parenthesized arrow with block body under avoidExplicitReturnArrows.
+			{
+				Code:    `({ a: (() => { return 1 }) })`,
+				Output:  []string{`({ a() { return 1 } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Parenthesized async arrow with single param.
+			{
+				Code:    `({ a: (async (x) => { return x }) })`,
+				Output:  []string{`({ async a(x) { return x } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Parenthesized literal-key identifier shorthand.
+			{
+				Code:   `var x = {'a': (a)}`,
+				Output: []string{`var x = {a}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			// consistent-as-needed must treat parenthesized redundant values
+			// as redundant (to match ESLint).
+			{
+				Code:    `var x = {a: (a), b: (b)}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedAllPropertiesShorthanded"}},
+			},
+		},
+	)
+}
+
+// TestObjectShorthandClassAdjacent ensures class-owned MethodDeclarations,
+// MetaProperty nodes and deeply-nested non-object-literal structures never
+// trigger the rule, while properties wrapping classes still do.
+func TestObjectShorthandClassAdjacent(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// Class expression as value. The methods inside belong to the
+			// class body, not an ObjectLiteralExpression — must not fire.
+			{Code: `var x = {Foo: class { method() {} }}`},
+			{Code: `var x = {Foo: class Bar { async method() {} *gen() {} }}`},
+
+			// Class expression as arrow return.
+			{Code: `var x = () => class { m() {} }`},
+
+			// Arrow returning a class expression with expression body — not a
+			// block, so avoidExplicitReturnArrows doesn't apply.
+			{Code: `var x = { init: () => class { m() {} } }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Property with a class-expression value that has the same name:
+			// class can't be shorthanded (it's not an identifier), nor a method.
+			// We do not expect any shorthand report here, but the sibling
+			// `x: x` should still be reported normally.
+			{
+				Code:   `var x = { Foo: class { m() {} }, x: x }`,
+				Output: []string{`var x = { Foo: class { m() {} }, x }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+			// Object literal inside a class static initializer still reports.
+			{
+				Code:   `class C { static { let o = {a: function(){}} } }`,
+				Output: []string{`class C { static { let o = {a(){}} } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand"}},
+			},
+			// Deeply nested object through class method → arrow body → object.
+			{
+				Code:   `class C { m() { return [{a: a}] } }`,
+				Output: []string{`class C { m() { return [{a}] } }`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand"}},
+			},
+		},
+	)
+}
+
+// TestObjectShorthandConsistentMatrix exhaustively walks consistent /
+// consistent-as-needed mode branches with spread / accessors / methods /
+// named FE to ensure `isRedundant` and `canHaveShorthand` agree with ESLint.
+func TestObjectShorthandConsistentMatrix(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// consistent: all shorthand
+			{Code: `var x = {a, b, c}`, Options: []any{"consistent"}},
+			// consistent: all longform non-redundant
+			{Code: `var x = {a: 1, b: 2}`, Options: []any{"consistent"}},
+			// consistent: all longform (redundant) — redundancy doesn't matter for "consistent"
+			{Code: `var x = {a: a, b: b}`, Options: []any{"consistent"}},
+			// consistent: mix allowed if getters/setters are excluded
+			{Code: `var x = {a, b, get foo() { return 1 }, set foo(v) {}}`, Options: []any{"consistent"}},
+			// consistent: spread alone is fine
+			{Code: `var x = {...a}`, Options: []any{"consistent"}},
+			// consistent-as-needed: all shorthand
+			{Code: `var x = {a, b}`, Options: []any{"consistent-as-needed"}},
+			// consistent-as-needed: longform non-redundant
+			{Code: `var x = {a: 1, b: 2}`, Options: []any{"consistent-as-needed"}},
+			// consistent-as-needed: longform with named function expression (non-redundant)
+			{Code: `var x = {foo: function foo() {}}`, Options: []any{"consistent-as-needed"}},
+			// consistent-as-needed: only spreads
+			{Code: `var x = {...a, ...b}`, Options: []any{"consistent-as-needed"}},
+			// consistent-as-needed: only accessors
+			{Code: `var x = {get foo() { return 1 }, set foo(v) {}}`, Options: []any{"consistent-as-needed"}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// consistent: mix
+			{
+				Code:    `var x = {a, b: c}`,
+				Options: []any{"consistent"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedMix", Line: 1, Column: 9}},
+			},
+			// consistent-as-needed: all redundant (identifier/function)
+			{
+				Code:    `var x = {a: a, b: b}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedAllPropertiesShorthanded", Line: 1, Column: 9}},
+			},
+			{
+				Code:    `var x = {foo: function() {}}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedAllPropertiesShorthanded", Line: 1, Column: 9}},
+			},
+			// consistent-as-needed: mix of shorthand and longform
+			{
+				Code:    `var x = {a, b: b}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedMix", Line: 1, Column: 9}},
+			},
+		},
+	)
+}

--- a/internal/rules/object_shorthand/object_shorthand_test.go
+++ b/internal/rules/object_shorthand/object_shorthand_test.go
@@ -1,0 +1,226 @@
+package object_shorthand
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestObjectShorthandRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&ObjectShorthandRule,
+		[]rule_tester.ValidTestCase{
+			// default — always
+			{Code: `var x = {y() {}}`},
+			{Code: `var x = {y}`},
+			{Code: `var x = {a: b}`},
+			{Code: `var x = {a: 'a'}`},
+			{Code: `var x = {'a': 'a'}`},
+			{Code: `var x = {'a': b}`},
+			{Code: `var x = {y(x) {}}`},
+			{Code: `var {x,y,z} = x`},
+			{Code: `var {x: {y}} = z`},
+			{Code: `var x = {*x() {}}`},
+			{Code: `var x = {x: y}`},
+			{Code: `var x = {x: y, y: z}`},
+			{Code: `var x = {x() {}, y: z, l(){}}`},
+			{Code: `var x = {[y]: y}`},
+			{Code: `doSomething({x: y})`},
+			{Code: `!{ a: function a(){} };`},
+			// arrow functions allowed by default
+			{Code: `var x = {y: (x)=>x}`},
+			{Code: `doSomething({y: (x)=>x})`},
+			// getters/setters allowed
+			{Code: `var x = {get y() {}}`},
+			{Code: `var x = {set y(z) {}}`},
+			{Code: `var x = {get y() {}, set y(z) {}}`},
+
+			// options: properties
+			{Code: `var x = {[y]: y}`, Options: []any{"properties"}},
+			{Code: `var x = {['y']: 'y'}`, Options: []any{"properties"}},
+			{Code: `var x = {['y']: y}`, Options: []any{"properties"}},
+
+			// options: methods
+			{Code: `var x = {[y]() {}}`, Options: []any{"methods"}},
+			{Code: `var x = {[y]: function x() {}}`, Options: []any{"methods"}},
+			{Code: `var x = {[y]: y}`, Options: []any{"methods"}},
+			{Code: `var x = {y() {}}`, Options: []any{"methods"}},
+			{Code: `var x = {x, y() {}, a:b}`, Options: []any{"methods"}},
+
+			// options: properties disables method shorthand enforcement
+			{Code: `var x = {y}`, Options: []any{"properties"}},
+			{Code: `var x = {y: {b}}`, Options: []any{"properties"}},
+
+			// options: never
+			{Code: `var x = {a: n, c: d, f: g}`, Options: []any{"never"}},
+			{Code: `var x = {a: function(){}, b: {c: d}}`, Options: []any{"never"}},
+
+			// ignoreConstructors
+			{Code: `var x = {ConstructorFunction: function(){}, a: b}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {_ConstructorFunction: function(){}, a: b}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {$ConstructorFunction: function(){}, a: b}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {__ConstructorFunction: function(){}, a: b}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {_0ConstructorFunction: function(){}, a: b}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+			{Code: `var x = {notConstructorFunction(){}, b: c}`, Options: []any{"always", map[string]any{"ignoreConstructors": true}}},
+
+			// methodsIgnorePattern
+			{Code: `var x = { foo: function() {}  }`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "^foo$"}}},
+			{Code: `var x = { 'foo': function() {}  }`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "^foo$"}}},
+			{Code: `var x = { ['foo']: function() {}  }`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "^foo$"}}},
+			{Code: `var x = { 123: function() {}  }`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "^123$"}}},
+			{Code: `var x = { afoob: function() {}  }`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "foo"}}},
+			{Code: `var x = { afoob: function() {}  }`, Options: []any{"always", map[string]any{"methodsIgnorePattern": "^.foo.$"}}},
+
+			// avoidQuotes
+			{Code: `var x = {'a': function(){}}`, Options: []any{"always", map[string]any{"avoidQuotes": true}}},
+			{Code: `var x = {['a']: function(){}}`, Options: []any{"methods", map[string]any{"avoidQuotes": true}}},
+			{Code: `var x = {'y': y}`, Options: []any{"properties", map[string]any{"avoidQuotes": true}}},
+
+			// consistent
+			{Code: `var x = {a: a, b: b}`, Options: []any{"consistent"}},
+			{Code: `var x = {a: b, c: d, f: g}`, Options: []any{"consistent"}},
+			{Code: `var x = {a, b}`, Options: []any{"consistent"}},
+			{Code: `var x = {a, b, get test() { return 1; }}`, Options: []any{"consistent"}},
+
+			// consistent-as-needed
+			{Code: `var x = {a, b}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {0: 'foo'}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {'key': 'baz'}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {foo: 'foo'}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {[foo]: foo}`, Options: []any{"consistent-as-needed"}},
+			{Code: `var x = {foo: function foo() {}}`, Options: []any{"consistent-as-needed"}},
+
+			// avoidExplicitReturnArrows
+			{Code: `({ x: () => foo })`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": false}}},
+			{Code: `({ x: () => foo })`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `({ x() { return; } })`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `({ x: () => { this; } })`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+			{Code: `function foo() { ({ x: () => { arguments; } }) }`, Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}}},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				Code:   `var x = {x: x}`,
+				Output: []string{`var x = {x}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var x = {'x': x}`,
+				Output: []string{`var x = {x}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var x = {y: y, x: x}`,
+				Output: []string{`var x = {y, x}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10},
+					{MessageId: "expectedPropertyShorthand", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `var x = {y: function() {}}`,
+				Output: []string{`var x = {y() {}}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `var x = {y: function*() {}}`,
+				Output: []string{`var x = {*y() {}}`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			{
+				Code:   `doSomething({x: x})`,
+				Output: []string{`doSomething({x})`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `doSomething({y: function() {}})`,
+				Output: []string{`doSomething({y() {}})`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 14}},
+			},
+			{
+				Code:   `doSomething({[y]: function() {}})`,
+				Output: []string{`doSomething({[y]() {}})`},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 14}},
+			},
+			// `options: ["never"]`
+			{
+				Code:    `var x = {y() {}}`,
+				Output:  []string{`var x = {y: function() {}}`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodLongform", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `var x = {*y() {}}`,
+				Output:  []string{`var x = {y: function*() {}}`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodLongform", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `var x = {y}`,
+				Output:  []string{`var x = {y: y}`},
+				Options: []any{"never"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyLongform", Line: 1, Column: 10}},
+			},
+			// properties option
+			{
+				Code:    `var x = {x: x}`,
+				Output:  []string{`var x = {x}`},
+				Options: []any{"properties"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedPropertyShorthand", Line: 1, Column: 10}},
+			},
+			// methods option
+			{
+				Code:    `var x = {y: function() {}}`,
+				Output:  []string{`var x = {y() {}}`},
+				Options: []any{"methods"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			// avoidQuotes
+			{
+				Code:    `var x = {a: function(){}}`,
+				Output:  []string{`var x = {a(){}}`},
+				Options: []any{"methods", map[string]any{"avoidQuotes": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 10}},
+			},
+			{
+				Code:    `var x = {'a'(){}}`,
+				Output:  []string{`var x = {'a': function(){}}`},
+				Options: []any{"always", map[string]any{"avoidQuotes": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedLiteralMethodLongform", Line: 1, Column: 10}},
+			},
+			// consistent
+			{
+				Code:    `var x = {a: a, b}`,
+				Options: []any{"consistent"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedMix", Line: 1, Column: 9}},
+			},
+			// consistent-as-needed
+			{
+				Code:    `var x = {a: a, b: b}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedAllPropertiesShorthanded", Line: 1, Column: 9}},
+			},
+			{
+				Code:    `var x = {a, z: function z(){}}`,
+				Options: []any{"consistent-as-needed"},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedMix", Line: 1, Column: 9}},
+			},
+			// avoidExplicitReturnArrows
+			{
+				Code:    `({ x: () => { return; } })`,
+				Output:  []string{`({ x() { return; } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+			{
+				Code:    `({ x: foo => { return; } })`,
+				Output:  []string{`({ x(foo) { return; } })`},
+				Options: []any{"always", map[string]any{"avoidExplicitReturnArrows": true}},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "expectedMethodShorthand", Line: 1, Column: 4}},
+			},
+		},
+	)
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -162,22 +162,22 @@ func Flatten[T any](array [][]T) []T {
 }
 
 // IsConstructorName reports whether `name` follows the ESLint constructor
-// naming convention: the first character that is not `_`, `$`, or a digit is
-// uppercase. Names consisting only of `_`, `$` and digits (e.g. `_`, `$$`,
-// `_8`) are not treated as constructors.
+// naming convention: the first character that is not `_`, `$`, or an ASCII
+// digit is uppercase. Names consisting only of `_`, `$` and ASCII digits
+// (e.g. `_`, `$$`, `_8`) are not treated as constructors.
 //
 // Matches the `isConstructor` helper used by ESLint's `new-cap` and
-// `object-shorthand` rules.
+// `object-shorthand` rules, including Unicode identifier characters
+// (e.g. `Π`). ESLint's regex `/[^_$0-9]/u` pairs an ASCII-only digit range
+// with a Unicode-aware `toUpperCase()` check — we mirror that: the digit
+// prefix is strictly ASCII while the case test is `unicode.IsUpper`.
 func IsConstructorName(name string) bool {
-	for i := range len(name) {
-		c := name[i]
-		if c == '_' || c == '$' || (c >= '0' && c <= '9') {
+	for _, r := range name {
+		if r == '_' || r == '$' || (r >= '0' && r <= '9') {
 			continue
 		}
-		// First non-prefix character: constructor iff uppercase.
-		upper := strings.ToUpper(string(c))
-		lower := strings.ToLower(string(c))
-		return upper != lower && string(c) == upper
+		// First non-prefix rune: constructor iff uppercase.
+		return unicode.IsUpper(r)
 	}
 	return false
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -161,6 +161,27 @@ func Flatten[T any](array [][]T) []T {
 	return result
 }
 
+// IsConstructorName reports whether `name` follows the ESLint constructor
+// naming convention: the first character that is not `_`, `$`, or a digit is
+// uppercase. Names consisting only of `_`, `$` and digits (e.g. `_`, `$$`,
+// `_8`) are not treated as constructors.
+//
+// Matches the `isConstructor` helper used by ESLint's `new-cap` and
+// `object-shorthand` rules.
+func IsConstructorName(name string) bool {
+	for i := range len(name) {
+		c := name[i]
+		if c == '_' || c == '$' || (c >= '0' && c <= '9') {
+			continue
+		}
+		// First non-prefix character: constructor iff uppercase.
+		upper := strings.ToUpper(string(c))
+		lower := strings.ToLower(string(c))
+		return upper != lower && string(c) == upper
+	}
+	return false
+}
+
 func IncludesModifier(node interface{ Modifiers() *ast.ModifierList }, modifier ast.Kind) bool {
 	modifiers := node.Modifiers()
 	if modifiers == nil {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -92,3 +92,61 @@ func TestNaturalCompare(t *testing.T) {
 		}
 	}
 }
+
+func TestIsConstructorName(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// ── ASCII constructor forms ──
+		{"Foo", true},
+		{"FooBar", true},
+		{"_Foo", true},
+		{"$Foo", true},
+		{"__Foo", true},
+		{"_0Foo", true},
+		{"$_Foo", true},
+		{"____Foo", true},
+
+		// ── ASCII non-constructor forms ──
+		{"foo", false},
+		{"fooBar", false},
+		{"_foo", false},
+		{"$foo", false},
+		{"_0foo", false},
+
+		// ── All-prefix → not a constructor ──
+		{"", false},
+		{"_", false},
+		{"$", false},
+		{"$$", false},
+		{"_8", false},
+		{"_0$_", false},
+
+		// ── Unicode uppercase identifiers → constructor ──
+		// Greek capital Pi; verifies rune-aware iteration.
+		{"Πfoo", true},
+		{"_Πfoo", true},
+		// Cyrillic capital "Д".
+		{"Дelta", true},
+		// Latin Extended capital "Ǆ".
+		{"ǄName", true},
+
+		// ── Unicode lowercase identifiers → not constructor ──
+		{"πfoo", false},
+		{"_πfoo", false},
+		{"дelta", false},
+
+		// ── Non-ASCII digits are NOT stripped as prefix (matches ESLint's
+		// `[0-9]` which only accepts ASCII 0–9). An Arabic-Indic digit at
+		// the start is the first non-prefix rune and `unicode.IsUpper`
+		// returns false for it → not a constructor.
+		{"٠Foo", false},
+	}
+	for _, tt := range tests {
+		got := IsConstructorName(tt.name)
+		if got != tt.want {
+			t.Errorf("IsConstructorName(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -262,6 +262,7 @@ export default defineConfig({
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
+    './tests/eslint/rules/object-shorthand.test.ts',
     './tests/eslint/rules/no-octal-escape.test.ts',
     './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/object-shorthand.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/object-shorthand.test.ts.snap
@@ -1,0 +1,692 @@
+// Rstest Snapshot v1
+
+exports[`object-shorthand > invalid 1`] = `
+{
+  "code": "var x = {x: x}",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 2`] = `
+{
+  "code": "var x = {'x': x}",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 3`] = `
+{
+  "code": "var x = {y: y, x: x}",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 4`] = `
+{
+  "code": "var x = {y: function() {}}",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 5`] = `
+{
+  "code": "var x = {y: function*() {}}",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 6`] = `
+{
+  "code": "doSomething({x: x})",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 7`] = `
+{
+  "code": "doSomething({y: function() {}})",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 8`] = `
+{
+  "code": "doSomething({[y]: function() {}})",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 9`] = `
+{
+  "code": "var x = {y() {}}",
+  "diagnostics": [
+    {
+      "message": "Expected longform method syntax.",
+      "messageId": "expectedMethodLongform",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 10`] = `
+{
+  "code": "var x = {*y() {}}",
+  "diagnostics": [
+    {
+      "message": "Expected longform method syntax.",
+      "messageId": "expectedMethodLongform",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 11`] = `
+{
+  "code": "var x = {y}",
+  "diagnostics": [
+    {
+      "message": "Expected longform property syntax.",
+      "messageId": "expectedPropertyLongform",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 12`] = `
+{
+  "code": "var x = {x: x}",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 13`] = `
+{
+  "code": "var x = {y: function() {}}",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 14`] = `
+{
+  "code": "var x = {a: function(){}}",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 15`] = `
+{
+  "code": "var x = {'a'(){}}",
+  "diagnostics": [
+    {
+      "message": "Expected longform method syntax for string literal keys.",
+      "messageId": "expectedLiteralMethodLongform",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 16`] = `
+{
+  "code": "var x = {a: a, b}",
+  "diagnostics": [
+    {
+      "message": "Unexpected mix of shorthand and non-shorthand properties.",
+      "messageId": "unexpectedMix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 17`] = `
+{
+  "code": "var x = {a: a, b: b}",
+  "diagnostics": [
+    {
+      "message": "Expected shorthand for all properties.",
+      "messageId": "expectedAllPropertiesShorthanded",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 18`] = `
+{
+  "code": "var x = {a, z: function z(){}}",
+  "diagnostics": [
+    {
+      "message": "Unexpected mix of shorthand and non-shorthand properties.",
+      "messageId": "unexpectedMix",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 19`] = `
+{
+  "code": "({ x: () => { return; } })",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 20`] = `
+{
+  "code": "({ x: foo => { return; } })",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 21`] = `
+{
+  "code": "({ x: (foo = 1) => { return; } })",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 22`] = `
+{
+  "code": "var x = {a: (a)}",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 23`] = `
+{
+  "code": "var x = {a: (((a)))}",
+  "diagnostics": [
+    {
+      "message": "Expected property shorthand.",
+      "messageId": "expectedPropertyShorthand",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 24`] = `
+{
+  "code": "var x = {a: (function(){ return 1 })}",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 25`] = `
+{
+  "code": "({ a: (() => { return 1 }) })",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`object-shorthand > invalid 26`] = `
+{
+  "code": "({ x: () => { arguments } })",
+  "diagnostics": [
+    {
+      "message": "Expected method shorthand.",
+      "messageId": "expectedMethodShorthand",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "object-shorthand",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/object-shorthand.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/object-shorthand.test.ts
@@ -1,0 +1,299 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('object-shorthand', {
+  valid: [
+    'var x = {y() {}}',
+    'var x = {y}',
+    'var x = {a: b}',
+    `var x = {a: 'a'}`,
+    `var x = {'a': 'a'}`,
+    `var x = {'a': b}`,
+    'var x = {y(x) {}}',
+    'var {x,y,z} = x',
+    'var {x: {y}} = z',
+    'var x = {*x() {}}',
+    'var x = {x: y}',
+    'var x = {x: y, y: z}',
+    'var x = {x() {}, y: z, l(){}}',
+    'var x = {[y]: y}',
+    'doSomething({x: y})',
+    'doSomething({y() {}})',
+    'doSomething({x: y, y() {}})',
+    '!{ a: function a(){} };',
+
+    // arrow functions are allowed by default
+    'var x = {y: (x)=>x}',
+    'doSomething({y: (x)=>x})',
+
+    // getters and setters
+    'var x = {get y() {}}',
+    'var x = {set y(z) {}}',
+    'var x = {get y() {}, set y(z) {}}',
+
+    // properties option
+    { code: 'var x = {[y]: y}', options: ['properties'] as any },
+    { code: `var x = {['y']: 'y'}`, options: ['properties'] as any },
+    { code: `var x = {['y']: y}`, options: ['properties'] as any },
+    { code: 'var x = {y}', options: ['properties'] as any },
+    { code: 'var x = {y: {b}}', options: ['properties'] as any },
+
+    // methods option
+    { code: 'var x = {[y]() {}}', options: ['methods'] as any },
+    { code: 'var x = {[y]: function x() {}}', options: ['methods'] as any },
+    { code: 'var x = {[y]: y}', options: ['methods'] as any },
+    { code: 'var x = {y() {}}', options: ['methods'] as any },
+    { code: 'var x = {x, y() {}, a:b}', options: ['methods'] as any },
+
+    // never
+    { code: 'var x = {a: n, c: d, f: g}', options: ['never'] as any },
+    { code: 'var x = {a: function(){}, b: {c: d}}', options: ['never'] as any },
+
+    // ignoreConstructors
+    {
+      code: 'var x = {ConstructorFunction: function(){}, a: b}',
+      options: ['always', { ignoreConstructors: true }] as any,
+    },
+    {
+      code: 'var x = {_ConstructorFunction: function(){}, a: b}',
+      options: ['always', { ignoreConstructors: true }] as any,
+    },
+    {
+      code: 'var x = {$ConstructorFunction: function(){}, a: b}',
+      options: ['always', { ignoreConstructors: true }] as any,
+    },
+    {
+      code: 'var x = {__ConstructorFunction: function(){}, a: b}',
+      options: ['always', { ignoreConstructors: true }] as any,
+    },
+    {
+      code: 'var x = {_0ConstructorFunction: function(){}, a: b}',
+      options: ['always', { ignoreConstructors: true }] as any,
+    },
+    {
+      code: 'var x = {notConstructorFunction(){}, b: c}',
+      options: ['always', { ignoreConstructors: true }] as any,
+    },
+
+    // methodsIgnorePattern
+    {
+      code: 'var x = { foo: function() {}  }',
+      options: ['always', { methodsIgnorePattern: '^foo$' }] as any,
+    },
+    {
+      code: `var x = { 'foo': function() {}  }`,
+      options: ['always', { methodsIgnorePattern: '^foo$' }] as any,
+    },
+    {
+      code: `var x = { ['foo']: function() {}  }`,
+      options: ['always', { methodsIgnorePattern: '^foo$' }] as any,
+    },
+    {
+      code: 'var x = { 123: function() {}  }',
+      options: ['always', { methodsIgnorePattern: '^123$' }] as any,
+    },
+    {
+      code: 'var x = { afoob: function() {}  }',
+      options: ['always', { methodsIgnorePattern: 'foo' }] as any,
+    },
+
+    // avoidQuotes
+    {
+      code: `var x = {'a': function(){}}`,
+      options: ['always', { avoidQuotes: true }] as any,
+    },
+    {
+      code: `var x = {['a']: function(){}}`,
+      options: ['methods', { avoidQuotes: true }] as any,
+    },
+    {
+      code: `var x = {'y': y}`,
+      options: ['properties', { avoidQuotes: true }] as any,
+    },
+
+    // consistent
+    { code: 'var x = {a: a, b: b}', options: ['consistent'] as any },
+    { code: 'var x = {a: b, c: d, f: g}', options: ['consistent'] as any },
+    { code: 'var x = {a, b}', options: ['consistent'] as any },
+    {
+      code: 'var x = {a, b, get test() { return 1; }}',
+      options: ['consistent'] as any,
+    },
+
+    // consistent-as-needed
+    { code: 'var x = {a, b}', options: ['consistent-as-needed'] as any },
+    { code: `var x = {0: 'foo'}`, options: ['consistent-as-needed'] as any },
+    {
+      code: `var x = {'key': 'baz'}`,
+      options: ['consistent-as-needed'] as any,
+    },
+    { code: `var x = {foo: 'foo'}`, options: ['consistent-as-needed'] as any },
+    { code: 'var x = {[foo]: foo}', options: ['consistent-as-needed'] as any },
+    {
+      code: 'var x = {foo: function foo() {}}',
+      options: ['consistent-as-needed'] as any,
+    },
+
+    // avoidExplicitReturnArrows
+    {
+      code: '({ x: () => foo })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+    },
+    {
+      code: '({ x() { return; } })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+    },
+    {
+      code: '({ x: () => { this; } })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+    },
+    {
+      code: 'function foo() { ({ x: () => { arguments; } }) }',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'var x = {x: x}',
+      errors: [{ messageId: 'expectedPropertyShorthand' }],
+    },
+    {
+      code: `var x = {'x': x}`,
+      errors: [{ messageId: 'expectedPropertyShorthand' }],
+    },
+    {
+      code: 'var x = {y: y, x: x}',
+      errors: [
+        { messageId: 'expectedPropertyShorthand' },
+        { messageId: 'expectedPropertyShorthand' },
+      ],
+    },
+    {
+      code: 'var x = {y: function() {}}',
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: 'var x = {y: function*() {}}',
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: 'doSomething({x: x})',
+      errors: [{ messageId: 'expectedPropertyShorthand' }],
+    },
+    {
+      code: 'doSomething({y: function() {}})',
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: 'doSomething({[y]: function() {}})',
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+
+    // never
+    {
+      code: 'var x = {y() {}}',
+      options: ['never'] as any,
+      errors: [{ messageId: 'expectedMethodLongform' }],
+    },
+    {
+      code: 'var x = {*y() {}}',
+      options: ['never'] as any,
+      errors: [{ messageId: 'expectedMethodLongform' }],
+    },
+    {
+      code: 'var x = {y}',
+      options: ['never'] as any,
+      errors: [{ messageId: 'expectedPropertyLongform' }],
+    },
+
+    // properties
+    {
+      code: 'var x = {x: x}',
+      options: ['properties'] as any,
+      errors: [{ messageId: 'expectedPropertyShorthand' }],
+    },
+
+    // methods
+    {
+      code: 'var x = {y: function() {}}',
+      options: ['methods'] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+
+    // avoidQuotes
+    {
+      code: 'var x = {a: function(){}}',
+      options: ['methods', { avoidQuotes: true }] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: `var x = {'a'(){}}`,
+      options: ['always', { avoidQuotes: true }] as any,
+      errors: [{ messageId: 'expectedLiteralMethodLongform' }],
+    },
+
+    // consistent
+    {
+      code: 'var x = {a: a, b}',
+      options: ['consistent'] as any,
+      errors: [{ messageId: 'unexpectedMix' }],
+    },
+
+    // consistent-as-needed
+    {
+      code: 'var x = {a: a, b: b}',
+      options: ['consistent-as-needed'] as any,
+      errors: [{ messageId: 'expectedAllPropertiesShorthanded' }],
+    },
+    {
+      code: 'var x = {a, z: function z(){}}',
+      options: ['consistent-as-needed'] as any,
+      errors: [{ messageId: 'unexpectedMix' }],
+    },
+
+    // avoidExplicitReturnArrows
+    {
+      code: '({ x: () => { return; } })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: '({ x: foo => { return; } })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: '({ x: (foo = 1) => { return; } })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+
+    // Parenthesized values (tsgo preserves ParenthesizedExpression).
+    {
+      code: 'var x = {a: (a)}',
+      errors: [{ messageId: 'expectedPropertyShorthand' }],
+    },
+    {
+      code: 'var x = {a: (((a)))}',
+      errors: [{ messageId: 'expectedPropertyShorthand' }],
+    },
+    {
+      code: 'var x = {a: (function(){ return 1 })}',
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+    {
+      code: '({ a: (() => { return 1 }) })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+
+    // `arguments` at module scope is NOT a lexical identifier (no enclosing
+    // function provides it). Arrow must still be convertible.
+    {
+      code: '({ x: () => { arguments } })',
+      options: ['always', { avoidExplicitReturnArrows: true }] as any,
+      errors: [{ messageId: 'expectedMethodShorthand' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,6 +1,7 @@
 # Custom Dictionary Words
 aavascript
 accum
+afoob
 anee
 arraybindingpattern
 arrayish

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -198,3 +198,7 @@ xdescribe
 xitiViewMap
 xjavascript
 xtest
+Πfoo
+πfoo
+Дelta
+дelta


### PR DESCRIPTION
## Summary

Port the [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand) rule from ESLint to rslint.

The rule enforces (or disallows) ES6 shorthand syntax for object-literal methods and properties. All six option modes and four additional flags are supported:

- Modes: `"always"` (default), `"methods"`, `"properties"`, `"never"`, `"consistent"`, `"consistent-as-needed"`
- Flags: `avoidQuotes`, `ignoreConstructors`, `methodsIgnorePattern`, `avoidExplicitReturnArrows`

Highlights of the Go implementation:

- AST-level scope tracking for `this` / `super` / `new.target` / `arguments` so `avoidExplicitReturnArrows` preserves arrow functions whose semantics would change after conversion to methods.
- Full shadow-resolution for `arguments` (block-scoped `let` / `const` / `using`, `for (let arguments …)`, `catch (arguments)`) — matches ESLint's scope-manager semantics without requiring a dedicated scope analysis pass.
- Unwraps tsgo-only `ParenthesizedExpression` via `ast.SkipParentheses` so `{a: (a)}`, `{a: (function(){})}` and `({a: (() => {…})})` all report / autofix correctly.
- JSDoc `@type` detection follows ESLint's two-branch behavior (tolerant `/^\s*\*/` for Identifier keys, strict `startsWith(\"*\")` for StringLiteral keys).
- Autofix preserves TypeScript syntax: generics, parameter / return types, default values, async/generator modifiers, destructuring patterns.

Behavior validated against ESLint's reference implementation on real-world codebases: identical reports (file / line / column / messageId) across rsbuild (3 findings) and rspack (25 findings).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/object-shorthand
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/object-shorthand.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).