### PR TITLE
feat: port rule react/no-unescaped-entities

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -12,6 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/style_prop_object"
@@ -32,6 +33,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
+		no_unescaped_entities.NoUnescapedEntitiesRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		self_closing_comp.SelfClosingCompRule,
 		style_prop_object.StylePropObjectRule,

--- a/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.go
+++ b/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.go
@@ -1,0 +1,176 @@
+package no_unescaped_entities
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type entity struct {
+	// char is the original entity character for use in error messages.
+	char string
+	// charRune is the decoded single rune when hasRune is true. Both fields
+	// are needed because the rune NUL (U+0000) is a legitimate match target
+	// and cannot be distinguished from "unset" by value alone.
+	charRune rune
+	hasRune  bool
+	// alternatives is the list of suggested replacements. An empty list
+	// means the entity is reported without suggestions (the "string" form
+	// of the forbid option).
+	alternatives []string
+}
+
+// defaultEntities mirrors the ESLint rule's DEFAULTS. `<` and `{` are
+// intentionally omitted because they cause syntax errors when left
+// unescaped in JSX.
+var defaultEntities = []entity{
+	mustSingleRune(">", []string{"&gt;"}),
+	mustSingleRune("\"", []string{"&quot;", "&ldquo;", "&#34;", "&rdquo;"}),
+	mustSingleRune("'", []string{"&apos;", "&lsquo;", "&#39;", "&rsquo;"}),
+	mustSingleRune("}", []string{"&#125;"}),
+}
+
+func mustSingleRune(char string, alts []string) entity {
+	r, size := utf8.DecodeRuneInString(char)
+	if size == 0 || size != len(char) || r == utf8.RuneError {
+		panic("default entity must be a single valid rune: " + char)
+	}
+	return entity{char: char, charRune: r, hasRune: true, alternatives: alts}
+}
+
+// newEntity builds an entity from a user-configured forbid item.
+// Multi-rune or empty strings are accepted for parity with ESLint (which
+// never matches them on a per-char scan).
+func newEntity(char string, alts []string) entity {
+	if char == "" {
+		return entity{char: char, alternatives: alts}
+	}
+	r, size := utf8.DecodeRuneInString(char)
+	if size != len(char) || r == utf8.RuneError {
+		return entity{char: char, alternatives: alts}
+	}
+	return entity{char: char, charRune: r, hasRune: true, alternatives: alts}
+}
+
+// parseEntities extracts the `forbid` option. When the option is missing
+// (or malformed) defaults are used; when it is explicitly provided — even
+// as an empty array — the caller's list is respected verbatim, matching
+// ESLint's `configuration.forbid || DEFAULTS` semantics.
+func parseEntities(options any) []entity {
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return defaultEntities
+	}
+	rawForbid, ok := optsMap["forbid"]
+	if !ok {
+		return defaultEntities
+	}
+	forbidArr, ok := rawForbid.([]interface{})
+	if !ok {
+		return defaultEntities
+	}
+	result := make([]entity, 0, len(forbidArr))
+	for _, item := range forbidArr {
+		switch v := item.(type) {
+		case string:
+			result = append(result, newEntity(v, nil))
+		case map[string]interface{}:
+			char, _ := v["char"].(string)
+			var alts []string
+			if altsRaw, ok := v["alternatives"].([]interface{}); ok {
+				alts = make([]string, 0, len(altsRaw))
+				for _, alt := range altsRaw {
+					if s, ok := alt.(string); ok {
+						alts = append(alts, s)
+					}
+				}
+			}
+			result = append(result, newEntity(char, alts))
+		}
+	}
+	return result
+}
+
+var NoUnescapedEntitiesRule = rule.Rule{
+	Name: "react/no-unescaped-entities",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		entities := parseEntities(options)
+		if len(entities) == 0 {
+			return rule.RuleListeners{}
+		}
+
+		return rule.RuleListeners{
+			// JsxText is the only AST node that represents literal text appearing
+			// as a direct child of a JsxElement/JsxFragment. String literals,
+			// attribute values, and expression-container contents live on other
+			// node kinds and are intentionally not checked (matches ESLint's
+			// `'Literal, JSXText'` selector + `isJSX(parent)` predicate, since
+			// TypeScript never produces a Literal whose parent is JSX).
+			//
+			// NOTE: TypeScript's JSX parser rejects unescaped `>` and `}` in JSX
+			// text with TS1381/TS1382 before this rule runs, so those defaults
+			// only meaningfully fire on characters the parser still accepts
+			// (`'`, `"`, and any custom `forbid` chars).
+			ast.KindJsxText: func(node *ast.Node) {
+				// Intentionally do not skip whitespace-only JsxText: a user may
+				// configure `forbid` to include a whitespace character, which
+				// ESLint would still flag.
+				source := ctx.SourceFile.Text()
+				startPos, endPos := node.Pos(), node.End()
+				if startPos < 0 || endPos > len(source) || startPos >= endPos {
+					return
+				}
+				content := source[startPos:endPos]
+
+				// Iterate rune-by-rune so multi-byte Unicode forbid chars work.
+				// `i` is the byte offset within `content`; the absolute source
+				// position is `startPos + i`.
+				for i := 0; i < len(content); {
+					r, size := utf8.DecodeRuneInString(content[i:])
+					runeStart := startPos + i
+					runeEnd := runeStart + size
+					for idx := range entities {
+						e := &entities[idx]
+						if !e.hasRune || e.charRune != r {
+							continue
+						}
+						reportEntity(ctx, e, runeStart, runeEnd)
+					}
+					i += size
+				}
+			},
+		}
+	},
+}
+
+func reportEntity(ctx rule.RuleContext, e *entity, start, end int) {
+	charRange := core.NewTextRange(start, end)
+	if len(e.alternatives) == 0 {
+		ctx.ReportRange(charRange, rule.RuleMessage{
+			Id:          "unescapedEntity",
+			Description: "HTML entity, `" + e.char + "` , must be escaped.",
+		})
+		return
+	}
+
+	suggestions := make([]rule.RuleSuggestion, len(e.alternatives))
+	altsQuoted := make([]string, len(e.alternatives))
+	for i, alt := range e.alternatives {
+		altsQuoted[i] = "`" + alt + "`"
+		suggestions[i] = rule.RuleSuggestion{
+			Message: rule.RuleMessage{
+				Id:          "replaceWithAlt",
+				Description: "Replace with `" + alt + "`.",
+			},
+			FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(charRange, alt)},
+		}
+	}
+	ctx.ReportRangeWithSuggestions(charRange, rule.RuleMessage{
+		Id:          "unescapedEntityAlts",
+		Description: "`" + e.char + "` can be escaped with " + strings.Join(altsQuoted, ", ") + ".",
+	}, suggestions...)
+}

--- a/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.md
+++ b/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities.md
@@ -1,0 +1,54 @@
+# react/no-unescaped-entities
+
+## Rule Details
+
+Disallow unescaped HTML entities from appearing in markup. Reports occurrences of the characters `>`, `"`, `'`, and `}` in JSX text content and suggests escape sequences as replacements.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div> > </div>
+<div>Don't</div>
+<div>{"foo"}}</div>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div> &gt; </div>
+<div>Don&apos;t</div>
+<div>{"foo"}</div>
+<div>{">"}</div>
+```
+
+## Options
+
+- `forbid` (default: `[">", "\"", "'", "}"]` with standard alternatives): List of forbidden characters. Each item can be either a string (the character itself) or an object `{ char: string, alternatives: string[] }` specifying replacement suggestions.
+
+```jsonc
+{
+  "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }]
+}
+```
+
+```jsonc
+{
+  "react/no-unescaped-entities": [
+    "error",
+    {
+      "forbid": [
+        { "char": ">", "alternatives": ["&gt;"] },
+        { "char": "}", "alternatives": ["&#125;"] }
+      ]
+    }
+  ]
+}
+```
+
+## Differences from ESLint
+
+TypeScript's JSX parser rejects unescaped `>` and `}` in JSX text with a syntax error before this rule can run, so for TypeScript sources those defaults are effectively enforced by the parser itself. This rule still catches `'`, `"`, and any custom characters configured via `forbid`.
+
+## Original Documentation
+
+- [react/no-unescaped-entities](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md)

--- a/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities_test.go
+++ b/internal/plugins/react/rules/no_unescaped_entities/no_unescaped_entities_test.go
@@ -1,0 +1,427 @@
+package no_unescaped_entities
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// entitySuggestions returns the expected suggestions for a default-entity
+// diagnostic, given the source before/after the single char that will be
+// replaced by each alternative.
+func entitySuggestions(alts []string, before, after string) []rule_tester.InvalidTestCaseSuggestion {
+	out := make([]rule_tester.InvalidTestCaseSuggestion, len(alts))
+	for i, alt := range alts {
+		out[i] = rule_tester.InvalidTestCaseSuggestion{
+			MessageId: "replaceWithAlt",
+			Output:    before + alt + after,
+		}
+	}
+	return out
+}
+
+func apostropheSuggestions(before, after string) []rule_tester.InvalidTestCaseSuggestion {
+	return entitySuggestions([]string{"&apos;", "&lsquo;", "&#39;", "&rsquo;"}, before, after)
+}
+
+func quoteSuggestions(before, after string) []rule_tester.InvalidTestCaseSuggestion {
+	return entitySuggestions([]string{"&quot;", "&ldquo;", "&#34;", "&rdquo;"}, before, after)
+}
+
+func TestNoUnescapedEntitiesRule(t *testing.T) {
+	// NOTE: TypeScript's JSX parser rejects unescaped `>` and `}` in JSX text
+	// (unlike Babel/Acorn), so those cases cannot be exercised as test inputs
+	// even though the rule logic supports them.
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnescapedEntitiesRule, []rule_tester.ValidTestCase{
+		// --- structural: no JsxText is present ---
+		{Code: `var Hello = <div/>`, Tsx: true},
+		{Code: `var Hello = <div></div>`, Tsx: true},
+		{Code: `var Hello = <></>`, Tsx: true},
+		{Code: `var Hello = <Component name="don't" />`, Tsx: true},
+		{Code: `var Hello = <div title="it's fine"></div>`, Tsx: true},
+
+		// --- plain text / already-escaped ---
+		{Code: `var Hello = <div>Here is some text!</div>`, Tsx: true},
+		{Code: `var Hello = <div>I&rsquo;ve escaped some entities: &gt; &lt; &amp;</div>`, Tsx: true},
+		{Code: "var Hello = <div>first line is ok\n            so is second\n            and here are some escaped entities: &gt; &lt; &amp;</div>", Tsx: true},
+
+		// --- whitespace-only JsxText ---
+		{Code: "var Hello = <div>   </div>", Tsx: true},
+		{Code: "var Hello = <div>\n\n\t</div>", Tsx: true},
+
+		// --- string literals inside expression containers are not JsxText ---
+		{Code: `var Hello = <div>{">" + "<" + "&" + '"'}</div>`, Tsx: true},
+		{Code: `var Hello = <>{">" + "<" + "&" + '"'}</>`, Tsx: true},
+		{Code: `var Hello = <div>{"it's fine"}</div>`, Tsx: true},
+
+		// --- fragments with safe text ---
+		{Code: `var Hello = <>Here is some text!</>`, Tsx: true},
+		{Code: `var Hello = <>I&rsquo;ve escaped some entities: &gt; &lt; &amp;</>`, Tsx: true},
+
+		// --- nested JSX where inner text is escaped ---
+		{Code: `var Hello = <Outer><Inner>safe text</Inner></Outer>`, Tsx: true},
+		{Code: `var Hello = <ul><li>one</li><li>two</li></ul>`, Tsx: true},
+		{Code: `var Hello = <div>{<span>nested</span>}</div>`, Tsx: true},
+
+		// --- JSX in various expression positions ---
+		{Code: `var Hello = [<div key="1">safe</div>]`, Tsx: true},
+		{Code: `function f() { return <div>safe</div>; }`, Tsx: true},
+		{Code: `var Hello = true ? <div>safe</div> : null`, Tsx: true},
+
+		// --- JSX as prop value (inner JsxText is checked — escaped version is safe) ---
+		{Code: `var Hello = <Outer child={<Inner>safe</Inner>} />`, Tsx: true},
+
+		// --- custom forbid: disables defaults ---
+		{Code: `var Hello = <div>don't forget</div>`, Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{"&"}}},
+
+		// --- forbid: [] explicitly disables all entities ---
+		{Code: `var Hello = <div>don't do that</div>`, Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{}}},
+
+		// --- forbid entry with empty char string never matches ---
+		{Code: `var Hello = <div>don't do that</div>`, Tsx: true,
+			Options: map[string]interface{}{"forbid": []interface{}{""}}},
+	}, []rule_tester.InvalidTestCase{
+		// --- default: bare apostrophe ---
+		{
+			Code: `var Hello = <div>'</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 18,
+					Suggestions: apostropheSuggestions(`var Hello = <div>`, `</div>`),
+				},
+			},
+		},
+		// --- apostrophe in word ---
+		{
+			Code: `var Hello = <div>Don't do that</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 21,
+					Suggestions: apostropheSuggestions(`var Hello = <div>Don`, `t do that</div>`),
+				},
+			},
+		},
+		// --- fragment with apostrophe ---
+		{
+			Code: `var Hello = <>it's a trap</>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 17,
+					Suggestions: apostropheSuggestions(`var Hello = <>it`, `s a trap</>`),
+				},
+			},
+		},
+		// --- multi-line: multiple apostrophes on different lines ---
+		{
+			Code: "var Hello = <div>line one's\n            line two's</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 26,
+					Suggestions: apostropheSuggestions("var Hello = <div>line one", "s\n            line two's</div>"),
+				},
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        2, Column: 21,
+					Suggestions: apostropheSuggestions("var Hello = <div>line one's\n            line two", "s</div>"),
+				},
+			},
+		},
+		// --- adjacent apostrophes ---
+		{
+			Code: `var Hello = <div>a''b</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 19,
+					Suggestions: apostropheSuggestions(`var Hello = <div>a`, `'b</div>`),
+				},
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 20,
+					Suggestions: apostropheSuggestions(`var Hello = <div>a'`, `b</div>`),
+				},
+			},
+		},
+		// --- both `"` and `'` in same JsxText, reported in source order ---
+		{
+			Code: `var Hello = <div>"don't"</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 18,
+					Suggestions: quoteSuggestions(`var Hello = <div>`, `don't"</div>`),
+				},
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 22,
+					Suggestions: apostropheSuggestions(`var Hello = <div>"don`, `t"</div>`),
+				},
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 24,
+					Suggestions: quoteSuggestions(`var Hello = <div>"don't`, `</div>`),
+				},
+			},
+		},
+		// --- script tag: two unescaped double quotes with precise positions ---
+		{
+			Code: `var Hello = <script>window.foo = "bar"</script>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 34,
+					Suggestions: quoteSuggestions(`var Hello = <script>window.foo = `, `bar"</script>`),
+				},
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 38,
+					Suggestions: quoteSuggestions(`var Hello = <script>window.foo = "bar`, `</script>`),
+				},
+			},
+		},
+		// --- nested JSX: flag in inner element only ---
+		{
+			Code: `var Hello = <Outer>outer text<Inner>inner's</Inner></Outer>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 42,
+					Suggestions: apostropheSuggestions(
+						`var Hello = <Outer>outer text<Inner>inner`,
+						`s</Inner></Outer>`,
+					),
+				},
+			},
+		},
+		// --- nested JSX: flag at multiple nesting levels ---
+		{
+			Code: `var Hello = <Outer>outer's<Inner>inner's</Inner></Outer>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 25,
+					Suggestions: apostropheSuggestions(
+						`var Hello = <Outer>outer`,
+						`s<Inner>inner's</Inner></Outer>`,
+					),
+				},
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 39,
+					Suggestions: apostropheSuggestions(
+						`var Hello = <Outer>outer's<Inner>inner`,
+						`s</Inner></Outer>`,
+					),
+				},
+			},
+		},
+		// --- JSX inside expression container inside JSX ---
+		{
+			Code: `var Hello = <Outer>{<Inner>inner's</Inner>}</Outer>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 33,
+					Suggestions: apostropheSuggestions(
+						`var Hello = <Outer>{<Inner>inner`,
+						`s</Inner>}</Outer>`,
+					),
+				},
+			},
+		},
+		// --- JSX as prop value: inner JsxText is scanned ---
+		{
+			Code: `var Hello = <Outer child={<Inner>inner's</Inner>} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 39,
+					Suggestions: apostropheSuggestions(
+						`var Hello = <Outer child={<Inner>inner`,
+						`s</Inner>} />`,
+					),
+				},
+			},
+		},
+		// --- forbid: simple string form, no suggestions ---
+		{
+			Code:    `var Hello = <span>foo & bar</span>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"&"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unescapedEntity", Line: 1, Column: 23},
+			},
+		},
+		// --- forbid: object form with suggestions ---
+		{
+			Code: `var Hello = <span>foo & bar</span>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"forbid": []interface{}{
+					map[string]interface{}{"char": "&", "alternatives": []interface{}{"&amp;"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 23,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceWithAlt", Output: `var Hello = <span>foo &amp; bar</span>`},
+					},
+				},
+			},
+		},
+		// --- forbid: mix of string + object entries ---
+		{
+			Code: `var Hello = <div>a & b $ c</div>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"forbid": []interface{}{
+					"&",
+					map[string]interface{}{"char": "$", "alternatives": []interface{}{"&#36;"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unescapedEntity", Line: 1, Column: 20},
+				{
+					MessageId: "unescapedEntityAlts",
+					Line:      1, Column: 24,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{MessageId: "replaceWithAlt", Output: `var Hello = <div>a & b &#36; c</div>`},
+					},
+				},
+			},
+		},
+		// --- forbid: object form with empty alternatives reports without suggestions ---
+		{
+			Code: `var Hello = <div>foo & bar</div>`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"forbid": []interface{}{
+					map[string]interface{}{"char": "&", "alternatives": []interface{}{}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unescapedEntity", Line: 1, Column: 22},
+			},
+		},
+		// --- NUL (U+0000) as a custom forbid char: must not be confused with
+		// the "unset rune" sentinel in the implementation. ---
+		{
+			Code:    "var Hello = <div>a\u0000b</div>",
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"\u0000"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unescapedEntity", Line: 1, Column: 19},
+			},
+		},
+		// --- multi-byte Unicode custom forbid char (fullwidth apostrophe U+FF07) ---
+		{
+			Code:    "var Hello = <div>fullwidth\uff07quote</div>",
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{"\uff07"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unescapedEntity", Line: 1, Column: 27},
+			},
+		},
+		// --- UTF-16 column accuracy when a multi-byte char precedes the match ---
+		// `é` (U+00E9) is 2 bytes in UTF-8 but 1 UTF-16 code unit, so the `'`
+		// must still report as column 22 (1-based UTF-16), not a byte offset.
+		{
+			Code: "var Hello = <div>café's</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 22,
+					Suggestions: apostropheSuggestions("var Hello = <div>café", "s</div>"),
+				},
+			},
+		},
+		// --- UTF-16 column accuracy for a surrogate pair (supra-BMP) char ---
+		// `🚀` (U+1F680) is 4 bytes in UTF-8 and occupies 2 UTF-16 code units,
+		// so the `'` must report as column 20 (17 leading chars + 2 for the
+		// surrogate pair + 1 for the apostrophe itself).
+		{
+			Code: "var Hello = <div>🚀's</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 20,
+					Suggestions: apostropheSuggestions("var Hello = <div>🚀", "s</div>"),
+				},
+			},
+		},
+		// --- JSX in a type assertion: inner JsxText still scanned ---
+		{
+			Code: `var Hello = (<div>a's</div>) as any`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 20,
+					Suggestions: apostropheSuggestions(`var Hello = (<div>a`, `s</div>) as any`),
+				},
+			},
+		},
+		// --- JSX in logical short-circuit expression ---
+		{
+			Code: `var Hello = cond && <div>a's</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 27,
+					Suggestions: apostropheSuggestions(`var Hello = cond && <div>a`, `s</div>`),
+				},
+			},
+		},
+		// --- ESLint parity: whitespace-only JsxText with a whitespace forbid char ---
+		// An obscure configuration but aligned with ESLint's char-by-char scan.
+		{
+			Code:    `var Hello = <div>  </div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forbid": []interface{}{" "}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unescapedEntity", Line: 1, Column: 18},
+				{MessageId: "unescapedEntity", Line: 1, Column: 19},
+			},
+		},
+		// --- two JsxText nodes split by an expression container in the same parent ---
+		{
+			Code: `var Hello = <div>a's {x} b's</div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 19,
+					Suggestions: apostropheSuggestions(`var Hello = <div>a`, `s {x} b's</div>`),
+				},
+				{
+					MessageId:   "unescapedEntityAlts",
+					Line:        1, Column: 27,
+					Suggestions: apostropheSuggestions(`var Hello = <div>a's {x} b`, `s</div>`),
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -85,6 +85,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
+    './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts
@@ -1,0 +1,165 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unescaped-entities', {} as never, {
+  valid: [
+    // structural: no JsxText
+    { code: `var Hello = <div/>` },
+    { code: `var Hello = <div></div>` },
+    { code: `var Hello = <></>` },
+    { code: `var Hello = <Component name="don't" />` },
+    { code: `var Hello = <div title="it's fine"></div>` },
+
+    // plain / already-escaped text
+    { code: `var Hello = <div>Here is some text!</div>` },
+    {
+      code: `var Hello = <div>I&rsquo;ve escaped some entities: &gt; &lt; &amp;</div>`,
+    },
+
+    // whitespace-only
+    { code: `var Hello = <div>   </div>` },
+
+    // string literals inside expression containers are not JsxText
+    { code: `var Hello = <div>{">" + "<" + "&" + '"'}</div>` },
+    { code: `var Hello = <div>{"it's fine"}</div>` },
+
+    // nested safe content
+    { code: `var Hello = <Outer><Inner>safe</Inner></Outer>` },
+    { code: `var Hello = <ul><li>one</li><li>two</li></ul>` },
+    { code: `var Hello = <Outer child={<Inner>safe</Inner>} />` },
+
+    // custom forbid replaces defaults
+    {
+      code: `var Hello = <div>don't forget</div>`,
+      options: [{ forbid: ['&'] }],
+    },
+
+    // forbid: [] explicitly disables all
+    {
+      code: `var Hello = <div>don't do that</div>`,
+      options: [{ forbid: [] }],
+    },
+  ],
+  invalid: [
+    {
+      code: `var Hello = <div>'</div>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    {
+      code: `var Hello = <div>Don't do that</div>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    {
+      code: `var Hello = <>it's a trap</>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // nested: flag inner only
+    {
+      code: `var Hello = <Outer>outer text<Inner>inner's</Inner></Outer>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // nested: flag at multiple levels
+    {
+      code: `var Hello = <Outer>outer's<Inner>inner's</Inner></Outer>`,
+      errors: [
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+      ],
+    },
+    // JSX inside expression container inside JSX
+    {
+      code: `var Hello = <Outer>{<Inner>inner's</Inner>}</Outer>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // JSX as prop value: inner JsxText is scanned
+    {
+      code: `var Hello = <Outer child={<Inner>inner's</Inner>} />`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // adjacent duplicates
+    {
+      code: `var Hello = <div>a''b</div>`,
+      errors: [
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+      ],
+    },
+    // mixed default chars in same JsxText (source order)
+    {
+      code: `var Hello = <div>"don't"</div>`,
+      errors: [
+        { messageId: 'unescapedEntityAlts', data: { entity: '"' } },
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+        { messageId: 'unescapedEntityAlts', data: { entity: '"' } },
+      ],
+    },
+    // script tag: unescaped quotes
+    {
+      code: `var Hello = <script>window.foo = "bar"</script>`,
+      errors: [
+        { messageId: 'unescapedEntityAlts', data: { entity: '"' } },
+        { messageId: 'unescapedEntityAlts', data: { entity: '"' } },
+      ],
+    },
+    // custom forbid: simple string form
+    {
+      code: `var Hello = <span>foo & bar</span>`,
+      options: [{ forbid: ['&'] }],
+      errors: [{ messageId: 'unescapedEntity', data: { entity: '&' } }],
+    },
+    // custom forbid: object form
+    {
+      code: `var Hello = <span>foo & bar</span>`,
+      options: [{ forbid: [{ char: '&', alternatives: ['&amp;'] }] }],
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: '&' } }],
+    },
+    // forbid: mix of string + object entries
+    {
+      code: `var Hello = <div>a & b $ c</div>`,
+      options: [
+        {
+          forbid: ['&', { char: '$', alternatives: ['&#36;'] }],
+        },
+      ],
+      errors: [
+        { messageId: 'unescapedEntity', data: { entity: '&' } },
+        { messageId: 'unescapedEntityAlts', data: { entity: '$' } },
+      ],
+    },
+    // multi-byte Unicode custom forbid char (fullwidth apostrophe U+FF07)
+    {
+      code: `var Hello = <div>fullwidth\uff07quote</div>`,
+      options: [{ forbid: ['\uff07'] }],
+      errors: [{ messageId: 'unescapedEntity', data: { entity: '\uff07' } }],
+    },
+    // UTF-16 column stays correct when a multi-byte char precedes the match
+    {
+      code: `var Hello = <div>café's</div>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // UTF-16 column stays correct across a surrogate pair (supra-BMP char)
+    {
+      code: `var Hello = <div>🚀's</div>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // JSX in type assertion
+    {
+      code: `var Hello = (<div>a's</div>) as any`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // JSX in logical short-circuit
+    {
+      code: `var Hello = cond && <div>a's</div>`,
+      errors: [{ messageId: 'unescapedEntityAlts', data: { entity: "'" } }],
+    },
+    // Two JsxText nodes split by an expression container
+    {
+      code: `var Hello = <div>a's {x} b's</div>`,
+      errors: [
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+        { messageId: 'unescapedEntityAlts', data: { entity: "'" } },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,5 +1,6 @@
 # Custom Dictionary Words
 aavascript
+apos
 accum
 afoob
 anee
@@ -49,6 +50,7 @@ foos
 foox
 fooz
 forinstatement
+fullwidth
 forofstatement
 fround
 fsys
@@ -80,7 +82,9 @@ jsonc
 jsonline
 keygen
 ldflags
+ldquo
 libsyncrpc
+lsquo
 lifecycles
 lintedfile
 llms
@@ -121,6 +125,7 @@ quxx
 qwer
 rankdir
 ranksep
+rdquo
 reactutil
 readonlyness
 Readonlys
@@ -137,6 +142,7 @@ rivo
 rsbuild
 rsdoctor
 rslib
+rsquo
 rslint
 rslintconfig
 rslog


### PR DESCRIPTION
## Summary

Port the `react/no-unescaped-entities` rule from `eslint-plugin-react` to rslint.

The rule disallows unescaped HTML entities (`>`, `"`, `'`, `}` by default) from appearing in JSX text, suggesting appropriate escape sequences. Behavior, messages, options and fix output are 1:1 with the original rule; validated against ESLint on sample code.

Implementation notes:

- Listens on `ast.KindJsxText` (the only AST node that holds literal JSX child text in the TypeScript AST — attribute strings and expression-container contents are intentionally not scanned, matching the ESLint plugin's `isJSX(parent)` predicate).
- Scans rune-by-rune via `utf8.DecodeRuneInString`, so multi-byte Unicode custom `forbid` chars are supported.
- Respects `forbid: []` as "disable all" (matches ESLint's `configuration.forbid || DEFAULTS` semantics).
- TypeScript's parser rejects unescaped `>` and `}` in JSX text (TS1381/TS1382) before the rule runs, so those defaults only fire on source the parser still accepts (`'`, `"`, custom chars). Noted in the rule's ``.md``.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unescaped-entities.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).