### PR TITLE
feat: port rule guard-for-in

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,6 +116,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/eqeqeq"
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
+	"github.com/web-infra-dev/rslint/internal/rules/guard_for_in"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
@@ -517,6 +518,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("default-case-last", default_case_last.DefaultCaseLastRule)
 	GlobalRuleRegistry.Register("for-direction", for_direction.ForDirectionRule)
 	GlobalRuleRegistry.Register("getter-return", getter_return.GetterReturnRule)
+	GlobalRuleRegistry.Register("guard-for-in", guard_for_in.GuardForInRule)
 	GlobalRuleRegistry.Register("no-alert", no_alert.NoAlertRule)
 	GlobalRuleRegistry.Register("no-async-promise-executor", no_async_promise_executor.NoAsyncPromiseExecutorRule)
 	GlobalRuleRegistry.Register("no-await-in-loop", no_await_in_loop.NoAwaitInLoopRule)

--- a/internal/rules/guard_for_in/guard_for_in.go
+++ b/internal/rules/guard_for_in/guard_for_in.go
@@ -1,0 +1,69 @@
+package guard_for_in
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/guard-for-in
+var GuardForInRule = rule.Rule{
+	Name: "guard-for-in",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindForInStatement: func(node *ast.Node) {
+				if isGuarded(node.AsForInOrOfStatement().Statement) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "wrap",
+					Description: "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+				})
+			},
+		}
+	},
+}
+
+// isGuarded mirrors ESLint's accepted shapes for a for-in body: an empty/if
+// statement, an empty block, a block whose first statement is an `if`, and the
+// `if (...) continue;` short-circuit (direct or wrapped in a single-statement
+// block) that filters unwanted keys before the rest of the body runs.
+func isGuarded(body *ast.Node) bool {
+	if body == nil {
+		return false
+	}
+	switch body.Kind {
+	case ast.KindEmptyStatement, ast.KindIfStatement:
+		return true
+	case ast.KindBlock:
+		statements := body.AsBlock().Statements.Nodes
+		if len(statements) == 0 {
+			return true
+		}
+		first := statements[0]
+		if first.Kind != ast.KindIfStatement {
+			return false
+		}
+		if len(statements) == 1 {
+			return true
+		}
+		return isContinueGuard(first.AsIfStatement().ThenStatement)
+	}
+	return false
+}
+
+// isContinueGuard reports whether `consequent` is a `continue` (or a block
+// containing only a `continue`), which means later body statements run only for
+// keys that pass the `if` check.
+func isContinueGuard(consequent *ast.Node) bool {
+	if consequent == nil {
+		return false
+	}
+	if consequent.Kind == ast.KindContinueStatement {
+		return true
+	}
+	if consequent.Kind == ast.KindBlock {
+		statements := consequent.AsBlock().Statements.Nodes
+		return len(statements) == 1 && statements[0].Kind == ast.KindContinueStatement
+	}
+	return false
+}

--- a/internal/rules/guard_for_in/guard_for_in.md
+++ b/internal/rules/guard_for_in/guard_for_in.md
@@ -1,0 +1,38 @@
+# guard-for-in
+
+## Rule Details
+
+Require `for-in` loops to include an `if` statement. Iterating a `for-in` loop over an object exposes inherited prototype properties in addition to the object's own keys, so the body should typically be guarded (e.g. with `Object.hasOwn`, `Object.prototype.hasOwnProperty.call`, or a short-circuit `continue`) to filter unwanted properties.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+for (key in foo) {
+  doSomething(key);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+for (key in foo) {
+  if (Object.hasOwn(foo, key)) {
+    doSomething(key);
+  }
+}
+
+for (key in foo) {
+  if (Object.prototype.hasOwnProperty.call(foo, key)) {
+    doSomething(key);
+  }
+}
+
+for (key in foo) {
+  if (!Object.hasOwn(foo, key)) continue;
+  doSomething(key);
+}
+```
+
+## Original Documentation
+
+- https://eslint.org/docs/latest/rules/guard-for-in

--- a/internal/rules/guard_for_in/guard_for_in_test.go
+++ b/internal/rules/guard_for_in/guard_for_in_test.go
@@ -1,0 +1,301 @@
+package guard_for_in
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestGuardForInRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&GuardForInRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			// ================================================================
+			// ESLint upstream valid cases
+			// ================================================================
+			{Code: `for (var x in o);`},
+			{Code: `for (var x in o) {}`},
+			{Code: `for (var x in o) if (x) f();`},
+			{Code: `for (var x in o) { if (x) { f(); } }`},
+			{Code: `for (var x in o) { if (x) continue; f(); }`},
+			{Code: `for (var x in o) { if (x) { continue; } f(); }`},
+
+			// ================================================================
+			// Declaration forms
+			// ================================================================
+			{Code: `for (let x in o) if (x) f();`},
+			{Code: `for (const x in o) if (x) f();`},
+			{Code: `for (x in o) if (x) f();`},
+
+			// ================================================================
+			// Destructuring initializer (body shape is what matters)
+			// ================================================================
+			{Code: `for (const { a } in o) if (a) f();`},
+			{Code: `for (const [a, b] in o) if (a) f();`},
+
+			// ================================================================
+			// Labeled continue still counts as a continue-guard
+			// ================================================================
+			{Code: `outer: for (var x in o) { if (x) continue outer; f(); }`},
+			{Code: `outer: for (var x in o) { if (x) { continue outer; } f(); }`},
+
+			// ================================================================
+			// If-else: ESLint only inspects consequent. A continue-consequent
+			// guards the rest of the body even when an else branch is present.
+			// ================================================================
+			{Code: `for (var x in o) { if (x) continue; else f(); g(); }`},
+			{Code: `for (var x in o) { if (x) { continue; } else { f(); } g(); }`},
+
+			// ================================================================
+			// for-of must never be flagged (separate AST kind)
+			// ================================================================
+			{Code: `for (const x of arr) f();`},
+			{Code: `for (const x of arr) { f(); g(); }`},
+
+			// ================================================================
+			// Nested for-in, both guarded
+			// ================================================================
+			{Code: `for (var x in o) { if (x) continue; for (var y in o2) if (y) g(); }`},
+			{Code: `for (var x in o) if (x) { for (var y in o2) if (y) g(); }`},
+
+			// ================================================================
+			// Wrapped in various scope contexts — rule fires per for-in
+			// regardless of enclosing scope.
+			// ================================================================
+			{Code: `function f() { for (var x in o) if (x) g(); }`},
+			{Code: `const f = () => { for (var x in o) if (x) g(); }`},
+			{Code: `class A { static { for (var x in o) if (x) g(); } }`},
+			{Code: `class A { m() { for (var x in o) if (x) g(); } }`},
+			{Code: `(function () { for (var x in o) if (x) g(); })();`},
+
+			// ================================================================
+			// Block with only empty if (still matches "block with just if")
+			// ================================================================
+			{Code: `for (var x in o) { if (x); }`},
+
+			// ================================================================
+			// Comments between tokens are trivia — body shape unchanged
+			// ================================================================
+			{Code: `for (var x in o) /* c */ if (x) f();`},
+			{Code: `for (var x in o) { /* c1 */ if (x) /* c2 */ continue; /* c3 */ f(); }`},
+
+			// ================================================================
+			// TypeScript expressions on the iterated value don't affect body
+			// ================================================================
+			{Code: `for (var x in (o)) if (x) f();`},
+			{Code: `for (var x in o!) if (x) f();`},
+			{Code: `for (var x in o as any) if (x) f();`},
+
+			// ================================================================
+			// 3-level nesting, every level guarded
+			// ================================================================
+			{Code: `for (var a in x) { if (a) continue; for (var b in y) { if (b) continue; for (var c in z) if (c) g(); } }`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			// ================================================================
+			// ESLint upstream invalid cases
+			// ================================================================
+			{
+				Code: `for (var x in o) { if (x) { f(); continue; } g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) { if (x) { continue; f(); } g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) { if (x) { f(); } g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) { if (x) f(); g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) { foo() }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Single-statement body that isn't EmptyStatement/IfStatement
+			// ================================================================
+			{
+				Code: `for (var x in o) throw x;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) for (var y in o2) g();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+					{MessageId: "wrap", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `for (var x in o) lbl: continue;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Block variants that must NOT count as guarded
+			// ================================================================
+			{
+				// First statement is not an IfStatement
+				Code: `for (var x in o) { f(); if (x) continue; g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// First statement is an empty statement, not an if
+				Code: `for (var x in o) { ; if (x) continue; f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// First statement is a block, not an if
+				Code: `for (var x in o) { { if (x) continue; } f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// If-consequent is an EmptyStatement, not a continue
+				Code: `for (var x in o) { if (x); f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// If-consequent is an expression, not a continue
+				Code: `for (var x in o) { if (x) f(); else continue; g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// If-consequent is a multi-statement block
+				Code: `for (var x in o) { if (x) { continue; continue; } f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Nested: only the unguarded loop should be reported
+			// ================================================================
+			{
+				// Outer guarded, inner unguarded → inner only
+				Code: `for (var x in o) { if (x) continue; for (var y in o2) g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 37},
+				},
+			},
+			{
+				// Outer unguarded, inner guarded → outer only
+				Code: `for (var x in o) { for (var y in o2) if (y) g(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// Both unguarded → two reports
+				Code: `for (var x in o) { for (var y in o2) { g(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+					{MessageId: "wrap", Line: 1, Column: 20},
+				},
+			},
+
+			// ================================================================
+			// Multi-line: line/column must reflect the `for` keyword position
+			// ================================================================
+			{
+				Code: "function run() {\n  for (var x in o) {\n    bar();\n  }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 2, Column: 3},
+				},
+			},
+
+			// ================================================================
+			// Block first statement is not an IfStatement
+			// ================================================================
+			{
+				// VariableStatement first
+				Code: `for (var x in o) { var y = 1; if (x) continue; f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				// LabeledStatement wrapping an If — still not a plain IfStatement
+				Code: `for (var x in o) { lbl: if (x) continue; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// IfStatement with an empty-block consequent — not a continue-guard
+			// ================================================================
+			{
+				Code: `for (var x in o) { if (x) {} else { continue; } f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// Non-If/Empty single-statement bodies
+			// ================================================================
+			{
+				Code: `for (var x in o) switch (x) { case 1: f(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `for (var x in o) do f(); while (false);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 1},
+				},
+			},
+
+			// ================================================================
+			// 3-level nested for-in where only the deepest is unguarded
+			// ================================================================
+			{
+				Code: `for (var a in x) { if (a) continue; for (var b in y) { if (b) continue; for (var c in z) { g(); } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "wrap", Line: 1, Column: 73},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -38,6 +38,7 @@ export default defineConfig({
     './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/no-iterator.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
+    './tests/eslint/rules/guard-for-in.test.ts',
     './tests/eslint/rules/no-loss-of-precision.test.ts',
     './tests/eslint/rules/no-ex-assign.test.ts',
     './tests/eslint/rules/no-constant-binary-expression.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/guard-for-in.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/guard-for-in.test.ts.snap
@@ -1,0 +1,685 @@
+// Rstest Snapshot v1
+
+exports[`guard-for-in > invalid 1`] = `
+{
+  "code": "for (var x in o) { if (x) { f(); continue; } g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 2`] = `
+{
+  "code": "for (var x in o) { if (x) { continue; f(); } g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 3`] = `
+{
+  "code": "for (var x in o) { if (x) { f(); } g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 4`] = `
+{
+  "code": "for (var x in o) { if (x) f(); g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 5`] = `
+{
+  "code": "for (var x in o) { foo() }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 6`] = `
+{
+  "code": "for (var x in o) foo();",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 7`] = `
+{
+  "code": "for (var x in o) throw x;",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 8`] = `
+{
+  "code": "for (var x in o) for (var y in o2) g();",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 9`] = `
+{
+  "code": "for (var x in o) lbl: continue;",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 10`] = `
+{
+  "code": "for (var x in o) { f(); if (x) continue; g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 11`] = `
+{
+  "code": "for (var x in o) { ; if (x) continue; f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 12`] = `
+{
+  "code": "for (var x in o) { { if (x) continue; } f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 13`] = `
+{
+  "code": "for (var x in o) { if (x); f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 14`] = `
+{
+  "code": "for (var x in o) { if (x) f(); else continue; g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 15`] = `
+{
+  "code": "for (var x in o) { if (x) { continue; continue; } f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 16`] = `
+{
+  "code": "for (var x in o) { if (x) continue; for (var y in o2) g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 17`] = `
+{
+  "code": "for (var x in o) { for (var y in o2) if (y) g(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 18`] = `
+{
+  "code": "for (var x in o) { for (var y in o2) { g(); } }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 19`] = `
+{
+  "code": "function run() {
+  for (var x in o) {
+    bar();
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 20`] = `
+{
+  "code": "for (var x in o) { var y = 1; if (x) continue; f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 21`] = `
+{
+  "code": "for (var x in o) { lbl: if (x) continue; }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 22`] = `
+{
+  "code": "for (var x in o) { if (x) {} else { continue; } f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 23`] = `
+{
+  "code": "for (var x in o) switch (x) { case 1: f(); }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 24`] = `
+{
+  "code": "for (var x in o) do f(); while (false);",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`guard-for-in > invalid 25`] = `
+{
+  "code": "for (var a in x) { if (a) continue; for (var b in y) { if (b) continue; for (var c in z) { g(); } } }",
+  "diagnostics": [
+    {
+      "message": "The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 98,
+          "line": 1,
+        },
+        "start": {
+          "column": 73,
+          "line": 1,
+        },
+      },
+      "ruleName": "guard-for-in",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/guard-for-in.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/guard-for-in.test.ts
@@ -1,0 +1,231 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('guard-for-in', {
+  valid: [
+    // ================================================================
+    // ESLint upstream valid cases
+    // ================================================================
+    'for (var x in o);',
+    'for (var x in o) {}',
+    'for (var x in o) if (x) f();',
+    'for (var x in o) { if (x) { f(); } }',
+    'for (var x in o) { if (x) continue; f(); }',
+    'for (var x in o) { if (x) { continue; } f(); }',
+
+    // ================================================================
+    // Declaration forms
+    // ================================================================
+    'for (let x in o) if (x) f();',
+    'for (const x in o) if (x) f();',
+    'for (x in o) if (x) f();',
+
+    // ================================================================
+    // Destructuring initializer (body shape is what matters)
+    // ================================================================
+    'for (const { a } in o) if (a) f();',
+    'for (const [a, b] in o) if (a) f();',
+
+    // ================================================================
+    // Labeled continue still counts as a continue-guard
+    // ================================================================
+    'outer: for (var x in o) { if (x) continue outer; f(); }',
+    'outer: for (var x in o) { if (x) { continue outer; } f(); }',
+
+    // ================================================================
+    // If-else: ESLint only inspects consequent. A continue-consequent
+    // guards the rest of the body even when an else branch is present.
+    // ================================================================
+    'for (var x in o) { if (x) continue; else f(); g(); }',
+    'for (var x in o) { if (x) { continue; } else { f(); } g(); }',
+
+    // ================================================================
+    // for-of must never be flagged (separate AST kind)
+    // ================================================================
+    'for (const x of arr) f();',
+    'for (const x of arr) { f(); g(); }',
+
+    // ================================================================
+    // Nested for-in, both guarded
+    // ================================================================
+    'for (var x in o) { if (x) continue; for (var y in o2) if (y) g(); }',
+    'for (var x in o) if (x) { for (var y in o2) if (y) g(); }',
+
+    // ================================================================
+    // Wrapped in various scope contexts — rule fires per for-in
+    // regardless of enclosing scope.
+    // ================================================================
+    'function f() { for (var x in o) if (x) g(); }',
+    'const f = () => { for (var x in o) if (x) g(); }',
+    'class A { static { for (var x in o) if (x) g(); } }',
+    'class A { m() { for (var x in o) if (x) g(); } }',
+    '(function () { for (var x in o) if (x) g(); })();',
+
+    // ================================================================
+    // Block with only empty if (still matches "block with just if")
+    // ================================================================
+    'for (var x in o) { if (x); }',
+
+    // ================================================================
+    // Comments between tokens are trivia — body shape unchanged
+    // ================================================================
+    'for (var x in o) /* c */ if (x) f();',
+    'for (var x in o) { /* c1 */ if (x) /* c2 */ continue; /* c3 */ f(); }',
+
+    // ================================================================
+    // TypeScript expressions on the iterated value don't affect body
+    // ================================================================
+    'for (var x in (o)) if (x) f();',
+    'for (var x in o!) if (x) f();',
+    'for (var x in o as any) if (x) f();',
+
+    // ================================================================
+    // 3-level nesting, every level guarded
+    // ================================================================
+    'for (var a in x) { if (a) continue; for (var b in y) { if (b) continue; for (var c in z) if (c) g(); } }',
+  ],
+  invalid: [
+    // ================================================================
+    // ESLint upstream invalid cases
+    // ================================================================
+    {
+      code: 'for (var x in o) { if (x) { f(); continue; } g(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { if (x) { continue; f(); } g(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { if (x) { f(); } g(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { if (x) f(); g(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { foo() }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) foo();',
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // ================================================================
+    // Single-statement body that isn't EmptyStatement/IfStatement
+    // ================================================================
+    {
+      code: 'for (var x in o) throw x;',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) for (var y in o2) g();',
+      errors: [
+        { messageId: 'wrap', line: 1, column: 1 },
+        { messageId: 'wrap', line: 1, column: 18 },
+      ],
+    },
+    {
+      code: 'for (var x in o) lbl: continue;',
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // ================================================================
+    // Block variants that must NOT count as guarded
+    // ================================================================
+    {
+      code: 'for (var x in o) { f(); if (x) continue; g(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { ; if (x) continue; f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { { if (x) continue; } f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { if (x); f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { if (x) f(); else continue; g(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { if (x) { continue; continue; } f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // ================================================================
+    // Nested: only the unguarded loop should be reported
+    // ================================================================
+    {
+      code: 'for (var x in o) { if (x) continue; for (var y in o2) g(); }',
+      errors: [{ messageId: 'wrap', line: 1, column: 37 }],
+    },
+    {
+      code: 'for (var x in o) { for (var y in o2) if (y) g(); }',
+      errors: [{ messageId: 'wrap', line: 1, column: 1 }],
+    },
+    {
+      code: 'for (var x in o) { for (var y in o2) { g(); } }',
+      errors: [
+        { messageId: 'wrap', line: 1, column: 1 },
+        { messageId: 'wrap', line: 1, column: 20 },
+      ],
+    },
+
+    // ================================================================
+    // Multi-line: line/column must reflect the `for` keyword position
+    // ================================================================
+    {
+      code: 'function run() {\n  for (var x in o) {\n    bar();\n  }\n}',
+      errors: [{ messageId: 'wrap', line: 2, column: 3 }],
+    },
+
+    // ================================================================
+    // Block first statement is not an IfStatement
+    // ================================================================
+    {
+      code: 'for (var x in o) { var y = 1; if (x) continue; f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) { lbl: if (x) continue; }',
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // ================================================================
+    // IfStatement with an empty-block consequent — not a continue-guard
+    // ================================================================
+    {
+      code: 'for (var x in o) { if (x) {} else { continue; } f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // ================================================================
+    // Non-If/Empty single-statement bodies
+    // ================================================================
+    {
+      code: 'for (var x in o) switch (x) { case 1: f(); }',
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'for (var x in o) do f(); while (false);',
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // ================================================================
+    // 3-level nested for-in where only the deepest is unguarded
+    // ================================================================
+    {
+      code: 'for (var a in x) { if (a) continue; for (var b in y) { if (b) continue; for (var c in z) { g(); } } }',
+      errors: [{ messageId: 'wrap', line: 1, column: 73 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `guard-for-in` rule from ESLint to rslint.

Require `for-in` loops to include an `if` statement filtering inherited prototype properties. The Go implementation mirrors every early-return branch of ESLint's upstream rule (empty statement, if statement, empty block, single-if block, and `if (...) continue;` short-circuit — direct or wrapped in a single-statement block), reports on the whole `ForInStatement` node, and uses the upstream `wrap` messageId and message text unchanged.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/guard-for-in
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/guard-for-in.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).