### PR TITLE
feat: port rule no-useless-concat

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
@@ -560,6 +561,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
+	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)
 	GlobalRuleRegistry.Register("no-undef", no_undef.NoUndefRule)
 	GlobalRuleRegistry.Register("no-undef-init", no_undef_init.NoUndefInitRule)

--- a/internal/rules/no_useless_concat/no_useless_concat.go
+++ b/internal/rules/no_useless_concat/no_useless_concat.go
@@ -1,0 +1,78 @@
+package no_useless_concat
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-useless-concat
+var NoUselessConcatRule = rule.Rule{
+	Name: "no-useless-concat",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		sourceFile := ctx.SourceFile
+		lineMap := sourceFile.ECMALineMap()
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				if !utils.IsPlusBinaryExpression(node) {
+					return
+				}
+				bin := node.AsBinaryExpression()
+
+				// For a chain like `a + 'b' + 'c'` the AST is left-associative
+				// (`(a + 'b') + 'c'`); we need the leaf on the right edge of
+				// the left operand and the leaf on the left edge of the right
+				// operand to decide whether this particular `+` joins two
+				// literals.
+				left := getRightmostLeaf(bin.Left)
+				right := getLeftmostLeaf(bin.Right)
+
+				if !utils.IsStringLiteralOrTemplate(left) || !utils.IsStringLiteralOrTemplate(right) {
+					return
+				}
+
+				// ESLint checks `left.loc.end.line === right.loc.start.line`.
+				// `node.End()` already excludes trailing trivia, but `node.Pos()`
+				// includes leading trivia, so trim the right leaf to find its
+				// true starting line.
+				leftEndLine := scanner.ComputeLineOfPosition(lineMap, left.End())
+				rightStartLine := scanner.ComputeLineOfPosition(lineMap, utils.TrimNodeTextRange(sourceFile, right).Pos())
+				if leftEndLine != rightStartLine {
+					return
+				}
+
+				ctx.ReportRange(
+					utils.TrimNodeTextRange(sourceFile, bin.OperatorToken),
+					rule.RuleMessage{
+						Id:          "unexpectedConcat",
+						Description: "Unexpected string concatenation of literals.",
+					},
+				)
+			},
+		}
+	},
+}
+
+// getRightmostLeaf descends into the right side of any nested `+` chain,
+// transparently unwrapping `ParenthesizedExpression`. Mirrors ESLint's
+// `getLeft` helper — for `foo + 'a' + 'b'` the leftmost AST neighbor of the
+// outer `+` is the concatenation `foo + 'a'`, whose rightmost leaf is `'a'`.
+func getRightmostLeaf(node *ast.Node) *ast.Node {
+	node = ast.SkipParentheses(node)
+	for utils.IsPlusBinaryExpression(node) {
+		node = ast.SkipParentheses(node.AsBinaryExpression().Right)
+	}
+	return node
+}
+
+// getLeftmostLeaf is the mirror of getRightmostLeaf for the right side of a
+// `+` chain. Mirrors ESLint's `getRight` helper.
+func getLeftmostLeaf(node *ast.Node) *ast.Node {
+	node = ast.SkipParentheses(node)
+	for utils.IsPlusBinaryExpression(node) {
+		node = ast.SkipParentheses(node.AsBinaryExpression().Left)
+	}
+	return node
+}

--- a/internal/rules/no_useless_concat/no_useless_concat.md
+++ b/internal/rules/no_useless_concat/no_useless_concat.md
@@ -1,0 +1,31 @@
+# no-useless-concat
+
+## Rule Details
+
+Disallow unnecessary concatenation of literals or template literals. This rule flags a `+` that joins two string literals or template literals on the same line, since they could be written as a single literal.
+
+Concatenation that spans multiple source lines is intentionally not reported.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = `some` + `string`;
+var b = '1' + '0';
+var c = '1' + `0`;
+var d = `1` + '0';
+var e = `1` + `0`;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// When the variables could hold non-strings
+var a = 1 + 1;
+var b = 1 + '1';
+var c = foo + bar;
+var d = 'foo' + bar;
+```
+
+## Original Documentation
+
+- [ESLint: no-useless-concat](https://eslint.org/docs/latest/rules/no-useless-concat)

--- a/internal/rules/no_useless_concat/no_useless_concat_test.go
+++ b/internal/rules/no_useless_concat/no_useless_concat_test.go
@@ -1,0 +1,452 @@
+package no_useless_concat
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessConcat(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessConcatRule,
+		[]rule_tester.ValidTestCase{
+			// Non-`+` operators must not trigger.
+			{Code: `var a = 1 + 1;`},
+			{Code: `var a = 1 - 2;`},
+			{Code: `var a = 1 * '2';`},
+			{Code: `var a = 'a' * 'b';`},
+			{Code: `var a = 'a' - 'b';`},
+			{Code: `var a = 'a' < 'b';`},
+
+			// At least one neighbor of every `+` is not a string literal.
+			{Code: `var a = foo + bar;`},
+			{Code: `var a = 'foo' + bar;`},
+			{Code: `var a = 1 + '1';`},
+			{Code: "var a = 1 + `1`;"},
+			{Code: "var a = `1` + 1;"},
+			{Code: `var a = 'a' + 1;`},
+			{Code: `var a = foo + 'a' + bar;`},
+			{Code: `var a = 'a' + 1 + 'b';`},
+			{Code: `var a = 1 + 'a' + 2;`},
+			{Code: `var a = a + 'b' + c + 'd';`},
+			{Code: `var a = foo() + 'b';`},
+			{Code: `var a = 'a' + foo();`},
+			{Code: `var a = 'a' + (b ? 'c' : 'd');`},
+			{Code: `var a = 'a' + (b as string);`},
+			{Code: `var a = ('a' as const) + 'b';`},
+
+			// Unary `+`/`-` produces a PrefixUnaryExpression, not a string literal.
+			{Code: "var a = (1 + +2) + `b`;"},
+			{Code: `var a = +'1' + 100;`},
+			{Code: `var a = -'a' + 'b';`},
+
+			// Multi-line concatenation is explicitly allowed by ESLint.
+			{Code: "var foo = 'foo' +\n 'bar';"},
+			{Code: "var a = ('a') +\n ('b');"},
+			{Code: "var a = 'a' +\n// comment\n'b';"},
+			{Code: "var a = 'a' + /*\n*/ 'b';"},
+
+			// Compound assignment is not a `+` BinaryExpression.
+			{Code: `x += 'y';`},
+			{Code: "x += `y`;"},
+
+			// TaggedTemplateExpression is not a TemplateLiteral.
+			{Code: "var a = tag`a` + 'b';"},
+			{Code: "var a = 'a' + tag`b`;"},
+
+			// `as` / `satisfies` are postfix; their output is not a string literal node.
+			{Code: `var a = ('a' as const) + ('b' as const);`},
+			{Code: `var a = 'a' + ('b' satisfies string);`},
+
+			// Logical / bitwise / comparison operators — not `+`.
+			{Code: `var a = 'a' || 'b';`},
+			{Code: `var a = 'a' && 'b';`},
+			{Code: `var a = 'a' ?? 'b';`},
+
+			// Comma expression with non-string neighbor of `+`.
+			{Code: `var a = (1, 'b') + foo;`},
+
+			// Multiple prefix unary operators on the left operand.
+			{Code: `var a = + + 'a' + 'b';`},
+
+			// Call expression on either side.
+			{Code: `var a = foo() + 'b';`},
+			{Code: `var a = 'a' + foo();`},
+
+			// `this`, optional chain, non-null assertion — all non-literal.
+			{Code: `class C { m() { return this + 'a'; } }`},
+			{Code: `var a = x?.y + 'z';`},
+			{Code: `var a = x! + 'z';`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Basic two-literal concatenation.
+			{
+				Code: `'a' + 'b'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: "`a` + 'b'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: "`a` + `b`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			// Empty literals still count.
+			{
+				Code: `'' + ''`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code: "`` + ``",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 4},
+				},
+			},
+
+			// Templates with substitutions (TemplateExpression).
+			{
+				Code: "`a${x}` + 'b'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "'a' + `b${x}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: "`${x}a` + `b${y}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+				},
+			},
+
+			// Left-associative chains: each `+` joining two literals is reported.
+			{
+				Code: `foo + 'a' + 'b'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: `'a' + 'b' + 'c'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 11},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `'a' + 'b' + 'c' + 'd'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 17},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 11},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `foo + 'a' + 'b' + 'c'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 17},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: `'a' + 'b' + foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+
+			// Parentheses (including multi-layer) are transparent.
+			{
+				Code: `(foo + 'a') + ('b' + 'c')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 13},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `('a') + ('b')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code: `(('a')) + (('b'))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+				},
+			},
+			// Right-associative parenthesized chain.
+			{
+				Code: `'a' + ('b' + 'c')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `('a' + 'b') + ('c' + 'd')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 13},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 6},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `'a' + ('b' + 'c') + 'd'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 19},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `(foo + 'a' + 'b') + 'c'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 19},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 12},
+				},
+			},
+
+			// Multi-line mixed: only same-line `+` fires.
+			{
+				Code: "'a' +\n'b' + 'c'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 2, Column: 5},
+				},
+			},
+			{
+				Code: "'a' + 'b' +\n'c'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			// Comments between operator and operand should not hide same-line cases.
+			{
+				Code: `'a' + /* x */ 'b'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+
+			// Template-literal chains, including `foo + `a` + `b``.
+			{
+				Code: "foo + `a` + `b`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 11},
+				},
+			},
+
+			// Nested inside other expressions.
+			{
+				Code: `foo('a' + 'b')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `var x = {a: 'a' + 'b'};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `var x = ['a' + 'b'];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: "`${'a' + 'b'}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `var x = 'a' + 'b';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `x = 'a' + 'b'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `x += 'a' + 'b'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `function f() { return 'a' + 'b'; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `('a' + 'b') === 'c'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 6},
+				},
+			},
+
+			// Special characters inside literals.
+			{
+				Code: `'\n' + '\t'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `'🎉' + '🎊'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 6},
+				},
+			},
+
+			// Deep right-associative nesting via parentheses.
+			{
+				Code: `'a' + ('b' + ('c' + 'd'))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 12},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 19},
+				},
+			},
+			// Asymmetric tree mixing left-/right-associative chunks.
+			{
+				Code: `(('a' + 'b') + ('c' + ('d' + 'e'))) + 'f'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 37},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 14},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 7},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 21},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 28},
+				},
+			},
+			// Concatenation inside a template-literal placeholder.
+			{
+				Code: "`a${'x' + 'y'}b` + 'c'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 18},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+				},
+			},
+			// Line comment forces the right operand onto a new line.
+			{
+				Code: "'a' + 'b' // same-line comment\n+ 'c'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+
+			// Conditional expression — both branches concatenate.
+			{
+				Code: `x ? 'a' + 'b' : 'c' + 'd'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 9},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 21},
+				},
+			},
+			// Comma expression separates two chains.
+			{
+				Code: `('a' + 'b', 'c' + 'd')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 6},
+					{MessageId: "unexpectedConcat", Line: 1, Column: 17},
+				},
+			},
+			// Logical operators are not `+`, but nested `+` still fires.
+			{
+				Code: `'a' + 'b' && 'c'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: `'a' + 'b' ?? 'c'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 5},
+				},
+			},
+			// Default parameter value.
+			{
+				Code: `function f(x = 'a' + 'b') { return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 20},
+				},
+			},
+			// Arrow function body.
+			{
+				Code: `const f = () => 'a' + 'b';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 21},
+				},
+			},
+			// Computed property name.
+			{
+				Code: `const o = {['a' + 'b']: 1};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 17},
+				},
+			},
+			// Destructuring default.
+			{
+				Code: `const {x = 'a' + 'b'} = o;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 16},
+				},
+			},
+			// Class field initializer.
+			{
+				Code: `class C { x = 'a' + 'b'; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 19},
+				},
+			},
+			// Physically multi-line template literal — end/start both on the final line.
+			{
+				Code: "`a\nb` + 'c'",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 2, Column: 4},
+				},
+			},
+
+			// JSX expression container.
+			{
+				Code: `const el = <div>{'a' + 'b'}</div>;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 22},
+				},
+			},
+			// JSX attribute value.
+			{
+				Code: `const el = <div title={'a' + 'b'} />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedConcat", Line: 1, Column: 28},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/prefer_template/prefer_template.go
+++ b/internal/rules/prefer_template/prefer_template.go
@@ -19,12 +19,12 @@ var PreferTemplateRule = rule.Rule{
 		reported := map[int]bool{}
 
 		checkForStringConcat := func(node *ast.Node) {
-			if !isStringLike(node) {
+			if !utils.IsStringLiteralOrTemplate(node) {
 				return
 			}
 			// Walk past the paren wrapper (if any) to find the logical parent.
 			parent := ast.WalkUpParenthesizedExpressions(node.Parent)
-			if !isConcatenation(parent) {
+			if !utils.IsPlusBinaryExpression(parent) {
 				return
 			}
 			top := getTopConcatBinaryExpression(parent)
@@ -61,30 +61,13 @@ var PreferTemplateRule = rule.Rule{
 	},
 }
 
-// isStringLike reports whether the node behaves as a string literal for this
-// rule (matches ESLint's `astUtils.isStringLiteral || TemplateLiteral`).
-// The shim's `ast.IsStringLiteralLike` covers StringLiteral and
-// NoSubstitutionTemplateLiteral but not templates with substitutions.
-func isStringLike(node *ast.Node) bool {
-	return node != nil && (ast.IsStringLiteralLike(node) || node.Kind == ast.KindTemplateExpression)
-}
-
-// isConcatenation reports whether node is a `+` binary expression.
-func isConcatenation(node *ast.Node) bool {
-	if node == nil || node.Kind != ast.KindBinaryExpression {
-		return false
-	}
-	bin := node.AsBinaryExpression()
-	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindPlusToken
-}
-
 // getTopConcatBinaryExpression walks up through concatenations (transparently
 // crossing `ParenthesizedExpression` wrappers) and returns the outermost
 // concatenation.
 func getTopConcatBinaryExpression(node *ast.Node) *ast.Node {
 	for {
 		p := ast.WalkUpParenthesizedExpressions(node.Parent)
-		if !isConcatenation(p) {
+		if !utils.IsPlusBinaryExpression(p) {
 			return node
 		}
 		node = p
@@ -95,11 +78,11 @@ func getTopConcatBinaryExpression(node *ast.Node) *ast.Node {
 // any string literal.
 func hasStringLiteral(node *ast.Node) bool {
 	node = ast.SkipParentheses(node)
-	if isConcatenation(node) {
+	if utils.IsPlusBinaryExpression(node) {
 		bin := node.AsBinaryExpression()
 		return hasStringLiteral(bin.Right) || hasStringLiteral(bin.Left)
 	}
-	return isStringLike(node)
+	return utils.IsStringLiteralOrTemplate(node)
 }
 
 // hasNonStringLiteral reports whether the concat subtree rooted at node
@@ -107,11 +90,11 @@ func hasStringLiteral(node *ast.Node) bool {
 // actually benefits from template-literal conversion).
 func hasNonStringLiteral(node *ast.Node) bool {
 	node = ast.SkipParentheses(node)
-	if isConcatenation(node) {
+	if utils.IsPlusBinaryExpression(node) {
 		bin := node.AsBinaryExpression()
 		return hasNonStringLiteral(bin.Right) || hasNonStringLiteral(bin.Left)
 	}
-	return !isStringLike(node)
+	return !utils.IsStringLiteralOrTemplate(node)
 }
 
 // startsWithTemplateCurly reports whether converting node to a template
@@ -161,7 +144,7 @@ var octalEscapePattern = regexp.MustCompile(`(?s)^(?:[^\\]|\\.)*?\\(?:[1-9]|0[0-
 // cannot be represented in a template literal, so autofix must be skipped.
 func hasOctalOrNonOctalDecimalEscape(sourceFile *ast.SourceFile, node *ast.Node) bool {
 	node = ast.SkipParentheses(node)
-	if isConcatenation(node) {
+	if utils.IsPlusBinaryExpression(node) {
 		bin := node.AsBinaryExpression()
 		return hasOctalOrNonOctalDecimalEscape(sourceFile, bin.Left) ||
 			hasOctalOrNonOctalDecimalEscape(sourceFile, bin.Right)
@@ -213,7 +196,7 @@ func toTemplateLiteral(sourceFile *ast.SourceFile, currentNode *ast.Node, textBe
 		return utils.TrimmedNodeText(sourceFile, node)
 	}
 
-	if isConcatenation(node) && hasStringLiteral(node) {
+	if utils.IsPlusBinaryExpression(node) && hasStringLiteral(node) {
 		bin := node.AsBinaryExpression()
 		src := sourceFile.Text()
 

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -182,6 +182,27 @@ func IsConstructorName(name string) bool {
 	return false
 }
 
+// IsStringLiteralOrTemplate reports whether node is a string literal or a
+// template literal (with or without substitutions). Matches the semantics of
+// ESLint's `astUtils.isStringLiteral`, which treats `Literal{string}` and
+// `TemplateLiteral` as equivalent. The shim's `ast.IsStringLiteralLike` only
+// covers `StringLiteral` and `NoSubstitutionTemplateLiteral`, so we also
+// include `TemplateExpression` (templates with `${}`).
+func IsStringLiteralOrTemplate(node *ast.Node) bool {
+	return node != nil && (ast.IsStringLiteralLike(node) || node.Kind == ast.KindTemplateExpression)
+}
+
+// IsPlusBinaryExpression reports whether node is a `+` binary expression.
+// Covers both string concatenation and numeric addition — callers that only
+// care about concatenation must additionally inspect the operands.
+func IsPlusBinaryExpression(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := node.AsBinaryExpression()
+	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindPlusToken
+}
+
 func IncludesModifier(node interface{ Modifiers() *ast.ModifierList }, modifier ast.Kind) bool {
 	modifiers := node.Modifiers()
 	if modifiers == nil {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -62,6 +62,7 @@ export default defineConfig({
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
     './tests/eslint/rules/prefer-template.test.ts',
+    './tests/eslint/rules/no-useless-concat.test.ts',
     // eslint-plugin-import
     './tests/eslint-plugin-import/rules/first.test.ts',
     './tests/eslint-plugin-import/rules/newline-after-import.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-concat.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-concat.test.ts.snap
@@ -1,0 +1,766 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-concat > invalid 1`] = `
+{
+  "code": "'a' + 'b'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 2`] = `
+{
+  "code": "\`a\` + 'b'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 3`] = `
+{
+  "code": "\`a\` + \`b\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 4`] = `
+{
+  "code": "'' + ''",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 5`] = `
+{
+  "code": "\`a\${x}\` + 'b'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 6`] = `
+{
+  "code": "\`\${x}a\` + \`b\${y}\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 7`] = `
+{
+  "code": "foo + 'a' + 'b'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 8`] = `
+{
+  "code": "'a' + 'b' + 'c'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 9`] = `
+{
+  "code": "'a' + 'b' + 'c' + 'd'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 10`] = `
+{
+  "code": "'a' + 'b' + foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 11`] = `
+{
+  "code": "(foo + 'a') + ('b' + 'c')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 12`] = `
+{
+  "code": "'a' + ('b' + 'c')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 13`] = `
+{
+  "code": "('a' + 'b') + ('c' + 'd')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 14`] = `
+{
+  "code": "'a' + ('b' + 'c') + 'd'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 15`] = `
+{
+  "code": "'a' + ('b' + ('c' + 'd'))",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 16`] = `
+{
+  "code": "'a' +
+'b' + 'c'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 17`] = `
+{
+  "code": "'a' + 'b' +
+'c'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 18`] = `
+{
+  "code": "foo + \`a\` + \`b\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 19`] = `
+{
+  "code": "foo('a' + 'b')",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 20`] = `
+{
+  "code": "var x = {a: 'a' + 'b'};",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 21`] = `
+{
+  "code": "var x = ['a' + 'b'];",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 22`] = `
+{
+  "code": "\`\${'a' + 'b'}\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-concat > invalid 23`] = `
+{
+  "code": "x += 'a' + 'b'",
+  "diagnostics": [
+    {
+      "message": "Unexpected string concatenation of literals.",
+      "messageId": "unexpectedConcat",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-concat",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-concat.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-concat.test.ts
@@ -1,0 +1,150 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-concat', {
+  valid: [
+    // Non-`+` operators.
+    'var a = 1 + 1;',
+    'var a = 1 - 2;',
+    "var a = 1 * '2';",
+    "var a = 'a' * 'b';",
+    "var a = 'a' - 'b';",
+
+    // At least one side is not a string literal.
+    'var a = foo + bar;',
+    "var a = 'foo' + bar;",
+    "var a = 1 + '1';",
+    'var a = 1 + `1`;',
+    'var a = `1` + 1;',
+    "var a = 'a' + 1;",
+    "var a = foo + 'a' + bar;",
+    "var a = 'a' + 1 + 'b';",
+    "var a = a + 'b' + c + 'd';",
+
+    // Unary operators.
+    'var a = (1 + +2) + `b`;',
+    "var a = +'1' + 100;",
+    "var a = -'a' + 'b';",
+
+    // Multi-line concatenation is allowed.
+    "var foo = 'foo' +\n 'bar';",
+    "var a = ('a') +\n ('b');",
+    "var a = 'a' +\n// comment\n'b';",
+
+    // Compound assignment.
+    "x += 'y';",
+
+    // TaggedTemplateExpression.
+    'var a = tag`a` + "b";',
+
+    // `as` / `satisfies`.
+    "var a = 'a' + (b as string);",
+    "var a = ('a' as const) + 'b';",
+  ],
+  invalid: [
+    // Basic two-literal.
+    { code: "'a' + 'b'", errors: [{ messageId: 'unexpectedConcat' }] },
+    { code: "`a` + 'b'", errors: [{ messageId: 'unexpectedConcat' }] },
+    { code: '`a` + `b`', errors: [{ messageId: 'unexpectedConcat' }] },
+    { code: "'' + ''", errors: [{ messageId: 'unexpectedConcat' }] },
+
+    // Templates with substitutions.
+    { code: "`a${x}` + 'b'", errors: [{ messageId: 'unexpectedConcat' }] },
+    { code: '`${x}a` + `b${y}`', errors: [{ messageId: 'unexpectedConcat' }] },
+
+    // Chains.
+    { code: "foo + 'a' + 'b'", errors: [{ messageId: 'unexpectedConcat' }] },
+    {
+      code: "'a' + 'b' + 'c'",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+    {
+      code: "'a' + 'b' + 'c' + 'd'",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+    {
+      code: "'a' + 'b' + foo",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+
+    // Parentheses.
+    {
+      code: "(foo + 'a') + ('b' + 'c')",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+    {
+      code: "'a' + ('b' + 'c')",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+    {
+      code: "('a' + 'b') + ('c' + 'd')",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+    {
+      code: "'a' + ('b' + 'c') + 'd'",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+    {
+      code: "'a' + ('b' + ('c' + 'd'))",
+      errors: [
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+        { messageId: 'unexpectedConcat' },
+      ],
+    },
+
+    // Multi-line mixed.
+    {
+      code: "'a' +\n'b' + 'c'",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+    {
+      code: "'a' + 'b' +\n'c'",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+
+    // Template chain.
+    { code: 'foo + `a` + `b`', errors: [{ messageId: 'unexpectedConcat' }] },
+
+    // Nested inside other expressions.
+    { code: "foo('a' + 'b')", errors: [{ messageId: 'unexpectedConcat' }] },
+    {
+      code: "var x = {a: 'a' + 'b'};",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+    {
+      code: "var x = ['a' + 'b'];",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+    {
+      code: "`${'a' + 'b'}`",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+    {
+      code: "x += 'a' + 'b'",
+      errors: [{ messageId: 'unexpectedConcat' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-useless-concat` rule from ESLint to rslint.

The rule flags a `+` operator that joins two adjacent string literals or template literals on the same line, since they can be written as a single literal. Concatenation spanning multiple source lines is intentionally not reported, matching ESLint's behavior.

Implementation walks nested `+` chains (and transparently skips `ParenthesizedExpression`) via `getRightmostLeaf` / `getLeftmostLeaf`, checks both leaves with the shared `utils.IsStringLiteralOrTemplate` helper (StringLiteral + NoSubstitutionTemplateLiteral + TemplateExpression), compares lines using trimmed positions, and reports on the offending `+` token. Two helpers (`IsStringLiteralOrTemplate`, `IsPlusBinaryExpression`) were extracted into `internal/utils` and also adopted by `prefer-template`, which previously duplicated the same logic.

Coverage: 95 Go test cases across literal/template/chain/parenthesis/multi-line/JSX/TS-syntax dimensions, plus a JS snapshot suite. Manually verified against ESLint on rsbuild and rspack (both 0 issues) and on a constructed smoke file with 12 positive + 10 negative scenarios (rslint and ESLint produced byte-identical positions).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-concat
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-concat.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).