### PR TITLE
feat: port rule no-implicit-coercion

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,6 +143,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
+	"github.com/web-infra-dev/rslint/internal/rules/no_implicit_coercion"
 	"github.com/web-infra-dev/rslint/internal/rules/no_import_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
@@ -543,6 +544,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)
 	GlobalRuleRegistry.Register("no-global-assign", no_global_assign.NoGlobalAssignRule)
+	GlobalRuleRegistry.Register("no-implicit-coercion", no_implicit_coercion.NoImplicitCoercionRule)
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion.go
@@ -327,6 +327,8 @@ func getNonNumericOperand(bin *ast.BinaryExpression) *ast.Node {
 // isNumeric reports whether node statically evaluates to a number: a numeric
 // literal or a call to `Number`, `parseInt`, or `parseFloat`. Shadowing of
 // these globals is ignored — matches ESLint, which also uses a syntactic check.
+// Parens on the callee (e.g. `(Number)(x)`) are peeled off to match ESLint's
+// paren-transparent AST.
 func isNumeric(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -335,7 +337,7 @@ func isNumeric(node *ast.Node) bool {
 		return true
 	}
 	if node.Kind == ast.KindCallExpression {
-		callee := node.AsCallExpression().Expression
+		callee := ast.SkipParentheses(node.AsCallExpression().Expression)
 		if callee != nil && callee.Kind == ast.KindIdentifier {
 			switch callee.AsIdentifier().Text {
 			case "Number", "parseInt", "parseFloat":
@@ -347,7 +349,8 @@ func isNumeric(node *ast.Node) bool {
 }
 
 // isStringType reports whether node statically evaluates to a string: any
-// string/template literal, or a call to `String`.
+// string/template literal, or a call to `String`. Parens on the callee
+// (e.g. `(String)(x)`) are peeled off to match ESLint's paren-transparent AST.
 func isStringType(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -356,7 +359,7 @@ func isStringType(node *ast.Node) bool {
 	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression:
 		return true
 	case ast.KindCallExpression:
-		callee := node.AsCallExpression().Expression
+		callee := ast.SkipParentheses(node.AsCallExpression().Expression)
 		if callee != nil && callee.Kind == ast.KindIdentifier && callee.AsIdentifier().Text == "String" {
 			return true
 		}

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion.go
@@ -255,7 +255,9 @@ func isBinaryNegatingOfIndexOf(pue *ast.PrefixUnaryExpression) bool {
 		name := callee.AsPropertyAccessExpression().Name()
 		return name != nil && isIndexOfName(name.Text())
 	case ast.KindElementAccessExpression:
-		arg := callee.AsElementAccessExpression().ArgumentExpression
+		// Strip parens on the computed key so `foo[('indexOf')](x)` matches —
+		// ESLint treats parens transparently in `isSpecificMemberAccess`.
+		arg := ast.SkipParentheses(callee.AsElementAccessExpression().ArgumentExpression)
 		if arg == nil {
 			return false
 		}

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion.go
@@ -1,0 +1,423 @@
+package no_implicit_coercion
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type options struct {
+	boolean                   bool
+	number                    bool
+	str                       bool
+	disallowTemplateShorthand bool
+	allow                     *utils.Set[string]
+}
+
+func parseOptions(raw any) options {
+	opts := options{
+		boolean: true,
+		number:  true,
+		str:     true,
+		allow:   utils.NewSetWithSizeHint[string](0),
+	}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["boolean"].(bool); ok {
+		opts.boolean = v
+	}
+	if v, ok := m["number"].(bool); ok {
+		opts.number = v
+	}
+	if v, ok := m["string"].(bool); ok {
+		opts.str = v
+	}
+	if v, ok := m["disallowTemplateShorthand"].(bool); ok {
+		opts.disallowTemplateShorthand = v
+	}
+	for _, op := range utils.ToStringSlice(m["allow"]) {
+		opts.allow.Add(op)
+	}
+	return opts
+}
+
+// NoImplicitCoercionRule disallows shorthand type conversions, suggesting
+// explicit `Boolean()` / `Number()` / `String()` calls instead.
+// https://eslint.org/docs/latest/rules/no-implicit-coercion
+var NoImplicitCoercionRule = rule.Rule{
+	Name: "no-implicit-coercion",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// report emits the diagnostic for `node` (replaced with `recommendation`).
+		// ESLint's semantics:
+		//   - shouldFix  → autofix applied (no suggestion).
+		//   - shouldSuggest (and !shouldFix) → suggestion only.
+		//   - neither → plain report (no fix, no suggestion).
+		report := func(node *ast.Node, recommendation string, shouldSuggest, shouldFix bool) {
+			msg := rule.RuleMessage{
+				Id:          "implicitCoercion",
+				Description: "Unexpected implicit coercion encountered. Use `" + recommendation + "` instead.",
+			}
+			replacement := recommendation
+			// Guard `typeof+foo` → `typeof Number(foo)`: without a space, the fix
+			// would lex as a single `typeofNumber` identifier.
+			start := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos()
+			if utils.NeedsLeadingSpaceForReplacement(ctx.SourceFile.Text(), start, recommendation) {
+				replacement = " " + recommendation
+			}
+
+			if shouldFix {
+				ctx.ReportNodeWithFixes(node, msg, rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+				return
+			}
+			if shouldSuggest {
+				ctx.ReportNodeWithSuggestions(node, msg, rule.RuleSuggestion{
+					Message: rule.RuleMessage{
+						Id:          "useRecommendation",
+						Description: "Use `" + recommendation + "` instead.",
+					},
+					FixesArr: []rule.RuleFix{rule.RuleFixReplace(ctx.SourceFile, node, replacement)},
+				})
+				return
+			}
+			ctx.ReportNode(node, msg)
+		}
+
+		checkUnary := func(node *ast.Node) {
+			pue := node.AsPrefixUnaryExpression()
+			if pue == nil || pue.Operand == nil {
+				return
+			}
+
+			// !!foo → Boolean(foo) — autofix unless `Boolean` is locally shadowed.
+			// Parens between the two `!`s (e.g. `!(!foo)`) are transparent in
+			// ESLint's AST, so we peel them off to match that behavior.
+			if opts.boolean && !opts.allow.Has("!!") && isDoubleLogicalNegating(pue) {
+				innerPue := ast.SkipParentheses(pue.Operand).AsPrefixUnaryExpression()
+				target := ast.SkipParentheses(innerPue.Operand)
+				recommendation := "Boolean(" + utils.TrimmedNodeText(ctx.SourceFile, target) + ")"
+				shouldFix := !utils.IsShadowed(node, "Boolean")
+				report(node, recommendation, true, shouldFix)
+			}
+
+			// ~foo.indexOf(bar) → foo.indexOf(bar) !== -1 (or `>= 0` on an
+			// optional chain, since `?.indexOf(x) !== -1` flips to true when
+			// `foo` is nullish). No autofix: the rewrite changes semantics on
+			// non-array targets (e.g. `String.prototype.indexOf`).
+			if opts.boolean && !opts.allow.Has("~") && isBinaryNegatingOfIndexOf(pue) {
+				callNode := ast.SkipParentheses(pue.Operand)
+				comparison := "!== -1"
+				if ast.IsOptionalChain(callNode) {
+					comparison = ">= 0"
+				}
+				recommendation := utils.TrimmedNodeText(ctx.SourceFile, callNode) + " " + comparison
+				report(node, recommendation, false, false)
+			}
+
+			// +foo → Number(foo) (suggestion only — `+` on BigInt throws).
+			if opts.number && !opts.allow.Has("+") && pue.Operator == ast.KindPlusToken {
+				operand := ast.SkipParentheses(pue.Operand)
+				if !isNumeric(operand) {
+					recommendation := "Number(" + utils.TrimmedNodeText(ctx.SourceFile, operand) + ")"
+					report(node, recommendation, true, false)
+				}
+			}
+
+			// -(-foo) → Number(foo) (suggestion only — same BigInt caveat).
+			if opts.number && !opts.allow.Has("- -") && pue.Operator == ast.KindMinusToken {
+				inner := ast.SkipParentheses(pue.Operand)
+				if inner != nil && inner.Kind == ast.KindPrefixUnaryExpression {
+					innerPue := inner.AsPrefixUnaryExpression()
+					operand := ast.SkipParentheses(innerPue.Operand)
+					if innerPue.Operator == ast.KindMinusToken && !isNumeric(operand) {
+						recommendation := "Number(" + utils.TrimmedNodeText(ctx.SourceFile, operand) + ")"
+						report(node, recommendation, true, false)
+					}
+				}
+			}
+		}
+
+		checkBinary := func(node *ast.Node) {
+			bin := node.AsBinaryExpression()
+			if bin == nil || bin.OperatorToken == nil {
+				return
+			}
+
+			switch bin.OperatorToken.Kind {
+			case ast.KindAsteriskToken:
+				// `1 * foo` / `foo * 1` → Number(foo). `a * 1 / b` is skipped:
+				// the reader naturally parses it as `a * (1 / b)` rather than
+				// `(a * 1) / b`, so there's no coercion intent (issue eslint#16373).
+				if opts.number && !opts.allow.Has("*") && isMultiplyByOne(bin) && !isMultiplyByFractionOfOne(node) {
+					if operand := getNonNumericOperand(bin); operand != nil {
+						recommendation := "Number(" + utils.TrimmedNodeText(ctx.SourceFile, operand) + ")"
+						report(node, recommendation, true, false)
+					}
+				}
+			case ast.KindMinusToken:
+				// foo - 0 → Number(foo).
+				if opts.number && !opts.allow.Has("-") {
+					left := ast.SkipParentheses(bin.Left)
+					if isLiteralZero(ast.SkipParentheses(bin.Right)) && !isNumeric(left) {
+						recommendation := "Number(" + utils.TrimmedNodeText(ctx.SourceFile, left) + ")"
+						report(node, recommendation, true, false)
+					}
+				}
+			case ast.KindPlusToken:
+				// "" + foo / foo + "" → String(foo).
+				if opts.str && !opts.allow.Has("+") && isConcatWithEmptyString(bin) {
+					operand := ast.SkipParentheses(getNonEmptyOperand(bin))
+					recommendation := "String(" + utils.TrimmedNodeText(ctx.SourceFile, operand) + ")"
+					report(node, recommendation, true, false)
+				}
+			case ast.KindPlusEqualsToken:
+				// foo += "" → foo = String(foo).
+				if opts.str && !opts.allow.Has("+") && isEmptyString(ast.SkipParentheses(bin.Right)) {
+					leftText := utils.TrimmedNodeText(ctx.SourceFile, ast.SkipParentheses(bin.Left))
+					recommendation := leftText + " = String(" + leftText + ")"
+					report(node, recommendation, true, false)
+				}
+			}
+		}
+
+		checkTemplate := func(node *ast.Node) {
+			if !opts.disallowTemplateShorthand {
+				return
+			}
+			// tag`${foo}` is not a coercion — the tag function decides the result.
+			if node.Parent != nil && node.Parent.Kind == ast.KindTaggedTemplateExpression {
+				return
+			}
+			te := node.AsTemplateExpression()
+			if te == nil || te.Head == nil || te.TemplateSpans == nil {
+				return
+			}
+			// Only `` `${expr}` `` — exactly one span and empty head/tail.
+			if len(te.TemplateSpans.Nodes) != 1 || te.Head.Text() != "" {
+				return
+			}
+			span := te.TemplateSpans.Nodes[0].AsTemplateSpan()
+			if span == nil || span.Literal == nil || span.Expression == nil || span.Literal.Text() != "" {
+				return
+			}
+			// Already a string — no coercion happening.
+			expr := ast.SkipParentheses(span.Expression)
+			if isStringType(expr) {
+				return
+			}
+			recommendation := "String(" + utils.TrimmedNodeText(ctx.SourceFile, expr) + ")"
+			report(node, recommendation, true, false)
+		}
+
+		return rule.RuleListeners{
+			ast.KindPrefixUnaryExpression: checkUnary,
+			// :exit on BinaryExpression matches ESLint's ordering and keeps us
+			// from reporting the same multiplicative chain twice.
+			rule.ListenerOnExit(ast.KindBinaryExpression): checkBinary,
+			ast.KindTemplateExpression:                    checkTemplate,
+		}
+	},
+}
+
+// isDoubleLogicalNegating reports whether node is `!!x` (with any number of
+// intervening parentheses around the inner `!x`).
+func isDoubleLogicalNegating(pue *ast.PrefixUnaryExpression) bool {
+	if pue.Operator != ast.KindExclamationToken {
+		return false
+	}
+	operand := ast.SkipParentheses(pue.Operand)
+	if operand == nil || operand.Kind != ast.KindPrefixUnaryExpression {
+		return false
+	}
+	inner := operand.AsPrefixUnaryExpression()
+	return inner != nil && inner.Operator == ast.KindExclamationToken
+}
+
+// isBinaryNegatingOfIndexOf reports whether node is `~x.indexOf(y)` or
+// `~x.lastIndexOf(y)` (optionally chained, optionally parenthesised).
+func isBinaryNegatingOfIndexOf(pue *ast.PrefixUnaryExpression) bool {
+	if pue.Operator != ast.KindTildeToken {
+		return false
+	}
+	call := ast.SkipParentheses(pue.Operand)
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(call.AsCallExpression().Expression)
+	if callee == nil {
+		return false
+	}
+	switch callee.Kind {
+	case ast.KindPropertyAccessExpression:
+		name := callee.AsPropertyAccessExpression().Name()
+		return name != nil && isIndexOfName(name.Text())
+	case ast.KindElementAccessExpression:
+		arg := callee.AsElementAccessExpression().ArgumentExpression
+		if arg == nil {
+			return false
+		}
+		switch arg.Kind {
+		case ast.KindStringLiteral:
+			return isIndexOfName(arg.AsStringLiteral().Text)
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return isIndexOfName(arg.AsNoSubstitutionTemplateLiteral().Text)
+		}
+	}
+	return false
+}
+
+func isIndexOfName(s string) bool {
+	return s == "indexOf" || s == "lastIndexOf"
+}
+
+// isMultiplyByOne reports whether bin is a `*` expression with an operand
+// equal to the literal `1`.
+func isMultiplyByOne(bin *ast.BinaryExpression) bool {
+	if bin.OperatorToken.Kind != ast.KindAsteriskToken {
+		return false
+	}
+	return isLiteralOne(ast.SkipParentheses(bin.Left)) || isLiteralOne(ast.SkipParentheses(bin.Right))
+}
+
+// isMultiplyByFractionOfOne reports whether node is the `x * 1` half of a
+// `x * 1 / y` expression. In that case the whole expression is naturally
+// read as `x * (1 / y)`, so there's no coercion intent worth flagging.
+// Mirrors ESLint's fix for eslint/eslint#16373.
+func isMultiplyByFractionOfOne(node *ast.Node) bool {
+	bin := node.AsBinaryExpression()
+	if bin.OperatorToken.Kind != ast.KindAsteriskToken {
+		return false
+	}
+	if !isLiteralOne(ast.SkipParentheses(bin.Right)) {
+		return false
+	}
+	// If the node is parenthesised, `(x * 1) / y` can't be reinterpreted as
+	// `x * (1 / y)` — the parens pin the grouping to the coercion form.
+	if node.Parent == nil || node.Parent.Kind == ast.KindParenthesizedExpression {
+		return false
+	}
+	parent := node.Parent
+	if parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	parentBin := parent.AsBinaryExpression()
+	if parentBin.OperatorToken.Kind != ast.KindSlashToken {
+		return false
+	}
+	return parentBin.Left == node
+}
+
+// getNonNumericOperand returns the non-numeric operand of a `*` expression
+// when exactly one non-BinaryExpression side is non-numeric. Walked bottom-up
+// (hence the right-then-left order) to match ESLint's traversal behavior.
+func getNonNumericOperand(bin *ast.BinaryExpression) *ast.Node {
+	left, right := ast.SkipParentheses(bin.Left), ast.SkipParentheses(bin.Right)
+	if right != nil && right.Kind != ast.KindBinaryExpression && !isNumeric(right) {
+		return right
+	}
+	if left != nil && left.Kind != ast.KindBinaryExpression && !isNumeric(left) {
+		return left
+	}
+	return nil
+}
+
+// isNumeric reports whether node statically evaluates to a number: a numeric
+// literal or a call to `Number`, `parseInt`, or `parseFloat`. Shadowing of
+// these globals is ignored — matches ESLint, which also uses a syntactic check.
+func isNumeric(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if node.Kind == ast.KindNumericLiteral {
+		return true
+	}
+	if node.Kind == ast.KindCallExpression {
+		callee := node.AsCallExpression().Expression
+		if callee != nil && callee.Kind == ast.KindIdentifier {
+			switch callee.AsIdentifier().Text {
+			case "Number", "parseInt", "parseFloat":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isStringType reports whether node statically evaluates to a string: any
+// string/template literal, or a call to `String`.
+func isStringType(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression:
+		return true
+	case ast.KindCallExpression:
+		callee := node.AsCallExpression().Expression
+		if callee != nil && callee.Kind == ast.KindIdentifier && callee.AsIdentifier().Text == "String" {
+			return true
+		}
+	}
+	return false
+}
+
+// isEmptyString reports whether node is `""` or “ “ “.
+func isEmptyString(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text == ""
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text == ""
+	}
+	return false
+}
+
+// isConcatWithEmptyString reports whether bin is `"" + x` or `x + ""` where
+// `x` isn't already a string (otherwise `+` is plain concatenation).
+func isConcatWithEmptyString(bin *ast.BinaryExpression) bool {
+	if bin.OperatorToken.Kind != ast.KindPlusToken {
+		return false
+	}
+	left, right := ast.SkipParentheses(bin.Left), ast.SkipParentheses(bin.Right)
+	if isEmptyString(left) && !isStringType(right) {
+		return true
+	}
+	if isEmptyString(right) && !isStringType(left) {
+		return true
+	}
+	return false
+}
+
+// getNonEmptyOperand returns the side of a `"" + x` / `x + ""` that isn't the
+// empty string. Returns the original (possibly parenthesised) node so the
+// recommendation text reproduces the source verbatim.
+func getNonEmptyOperand(bin *ast.BinaryExpression) *ast.Node {
+	if isEmptyString(ast.SkipParentheses(bin.Left)) {
+		return bin.Right
+	}
+	return bin.Left
+}
+
+// isLiteralOne / isLiteralZero match numeric literals whose value equals
+// `1` / `0` (including `1.0`, `0x1`, `1e0`, etc.), mirroring ESLint's
+// `value === 1` / `value === 0` check on Literal nodes.
+func isLiteralOne(node *ast.Node) bool {
+	return isLiteralNumberEqual(node, "1")
+}
+
+func isLiteralZero(node *ast.Node) bool {
+	return isLiteralNumberEqual(node, "0")
+}
+
+func isLiteralNumberEqual(node *ast.Node, normalized string) bool {
+	if node == nil || node.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	return utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text) == normalized
+}

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion.md
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion.md
@@ -1,0 +1,72 @@
+# no-implicit-coercion
+
+Disallow shorthand type conversions in favor of explicit `Boolean()` / `Number()` / `String()` calls.
+
+## Rule Details
+
+In JavaScript, type conversions are often performed using shorthand syntax. While these idioms work, they obscure intent; the rule flags them so they can be replaced with explicit conversions.
+
+Patterns flagged:
+
+- `!!foo` instead of `Boolean(foo)`
+- `~foo.indexOf(bar)` (or `lastIndexOf`) instead of `foo.indexOf(bar) !== -1`
+- `+foo` or `-(-foo)` instead of `Number(foo)`
+- `1 * foo` or `foo * 1` instead of `Number(foo)`
+- `foo - 0` instead of `Number(foo)`
+- `"" + foo` / `foo + ""` (including ` ` ``) instead of `String(foo)`
+- `foo += ""` instead of `foo = String(foo)`
+- Template shorthand `` `${foo}` `` instead of `String(foo)` — only when the `disallowTemplateShorthand` option is enabled.
+
+### Options
+
+```json
+{
+  "no-implicit-coercion": [
+    "error",
+    {
+      "boolean": true,
+      "number": true,
+      "string": true,
+      "disallowTemplateShorthand": false,
+      "allow": []
+    }
+  ]
+}
+```
+
+- `boolean` (default `true`) — disallow boolean shorthand conversions (`!!`, `~`).
+- `number` (default `true`) — disallow numeric shorthand conversions (`+`, `- -`, `- 0`, `* 1`).
+- `string` (default `true`) — disallow string shorthand conversions (`"" +`, `+= ""`).
+- `disallowTemplateShorthand` (default `false`) — also disallow `` `${foo}` `` as a coercion.
+- `allow` — operators to exempt from the above. Allowed values: `"~"`, `"!!"`, `"+"`, `"- -"`, `"-"`, `"*"`.
+
+### Fix vs suggestion
+
+Only `!!foo` → `Boolean(foo)` applies as an autofix (and only when `Boolean` is not shadowed in scope). The other rewrites are offered as suggestions because they can change runtime behavior — `Number(1n)` throws, `foo.indexOf(x) !== -1` differs from `~foo.indexOf(x)` on non-array targets, etc.
+
+## Examples
+
+Incorrect:
+
+```javascript
+const b = !!foo;
+const b1 = ~foo.indexOf('.');
+const n = +foo;
+const n2 = foo - 0;
+const n3 = 1 * foo;
+const s = '' + foo;
+foo += '';
+```
+
+Correct:
+
+```javascript
+const b = Boolean(foo);
+const b1 = foo.indexOf('.') !== -1;
+const n = Number(foo);
+const s = String(foo);
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-implicit-coercion

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
@@ -1,0 +1,1276 @@
+package no_implicit_coercion
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoImplicitCoercion(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoImplicitCoercionRule,
+		[]rule_tester.ValidTestCase{
+			// Idiomatic replacements (what the rule recommends).
+			{Code: `Boolean(foo)`},
+			{Code: `foo.indexOf(1) !== -1`},
+			{Code: `Number(foo)`},
+			{Code: `parseInt(foo)`},
+			{Code: `parseFloat(foo)`},
+			{Code: `String(foo)`},
+
+			// Single unary/binary operator on non-coerce target.
+			{Code: `!foo`},
+			{Code: `~foo`},
+			{Code: `-foo`},
+			{Code: `+1234`},
+			{Code: `-1234`},
+			{Code: `- -1234`},
+			{Code: `+Number(lol)`},
+			{Code: `-parseFloat(lol)`},
+
+			// Multiplicative chains that aren't `1 * non-numeric`.
+			{Code: `2 * foo`},
+			{Code: `1 * 1234`},
+			{Code: `123 - 0`},
+			{Code: `1 * Number(foo)`},
+			{Code: `1 * parseInt(foo)`},
+			{Code: `1 * parseFloat(foo)`},
+			{Code: `Number(foo) * 1`},
+			{Code: `Number(foo) - 0`},
+			{Code: `parseInt(foo) * 1`},
+			{Code: `parseFloat(foo) * 1`},
+			{Code: `- -Number(foo)`},
+			{Code: `1 * 1234 * 678 * Number(foo)`},
+			{Code: `1 * 1234 * 678 * parseInt(foo)`},
+			{Code: `(1 - 0) * parseInt(foo)`},
+			{Code: `1234 * 1 * 678 * Number(foo)`},
+			{Code: `1234 * 1 * Number(foo) * Number(bar)`},
+			{Code: `1234 * 1 * Number(foo) * parseInt(bar)`},
+			{Code: `1234 * 1 * Number(foo) * parseFloat(bar)`},
+			{Code: `1234 * 1 * parseInt(foo) * parseFloat(bar)`},
+			{Code: `1234 * 1 * parseInt(foo) * Number(bar)`},
+			{Code: `1234 * 1 * parseFloat(foo) * Number(bar)`},
+			{Code: `1234 * Number(foo) * 1 * Number(bar)`},
+			{Code: `1234 * parseInt(foo) * 1 * Number(bar)`},
+			{Code: `1234 * parseFloat(foo) * 1 * parseInt(bar)`},
+			{Code: `1234 * parseFloat(foo) * 1 * Number(bar)`},
+			{Code: `(- -1234) * (parseFloat(foo) - 0) * (Number(bar) - 0)`},
+			{Code: `1234*foo*1`},
+			{Code: `1234*1*foo`},
+			{Code: `1234*bar*1*foo`},
+			{Code: `1234*1*foo*bar`},
+			{Code: `1234*1*foo*Number(bar)`},
+			{Code: `1234*1*Number(foo)*bar`},
+			{Code: `1234*1*parseInt(foo)*bar`},
+			{Code: `0 + foo`},
+			{Code: `~foo.bar()`},
+
+			// String concatenation with a non-empty literal is fine.
+			{Code: `foo + 'bar'`},
+			{Code: "foo + `${bar}`"},
+
+			// Option toggles — rule types individually disabled.
+			{Code: `!!foo`, Options: map[string]interface{}{"boolean": false}},
+			{Code: `~foo.indexOf(1)`, Options: map[string]interface{}{"boolean": false}},
+			{Code: `+foo`, Options: map[string]interface{}{"number": false}},
+			{Code: `-(-foo)`, Options: map[string]interface{}{"number": false}},
+			{Code: `foo - 0`, Options: map[string]interface{}{"number": false}},
+			{Code: `1*foo`, Options: map[string]interface{}{"number": false}},
+			{Code: `""+foo`, Options: map[string]interface{}{"string": false}},
+			{Code: `foo += ""`, Options: map[string]interface{}{"string": false}},
+
+			// Allowlist entries.
+			{Code: `var a = !!foo`, Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"!!"}}},
+			{Code: `var a = ~foo.indexOf(1)`, Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"~"}}},
+			{Code: `var a = ~foo`, Options: map[string]interface{}{"boolean": true}},
+			{Code: `var a = 1 * foo`, Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"*"}}},
+			{Code: `- -foo`, Options: map[string]interface{}{"number": true, "allow": []interface{}{"- -"}}},
+			{Code: `foo - 0`, Options: map[string]interface{}{"number": true, "allow": []interface{}{"-"}}},
+			{Code: `var a = +foo`, Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"+"}}},
+			{Code: `var a = "" + foo`, Options: map[string]interface{}{"boolean": true, "string": true, "allow": []interface{}{"+"}}},
+
+			// https://github.com/eslint/eslint/issues/7057 — both operands already string.
+			{Code: `'' + 'foo'`},
+			{Code: "`` + 'foo'"},
+			{Code: "'' + `${foo}`"},
+			{Code: `'foo' + ''`},
+			{Code: "'foo' + ``"},
+			{Code: "`${foo}` + ''"},
+			{Code: `foo += 'bar'`},
+			{Code: "foo += `${bar}`"},
+
+			// disallowTemplateShorthand: non-shorthand templates don't trigger.
+			{Code: "`a${foo}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			{Code: "`${foo}b`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			{Code: "`${foo}${bar}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			{Code: "tag`${foo}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			// Default is off.
+			{Code: "`${foo}`"},
+			{Code: "`${foo}`", Options: map[string]interface{}{"disallowTemplateShorthand": false}},
+			{Code: `+42`},
+
+			// https://github.com/eslint/eslint/issues/14623 — String(...) operand is already string.
+			{Code: `'' + String(foo)`},
+			{Code: `String(foo) + ''`},
+			{Code: "`` + String(foo)"},
+			{Code: "String(foo) + ``"},
+			{Code: "`${'foo'}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			{Code: "`${`foo`}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			{Code: "`${String(foo)}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+
+			// https://github.com/eslint/eslint/issues/16373 — fraction-of-one pattern.
+			{Code: `console.log(Math.PI * 1/4)`},
+			{Code: `a * 1 / 2`},
+			{Code: `a * 1 / b`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// !!foo — fix applied when Boolean not shadowed. Autofix cases have
+			// no suggestions (ESLint drops the suggestion when `shouldFix`).
+			{
+				Code:   `!!foo`,
+				Output: []string{`Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:   `!!(foo + bar)`,
+				Output: []string{`Boolean(foo + bar)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Boolean shadowed — suggestion only, no autofix.
+			{
+				Code: `!!(foo + bar); var Boolean = null;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Boolean(foo + bar); var Boolean = null;`},
+						},
+					},
+				},
+			},
+			// ~foo.indexOf(x) — no fix, no suggestion (reported only).
+			{
+				Code: `~foo.indexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `~foo.bar.indexOf(2)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// +foo — suggestion only.
+			{
+				Code: `+foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `-(-foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `+foo.bar`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo.bar)`},
+						},
+					},
+				},
+			},
+			// Multiply by 1.
+			{
+				Code: `1*foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo*1`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `1*foo.bar`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo.bar)`},
+						},
+					},
+				},
+			},
+			// Subtract 0.
+			{
+				Code: `foo.bar-0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo.bar)`},
+						},
+					},
+				},
+			},
+			// "" + x / x + "".
+			{
+				Code: `""+foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: "``+foo",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo+""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: "foo+``",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `""+foo.bar`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo.bar)`},
+						},
+					},
+				},
+			},
+			{
+				Code: "``+foo.bar",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo.bar)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo.bar+""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo.bar)`},
+						},
+					},
+				},
+			},
+			{
+				Code: "foo.bar+``",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo.bar)`},
+						},
+					},
+				},
+			},
+			// Template shorthand.
+			{
+				Code:    "`${foo}`",
+				Options: map[string]interface{}{"disallowTemplateShorthand": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			// x += "".
+			{
+				Code: `foo += ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `foo = String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: "foo += ``",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `foo = String(foo)`},
+						},
+					},
+				},
+			},
+			// allow list doesn't suppress a different operator.
+			{
+				Code:    `var a = !!foo`,
+				Output:  []string{`var a = Boolean(foo)`},
+				Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"~"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:    `var a = ~foo.indexOf(1)`,
+				Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"!!"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:    `var a = 1 * foo`,
+				Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"+"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `var a = Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code:    `var a = +foo`,
+				Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"*"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `var a = Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code:    `var a = "" + foo`,
+				Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"*"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `var a = String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code:    "var a = `` + foo",
+				Options: map[string]interface{}{"boolean": true, "allow": []interface{}{"*"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 9,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `var a = String(foo)`},
+						},
+					},
+				},
+			},
+			// typeof+foo — leading-space handling keeps output lexable.
+			{
+				Code: `typeof+foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `typeof Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `typeof +foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 8,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `typeof Number(foo)`},
+						},
+					},
+				},
+			},
+			// BigInt operand: `'' + 1n` still flagged (1n is not isNumeric).
+			{
+				Code: `let x ='' + 1n;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 8,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `let x =String(1n);`},
+						},
+					},
+				},
+			},
+			// Optional chaining — `>= 0` recommendation.
+			{
+				Code: `~foo?.indexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Parens around the optional chain callee break the chain — `!== -1`.
+			{
+				Code: `~(foo?.indexOf)(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Fraction-of-one regression cases (issue 16373).
+			{
+				Code: `1 * a / 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(a) / 2`},
+						},
+					},
+				},
+			},
+			{
+				Code: `(a * 1) / 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 2,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `(Number(a)) / 2`},
+						},
+					},
+				},
+			},
+			{
+				Code: `a * 1 / (b * 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 10,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `a * 1 / (Number(b))`},
+						},
+					},
+				},
+			},
+			{
+				Code: `a * 1 + 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(a) + 2`},
+						},
+					},
+				},
+			},
+
+			// --- Additional edge cases: parenthesised variants ---
+
+			// `!!` with parens between the two `!`s (transparent in ESLint).
+			{
+				Code:   `!(!foo)`,
+				Output: []string{`Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Deeply nested parens between `!`s.
+			{
+				Code:   `!((!foo))`,
+				Output: []string{`Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// `!!` on a parenthesised inner — recommendation drops the parens.
+			{
+				Code:   `!!((foo))`,
+				Output: []string{`Boolean(foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Triple negation: the outer `!!` (`!!` of `!foo`) and the middle
+			// `!!` (`!!foo`) each match, same as ESLint.
+			{
+				Code:   `!!!foo`,
+				Output: []string{`Boolean(!foo)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+					{MessageId: "implicitCoercion", Line: 1, Column: 2},
+				},
+			},
+			// TS `as` expression wrapped in `!!` — target text keeps the cast.
+			{
+				Code:   `!!(foo as any)`,
+				Output: []string{`Boolean(foo as any)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+
+			// `~indexOf` variants.
+			{
+				Code: `~foo.lastIndexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `~foo['indexOf'](1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "~foo[`indexOf`](1)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Outer parens around the call argument.
+			{
+				Code: `~(foo.indexOf(1))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Optional call: `?.(` on the call itself — still an optional chain.
+			{
+				Code: `~foo.indexOf?.(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// Chained member before `.indexOf` with optional access — chain flag propagates.
+			{
+				Code: `~foo?.bar.indexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+
+			// `+foo` with parens.
+			{
+				Code: `+(foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			// `+` on BigInt (not isNumeric) — still reported; `Number(1n)` throws
+			// at runtime but that mirrors ESLint's behavior exactly.
+			{
+				Code: `+1n`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(1n)`},
+						},
+					},
+				},
+			},
+			// Stacked `+`: both are reported independently.
+			{
+				Code: `+ +foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(+foo)`},
+						},
+					},
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 3,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `+ Number(foo)`},
+						},
+					},
+				},
+			},
+			// `- -` with inner parens.
+			{
+				Code: `-(- foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			// `- -` with double parens.
+			{
+				Code: `-((-foo))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+
+			// `*1` / `1*` with parens around the numeric or operand.
+			{
+				Code: `(1) * foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo * (1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			// Normalized numeric literals (1.0, 0x1, 1e0).
+			{
+				Code: `1.0 * foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `0x1 * foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `1e0 * foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			// Stacked `*1`: inner is flagged but outer (non-literal chain) isn't.
+			{
+				Code: `1 * foo * 1`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo) * 1`},
+						},
+					},
+				},
+			},
+
+			// `- 0` with parens on operand (node replaced whole, parens absorbed).
+			{
+				Code: `(foo) - 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo - (0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			// Normalized zero (0.0, 0x0).
+			{
+				Code: `foo - 0.0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo - 0x0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo)`},
+						},
+					},
+				},
+			},
+
+			// `"" + x` with parens on operand — parens dropped in recommendation.
+			{
+				Code: `"" + (foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `(foo) + ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			// Member access / element access.
+			{
+				Code: `obj.prop + ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(obj.prop)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `arr[0] + ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(arr[0])`},
+						},
+					},
+				},
+			},
+			// "" + (x + y) — parens preserved in the inner expression text.
+			{
+				Code: `"" + (foo + bar)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo + bar)`},
+						},
+					},
+				},
+			},
+
+			// `` `${expr}` `` variants.
+			{
+				Code:    "`${foo.bar}`",
+				Options: map[string]interface{}{"disallowTemplateShorthand": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo.bar)`},
+						},
+					},
+				},
+			},
+			// Parens around the interpolated expression — stripped in output.
+			{
+				Code:    "`${(foo)}`",
+				Options: map[string]interface{}{"disallowTemplateShorthand": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			// Nested coercion: outer template is a string (inner template counts as
+			// string type), so only the inner `` `${foo}` `` is flagged.
+			{
+				Code:    "`${`${foo}`}`",
+				Options: map[string]interface{}{"disallowTemplateShorthand": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: "`${String(foo)}`"},
+						},
+					},
+				},
+			},
+
+			// `+=` with parens or member targets.
+			{
+				Code: `obj.prop += ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `obj.prop = String(obj.prop)`},
+						},
+					},
+				},
+			},
+			{
+				Code: `arr[0] += ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `arr[0] = String(arr[0])`},
+						},
+					},
+				},
+			},
+
+			// Scope/shadowing edge cases for `!!`.
+			{
+				// Shadowed in a function — suggestion only.
+				Code: `function f() { var Boolean = 1; return !!foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 40,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `function f() { var Boolean = 1; return Boolean(foo); }`},
+						},
+					},
+				},
+			},
+			{
+				// Shadowed by a block-scoped let — suggestion only.
+				Code: `{ let Boolean = 1; !!foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `{ let Boolean = 1; Boolean(foo); }`},
+						},
+					},
+				},
+			},
+			{
+				// Shadowing in an enclosing scope outside the block — autofix
+				// applies because the reference is not shadowed where it appears.
+				Code:   `{ let Boolean = 1; } !!foo;`,
+				Output: []string{`{ let Boolean = 1; } Boolean(foo);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 22},
+				},
+			},
+
+			// Mixed/nested coercion chains (each inner pattern reported).
+			{
+				// `"" + foo + bar` parses as `("" + foo) + bar`; the inner is
+				// the coercion, the outer is plain concatenation.
+				Code: `"" + foo + bar`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo) + bar`},
+						},
+					},
+				},
+			},
+			{
+				// `!!foo && !!bar` — both outer `!!` patterns are reported.
+				Code:   `!!foo && !!bar`,
+				Output: []string{`Boolean(foo) && Boolean(bar)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+					{MessageId: "implicitCoercion", Line: 1, Column: 10},
+				},
+			},
+			// `!!` inside a conditional — each branch reported independently.
+			{
+				Code:   `cond ? !!foo : !!bar`,
+				Output: []string{`cond ? Boolean(foo) : Boolean(bar)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 8},
+					{MessageId: "implicitCoercion", Line: 1, Column: 16},
+				},
+			},
+			// `!!` in an arrow body.
+			{
+				Code:   `const f = x => !!x;`,
+				Output: []string{`const f = x => Boolean(x);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 16},
+				},
+			},
+			// `- -` applied to a call result (non-numeric wrapper).
+			{
+				Code: `- -foo()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo())`},
+						},
+					},
+				},
+			},
+			// `- -` with inner numeric: skipped (no coercion needed).
+			// (Already covered as valid: `- -1234`, `- -Number(foo)`.)
+
+			// String concat inside a larger chain — ensure the outer (which
+			// treats the left side as a non-string BinaryExpression) isn't
+			// flagged; only the inner `"" + foo` is.
+			{
+				Code: `"" + foo + bar + baz`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo) + bar + baz`},
+						},
+					},
+				},
+			},
+
+			// Multiply inside a division chain that doesn't form a `(x*1)/y`
+			// fraction — the inner `x*1` is still coercion.
+			{
+				Code: `x * 1 * y / z`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						// inner `x * 1`: parent is `* y`, not `/`, so fraction
+						// check fails and we report.
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(x) * y / z`},
+						},
+					},
+				},
+			},
+
+			// Optional chain variants for the `~` pattern — recommendation text
+			// keeps the callee intact.
+			{
+				Code: `~foo?.bar.indexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+
+			// --- More nesting: coercion patterns inside other expression contexts ---
+
+			// `!!` inside object property value.
+			{
+				Code:   `const o = { a: !!foo };`,
+				Output: []string{`const o = { a: Boolean(foo) };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 16},
+				},
+			},
+			// `!!` inside destructuring default.
+			{
+				Code:   `const { x = !!foo } = obj;`,
+				Output: []string{`const { x = Boolean(foo) } = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 13},
+				},
+			},
+			// `!!` inside spread in array literal.
+			{
+				Code:   `const a = [...!!foo];`,
+				Output: []string{`const a = [...Boolean(foo)];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 15},
+				},
+			},
+			// `!!` over non-null assertion (TS-specific node, preserved verbatim).
+			{
+				Code:   `!!(foo!)`,
+				Output: []string{`Boolean(foo!)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+
+			// `"" + foo` inside a template — inner BinExpr is flagged.
+			{
+				Code: "`${'' + foo}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 4,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: "`${String(foo)}`"},
+						},
+					},
+				},
+			},
+
+			// `*1` multiplied with BigInt on the other side — non-numeric so reported.
+			{
+				Code: `1n * 1`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(1n)`},
+						},
+					},
+				},
+			},
+
+			// `+` on a call result (non-numeric) — still flagged.
+			{
+				Code: `+foo()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `Number(foo())`},
+						},
+					},
+				},
+			},
+
+			// Both `(x * 1)` and `(y * 1)` parenthesised — neither qualifies as
+			// a fraction-of-one, so both are reported.
+			{
+				Code: `(a * 1) * (b * 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 2,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `(Number(a)) * (b * 1)`},
+						},
+					},
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 12,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `(a * 1) * (Number(b))`},
+						},
+					},
+				},
+			},
+
+			// --- Remaining corner cases ---
+
+			// `Boolean` shadowed as a function parameter — suggestion only.
+			{
+				Code: `function f(Boolean) { return !!foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 30,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `function f(Boolean) { return Boolean(foo); }`},
+						},
+					},
+				},
+			},
+			// `"" + foo + ""` — parses as `("" + foo) + ""`; both layers match
+			// ESLint's literal check (outer's left is a BinaryExpression, which
+			// isStringType does not recognize as string), so both are reported.
+			{
+				Code: `"" + foo + ""`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo) + ""`},
+						},
+					},
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String("" + foo)`},
+						},
+					},
+				},
+			},
+			// Template shorthand with a trailing line-continuation (cooked tail
+			// still empty, so the shorthand pattern applies).
+			{
+				Code:    "`${foo}\\\n`",
+				Options: map[string]interface{}{"disallowTemplateShorthand": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `String(foo)`},
+						},
+					},
+				},
+			},
+			// `!!` on an awaited expression — flagged, inner text preserved.
+			{
+				Code:   `async function f() { return !!(await g()); }`,
+				Output: []string{`async function f() { return Boolean(await g()); }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 29},
+				},
+			},
+			// `~` on `indexOf` applied to a call-result receiver.
+			{
+				Code: `~foo().indexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// `~` with parens around the non-optional callee.
+			{
+				Code: `~(foo.indexOf)(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			// `Boolean` shadowed by a class name at the top level — suggestion only.
+			{
+				Code: `class Boolean {} !!foo;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `class Boolean {} Boolean(foo);`},
+						},
+					},
+				},
+			},
+			// `Boolean` shadowed by a namespace at the top level — suggestion only.
+			{
+				Code: `namespace Boolean {} !!foo;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 22,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `namespace Boolean {} Boolean(foo);`},
+						},
+					},
+				},
+			},
+			// Keyword adjacency: `void+foo` — fix must keep a separating space.
+			{
+				Code: `void+foo`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 5,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `void Number(foo)`},
+						},
+					},
+				},
+			},
+			// `~` applied to `+call.indexOf(...)` — the outer `~` doesn't match
+			// (operand isn't a CallExpression), but the inner `+call` does.
+			{
+				Code: `~+foo.indexOf(1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "implicitCoercion", Line: 1, Column: 2,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "useRecommendation", Output: `~Number(foo.indexOf(1))`},
+						},
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
@@ -1236,6 +1236,20 @@ func TestNoImplicitCoercion(t *testing.T) {
 					{MessageId: "implicitCoercion", Line: 1, Column: 1},
 				},
 			},
+			// Computed property key wrapped in parens — ESLint treats parens
+			// transparently in the `isSpecificMemberAccess` check.
+			{
+				Code: `~foo[('indexOf')](1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "~foo[(`lastIndexOf`)](1)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "implicitCoercion", Line: 1, Column: 1},
+				},
+			},
 			// `Boolean` shadowed by a class name at the top level — suggestion only.
 			{
 				Code: `class Boolean {} !!foo;`,

--- a/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
+++ b/internal/rules/no_implicit_coercion/no_implicit_coercion_test.go
@@ -126,6 +126,20 @@ func TestNoImplicitCoercion(t *testing.T) {
 			{Code: `console.log(Math.PI * 1/4)`},
 			{Code: `a * 1 / 2`},
 			{Code: `a * 1 / b`},
+
+			// Parenthesised callee — ESLint treats `(Number)(x)` as numeric and
+			// `(String)(x)` as string, since parens are transparent.
+			{Code: `+(Number)(foo)`},
+			{Code: `- -(Number)(foo)`},
+			{Code: `(Number)(foo) * 1`},
+			{Code: `(Number)(foo) - 0`},
+			{Code: `'' + (String)(foo)`},
+			{Code: `(String)(foo) + ''`},
+			{Code: "`` + (String)(foo)"},
+			{Code: "(String)(foo) + ``"},
+			{Code: "`${(String)(foo)}`", Options: map[string]interface{}{"disallowTemplateShorthand": true}},
+			// Doubly-parenthesised callee.
+			{Code: `+((Number))(foo)`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// !!foo — fix applied when Boolean not shadowed. Autofix cases have

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -286,6 +287,31 @@ func ToStringSlice(val interface{}) []string {
 		return nil
 	}
 	return result
+}
+
+// NeedsLeadingSpaceForReplacement reports whether inserting `replacement`
+// at `insertPos` in `src` would merge with the preceding character into a
+// single identifier token. Callers use this when synthesizing a fix whose
+// text starts with an identifier (e.g. `Boolean(foo)`, `Number(foo)`,
+// `String(foo)`) to decide whether a leading space is required.
+//
+// Mirrors the identifier/keyword case of ESLint's `canTokensBeAdjacent`:
+// `typeof+foo` replaced with `Number(foo)` would otherwise become
+// `typeofNumber(foo)` (a single identifier). Multi-byte identifier chars
+// are handled via `scanner.IsIdentifierPart` / `scanner.IsIdentifierStart`.
+func NeedsLeadingSpaceForReplacement(src string, insertPos int, replacement string) bool {
+	if insertPos <= 0 || insertPos > len(src) || replacement == "" {
+		return false
+	}
+	firstRune, _ := utf8.DecodeRuneInString(replacement)
+	if firstRune == utf8.RuneError || !scanner.IsIdentifierStart(firstRune) {
+		return false
+	}
+	prevRune, _ := utf8.DecodeLastRuneInString(src[:insertPos])
+	if prevRune == utf8.RuneError {
+		return false
+	}
+	return scanner.IsIdentifierPart(prevRune)
 }
 
 // NaturalCompare compares two strings using natural sort order,

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -36,6 +36,7 @@ export default defineConfig({
     './tests/eslint/rules/no-empty.test.ts',
     './tests/eslint/rules/no-empty-pattern.test.ts',
     './tests/eslint/rules/no-eval.test.ts',
+    './tests/eslint/rules/no-implicit-coercion.test.ts',
     './tests/eslint/rules/no-iterator.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
     './tests/eslint/rules/no-loss-of-precision.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-implicit-coercion.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-implicit-coercion.test.ts.snap
@@ -886,6 +886,58 @@ exports[`no-implicit-coercion > invalid 34`] = `
 
 exports[`no-implicit-coercion > invalid 35`] = `
 {
+  "code": "~foo[('indexOf')](1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo[('indexOf')](1) !== -1\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 36`] = `
+{
+  "code": "~foo[(\`lastIndexOf\`)](1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo[(\`lastIndexOf\`)](1) !== -1\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 37`] = `
+{
   "code": "1 * a / 2",
   "diagnostics": [
     {
@@ -910,7 +962,7 @@ exports[`no-implicit-coercion > invalid 35`] = `
 }
 `;
 
-exports[`no-implicit-coercion > invalid 36`] = `
+exports[`no-implicit-coercion > invalid 38`] = `
 {
   "code": "(a * 1) / 2",
   "diagnostics": [
@@ -936,7 +988,7 @@ exports[`no-implicit-coercion > invalid 36`] = `
 }
 `;
 
-exports[`no-implicit-coercion > invalid 37`] = `
+exports[`no-implicit-coercion > invalid 39`] = `
 {
   "code": "a * 1 / (b * 1)",
   "diagnostics": [
@@ -962,7 +1014,7 @@ exports[`no-implicit-coercion > invalid 37`] = `
 }
 `;
 
-exports[`no-implicit-coercion > invalid 38`] = `
+exports[`no-implicit-coercion > invalid 40`] = `
 {
   "code": "a * 1 + 2",
   "diagnostics": [

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-implicit-coercion.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-implicit-coercion.test.ts.snap
@@ -1,0 +1,989 @@
+// Rstest Snapshot v1
+
+exports[`no-implicit-coercion > invalid 1`] = `
+{
+  "code": "!!foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Boolean(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 2`] = `
+{
+  "code": "!!(foo + bar)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Boolean(foo + bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 3`] = `
+{
+  "code": "!!(foo + bar); var Boolean = null;",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Boolean(foo + bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 4`] = `
+{
+  "code": "~foo.indexOf(1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo.indexOf(1) !== -1\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 5`] = `
+{
+  "code": "~foo.bar.indexOf(2)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo.bar.indexOf(2) !== -1\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 6`] = `
+{
+  "code": "+foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 7`] = `
+{
+  "code": "-(-foo)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 8`] = `
+{
+  "code": "+foo.bar",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 9`] = `
+{
+  "code": "1*foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 10`] = `
+{
+  "code": "foo*1",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 11`] = `
+{
+  "code": "1*foo.bar",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 12`] = `
+{
+  "code": "foo.bar-0",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 13`] = `
+{
+  "code": """+foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 14`] = `
+{
+  "code": "\`\`+foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 15`] = `
+{
+  "code": "foo+""",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 16`] = `
+{
+  "code": "foo+\`\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 17`] = `
+{
+  "code": """+foo.bar",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 18`] = `
+{
+  "code": "\`\`+foo.bar",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 19`] = `
+{
+  "code": "foo.bar+""",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 20`] = `
+{
+  "code": "foo.bar+\`\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo.bar)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 21`] = `
+{
+  "code": "\`\${foo}\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 22`] = `
+{
+  "code": "foo += """,
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo = String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 23`] = `
+{
+  "code": "foo += \`\`",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo = String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 24`] = `
+{
+  "code": "var a = !!foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Boolean(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 25`] = `
+{
+  "code": "var a = ~foo.indexOf(1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo.indexOf(1) !== -1\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 26`] = `
+{
+  "code": "var a = 1 * foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 27`] = `
+{
+  "code": "var a = +foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 28`] = `
+{
+  "code": "var a = "" + foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 29`] = `
+{
+  "code": "var a = \`\` + foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 30`] = `
+{
+  "code": "typeof+foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 31`] = `
+{
+  "code": "typeof +foo",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(foo)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 32`] = `
+{
+  "code": "let x ='' + 1n;",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`String(1n)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 33`] = `
+{
+  "code": "~foo?.indexOf(1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`foo?.indexOf(1) >= 0\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 34`] = `
+{
+  "code": "~(foo?.indexOf)(1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`(foo?.indexOf)(1) !== -1\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 35`] = `
+{
+  "code": "1 * a / 2",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(a)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 36`] = `
+{
+  "code": "(a * 1) / 2",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(a)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 37`] = `
+{
+  "code": "a * 1 / (b * 1)",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(b)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implicit-coercion > invalid 38`] = `
+{
+  "code": "a * 1 + 2",
+  "diagnostics": [
+    {
+      "message": "Unexpected implicit coercion encountered. Use \`Number(a)\` instead.",
+      "messageId": "implicitCoercion",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implicit-coercion",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-implicit-coercion.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-implicit-coercion.test.ts
@@ -1,0 +1,298 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-implicit-coercion', {
+  valid: [
+    'Boolean(foo)',
+    'foo.indexOf(1) !== -1',
+    'Number(foo)',
+    'parseInt(foo)',
+    'parseFloat(foo)',
+    'String(foo)',
+    '!foo',
+    '~foo',
+    '-foo',
+    '+1234',
+    '-1234',
+    '- -1234',
+    '+Number(lol)',
+    '-parseFloat(lol)',
+    '2 * foo',
+    '1 * 1234',
+    '123 - 0',
+    '1 * Number(foo)',
+    '1 * parseInt(foo)',
+    '1 * parseFloat(foo)',
+    'Number(foo) * 1',
+    'Number(foo) - 0',
+    'parseInt(foo) * 1',
+    'parseFloat(foo) * 1',
+    '- -Number(foo)',
+    '1 * 1234 * 678 * Number(foo)',
+    '1 * 1234 * 678 * parseInt(foo)',
+    '(1 - 0) * parseInt(foo)',
+    '1234 * 1 * 678 * Number(foo)',
+    '1234 * 1 * Number(foo) * Number(bar)',
+    '1234 * 1 * Number(foo) * parseInt(bar)',
+    '1234 * 1 * Number(foo) * parseFloat(bar)',
+    '1234 * 1 * parseInt(foo) * parseFloat(bar)',
+    '1234 * 1 * parseInt(foo) * Number(bar)',
+    '1234 * 1 * parseFloat(foo) * Number(bar)',
+    '1234 * Number(foo) * 1 * Number(bar)',
+    '1234 * parseInt(foo) * 1 * Number(bar)',
+    '1234 * parseFloat(foo) * 1 * parseInt(bar)',
+    '1234 * parseFloat(foo) * 1 * Number(bar)',
+    '(- -1234) * (parseFloat(foo) - 0) * (Number(bar) - 0)',
+    '1234*foo*1',
+    '1234*1*foo',
+    '1234*bar*1*foo',
+    '1234*1*foo*bar',
+    '1234*1*foo*Number(bar)',
+    '1234*1*Number(foo)*bar',
+    '1234*1*parseInt(foo)*bar',
+    '0 + foo',
+    '~foo.bar()',
+    "foo + 'bar'",
+    'foo + `${bar}`',
+
+    { code: '!!foo', options: { boolean: false } },
+    { code: '~foo.indexOf(1)', options: { boolean: false } },
+    { code: '+foo', options: { number: false } },
+    { code: '-(-foo)', options: { number: false } },
+    { code: 'foo - 0', options: { number: false } },
+    { code: '1*foo', options: { number: false } },
+    { code: '""+foo', options: { string: false } },
+    { code: 'foo += ""', options: { string: false } },
+    { code: 'var a = !!foo', options: { boolean: true, allow: ['!!'] } },
+    {
+      code: 'var a = ~foo.indexOf(1)',
+      options: { boolean: true, allow: ['~'] },
+    },
+    { code: 'var a = ~foo', options: { boolean: true } },
+    { code: 'var a = 1 * foo', options: { boolean: true, allow: ['*'] } },
+    { code: '- -foo', options: { number: true, allow: ['- -'] } },
+    { code: 'foo - 0', options: { number: true, allow: ['-'] } },
+    { code: 'var a = +foo', options: { boolean: true, allow: ['+'] } },
+    {
+      code: 'var a = "" + foo',
+      options: { boolean: true, string: true, allow: ['+'] },
+    },
+
+    // https://github.com/eslint/eslint/issues/7057
+    "'' + 'foo'",
+    "`` + 'foo'",
+    "'' + `${foo}`",
+    "'foo' + ''",
+    "'foo' + ``",
+    '`${foo}` + ""',
+    "foo += 'bar'",
+    'foo += `${bar}`',
+    {
+      code: '`a${foo}`',
+      options: { disallowTemplateShorthand: true },
+    },
+    {
+      code: '`${foo}b`',
+      options: { disallowTemplateShorthand: true },
+    },
+    {
+      code: '`${foo}${bar}`',
+      options: { disallowTemplateShorthand: true },
+    },
+    {
+      code: 'tag`${foo}`',
+      options: { disallowTemplateShorthand: true },
+    },
+    '`${foo}`',
+    {
+      code: '`${foo}`',
+      options: { disallowTemplateShorthand: false },
+    },
+    '+42',
+
+    // https://github.com/eslint/eslint/issues/14623
+    "'' + String(foo)",
+    "String(foo) + ''",
+    '`` + String(foo)',
+    'String(foo) + ``',
+    {
+      code: "`${'foo'}`",
+      options: { disallowTemplateShorthand: true },
+    },
+    {
+      code: '`${`foo`}`',
+      options: { disallowTemplateShorthand: true },
+    },
+    {
+      code: '`${String(foo)}`',
+      options: { disallowTemplateShorthand: true },
+    },
+
+    // https://github.com/eslint/eslint/issues/16373
+    'console.log(Math.PI * 1/4)',
+    'a * 1 / 2',
+    'a * 1 / b',
+  ],
+  invalid: [
+    {
+      code: '!!foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '!!(foo + bar)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '!!(foo + bar); var Boolean = null;',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '~foo.indexOf(1)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '~foo.bar.indexOf(2)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '+foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '-(-foo)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '+foo.bar',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '1*foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo*1',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '1*foo.bar',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo.bar-0',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '""+foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '``+foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo+""',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo+``',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '""+foo.bar',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '``+foo.bar',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo.bar+""',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo.bar+``',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '`${foo}`',
+      options: { disallowTemplateShorthand: true },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo += ""',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'foo += ``',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'var a = !!foo',
+      options: { boolean: true, allow: ['~'] },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'var a = ~foo.indexOf(1)',
+      options: { boolean: true, allow: ['!!'] },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'var a = 1 * foo',
+      options: { boolean: true, allow: ['+'] },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'var a = +foo',
+      options: { boolean: true, allow: ['*'] },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'var a = "" + foo',
+      options: { boolean: true, allow: ['*'] },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'var a = `` + foo',
+      options: { boolean: true, allow: ['*'] },
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'typeof+foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'typeof +foo',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: "let x ='' + 1n;",
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '~foo?.indexOf(1)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '~(foo?.indexOf)(1)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '1 * a / 2',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '(a * 1) / 2',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'a * 1 / (b * 1)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: 'a * 1 + 2',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/no-implicit-coercion.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-implicit-coercion.test.ts
@@ -295,6 +295,14 @@ ruleTester.run('no-implicit-coercion', {
       errors: [{ messageId: 'implicitCoercion' }],
     },
     {
+      code: "~foo[('indexOf')](1)",
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
+      code: '~foo[(`lastIndexOf`)](1)',
+      errors: [{ messageId: 'implicitCoercion' }],
+    },
+    {
       code: '1 * a / 2',
       errors: [{ messageId: 'implicitCoercion' }],
     },

--- a/packages/rslint-test-tools/tests/eslint/rules/no-implicit-coercion.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-implicit-coercion.test.ts
@@ -133,6 +133,22 @@ ruleTester.run('no-implicit-coercion', {
     'console.log(Math.PI * 1/4)',
     'a * 1 / 2',
     'a * 1 / b',
+
+    // Parenthesised callee on Number/String — parens are transparent in ESLint,
+    // so these are treated as already-coerced and NOT flagged.
+    '+(Number)(foo)',
+    '- -(Number)(foo)',
+    '(Number)(foo) * 1',
+    '(Number)(foo) - 0',
+    "'' + (String)(foo)",
+    "(String)(foo) + ''",
+    '`` + (String)(foo)',
+    '(String)(foo) + ``',
+    {
+      code: '`${(String)(foo)}`',
+      options: { disallowTemplateShorthand: true },
+    },
+    '+((Number))(foo)',
   ],
   invalid: [
     {


### PR DESCRIPTION
## Summary

Port the `no-implicit-coercion` rule from ESLint to rslint.

Disallows shorthand type conversions (`!!foo`, `~foo.indexOf(bar)`, `+foo`, `-(-foo)`, `1 * foo`, `foo - 0`, `"" + foo`, `foo += ""`, and optionally `` `${foo}` ``), recommending explicit `Boolean()` / `Number()` / `String()` calls instead.

### Fix / suggestion semantics (mirrors ESLint exactly)

| Pattern | Behavior |
|---|---|
| `!!foo` → `Boolean(foo)` | autofix when `Boolean` is not locally shadowed; suggestion otherwise |
| `~foo.indexOf(bar)` → `foo.indexOf(bar) !== -1` (or `>= 0` on an optional chain) | plain report — no fix, no suggestion |
| `+foo` / `-(-foo)` / `1 * foo` / `foo - 0` / `"" + foo` / `foo += ""` / `` `${foo}` `` | suggestion only |

### Real-world validation

Behavior verified against two production projects, byte-for-byte identical to ESLint (file / line / column / recommendation text):

- `web-infra-dev/rsbuild`: 3/3 reports match
- `web-infra-dev/rspack`: 29/29 reports match
- 0 false positives, 0 false negatives

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-implicit-coercion
- Source: https://github.com/eslint/eslint/blob/main/lib/rules/no-implicit-coercion.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).