### PR TITLE
feat: port rule no-bitwise

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
+	"github.com/web-infra-dev/rslint/internal/rules/no_bitwise"
 	"github.com/web-infra-dev/rslint/internal/rules/no_caller"
 	"github.com/web-infra-dev/rslint/internal/rules/no_case_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_class_assign"
@@ -520,6 +521,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-alert", no_alert.NoAlertRule)
 	GlobalRuleRegistry.Register("no-async-promise-executor", no_async_promise_executor.NoAsyncPromiseExecutorRule)
 	GlobalRuleRegistry.Register("no-await-in-loop", no_await_in_loop.NoAwaitInLoopRule)
+	GlobalRuleRegistry.Register("no-bitwise", no_bitwise.NoBitwiseRule)
 	GlobalRuleRegistry.Register("no-caller", no_caller.NoCallerRule)
 	GlobalRuleRegistry.Register("no-case-declarations", no_case_declarations.NoCaseDeclarationsRule)
 	GlobalRuleRegistry.Register("no-class-assign", no_class_assign.NoClassAssignRule)

--- a/internal/rules/no_bitwise/no_bitwise.go
+++ b/internal/rules/no_bitwise/no_bitwise.go
@@ -1,0 +1,131 @@
+package no_bitwise
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// bitwiseOperatorKinds is the set of AST token kinds that represent bitwise
+// operators (both binary forms like `|`, `<<` and their assignment variants,
+// plus the unary `~`). Membership is all the rule needs — the string form
+// of the operator is produced on demand via scanner.TokenToString.
+var bitwiseOperatorKinds = map[ast.Kind]bool{
+	ast.KindBarToken:                                     true, // |
+	ast.KindAmpersandToken:                               true, // &
+	ast.KindCaretToken:                                   true, // ^
+	ast.KindLessThanLessThanToken:                        true, // <<
+	ast.KindGreaterThanGreaterThanToken:                  true, // >>
+	ast.KindGreaterThanGreaterThanGreaterThanToken:       true, // >>>
+	ast.KindBarEqualsToken:                               true, // |=
+	ast.KindAmpersandEqualsToken:                         true, // &=
+	ast.KindCaretEqualsToken:                             true, // ^=
+	ast.KindLessThanLessThanEqualsToken:                  true, // <<=
+	ast.KindGreaterThanGreaterThanEqualsToken:            true, // >>=
+	ast.KindGreaterThanGreaterThanGreaterThanEqualsToken: true, // >>>=
+	ast.KindTildeToken:                                   true, // ~
+}
+
+type noBitwiseOptions struct {
+	allow     map[string]bool
+	int32Hint bool
+}
+
+func parseOptions(opts any) noBitwiseOptions {
+	result := noBitwiseOptions{
+		allow:     map[string]bool{},
+		int32Hint: false,
+	}
+
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap == nil {
+		return result
+	}
+
+	if raw, ok := optsMap["allow"].([]interface{}); ok {
+		for _, v := range raw {
+			if s, ok := v.(string); ok {
+				result.allow[s] = true
+			}
+		}
+	}
+
+	if b, ok := optsMap["int32Hint"].(bool); ok {
+		result.int32Hint = b
+	}
+
+	return result
+}
+
+// isZeroNumericLiteral reports whether the node — after unwrapping parentheses
+// — is a numeric literal whose value is 0. Used by the int32Hint branch to
+// detect the `x | 0` typecasting idiom.
+//
+// Parens are unwrapped because ESTree (ESLint's AST) is transparent to them;
+// `x | (0)` has `right.type === 'Literal'` in ESLint, so we must match.
+//
+// TS-go's parser stores NumericLiteral.Text in decimal form (e.g. `0x0`,
+// `0b0`, `0o0`, `0.0`, `0e0` all surface as "0"), so a plain text compare
+// suffices. BigInt literals (`0n`) are a distinct AST kind and remain
+// excluded, matching ESLint (where `0n !== 0`).
+func isZeroNumericLiteral(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	unwrapped := ast.SkipParentheses(node)
+	if !ast.IsNumericLiteral(unwrapped) {
+		return false
+	}
+	return unwrapped.AsNumericLiteral().Text == "0"
+}
+
+func buildUnexpectedMessage(operator string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unexpected",
+		Description: "Unexpected use of '" + operator + "'.",
+	}
+}
+
+// NoBitwiseRule disallows bitwise operators.
+// https://eslint.org/docs/latest/rules/no-bitwise
+var NoBitwiseRule = rule.Rule{
+	Name: "no-bitwise",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		// report emits the diagnostic after shared allow / int32Hint filtering.
+		report := func(node *ast.Node, opKind ast.Kind, rightOperand *ast.Node) {
+			if !bitwiseOperatorKinds[opKind] {
+				return
+			}
+			op := scanner.TokenToString(opKind)
+			if opts.allow[op] {
+				return
+			}
+			// int32Hint: allow the `x | 0` integer-cast idiom when enabled.
+			if opts.int32Hint && opKind == ast.KindBarToken && isZeroNumericLiteral(rightOperand) {
+				return
+			}
+			ctx.ReportNode(node, buildUnexpectedMessage(op))
+		}
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				binary := node.AsBinaryExpression()
+				if binary == nil || binary.OperatorToken == nil {
+					return
+				}
+				report(node, binary.OperatorToken.Kind, binary.Right)
+			},
+			ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+				prefix := node.AsPrefixUnaryExpression()
+				if prefix == nil {
+					return
+				}
+				// Unary bitwise (`~`) has no right operand for the int32Hint check.
+				report(node, prefix.Operator, nil)
+			},
+		}
+	},
+}

--- a/internal/rules/no_bitwise/no_bitwise.md
+++ b/internal/rules/no_bitwise/no_bitwise.md
@@ -52,28 +52,51 @@ x += y;
 
 ## Options
 
-This rule supports the following options:
+This rule accepts a single object option with the following properties:
 
-- `allow` (`string[]`): Allows a list of bitwise operators to be used as exceptions.
-- `int32Hint` (`boolean`): Allows the use of bitwise OR in `|0` pattern for type casting.
+### `allow`
 
-### allow
+- Type: `string[]` (subset of `"|"`, `"&"`, `"^"`, `"<<"`, `">>"`, `">>>"`, `"|="`, `"&="`, `"^="`, `"<<="`, `">>="`, `">>>="`, `"~"`)
+- Default: `[]`
 
-Examples of **correct** code for this rule with the `{ "allow": ["~"] }` option:
+Whitelists the listed bitwise operators as exceptions. Only operators exactly matching a string in this list are allowed; all others still report.
+
+Example configuration:
+
+```json
+{
+  "rules": {
+    "no-bitwise": ["error", { "allow": ["~"] }]
+  }
+}
+```
+
+Examples of **correct** code with the above configuration:
 
 ```javascript
-/*eslint no-bitwise: ["error", { "allow": ["~"] }] */
-
 ~[1, 2, 3].indexOf(1) === -1;
 ```
 
-### int32Hint
+### `int32Hint`
 
-Examples of **correct** code for this rule with the `{ "int32Hint": true }` option:
+- Type: `boolean`
+- Default: `false`
+
+When `true`, permits the `x | 0` idiom commonly used to coerce a number to a 32-bit integer. Only `|` with a literal `0` on the right-hand side is allowed — `0 | x`, `x & 0`, `x | 1`, `x | -0`, and `x | 0n` still report.
+
+Example configuration:
+
+```json
+{
+  "rules": {
+    "no-bitwise": ["error", { "int32Hint": true }]
+  }
+}
+```
+
+Examples of **correct** code with the above configuration:
 
 ```javascript
-/*eslint no-bitwise: ["error", { "int32Hint": true }] */
-
 var b = a | 0;
 ```
 

--- a/internal/rules/no_bitwise/no_bitwise.md
+++ b/internal/rules/no_bitwise/no_bitwise.md
@@ -1,0 +1,82 @@
+# no-bitwise
+
+## Rule Details
+
+The use of bitwise operators in JavaScript is very rare and often `&` or `|` is simply a mistyped `&&` or `||`, which will lead to unexpected behavior.
+
+This rule disallows bitwise operators.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x = y | z;
+
+var x = y & z;
+
+var x = y ^ z;
+
+var x = ~z;
+
+var x = y << z;
+
+var x = y >> z;
+
+var x = y >>> z;
+
+x |= y;
+
+x &= y;
+
+x ^= y;
+
+x <<= y;
+
+x >>= y;
+
+x >>>= y;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var x = y || z;
+
+var x = y && z;
+
+var x = y > z;
+
+var x = y < z;
+
+x += y;
+```
+
+## Options
+
+This rule supports the following options:
+
+- `allow` (`string[]`): Allows a list of bitwise operators to be used as exceptions.
+- `int32Hint` (`boolean`): Allows the use of bitwise OR in `|0` pattern for type casting.
+
+### allow
+
+Examples of **correct** code for this rule with the `{ "allow": ["~"] }` option:
+
+```javascript
+/*eslint no-bitwise: ["error", { "allow": ["~"] }] */
+
+~[1, 2, 3].indexOf(1) === -1;
+```
+
+### int32Hint
+
+Examples of **correct** code for this rule with the `{ "int32Hint": true }` option:
+
+```javascript
+/*eslint no-bitwise: ["error", { "int32Hint": true }] */
+
+var b = a | 0;
+```
+
+## Original Documentation
+
+- [ESLint rule: no-bitwise](https://eslint.org/docs/latest/rules/no-bitwise)

--- a/internal/rules/no_bitwise/no_bitwise_test.go
+++ b/internal/rules/no_bitwise/no_bitwise_test.go
@@ -1,0 +1,356 @@
+package no_bitwise
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoBitwiseRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoBitwiseRule,
+		[]rule_tester.ValidTestCase{
+			// ── Non-bitwise operators are ignored ────────────────────────
+			{Code: `a + b`},
+			{Code: `!a`},
+			{Code: `a && b`},
+			{Code: `a || b`},
+			{Code: `a += b`},
+			{Code: `a &&= b`},
+			{Code: `a ||= b`},
+			{Code: `a ??= b`},
+
+			// ── `allow` option ────────────────────────────────────────────
+			{
+				Code:    `~[1, 2, 3].indexOf(1)`,
+				Options: map[string]interface{}{"allow": []interface{}{"~"}},
+			},
+			{
+				Code:    `~1<<2 === -8`,
+				Options: map[string]interface{}{"allow": []interface{}{"~", "<<"}},
+			},
+
+			// ── `int32Hint` option: canonical + alternative zero forms ────
+			{
+				Code:    `a|0`,
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | (0)`, // Parenthesized zero; ESLint treats parens as transparent.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0.0`, // Float zero — Number("0.0") === 0.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0x0`, // Hex zero.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0b0`, // Binary zero.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0o0`, // Octal zero.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0e0`, // Scientific zero.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0E0`, // Uppercase exponent.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0e+0`, // Signed positive exponent.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0e-0`, // Signed negative exponent.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0.`, // Trailing decimal point.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | .0`, // Leading decimal point.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0.0e0`, // Combined float + exponent.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+			{
+				Code:    `a | 0X0`, // Uppercase hex prefix.
+				Options: map[string]interface{}{"int32Hint": true},
+			},
+
+			// ── `allow` takes precedence; int32Hint may be off explicitly ─
+			{
+				Code: `a|0`,
+				Options: map[string]interface{}{
+					"allow":     []interface{}{"|"},
+					"int32Hint": false,
+				},
+			},
+
+			// ── Type-level unions/intersections are NOT BinaryExpression ─
+			// Ensures the rule does not fire on TypeScript type syntax.
+			{Code: `type T = A | B`},
+			{Code: `type T = A & B`},
+			{Code: `let x: string | number = 1`},
+			{Code: `let x: { a: 1 } & { b: 2 } = { a: 1, b: 2 }`},
+			{Code: `function f<T extends A | B>(x: T): T { return x; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ── All 7 binary + 6 compound assignment + unary ~ operators ──
+			{
+				Code: `a ^ b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a | b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a & b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a << b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a >> b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a >>> b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a|0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `~a`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a ^= b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a |= b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a &= b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a <<= b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a >>= b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a >>>= b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ── Nested / chained uses: each operator reports separately ──
+			{
+				Code: `a | b | c`, // Parses as (a | b) | c — inner + outer.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `~~a`, // Double bitwise NOT — outer + inner.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code: `~(a | b)`, // Unary over parenthesized binary — both report.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 3},
+				},
+			},
+
+			// ── Parenthesized wrapping does not suppress the report ──────
+			{
+				Code: `(a | b)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 2},
+				},
+			},
+
+			// ── int32Hint boundaries ──────────────────────────────────────
+			{
+				Code:    `a | 1`, // int32Hint is only for `| 0`.
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `a | 0x10`, // Non-zero hex must still report (sanity).
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `a | 1.0`, // Non-zero float must still report.
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `0 | a`, // int32Hint requires zero on the RIGHT.
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `a & 0`, // int32Hint is `|` only, not `&`.
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `a | -0`, // Unary minus → not a Literal node in ESTree.
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `a | 0n`, // BigInt zero is distinct from numeric 0.
+				Options: map[string]interface{}{"int32Hint": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ── Bitwise inside TypeScript value-level constructs ─────────
+			{
+				Code: `enum E { A = 1 << 0, B = 1 << 1 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `const o = { [a | b]: 1 }`, // Computed property name.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: `class C { m() { return a | b; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+
+			// ── `~` not listed in `allow` still reports ──────────────────
+			{
+				Code:    `~a`,
+				Options: map[string]interface{}{"allow": []interface{}{"|"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ── Mixed precedence: arithmetic binds tighter than bitwise ──
+			// Parses as `(a + b) & c` — only `&` is bitwise.
+			{
+				Code: `a + b & c`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ── Right-associative compound bitwise assignment ────────────
+			// `a |= b |= c` parses as `a |= (b |= c)` → both fire.
+			{
+				Code: `a |= b |= c`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 6},
+				},
+			},
+
+			// ── Unary `~` stacked on binary result ───────────────────────
+			{
+				Code: `~(a & b)`, // outer `~` + inner `&`.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 3},
+				},
+			},
+
+			// ── Bitwise in Identifier-looking-but-computed positions ─────
+			{
+				Code: `obj[a | b]`, // computed element access.
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5},
+				},
+			},
+
+			// ── Bitwise inside template literal span ─────────────────────
+			{
+				Code: "`${a | b}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 4},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -261,6 +261,7 @@ export default defineConfig({
     './tests/eslint/rules/valid-typeof.test.ts',
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
+    './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-bitwise.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-bitwise.test.ts.snap
@@ -1,0 +1,934 @@
+// Rstest Snapshot v1
+
+exports[`no-bitwise > invalid 1`] = `
+{
+  "code": "a ^ b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '^'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 2`] = `
+{
+  "code": "a | b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 3`] = `
+{
+  "code": "a & b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '&'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 4`] = `
+{
+  "code": "a << b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '<<'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 5`] = `
+{
+  "code": "a >> b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '>>'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 6`] = `
+{
+  "code": "a >>> b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '>>>'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 7`] = `
+{
+  "code": "a|0",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 8`] = `
+{
+  "code": "~a",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '~'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 9`] = `
+{
+  "code": "a ^= b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '^='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 10`] = `
+{
+  "code": "a |= b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 11`] = `
+{
+  "code": "a &= b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '&='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 12`] = `
+{
+  "code": "a <<= b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '<<='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 13`] = `
+{
+  "code": "a >>= b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '>>='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 14`] = `
+{
+  "code": "a >>>= b",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '>>>='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 15`] = `
+{
+  "code": "a | b | c",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 16`] = `
+{
+  "code": "~~a",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '~'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+    {
+      "message": "Unexpected use of '~'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 17`] = `
+{
+  "code": "~(a | b)",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '~'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 18`] = `
+{
+  "code": "(a | b)",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 19`] = `
+{
+  "code": "a | 1",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 20`] = `
+{
+  "code": "a | 0x10",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 21`] = `
+{
+  "code": "a | 1.0",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 22`] = `
+{
+  "code": "0 | a",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 23`] = `
+{
+  "code": "a & 0",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '&'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 24`] = `
+{
+  "code": "a | -0",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 25`] = `
+{
+  "code": "a | 0n",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 26`] = `
+{
+  "code": "enum E { A = 1 << 0, B = 1 << 1 }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '<<'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+    {
+      "message": "Unexpected use of '<<'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 27`] = `
+{
+  "code": "const o = { [a | b]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 28`] = `
+{
+  "code": "class C { m() { return a | b; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 29`] = `
+{
+  "code": "~a",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '~'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 30`] = `
+{
+  "code": "a + b & c",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '&'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 31`] = `
+{
+  "code": "a |= b |= c",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+    {
+      "message": "Unexpected use of '|='.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 32`] = `
+{
+  "code": "obj[a | b]",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-bitwise > invalid 33`] = `
+{
+  "code": "\`\${a | b}\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of '|'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-bitwise",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-bitwise.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-bitwise.test.ts
@@ -1,0 +1,134 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-bitwise', {
+  valid: [
+    // Non-bitwise operators
+    'a + b',
+    '!a',
+    'a && b',
+    'a || b',
+    'a += b',
+    'a &&= b',
+    'a ||= b',
+    'a ??= b',
+    // allow
+    { code: '~[1, 2, 3].indexOf(1)', options: [{ allow: ['~'] }] as any },
+    { code: '~1<<2 === -8', options: [{ allow: ['~', '<<'] }] as any },
+    // int32Hint
+    { code: 'a|0', options: [{ int32Hint: true }] as any },
+    { code: 'a | (0)', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0.0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0x0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0b0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0o0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0e0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0E0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0e+0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0e-0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0.', options: [{ int32Hint: true }] as any },
+    { code: 'a | .0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0.0e0', options: [{ int32Hint: true }] as any },
+    { code: 'a | 0X0', options: [{ int32Hint: true }] as any },
+    { code: 'a|0', options: [{ allow: ['|'], int32Hint: false }] as any },
+    // Type-level unions/intersections must not be flagged
+    'type T = A | B',
+    'type T = A & B',
+    'let x: string | number = 1',
+    'function f<T extends A | B>(x: T): T { return x; }',
+  ],
+  invalid: [
+    { code: 'a ^ b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a | b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a & b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a << b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a >> b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a >>> b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a|0', errors: [{ messageId: 'unexpected' }] },
+    { code: '~a', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a ^= b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a |= b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a &= b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a <<= b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a >>= b', errors: [{ messageId: 'unexpected' }] },
+    { code: 'a >>>= b', errors: [{ messageId: 'unexpected' }] },
+    // Nested / chained
+    {
+      code: 'a | b | c',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: '~~a',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: '~(a | b)',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    { code: '(a | b)', errors: [{ messageId: 'unexpected' }] },
+    // int32Hint boundaries
+    {
+      code: 'a | 1',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'a | 0x10',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'a | 1.0',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '0 | a',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'a & 0',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'a | -0',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'a | 0n',
+      options: [{ int32Hint: true }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // TS value-level contexts
+    {
+      code: 'enum E { A = 1 << 0, B = 1 << 1 }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    { code: 'const o = { [a | b]: 1 }', errors: [{ messageId: 'unexpected' }] },
+    {
+      code: 'class C { m() { return a | b; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // allow only covers listed operators
+    {
+      code: '~a',
+      options: [{ allow: ['|'] }] as any,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Mixed precedence — (a + b) & c — only `&` reports
+    { code: 'a + b & c', errors: [{ messageId: 'unexpected' }] },
+    // Right-associative compound bitwise assignment
+    {
+      code: 'a |= b |= c',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    // Computed element access
+    { code: 'obj[a | b]', errors: [{ messageId: 'unexpected' }] },
+    // Template literal span
+    { code: '`${a | b}`', errors: [{ messageId: 'unexpected' }] },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-bitwise` rule from ESLint to rslint.

This rule disallows bitwise operators (`|`, `&`, `^`, `<<`, `>>`, `>>>`, `~`, and their compound-assignment variants). It supports the standard `allow` (whitelist specific operators) and `int32Hint` (permit the `x | 0` integer-cast idiom) options.

Validated on real projects: **0 errors** on rsbuild (no bitwise usage), **76 errors** on rspack — all legitimate bitwise operations across 5 files (lightningcss feature flags, wasm-hash UTF-8 encoding, version packing, logger bit flags). No false positives on TypeScript-level union/intersection types.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-bitwise
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-bitwise.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).