### PR TITLE
docs(port-rule): add AST shape essentials and alignment audit guidance

### DIFF
--- a/agents/AST_PATTERNS.md
+++ b/agents/AST_PATTERNS.md
@@ -105,18 +105,20 @@ inner := ast.SkipParentheses(node.AsCallExpression().Expression)
 
 **Trap sites** — any expression-typed child can be parenthesised. The table below lists high-frequency offenders. The principle is universal: if you are about to read an expression-typed child and do anything with its kind/text/structure, unwrap it first.
 
-| Kind                                                                                                                                                                                              | Children to unwrap                   |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| `BinaryExpression`                                                                                                                                                                                | `Left`, `Right`                      |
-| `PrefixUnaryExpression` / `PostfixUnaryExpression`                                                                                                                                                | `Operand`                            |
-| `CallExpression` / `NewExpression`                                                                                                                                                                | `Expression` (callee)                |
-| `ElementAccessExpression`                                                                                                                                                                         | `Expression`, `ArgumentExpression`   |
-| `PropertyAccessExpression`                                                                                                                                                                        | `Expression` (object)                |
-| `TemplateSpan`                                                                                                                                                                                    | `Expression`                         |
-| `SpreadElement` / `AwaitExpression` / `YieldExpression` / `TypeOfExpression` / `VoidExpression` / `DeleteExpression`                                                                              | `Expression`                         |
-| `ConditionalExpression`                                                                                                                                                                           | `Condition`, `WhenTrue`, `WhenFalse` |
-| `VariableDeclaration` / `PropertyAssignment` / `BindingElement`                                                                                                                                   | `Initializer`                        |
-| `IfStatement` / `WhileStatement` / `DoStatement` / `ForStatement` (condition) / `SwitchStatement` / `CaseClause` / `WithStatement` / `ReturnStatement` / `ThrowStatement` / `ExpressionStatement` | `Expression`                         |
+| Kind                                                                                                                                                                 | Children to unwrap                        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `BinaryExpression`                                                                                                                                                   | `Left`, `Right`                           |
+| `PrefixUnaryExpression` / `PostfixUnaryExpression`                                                                                                                   | `Operand`                                 |
+| `CallExpression` / `NewExpression`                                                                                                                                   | `Expression` (callee)                     |
+| `ElementAccessExpression`                                                                                                                                            | `Expression`, `ArgumentExpression`        |
+| `PropertyAccessExpression`                                                                                                                                           | `Expression` (object)                     |
+| `TemplateSpan`                                                                                                                                                       | `Expression`                              |
+| `SpreadElement` / `AwaitExpression` / `YieldExpression` / `TypeOfExpression` / `VoidExpression` / `DeleteExpression`                                                 | `Expression`                              |
+| `ConditionalExpression`                                                                                                                                              | `Condition`, `WhenTrue`, `WhenFalse`      |
+| `VariableDeclaration` / `PropertyAssignment` / `BindingElement`                                                                                                      | `Initializer`                             |
+| `IfStatement` / `WhileStatement` / `DoStatement` / `SwitchStatement` / `CaseClause` / `WithStatement` / `ReturnStatement` / `ThrowStatement` / `ExpressionStatement` | `Expression`                              |
+| `ForStatement`                                                                                                                                                       | `Initializer`, `Condition`, `Incrementor` |
+| `ForInStatement` / `ForOfStatement`                                                                                                                                  | `Initializer`, `Expression`               |
 
 A helper that embeds the check (e.g. `isNumeric`, `isStringType`) should call `ast.SkipParentheses` at the top rather than require every call site to unwrap — otherwise one forgotten caller is a silent divergence.
 

--- a/agents/AST_PATTERNS.md
+++ b/agents/AST_PATTERNS.md
@@ -85,27 +85,96 @@ rule.RuleListeners{
 
 ---
 
-## Common Pitfalls
+## AST Shape Essentials
+
+The tsgo AST differs from ESTree (ESLint's AST) in a few systematic ways. Most porting bugs trace back to one of these shape differences. Work through each section before and after implementing a rule.
 
 ### ParenthesizedExpression
 
-TypeScript's AST preserves `ParenthesizedExpression` nodes (e.g., `(expr)`), while ESTree (used by ESLint) removes them during parsing. This means almost every rule that walks parent/child chains needs to unwrap parentheses explicitly.
+tsgo keeps parentheses as an explicit `KindParenthesizedExpression` node; ESTree drops them during parsing. Any time a rule reads a child expression, parentheses may be sitting in between.
+
+**Primary helpers** (from `shim/ast`, prefer these over hand-rolled loops):
+
+- `ast.SkipParentheses(node)` — returns the innermost non-paren expression.
+- `ast.WalkUpParenthesizedExpressions(node)` — returns the first non-paren ancestor.
 
 ```go
-// Walking UP the parent chain: skip ParenthesizedExpression
-current := node.Parent
-for current != nil && current.Kind == ast.KindParenthesizedExpression {
-    current = current.Parent
-}
-
-// Walking DOWN into an expression: unwrap ParenthesizedExpression
-expr := someNode
-for expr != nil && expr.Kind == ast.KindParenthesizedExpression {
-    expr = expr.AsParenthesizedExpression().Expression
-}
+inner := ast.SkipParentheses(node.AsCallExpression().Expression)
+// `inner` is the callee without any `( … )` wrapping
 ```
 
-**When to unwrap**: Any time you check `node.Parent.Kind` or `expr.Kind` and expect a specific node type, consider whether parentheses could appear in between.
+**Trap sites** — any expression-typed child can be parenthesised. The table below lists high-frequency offenders. The principle is universal: if you are about to read an expression-typed child and do anything with its kind/text/structure, unwrap it first.
+
+| Kind                                                                                                                                                                                              | Children to unwrap                   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `BinaryExpression`                                                                                                                                                                                | `Left`, `Right`                      |
+| `PrefixUnaryExpression` / `PostfixUnaryExpression`                                                                                                                                                | `Operand`                            |
+| `CallExpression` / `NewExpression`                                                                                                                                                                | `Expression` (callee)                |
+| `ElementAccessExpression`                                                                                                                                                                         | `Expression`, `ArgumentExpression`   |
+| `PropertyAccessExpression`                                                                                                                                                                        | `Expression` (object)                |
+| `TemplateSpan`                                                                                                                                                                                    | `Expression`                         |
+| `SpreadElement` / `AwaitExpression` / `YieldExpression` / `TypeOfExpression` / `VoidExpression` / `DeleteExpression`                                                                              | `Expression`                         |
+| `ConditionalExpression`                                                                                                                                                                           | `Condition`, `WhenTrue`, `WhenFalse` |
+| `VariableDeclaration` / `PropertyAssignment` / `BindingElement`                                                                                                                                   | `Initializer`                        |
+| `IfStatement` / `WhileStatement` / `DoStatement` / `ForStatement` (condition) / `SwitchStatement` / `CaseClause` / `WithStatement` / `ReturnStatement` / `ThrowStatement` / `ExpressionStatement` | `Expression`                         |
+
+A helper that embeds the check (e.g. `isNumeric`, `isStringType`) should call `ast.SkipParentheses` at the top rather than require every call site to unwrap — otherwise one forgotten caller is a silent divergence.
+
+### Optional Chain
+
+tsgo does not have a `ChainExpression` wrapper. Instead, every link in an optional chain (`PropertyAccess` / `ElementAccess` / `Call` / `NonNullExpression`) carries `NodeFlagsOptionalChain`. Parentheses break the chain — `(foo?.bar)(x)` parses as an ordinary call whose callee happens to be a paren-wrapped optional chain.
+
+- `ast.IsOptionalChain(node)` — true iff node is a link in an optional chain.
+- `ast.IsOptionalChainRoot(node)` — true iff node introduces the chain (holds the leading `?.`).
+- `ast.IsOutermostOptionalChain(node)` — true iff node is the top of its chain.
+
+When porting a rule that switches on "is the argument a `ChainExpression`?", translate to `ast.IsOptionalChain(arg)` on the tsgo-side argument after `ast.SkipParentheses`.
+
+### Literal Kinds
+
+ESTree uses one `Literal` node carrying a typed `value`. tsgo splits the literal family across kinds, and booleans / null are keyword tokens rather than literal nodes:
+
+| Value                   | tsgo kind                              | Text accessor                                                        |
+| ----------------------- | -------------------------------------- | -------------------------------------------------------------------- |
+| Number                  | `KindNumericLiteral`                   | `node.AsNumericLiteral().Text` (raw source — may be `0x1` / `1_000`) |
+| String                  | `KindStringLiteral`                    | `node.AsStringLiteral().Text` (cooked)                               |
+| BigInt                  | `KindBigIntLiteral`                    | `node.AsBigIntLiteral().Text` (includes `n` suffix in source text)   |
+| Regex                   | `KindRegularExpressionLiteral`         | `node.Text()`                                                        |
+| `true` / `false`        | `KindTrueKeyword` / `KindFalseKeyword` | —                                                                    |
+| `null`                  | `KindNullKeyword`                      | —                                                                    |
+| `` `…` `` without `${}` | `KindNoSubstitutionTemplateLiteral`    | `node.AsNoSubstitutionTemplateLiteral().Text` (cooked)               |
+| `` `…${x}…` ``          | `KindTemplateExpression`               | `Head.Text()` + each `TemplateSpan.Literal.Text()` (all cooked)      |
+
+Common translations:
+
+- ESTree `node.type === "Literal" && typeof node.value === "number"` → `node.Kind == ast.KindNumericLiteral`.
+- ESTree's `isStringLiteral` helper (StringLiteral + TemplateLiteral) → `ast.IsStringLiteralLike(node)` covers `StringLiteral` + `NoSubstitutionTemplateLiteral`. For TemplateExpression add it explicitly.
+- Comparing numeric literal value (e.g. "is this `1`"): `utils.NormalizeNumericLiteral(text) == "1"` — handles `1`, `1.0`, `0x1`, `1e0`, `1_000`, etc. with one comparison.
+
+### Binary Operator Kinds
+
+tsgo uses `BinaryExpression` for the entire family of binary operators, including assignment and comma:
+
+- `a + b`, `a * b`, `a && b`, `a ?? b`, … — plain arithmetic / logical
+- `a, b` — sequence (ESTree `SequenceExpression`) via `OperatorToken.Kind == ast.KindCommaToken`
+- `a = b`, `a += b`, `a **= b`, … — assignment (ESTree `AssignmentExpression`) via `ast.KindEqualsToken`, `ast.KindPlusEqualsToken`, etc.
+
+For a rule that registers separate ESTree listeners for `AssignmentExpression` / `SequenceExpression`, collapse into one `BinaryExpression` listener and switch on `OperatorToken.Kind`. Do not rely on `IsBinaryExpression` alone to exclude assignments.
+
+### Node Text and Positions
+
+Raw `node.Pos()` and `node.End()` include leading trivia (whitespace, comments, line breaks). This is almost never what a rule wants — reading source text across `node.Pos()..node.End()` yields leading blanks, and reporting at `node.Pos()` positions the diagnostic on the trivia.
+
+Prefer:
+
+- `utils.TrimNodeTextRange(sourceFile, node)` — range with leading trivia skipped.
+- `utils.TrimmedNodeText(sourceFile, node)` — source text over that trimmed range.
+- `ctx.ReportNode(node, msg)` — diagnostic range already uses the trimmed span; no manual adjustment needed.
+
+For fixes:
+
+- `rule.RuleFixReplace(sf, node, text)` — replaces the trimmed span.
+- `rule.RuleFixReplaceRange(range, text)` — replaces a specific range (useful for precision edits across multiple nodes).
 
 ---
 

--- a/agents/UTILS_REFERENCE.md
+++ b/agents/UTILS_REFERENCE.md
@@ -396,6 +396,55 @@ set.Clear()
 
 ---
 
+## `shim/ast/` - AST Utilities
+
+```go
+import "github.com/microsoft/typescript-go/shim/ast"
+```
+
+Reach for these **before** writing a helper of your own — the shim already covers a wide surface. This list is curated to the functions most commonly reused when porting rules; see `shim/ast/shim.go` for the full inventory.
+
+### Navigation (paren-transparency)
+
+Use these instead of hand-rolled loops. See [AST_PATTERNS.md § ParenthesizedExpression](./AST_PATTERNS.md#parenthesizedexpression).
+
+- `ast.SkipParentheses(node)` — innermost non-paren expression
+- `ast.WalkUpParenthesizedExpressions(node)` — first non-paren ancestor
+
+### Optional chain
+
+- `ast.IsOptionalChain(node)` — true iff node is in an optional chain
+- `ast.IsOptionalChainRoot(node)` — true iff node introduces the chain
+- `ast.IsOutermostOptionalChain(node)` — true iff node is the top of its chain
+- Flag: `ast.NodeFlagsOptionalChain`
+
+### Node-kind predicates (prefer over `node.Kind == ast.Kind*`)
+
+- `ast.IsStringLiteralLike(node)` — covers `KindStringLiteral` + `KindNoSubstitutionTemplateLiteral`
+- `ast.IsTemplateLiteralKind(kind)` — any of the `KindTemplate*` family
+- `ast.IsNumericLiteral(node)`
+- `ast.IsIdentifier(node)`
+- `ast.IsCallExpression(node)`, `ast.IsNewExpression(node)`
+- `ast.IsBinaryExpression(node)` (check `OperatorToken.Kind` separately for specific operator matching)
+- `ast.IsPropertyAccessExpression(node)`, `ast.IsElementAccessExpression(node)`
+- `ast.IsAssignmentExpression(node, excludeCompoundAssignment)`
+- `ast.IsBindingPattern(node)` — object / array destructuring
+- `ast.IsClassLike(node)` — class declaration or expression
+- `ast.IsIterationStatement(node, lookInLabeledStatements)` — for/while variants
+
+### Function-like
+
+- `ast.IsFunctionLike(node)` / `ast.IsFunctionLikeDeclaration(node)` — covers all 7 function-like kinds
+- `ast.IsFunctionLikeOrClassStaticBlockDeclaration(node)`
+- `ast.GetThisContainer(node, …, …)` — **warning**: treats `PropertyDeclaration`, `ClassStaticBlockDeclaration`, `ModuleDeclaration`, etc. as `this` containers, which does NOT match ESLint's scope model; verify before reusing
+
+### Modifiers
+
+- `ast.HasSyntacticModifier(node, flags)` — bit-flag check (readonly, static, abstract, …)
+- `ast.GetCombinedModifierFlags(node)`
+
+---
+
 ## `shim/scanner/` - Scanner Utilities
 
 ```go
@@ -411,6 +460,14 @@ Skip whitespace, comments (line and block), BOM, shebang, and conflict markers t
 sourceText := ctx.SourceFile.Text()
 nextTokenPos := scanner.SkipTrivia(sourceText, startPos)
 ```
+
+### Identifier character classification
+
+Unicode-aware, matches the scanner's own lexing rules. Use these instead of hand-written `[A-Za-z_$]` checks.
+
+- `scanner.IsIdentifierStart(ch rune) bool` — valid first character of an identifier
+- `scanner.IsIdentifierPart(ch rune) bool` — valid non-first character
+- `scanner.IsValidIdentifier(s string) bool` — whole-string check (start + parts + no reserved-word collision)
 
 ### GetScannerForSourceFile
 

--- a/agents/port-rule/references/PORT_RULE.md
+++ b/agents/port-rule/references/PORT_RULE.md
@@ -150,6 +150,8 @@ Before starting, familiarize yourself with these key source locations:
 
 ## Phase 2: Implementation (Go)
 
+> **AST note**: rslint is built on the tsgo AST, which is structurally different from ESLint's ESTree. Child-access patterns (`node.left`, `node.argument`, `node.callee`, …) do **not** correspond 1:1: parentheses are explicit nodes, optional chains are flag-based (no `ChainExpression` wrapper), `Literal` is split across several `Kind*Literal` kinds, and `AssignmentExpression` / `SequenceExpression` collapse into `BinaryExpression`. Review [AST_PATTERNS.md § AST Shape Essentials](../../AST_PATTERNS.md#ast-shape-essentials) before implementing, and run the Alignment Audit (end of Step 2) before tests.
+
 ### Step 1: Directory Setup
 
 - **Core Rules**: `internal/rules/<rule_name_snake_case>/`
@@ -255,6 +257,32 @@ func parseOptions(options any) Options {
     return opts
 }
 ```
+
+### Alignment Audit
+
+Before moving on, walk through each check. Each one targets a class of AST-shape bug that is not caught by compilation and may slip past narrowly-written unit tests. Skip a row when it doesn't apply to your rule.
+
+| If the rule …                                                                   | Audit                                                                                                                                                             | Reference                                                                                  |
+| ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Reads a child node (every rule)                                                 | Any `.Kind ==` / `.Kind !=` / `.As<Type>()` / `.Text` access on a child must go through `ast.SkipParentheses` first (directly or via a helper).                   | [AST_PATTERNS.md § ParenthesizedExpression](../../AST_PATTERNS.md#parenthesizedexpression) |
+| Handles `foo?.bar` / `foo?.()`                                                  | Use `ast.IsOptionalChain(node)`; don't hand-check node flags.                                                                                                     | [AST_PATTERNS.md § Optional Chain](../../AST_PATTERNS.md#optional-chain)                   |
+| Compares literal values                                                         | Match the precise `Kind*Literal`; normalize numeric text via `utils.NormalizeNumericLiteral` before value comparison.                                             | [AST_PATTERNS.md § Literal Kinds](../../AST_PATTERNS.md#literal-kinds)                     |
+| Has separate ESLint listeners for `AssignmentExpression` / `SequenceExpression` | Collapse into one `BinaryExpression` listener and branch on `OperatorToken.Kind`.                                                                                 | [AST_PATTERNS.md § Binary Operator Kinds](../../AST_PATTERNS.md#binary-operator-kinds)     |
+| Emits fix/suggestion text starting with an identifier                           | Guard against token fusion with the preceding character before emitting (otherwise e.g. `typeof` + `Number(foo)` becomes `typeofNumber(foo)`).                    | —                                                                                          |
+| Checks whether a name resolves to a global                                      | Use `utils.IsShadowed(node, name)`. Note: stricter than ESLint's scope manager on TS type-only bindings — document in the rule's `.md` if the difference matters. | —                                                                                          |
+| Reads source text for recommendation / fix                                      | Prefer `utils.TrimmedNodeText(sf, node)` (skips leading trivia) over raw `node.Pos()/End()`.                                                                      | [AST_PATTERNS.md § Node Text and Positions](../../AST_PATTERNS.md#node-text-and-positions) |
+
+### Helper Extraction
+
+After Step 2 is done, review each helper for extraction to `internal/utils/`:
+
+**Extract if all hold:**
+
+- Input/output is AST- or source-oriented (not encoding the rule's own semantics)
+- The name reads sensibly without context of the current rule
+- Another rule would plausibly need the same thing
+
+**Keep local otherwise.** Predicates that encode a specific rule's definition (e.g. a `isDoubleLogicalNegating`-style helper that codifies "what counts as a double-negation coercion for THIS rule") stay with the rule — extracting would mislead future readers.
 
 ### Step 3: Write Documentation
 
@@ -462,6 +490,41 @@ Follow this **strict order** — each step depends on the previous one:
    pnpm format      # Fix JS/TS formatting
    pnpm format:go   # Fix Go formatting (e.g., import order)
    ```
+
+7. **Differential Validation** (recommended for rules with non-trivial branching):
+
+   Unit tests verify cases you thought of; diffing against the reference implementation on a real codebase catches the rest. Skip when the rule has ≤ 2 branches and trivial messages, or when the rule is a new rslint invention with no reference.
+
+   **Procedure**:
+
+   ```bash
+   # 1. Scratch-install the reference tool.
+   mkdir -p /tmp/ref-cmp && cd /tmp/ref-cmp
+   npm init -y >/dev/null
+   npm i --silent eslint @typescript-eslint/parser  # + plugin if non-core
+   cat > eslint.config.mjs <<'EOF'
+   import parser from '@typescript-eslint/parser';
+   export default [{
+     files: ['**/*.ts', '**/*.tsx'],
+     languageOptions: { parser },
+     rules: { '<rule-name>': 'warn' },
+   }];
+   EOF
+
+   # 2. Pick a target codebase that exercises typical patterns.
+   # 3. Run both; normalize to sorted JSON of {file, line, col, messageId, message}; diff.
+   ```
+
+   **Prerequisite for type-info rules**: the reference tool must run with the same `parserOptions.project` / `tsconfig.json` as rslint, otherwise the comparison is meaningless. Pick a target codebase where the tsconfig loads cleanly under both tools.
+
+   **Interpreting a non-empty diff**:
+
+   | Diff kind                       | Likely cause                                           |
+   | ------------------------------- | ------------------------------------------------------ |
+   | rslint misses a report          | AST-shape mismatch (often a missing `SkipParentheses`) |
+   | rslint over-reports             | Same as above, inverted                                |
+   | Different message text          | paren / text-range handling in the recommendation      |
+   | Same count, different positions | column offset (0- vs 1-based, multibyte)               |
 
 ---
 


### PR DESCRIPTION
## Summary

Three evergreen improvements to the rule-porting skill, aimed at reducing common porting bugs (AST-shape mismatches) and cutting down on hand-rolled helpers that already exist in the shim.

### Changes

**`agents/AST_PATTERNS.md`** — replace the single "ParenthesizedExpression" pitfall section with a dedicated **AST Shape Essentials** section covering the systematic tsgo-vs-ESTree differences that most often cause porting bugs:

- ParenthesizedExpression — point at `ast.SkipParentheses` / `ast.WalkUpParenthesizedExpressions` with a trap-site table of high-frequency expression-typed children.
- Optional Chain — flag-based in tsgo; use `ast.IsOptionalChain`, no `ChainExpression` wrapper.
- Literal Kinds — tsgo splits `Literal` across `KindNumericLiteral` / `KindStringLiteral` / `KindBigIntLiteral` / `KindRegularExpressionLiteral` / keyword tokens / template variants, with text accessors and the `utils.NormalizeNumericLiteral` normalisation helper.
- Binary Operator Kinds — `BinaryExpression` covers `=`, `+=`, `,` etc.; one listener, switch on `OperatorToken.Kind`.
- Node Text and Positions — prefer `utils.TrimmedNodeText` / `utils.TrimNodeTextRange` over raw `Pos()` / `End()`.

**`agents/port-rule/references/PORT_RULE.md`**:

- Phase 2: short note that the tsgo AST is not a 1:1 port of ESTree, pointing at the Shape Essentials.
- New **Alignment Audit** checklist at the end of Step 2 — gated on whether the rule exhibits each pattern (paren transparency, optional chain, literal kinds, binary operators, token adjacency, scope shadowing, node text).
- New **Helper Extraction** criteria — when to lift a helper into `internal/utils/` vs keep it rule-local.
- New Phase 4 step: **Differential Validation** — procedure for diffing rslint output against the reference tool on a real codebase, prerequisites for type-info rules, and a table for interpreting diffs.

**`agents/UTILS_REFERENCE.md`**:

- New **`shim/ast/`** section with the shim helpers authors most commonly reach for (navigation, optional chain, kind predicates, function-like, modifiers). Every function listed is verified to exist in `shim/ast/shim.go`.
- Expand the `shim/scanner/` section with `IsIdentifierStart`, `IsIdentifierPart`, `IsValidIdentifier` so authors don't reinvent ASCII-only versions.

### Motivation

The changes are not specific to any one rule. They are the lessons generalised from recent rule-porting work where the same classes of shape bug recurred across ports. Capturing them in the skill should shrink the review loop on future ports.

## Related Links

- Follow-up from #687 (no-implicit-coercion port — surfaced the shape-bug patterns this doc codifies).

## Checklist

- [x] Tests updated (or not required). *(docs-only change)*
- [x] Documentation updated (or not required).