### PR TITLE
fix: align `require-atomic-updates` with ESLint implementation

### DIFF
--- a/internal/rules/require_atomic_updates/require_atomic_updates.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.go
@@ -23,28 +23,27 @@ func messageNonAtomicObjectUpdate(value, object string) rule.RuleMessage {
 	}
 }
 
-// analysisState tracks which variables have been read before/after an await/yield.
+// analysisState tracks which symbols have been read before/after an await/yield.
 //
-// Algorithm (mirrors ESLint's code-path segment approach):
-//   - When a variable is read, it is added to freshReads.
-//   - When an await/yield is encountered, all freshReads move to outdatedReads.
-//   - When an assignment targets an outdated variable, the rule reports.
-//   - Re-reading a variable removes it from outdated (the new read is current).
+// Mirrors ESLint's per-segment freshReadVariables / outdatedReadVariables sets,
+// keyed by *ast.Symbol (not name) so shadowing, imports, namespace aliasing,
+// catch bindings, block-scoped let/const, and TS type wrappers are handled
+// naturally — distinct symbols never collide in state regardless of their name.
 type analysisState struct {
-	freshReads    map[string]bool
-	outdatedReads map[string]bool
+	freshReads    map[*ast.Symbol]bool
+	outdatedReads map[*ast.Symbol]bool
 }
 
 func newAnalysisState() *analysisState {
 	return &analysisState{
-		freshReads:    make(map[string]bool),
-		outdatedReads: make(map[string]bool),
+		freshReads:    make(map[*ast.Symbol]bool),
+		outdatedReads: make(map[*ast.Symbol]bool),
 	}
 }
 
 func (s *analysisState) clone() *analysisState {
-	fresh := make(map[string]bool, len(s.freshReads))
-	outdated := make(map[string]bool, len(s.outdatedReads))
+	fresh := make(map[*ast.Symbol]bool, len(s.freshReads))
+	outdated := make(map[*ast.Symbol]bool, len(s.outdatedReads))
 	for k := range s.freshReads {
 		fresh[k] = true
 	}
@@ -54,7 +53,7 @@ func (s *analysisState) clone() *analysisState {
 	return &analysisState{freshReads: fresh, outdatedReads: outdated}
 }
 
-// merge unions another branch's state into this one (used after if/else, ternary, etc.).
+// merge unions another branch's state into this one (used after if/else, etc.).
 func (s *analysisState) merge(other *analysisState) {
 	for k := range other.freshReads {
 		s.freshReads[k] = true
@@ -64,10 +63,13 @@ func (s *analysisState) merge(other *analysisState) {
 	}
 }
 
-func (s *analysisState) markRead(varName string) {
-	s.freshReads[varName] = true
-	// A re-read after await captures the current value, so the variable is no longer outdated.
-	delete(s.outdatedReads, varName)
+func (s *analysisState) markRead(sym *ast.Symbol) {
+	if sym == nil {
+		return
+	}
+	s.freshReads[sym] = true
+	// A re-read after await captures the current value, clearing outdated.
+	delete(s.outdatedReads, sym)
 }
 
 // makeOutdated moves all fresh reads to outdated (called on await/yield).
@@ -75,317 +77,260 @@ func (s *analysisState) makeOutdated() {
 	for k := range s.freshReads {
 		s.outdatedReads[k] = true
 	}
-	s.freshReads = make(map[string]bool)
+	s.freshReads = make(map[*ast.Symbol]bool)
 }
 
-func (s *analysisState) isOutdated(varName string) bool {
-	return s.outdatedReads[varName]
+func (s *analysisState) isOutdated(sym *ast.Symbol) bool {
+	return sym != nil && s.outdatedReads[sym]
 }
 
-// getIdentifierName returns the name if the node (after stripping parentheses) is an Identifier.
-func getIdentifierName(node *ast.Node) string {
-	n := ast.SkipParentheses(node)
-	if n.Kind == ast.KindIdentifier {
-		return n.AsIdentifier().Text
-	}
-	return ""
-}
-
-// getBaseIdentifierNode walks down a member expression chain (foo.bar[baz].qux)
-// and returns the base identifier node and its name. Unlike ast.GetFirstIdentifier,
-// this handles ElementAccessExpression and returns nil instead of panicking.
-func getBaseIdentifierNode(node *ast.Node) (*ast.Node, string) {
-	n := ast.SkipParentheses(node)
-	for n != nil {
-		switch n.Kind {
-		case ast.KindIdentifier:
-			return n, n.AsIdentifier().Text
-		case ast.KindPropertyAccessExpression:
-			n = ast.SkipParentheses(n.AsPropertyAccessExpression().Expression)
-		case ast.KindElementAccessExpression:
-			n = ast.SkipParentheses(n.AsElementAccessExpression().Expression)
-		default:
-			return nil, ""
-		}
-	}
-	return nil, ""
-}
-
-// normalizedNodeText returns the source text of a node with internal whitespace collapsed.
-// For example, "foo . bar" → "foo.bar". Used in diagnostic messages.
-func normalizedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
-	return strings.Join(strings.Fields(utils.TrimmedNodeText(sourceFile, node)), "")
+// breakTarget captures state snapshots produced by `break` statements that
+// target this loop or switch (with optional label).
+type breakTarget struct {
+	label  string
+	states []*analysisState
 }
 
 // analyzer performs the require-atomic-updates analysis within one resumable
-// (async or generator) function. It walks the function body in evaluation order,
-// tracking variable reads relative to await/yield, and reports assignments that
-// may use stale values.
+// (async or generator) function.
 type analyzer struct {
 	ctx             rule.RuleContext
 	funcNode        *ast.Node
 	allowProperties bool
 
-	// localVarsSafe: true = declared in this function and never referenced in a closure.
-	localVarsSafe map[string]bool
-	paramNames    map[string]bool
-	// declaredOuterVars: variables declared in outer scopes. Together with
-	// localVarsSafe, this is used to distinguish declared variables from
-	// undeclared globals (which are not tracked per ESLint semantics).
-	declaredOuterVars map[string]bool
+	// Pre-computed once per function:
+	//   declaredInFunc : symbols whose declaration site is inside funcNode's
+	//                    subtree (including params, locals, nested block decls).
+	//   parameterSymbols  : subset that are parameters of funcNode itself
+	//                    (for the isMember+param escape quirk).
+	//   escapedSymbols : subset referenced inside a nested function/arrow/
+	//                    class-static-block — they can be observed by a
+	//                    concurrent context, so writes to them are race-prone.
+	declaredInFunc map[*ast.Symbol]bool
+	parameterSymbols  map[*ast.Symbol]bool
+	escapedSymbols map[*ast.Symbol]bool
+
+	// breakTargets is the stack of currently-enclosing loops/switches that
+	// can receive a `break` (optionally labeled). Innermost at the end.
+	breakTargets []*breakTarget
 }
 
 func newAnalyzer(ctx rule.RuleContext, funcNode *ast.Node, allowProperties bool) *analyzer {
 	a := &analyzer{
-		ctx:               ctx,
-		funcNode:          funcNode,
-		allowProperties:   allowProperties,
-		localVarsSafe:     make(map[string]bool),
-		paramNames:        make(map[string]bool),
-		declaredOuterVars: make(map[string]bool),
+		ctx:             ctx,
+		funcNode:        funcNode,
+		allowProperties: allowProperties,
+		declaredInFunc:  make(map[*ast.Symbol]bool),
+		parameterSymbols:   make(map[*ast.Symbol]bool),
+		escapedSymbols:  make(map[*ast.Symbol]bool),
 	}
-	a.collectLocalDeclarations()
-	a.collectOuterDeclarations()
+	a.collectDeclarations()
+	a.collectEscapes()
 	return a
 }
 
-// collectLocalDeclarations gathers all declarations local to this function
-// and determines which ones escape to closures.
-func (a *analyzer) collectLocalDeclarations() {
-	allLocals := make(map[string]bool)
-	escapedLocals := make(map[string]bool)
-
-	if params := a.funcNode.Parameters(); params != nil {
-		for _, param := range params {
-			utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
-				allLocals[name] = true
-				a.paramNames[name] = true
-			})
-		}
+// symbolOf returns the *ast.Symbol that `node` resolves to (or nil). The rule
+// is type-aware (RequiresTypeInfo is set), so TypeChecker is guaranteed non-nil
+// at runtime. Shorthand property identifiers resolve to their VALUE symbol
+// (the outer binding of the same name), and symbols augmented into the global
+// scope via `declare global { … }` are treated as unresolved — ESLint's
+// scope analyzer leaves those references unresolved too.
+func (a *analyzer) symbolOf(node *ast.Node) *ast.Symbol {
+	if node == nil || a.ctx.TypeChecker == nil {
+		return nil
 	}
-
-	body := a.funcNode.Body()
-	if body == nil {
-		return
+	var sym *ast.Symbol
+	if node.Kind == ast.KindIdentifier && node.Parent != nil &&
+		node.Parent.Kind == ast.KindShorthandPropertyAssignment &&
+		node.Parent.AsShorthandPropertyAssignment().Name() == node {
+		sym = a.ctx.TypeChecker.GetShorthandAssignmentValueSymbol(node.Parent)
 	}
-	a.collectDeclsInBlock(body, allLocals)
-	a.findEscapedVars(body, allLocals, escapedLocals, false, nil)
-
-	for name := range allLocals {
-		a.localVarsSafe[name] = !escapedLocals[name]
+	if sym == nil {
+		sym = a.ctx.TypeChecker.GetSymbolAtLocation(node)
 	}
+	if sym == nil {
+		return nil
+	}
+	if symbolIsDeclareGlobal(sym) {
+		return nil
+	}
+	return sym
 }
 
-// collectOuterDeclarations walks up from the function to the source file,
-// collecting variable declarations in outer scopes. Undeclared globals are
-// not tracked (ESLint skips unresolved references).
-func (a *analyzer) collectOuterDeclarations() {
-	current := a.funcNode.Parent
-	for current != nil {
-		switch current.Kind {
-		case ast.KindSourceFile:
-			for _, stmt := range current.AsSourceFile().Statements.Nodes {
-				a.collectOuterDeclsFromStmt(stmt)
-			}
-		case ast.KindBlock:
-			for _, stmt := range current.AsBlock().Statements.Nodes {
-				a.collectOuterDeclsFromStmt(stmt)
-			}
-		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
-			ast.KindArrowFunction, ast.KindMethodDeclaration:
-			if params := current.Parameters(); params != nil {
-				for _, param := range params {
-					utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
-						a.declaredOuterVars[name] = true
-					})
-				}
-			}
-		case ast.KindCatchClause:
-			cc := current.AsCatchClause()
-			if cc.VariableDeclaration != nil {
-				utils.CollectBindingNames(cc.VariableDeclaration.Name(), func(_ *ast.Node, name string) {
-					a.declaredOuterVars[name] = true
-				})
-			}
-		case ast.KindForStatement:
-			forStmt := current.AsForStatement()
-			if forStmt.Initializer != nil && forStmt.Initializer.Kind == ast.KindVariableDeclarationList {
-				a.collectDeclsFromVarList(forStmt.Initializer, a.declaredOuterVars)
-			}
-		case ast.KindForInStatement, ast.KindForOfStatement:
-			stmt := current.AsForInOrOfStatement()
-			if stmt.Initializer != nil && stmt.Initializer.Kind == ast.KindVariableDeclarationList {
-				a.collectDeclsFromVarList(stmt.Initializer, a.declaredOuterVars)
-			}
-		}
-		current = current.Parent
-	}
-}
-
-func (a *analyzer) collectOuterDeclsFromStmt(stmt *ast.Node) {
-	switch stmt.Kind {
-	case ast.KindVariableStatement:
-		stmt.ForEachChild(func(declList *ast.Node) bool {
-			if declList.Kind == ast.KindVariableDeclarationList {
-				a.collectDeclsFromVarList(declList, a.declaredOuterVars)
-			}
-			return false
-		})
-	case ast.KindFunctionDeclaration, ast.KindClassDeclaration:
-		if stmt.Name() != nil && stmt.Name().Kind == ast.KindIdentifier {
-			a.declaredOuterVars[stmt.Name().AsIdentifier().Text] = true
-		}
-	}
-}
-
-// collectDeclsFromVarList extracts variable names from a VariableDeclarationList.
-func (a *analyzer) collectDeclsFromVarList(declList *ast.Node, target map[string]bool) {
-	declList.ForEachChild(func(decl *ast.Node) bool {
-		if decl.Kind == ast.KindVariableDeclaration {
-			utils.CollectBindingNames(decl.Name(), func(_ *ast.Node, name string) {
-				target[name] = true
-			})
-		}
+// symbolIsDeclareGlobal reports whether every declaration of `sym` is nested
+// inside a `declare global { … }` block. Such globals augment the ambient
+// scope and are not visible to ESLint's scope analyzer, so the rule must
+// treat references to them like unresolved identifiers.
+func symbolIsDeclareGlobal(sym *ast.Symbol) bool {
+	if sym == nil || len(sym.Declarations) == 0 {
 		return false
-	})
-}
-
-// collectDeclsInBlock collects variable declarations from a block without
-// recursing into nested functions. The topLevel flag controls scoping:
-//   - topLevel=true  (function body): collect let/const/var/function/class
-//   - topLevel=false (nested block):  collect only var (it hoists to function scope)
-func (a *analyzer) collectDeclsInBlock(node *ast.Node, locals map[string]bool) {
-	a.collectDeclsInBlockImpl(node, locals, true)
-}
-
-func (a *analyzer) collectDeclsInBlockImpl(node *ast.Node, locals map[string]bool, topLevel bool) {
-	if node == nil {
-		return
 	}
-
-	node.ForEachChild(func(child *ast.Node) bool {
-		switch child.Kind {
-		case ast.KindVariableStatement:
-			child.ForEachChild(func(declList *ast.Node) bool {
-				if declList.Kind == ast.KindVariableDeclarationList {
-					// In nested blocks, only collect var (hoisted); skip let/const (block-scoped).
-					if topLevel || utils.IsVarKeyword(declList) {
-						a.collectDeclsFromVarList(declList, locals)
-					}
-				}
-				return false
-			})
-		case ast.KindFunctionDeclaration:
-			if child.Name() != nil && child.Name().Kind == ast.KindIdentifier {
-				locals[child.Name().AsIdentifier().Text] = true
-			}
-			// Don't recurse into the function body
-		case ast.KindClassDeclaration:
-			if child.Name() != nil && child.Name().Kind == ast.KindIdentifier {
-				locals[child.Name().AsIdentifier().Text] = true
-			}
-		default:
-			if !ast.IsFunctionLikeDeclaration(child) {
-				a.collectDeclsInBlockImpl(child, locals, false)
-			}
-		}
-		return false
-	})
-}
-
-// findEscapedVars finds local variables referenced inside nested functions.
-// shadowed tracks variables redeclared in inner scopes to avoid false positives
-// (e.g., inner `let foo` should not cause outer `foo` to be marked escaped).
-func (a *analyzer) findEscapedVars(node *ast.Node, locals map[string]bool, escaped map[string]bool, inNestedFunc bool, shadowed map[string]bool) {
-	if node == nil {
-		return
-	}
-
-	node.ForEachChild(func(child *ast.Node) bool {
-		if ast.IsFunctionLikeDeclaration(child) {
-			// Collect declarations in the nested function to detect shadowing
-			innerLocals := make(map[string]bool)
-			a.collectNestedFuncDecls(child, innerLocals)
-
-			innerShadowed := make(map[string]bool, len(shadowed)+len(innerLocals))
-			for k := range shadowed {
-				innerShadowed[k] = true
-			}
-			for k := range innerLocals {
-				innerShadowed[k] = true
-			}
-
-			a.findEscapedVars(child, locals, escaped, true, innerShadowed)
+	for _, decl := range sym.Declarations {
+		if !isInsideDeclareGlobal(decl) {
 			return false
 		}
+	}
+	return true
+}
 
-		if child.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(child) {
-			name := child.AsIdentifier().Text
-			if inNestedFunc && locals[name] && !shadowed[name] {
-				escaped[name] = true
+func isInsideDeclareGlobal(node *ast.Node) bool {
+	for cur := node; cur != nil; cur = cur.Parent {
+		if cur.Kind == ast.KindModuleDeclaration {
+			name := cur.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "global" {
+				return true
 			}
 		}
-
-		a.findEscapedVars(child, locals, escaped, inNestedFunc, shadowed)
-		return false
-	})
-}
-
-func (a *analyzer) collectNestedFuncDecls(funcNode *ast.Node, decls map[string]bool) {
-	if params := funcNode.Parameters(); params != nil {
-		for _, param := range params {
-			utils.CollectBindingNames(param.Name(), func(_ *ast.Node, name string) {
-				decls[name] = true
-			})
-		}
-	}
-	if body := funcNode.Body(); body != nil {
-		a.collectDeclsInBlock(body, decls)
-	}
-}
-
-// isDeclaredVariable returns true if the variable is declared in any scope
-// (local or outer). Falls back to TypeChecker to resolve globals from type
-// definitions (e.g., `process` from @types/node). Truly undeclared names return false.
-func (a *analyzer) isDeclaredVariable(name string, identNode *ast.Node) bool {
-	_, isLocal := a.localVarsSafe[name]
-	if isLocal || a.declaredOuterVars[name] {
-		return true
-	}
-	// TypeChecker can resolve globals from lib/types (e.g., process, console).
-	if a.ctx.TypeChecker != nil && identNode != nil {
-		sym := a.ctx.TypeChecker.GetSymbolAtLocation(identNode)
-		if sym == nil {
-			return false
-		}
-		// If the symbol is declared inside the current function, it's local (safe).
-		// This covers block-scoped variables (for-loop let, catch var) that our
-		// AST-based collection may have missed.
-		if sym.ValueDeclaration != nil && a.isNodeInsideFunc(sym.ValueDeclaration) {
-			a.localVarsSafe[name] = true
-			return true
-		}
-		return true
 	}
 	return false
 }
 
-// isNodeInsideFunc checks if a node is a descendant of the current function.
-func (a *analyzer) isNodeInsideFunc(node *ast.Node) bool {
-	return ast.FindAncestor(node, func(n *ast.Node) bool {
-		return n == a.funcNode
-	}) != nil
+// collectDeclarations walks funcNode (not descending into nested functions)
+// and records the symbol of every declaration name it finds.
+func (a *analyzer) collectDeclarations() {
+	if params := a.funcNode.Parameters(); params != nil {
+		for _, param := range params {
+			a.collectBindingSymbols(param.Name(), true)
+		}
+	}
+	if body := a.funcNode.Body(); body != nil {
+		a.collectDeclsIn(body)
+	}
 }
 
-// isLocalVariableWithoutEscape returns true if the variable is local and
-// never referenced in a closure (i.e., no other concurrent code can observe it).
-// For member access on parameters, returns false because the object comes from outside.
-func (a *analyzer) isLocalVariableWithoutEscape(name string, isMemberAccess bool) bool {
-	if isMemberAccess && a.paramNames[name] {
+// collectBindingSymbols walks a binding target (Identifier or
+// ObjectBindingPattern/ArrayBindingPattern) and registers each contained name's
+// symbol. isParam=true only when collecting parameters of funcNode itself.
+func (a *analyzer) collectBindingSymbols(nameNode *ast.Node, isParam bool) {
+	if nameNode == nil {
+		return
+	}
+	utils.CollectBindingNames(nameNode, func(ident *ast.Node, _ string) {
+		if sym := a.symbolOf(ident); sym != nil {
+			a.declaredInFunc[sym] = true
+			if isParam {
+				a.parameterSymbols[sym] = true
+			}
+		}
+	})
+}
+
+// collectDeclsIn descends into funcNode's body skipping nested functions and
+// registers every declaration's symbol. Shadowing is handled naturally by
+// distinct symbols, so there is no need to track which declarations belong
+// to which block.
+func (a *analyzer) collectDeclsIn(node *ast.Node) {
+	if node == nil {
+		return
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		if ast.IsFunctionLikeDeclaration(child) {
+			return false
+		}
+		switch child.Kind {
+		case ast.KindVariableDeclaration:
+			vd := child.AsVariableDeclaration()
+			if vd.Name() != nil {
+				a.collectBindingSymbols(vd.Name(), false)
+			}
+		case ast.KindFunctionDeclaration, ast.KindClassDeclaration,
+			ast.KindEnumDeclaration, ast.KindModuleDeclaration:
+			if n := child.Name(); n != nil && n.Kind == ast.KindIdentifier {
+				if sym := a.symbolOf(n); sym != nil {
+					a.declaredInFunc[sym] = true
+				}
+			}
+		case ast.KindCatchClause:
+			cc := child.AsCatchClause()
+			if cc.VariableDeclaration != nil {
+				if vd := cc.VariableDeclaration.AsVariableDeclaration(); vd != nil && vd.Name() != nil {
+					a.collectBindingSymbols(vd.Name(), false)
+				}
+			}
+		}
+		a.collectDeclsIn(child)
+		return false
+	})
+}
+
+// collectEscapes walks funcNode's body and marks any symbol in declaredInFunc
+// that is referenced inside a nested function as "escaped" — writes to such a
+// symbol can be observed by the nested function's body, so race analysis must
+// treat it like a non-local variable.
+func (a *analyzer) collectEscapes() {
+	a.walkForEscape(a.funcNode.Body(), false)
+}
+
+func (a *analyzer) walkForEscape(node *ast.Node, inNested bool) {
+	if node == nil {
+		return
+	}
+
+	// Check this node if it's a value-reference identifier inside a nested
+	// function (arrow expression body, method body, static block, …).
+	if inNested && node.Kind == ast.KindIdentifier && !utils.IsNonReferenceIdentifier(node) {
+		if sym := a.symbolOf(node); sym != nil && a.declaredInFunc[sym] {
+			a.escapedSymbols[sym] = true
+		}
+	}
+
+	node.ForEachChild(func(child *ast.Node) bool {
+		if ast.IsFunctionLikeDeclaration(child) {
+			// Walk the full function-like subtree with inNested=true so
+			// every identifier inside (body expression, block, parameter
+			// defaults, etc.) is scanned.
+			a.walkForEscape(child, true)
+			return false
+		}
+		a.walkForEscape(child, inNested)
+		return false
+	})
+}
+
+// isLocalWithoutEscape reports whether writes to `sym` can only be observed by
+// code inside funcNode — i.e. the symbol is declared in funcNode and never
+// referenced from a nested function scope. For member-access writes on a
+// parameter, the underlying object comes from outside, so we treat the param
+// as not-local (matches ESLint's isLocalVariableWithoutEscape param shortcut).
+func (a *analyzer) isLocalWithoutEscape(sym *ast.Symbol, isMember bool) bool {
+	if sym == nil {
 		return false
 	}
-	safe, exists := a.localVarsSafe[name]
-	return exists && safe
+	if !a.declaredInFunc[sym] {
+		return false
+	}
+	if a.escapedSymbols[sym] {
+		return false
+	}
+	if isMember && a.parameterSymbols[sym] {
+		return false
+	}
+	return true
+}
+
+// getBaseIdentifierNode walks down a member expression chain (foo.bar[baz].qux)
+// and returns the base identifier node. Only parentheses are transparent —
+// type assertions break the chain, matching ESLint's getWriteExpr.
+func getBaseIdentifierNode(node *ast.Node) *ast.Node {
+	n := ast.SkipParentheses(node)
+	for n != nil {
+		switch n.Kind {
+		case ast.KindIdentifier:
+			return n
+		case ast.KindPropertyAccessExpression:
+			n = ast.SkipParentheses(n.AsPropertyAccessExpression().Expression)
+		case ast.KindElementAccessExpression:
+			n = ast.SkipParentheses(n.AsElementAccessExpression().Expression)
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// normalizedNodeText returns the source text of a node with internal whitespace collapsed.
+func normalizedNodeText(sourceFile *ast.SourceFile, node *ast.Node) string {
+	return strings.Join(strings.Fields(utils.TrimmedNodeText(sourceFile, node)), "")
 }
 
 // run performs the analysis on parameter defaults and the function body.
@@ -395,7 +340,6 @@ func (a *analyzer) run() {
 		return
 	}
 	state := newAnalysisState()
-	// Parameter default values are evaluated at call time and may contain await.
 	if params := a.funcNode.Parameters(); params != nil {
 		for _, param := range params {
 			p := param.AsParameterDeclaration()
@@ -421,15 +365,20 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 		ast.KindConstructor,
 		ast.KindGetAccessor,
 		ast.KindSetAccessor:
-		// Function boundaries: don't recurse (inner functions are separate scopes)
 		return
 
 	case ast.KindClassDeclaration, ast.KindClassExpression:
-		// Class bodies contain methods which are separate function scopes
 		return
 
 	case ast.KindBlock:
+		// Shadowing is handled naturally by distinct symbols; no mask needed.
 		a.walkStatements(node.AsBlock().Statements.Nodes, state)
+
+	case ast.KindCatchClause:
+		cc := node.AsCatchClause()
+		if cc.Block != nil {
+			a.walkNode(cc.Block, state)
+		}
 
 	case ast.KindIfStatement:
 		a.walkIfStatement(node, state)
@@ -440,17 +389,34 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 	case ast.KindSwitchStatement:
 		a.walkSwitchStatement(node, state)
 
+	case ast.KindLabeledStatement:
+		a.walkLabeledStatement(node, state)
+
+	case ast.KindBreakStatement:
+		bs := node.AsBreakStatement()
+		label := ""
+		if bs.Label != nil && bs.Label.Kind == ast.KindIdentifier {
+			label = bs.Label.AsIdentifier().Text
+		}
+		a.recordBreak(label, state)
+
 	case ast.KindTryStatement:
 		a.walkTryStatement(node, state)
 
 	case ast.KindWhileStatement:
 		whileStmt := node.AsWhileStatement()
 		a.walkNode(whileStmt.Expression, state)
-		a.walkNode(whileStmt.Statement, state)
+		bodyState := state.clone()
+		tgt := a.pushBreakTarget("")
+		a.walkNode(whileStmt.Statement, bodyState)
+		a.popBreakTargetInto(tgt, state)
 
 	case ast.KindDoStatement:
 		doStmt := node.AsDoStatement()
-		a.walkNode(doStmt.Statement, state)
+		bodyState := state.clone()
+		tgt := a.pushBreakTarget("")
+		a.walkNode(doStmt.Statement, bodyState)
+		a.popBreakTargetInto(tgt, state)
 		a.walkNode(doStmt.Expression, state)
 
 	case ast.KindForStatement:
@@ -459,24 +425,31 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 	case ast.KindForInStatement, ast.KindForOfStatement:
 		stmt := node.AsForInOrOfStatement()
 		a.walkNode(stmt.Expression, state)
-		// for-await-of implicitly awaits on each iteration
+		// ESLint quirk: for-of / for-in / for-await-of bodies get a FRESH
+		// entry state (pre-loop reads are NOT inherited), but the body's
+		// END state IS union-merged back into post-loop — post-loop is
+		// reachable from the body's tail via the iterator-done edge, so
+		// reads that became outdated inside the body propagate.
+		bodyState := newAnalysisState()
 		if stmt.AwaitModifier != nil {
-			state.makeOutdated()
+			bodyState.makeOutdated()
 		}
-		a.walkNode(stmt.Statement, state)
+		a.walkForInOfInitializer(stmt.Initializer, bodyState)
+		tgt := a.pushBreakTarget("")
+		a.walkNode(stmt.Statement, bodyState)
+		state.merge(bodyState)
+		a.popBreakTargetInto(tgt, state)
 
 	case ast.KindBinaryExpression:
 		a.walkBinaryExpression(node, state)
 
 	case ast.KindAwaitExpression:
-		// The operand is evaluated BEFORE the await pauses
 		if node.Expression() != nil {
 			a.walkNode(node.Expression(), state)
 		}
 		state.makeOutdated()
 
 	case ast.KindYieldExpression:
-		// The operand is evaluated BEFORE the yield pauses
 		if node.Expression() != nil {
 			a.walkNode(node.Expression(), state)
 		}
@@ -484,15 +457,13 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 
 	case ast.KindIdentifier:
 		if !utils.IsNonReferenceIdentifier(node) {
-			if name := node.AsIdentifier().Text; name != "" {
-				state.markRead(name)
+			if sym := a.symbolOf(node); sym != nil {
+				state.markRead(sym)
 			}
 		}
 
 	case ast.KindVariableDeclaration:
 		vd := node.AsVariableDeclaration()
-		// Walk binding pattern defaults (e.g., `const {a = await bar} = obj`)
-		// Declaration identifiers are skipped by IsNonReferenceIdentifier.
 		a.walkBindingDefaults(vd.Name(), state)
 		if vd.Initializer != nil {
 			a.walkNode(vd.Initializer, state)
@@ -533,8 +504,6 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 		a.walkNode(node.AsParenthesizedExpression().Expression, state)
 
 	// TypeScript type wrappers: walk the runtime expression, skip the type annotation.
-	// Without this, type reference identifiers (e.g., MyType in `x as MyType`) would
-	// be incorrectly marked as variable reads.
 	case ast.KindAsExpression:
 		a.walkNode(node.AsAsExpression().Expression, state)
 	case ast.KindTypeAssertionExpression:
@@ -545,7 +514,6 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 		a.walkNode(node.AsNonNullExpression().Expression, state)
 
 	case ast.KindPropertyAccessExpression:
-		// Walk only the object expression, not the property name
 		a.walkNode(node.AsPropertyAccessExpression().Expression, state)
 
 	case ast.KindElementAccessExpression:
@@ -572,8 +540,10 @@ func (a *analyzer) walkNode(node *ast.Node, state *analysisState) {
 }
 
 // walkBindingDefaults walks only the default-value initializers inside a
-// destructuring binding pattern (e.g., `{a = await bar}` or `[x = await y]`).
-// This is needed because default values are evaluated at runtime and may contain await.
+// destructuring BINDING pattern (var/let/const declarations). Each default is
+// conditional (runs only if the key is undefined), so it's walked in a
+// cloned state and union-merged back — an await in one default outdates the
+// outer state, but a re-read in a later default doesn't clear it.
 func (a *analyzer) walkBindingDefaults(nameNode *ast.Node, state *analysisState) {
 	if nameNode == nil {
 		return
@@ -584,9 +554,10 @@ func (a *analyzer) walkBindingDefaults(nameNode *ast.Node, state *analysisState)
 			if child.Kind == ast.KindBindingElement {
 				be := child.AsBindingElement()
 				if be.Initializer != nil {
-					a.walkNode(be.Initializer, state)
+					branch := state.clone()
+					a.walkNode(be.Initializer, branch)
+					state.merge(branch)
 				}
-				// Recurse into nested patterns (e.g., `{a: {b = await c}} = obj`)
 				if be.Name() != nil {
 					a.walkBindingDefaults(be.Name(), state)
 				}
@@ -626,78 +597,325 @@ func (a *analyzer) walkBinaryExpression(node *ast.Node, state *analysisState) {
 	}
 
 	// --- Assignment expression ---
-	// Skip parentheses and TS type assertions (as T, <T>, !, satisfies T) on LHS.
 	left := ast.SkipOuterExpressions(binary.Left, ast.OEKParentheses|ast.OEKAssertions)
 	isCompound := ast.IsCompoundAssignment(opKind)
 	isMember := ast.IsAccessExpression(left)
 
-	// Determine the target variable name and its identifier node
-	var targetName string
+	var targetSym *ast.Symbol
 	var targetIdentNode *ast.Node
 	if isMember {
-		targetIdentNode, targetName = getBaseIdentifierNode(left)
-	} else {
-		targetName = getIdentifierName(left)
-		if left.Kind == ast.KindIdentifier {
-			targetIdentNode = left
-		}
+		targetIdentNode = getBaseIdentifierNode(left)
+	} else if left.Kind == ast.KindIdentifier {
+		targetIdentNode = left
+	}
+	if targetIdentNode != nil {
+		targetSym = a.symbolOf(targetIdentNode)
 	}
 
-	if targetName == "" {
+	if targetIdentNode == nil {
+		// Destructuring assignment: `({a, b} = src)` / `[a, b] = src`.
+		if !isCompound && isDestructuringAssignmentTarget(left) {
+			a.walkDestructuringAssignment(node, left, binary.Right, state)
+			return
+		}
 		a.walkNode(binary.Left, state)
 		a.walkNode(binary.Right, state)
 		return
 	}
 
-	// Skip undeclared globals (ESLint skips unresolved references)
-	if !a.isDeclaredVariable(targetName, targetIdentNode) {
-		if isCompound {
-			a.walkNode(binary.Left, state)
-		}
-		a.walkNode(binary.Right, state)
-		return
-	}
-
-	// Local variables that don't escape can't have race conditions
-	if a.isLocalVariableWithoutEscape(targetName, isMember) {
-		if isCompound {
-			a.walkNode(binary.Left, state)
-		}
-		a.walkNode(binary.Right, state)
-		return
-	}
-
-	// For compound assignments (+=, -=, etc.), the LHS is read first.
-	// For simple assignment (=), the LHS is NOT marked as a fresh read
-	// (matches ESLint behavior: only the write target is registered).
+	// Walk the LHS (side-reads always register; the write-target chain itself
+	// is skipped for simple assignments to match ESLint's getWriteExpr chain).
 	if isCompound {
 		a.walkNode(binary.Left, state)
+	} else {
+		a.walkSimpleAssignLHS(binary.Left, state)
 	}
 
 	a.walkNode(binary.Right, state)
 
-	// Check if the target variable was outdated when assigned
-	if state.isOutdated(targetName) {
-		a.report(node, left, targetName, isMember)
+	// Undeclared globals (sym == nil) and local-without-escape vars: no race.
+	if targetSym == nil {
+		return
+	}
+	if a.isLocalWithoutEscape(targetSym, isMember) {
+		return
+	}
+
+	// ESLint quirk: RHS that is a function/arrow expression silently skips
+	// the check (the :expression:exit fires inside the inner function's
+	// CodePath whose referenceMap is null).
+	if isFunctionLikeRHS(binary.Right) {
+		return
+	}
+
+	if state.isOutdated(targetSym) {
+		// TS type-wrapped simple target (e.g. `(foo as any) = 1`): ESLint
+		// reports nonAtomicObjectUpdate with the wrapper's source text as the
+		// value, and allowProperties: true suppresses it. Detect by comparing
+		// the raw LHS to its assertion-stripped form.
+		wrapped := !isMember && binary.Left != left
+		if wrapped {
+			a.report(node, binary.Left, targetSym, true)
+		} else {
+			a.report(node, left, targetSym, isMember)
+		}
 	}
 }
 
-func (a *analyzer) report(assignmentNode *ast.Node, left *ast.Node, targetName string, isMemberAccess bool) {
+func (a *analyzer) report(assignmentNode, left *ast.Node, sym *ast.Symbol, isMemberAccess bool) {
 	if isMemberAccess {
 		if a.allowProperties {
 			return
 		}
 		leftText := normalizedNodeText(a.ctx.SourceFile, left)
-		a.ctx.ReportNode(assignmentNode, messageNonAtomicObjectUpdate(leftText, targetName))
+		a.ctx.ReportNode(assignmentNode, messageNonAtomicObjectUpdate(leftText, sym.Name))
 	} else {
-		a.ctx.ReportNode(assignmentNode, messageNonAtomicUpdate(targetName))
+		a.ctx.ReportNode(assignmentNode, messageNonAtomicUpdate(sym.Name))
+	}
+}
+
+// isFunctionLikeRHS reports whether an assignment's RHS is a function-like
+// expression. ESLint's :expression:exit handler skips outdated checks when
+// the RHS starts a new CodePath with a non-async/non-generator scope.
+func isFunctionLikeRHS(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		return true
+	}
+	return false
+}
+
+// isDestructuringAssignmentTarget returns true if `node` is an ObjectLiteral
+// or ArrayLiteral being reinterpreted as a destructuring pattern.
+func isDestructuringAssignmentTarget(node *ast.Node) bool {
+	n := ast.SkipParentheses(node)
+	return n.Kind == ast.KindObjectLiteralExpression || n.Kind == ast.KindArrayLiteralExpression
+}
+
+// destructuringTarget records a single variable-write target collected from
+// a destructuring pattern.
+type destructuringTarget struct {
+	symbol *ast.Symbol
+	name   string
+}
+
+// walkDestructuringAssignment handles `({a, b = def} = src)` / `[a, b] = src`.
+func (a *analyzer) walkDestructuringAssignment(assignNode, pattern, rhs *ast.Node, state *analysisState) {
+	if rhs != nil {
+		a.walkNode(rhs, state)
+	}
+	var targets []destructuringTarget
+	a.collectDestructuringTargets(pattern, state, &targets)
+
+	if isFunctionLikeRHS(rhs) {
+		return
+	}
+	leftText := normalizedNodeText(a.ctx.SourceFile, pattern)
+	for _, t := range targets {
+		if t.symbol == nil {
+			continue
+		}
+		if a.isLocalWithoutEscape(t.symbol, false) {
+			continue
+		}
+		if state.isOutdated(t.symbol) {
+			a.ctx.ReportNode(assignNode, messageNonAtomicObjectUpdate(leftText, t.name))
+		}
+	}
+}
+
+// collectDestructuringTargets walks a destructuring pattern. Default
+// expressions are walked (in cloned branches) so awaits in defaults outdate
+// without letting re-reads clear the outer state. Each variable-target leaf is
+// appended to `targets`.
+func (a *analyzer) collectDestructuringTargets(node *ast.Node, state *analysisState, targets *[]destructuringTarget) {
+	if node == nil {
+		return
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindObjectLiteralExpression:
+		for _, prop := range n.AsObjectLiteralExpression().Properties.Nodes {
+			a.collectDestructuringProperty(prop, state, targets)
+		}
+	case ast.KindArrayLiteralExpression:
+		for _, elem := range n.AsArrayLiteralExpression().Elements.Nodes {
+			a.collectDestructuringElement(elem, state, targets)
+		}
+	case ast.KindIdentifier:
+		if sym := a.symbolOf(n); sym != nil {
+			*targets = append(*targets, destructuringTarget{symbol: sym, name: sym.Name})
+		}
+	default:
+		// Member target or other — walk as a normal expression so any side
+		// reads register, but don't record as a tracked target.
+		a.walkNode(n, state)
+	}
+}
+
+func (a *analyzer) collectDestructuringProperty(prop *ast.Node, state *analysisState, targets *[]destructuringTarget) {
+	switch prop.Kind {
+	case ast.KindShorthandPropertyAssignment:
+		sp := prop.AsShorthandPropertyAssignment()
+		if sp.ObjectAssignmentInitializer != nil {
+			branch := state.clone()
+			a.walkNode(sp.ObjectAssignmentInitializer, branch)
+			state.merge(branch)
+		}
+		name := sp.Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			if sym := a.symbolOf(name); sym != nil {
+				*targets = append(*targets, destructuringTarget{symbol: sym, name: sym.Name})
+			}
+		}
+	case ast.KindPropertyAssignment:
+		pa := prop.AsPropertyAssignment()
+		if pa.Name() != nil && pa.Name().Kind == ast.KindComputedPropertyName {
+			a.walkNode(pa.Name(), state)
+		}
+		a.collectDestructuringValue(pa.Initializer, state, targets)
+	case ast.KindSpreadAssignment:
+		a.collectDestructuringValue(prop.AsSpreadAssignment().Expression, state, targets)
+	default:
+		a.walkNode(prop, state)
+	}
+}
+
+func (a *analyzer) collectDestructuringElement(elem *ast.Node, state *analysisState, targets *[]destructuringTarget) {
+	if elem == nil || elem.Kind == ast.KindOmittedExpression {
+		return
+	}
+	if elem.Kind == ast.KindSpreadElement {
+		a.collectDestructuringValue(elem.Expression(), state, targets)
+		return
+	}
+	a.collectDestructuringValue(elem, state, targets)
+}
+
+func (a *analyzer) collectDestructuringValue(node *ast.Node, state *analysisState, targets *[]destructuringTarget) {
+	if node == nil {
+		return
+	}
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindBinaryExpression {
+		bin := n.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken {
+			branch := state.clone()
+			a.walkNode(bin.Right, branch)
+			state.merge(branch)
+			a.collectDestructuringValue(bin.Left, state, targets)
+			return
+		}
+	}
+	a.collectDestructuringTargets(n, state, targets)
+}
+
+// walkLabeledStatement handles `label: stmt`. Loops/switches inside a labeled
+// statement become reachable via `break <label>` from nested constructs.
+func (a *analyzer) walkLabeledStatement(node *ast.Node, state *analysisState) {
+	ls := node.AsLabeledStatement()
+	label := ""
+	if ls.Label != nil && ls.Label.Kind == ast.KindIdentifier {
+		label = ls.Label.AsIdentifier().Text
+	}
+	body := ls.Statement
+	switch body.Kind {
+	case ast.KindWhileStatement, ast.KindDoStatement, ast.KindForStatement,
+		ast.KindForInStatement, ast.KindForOfStatement, ast.KindSwitchStatement,
+		ast.KindBlock:
+		t := a.pushBreakTarget(label)
+		a.walkNode(body, state)
+		a.popBreakTargetInto(t, state)
+	default:
+		a.walkNode(body, state)
+	}
+}
+
+func (a *analyzer) pushBreakTarget(label string) *breakTarget {
+	t := &breakTarget{label: label}
+	a.breakTargets = append(a.breakTargets, t)
+	return t
+}
+
+func (a *analyzer) popBreakTargetInto(t *breakTarget, post *analysisState) {
+	if n := len(a.breakTargets); n > 0 && a.breakTargets[n-1] == t {
+		a.breakTargets = a.breakTargets[:n-1]
+	}
+	for _, s := range t.states {
+		post.merge(s)
+	}
+}
+
+func (a *analyzer) recordBreak(label string, state *analysisState) {
+	for i := len(a.breakTargets) - 1; i >= 0; i-- {
+		t := a.breakTargets[i]
+		if label == "" || t.label == label {
+			t.states = append(t.states, state.clone())
+			return
+		}
+	}
+}
+
+// walkForInOfInitializer walks a for-in / for-of statement's Initializer in
+// bodyState so awaits inside destructuring defaults correctly outdate per
+// iteration.
+func (a *analyzer) walkForInOfInitializer(init *ast.Node, state *analysisState) {
+	if init == nil {
+		return
+	}
+	if init.Kind == ast.KindVariableDeclarationList {
+		a.walkNode(init, state)
+		return
+	}
+	n := ast.SkipParentheses(init)
+	switch n.Kind {
+	case ast.KindIdentifier:
+		// `for (foo of gen)` — foo is a pure write target; no read.
+	case ast.KindObjectLiteralExpression, ast.KindArrayLiteralExpression:
+		var discard []destructuringTarget
+		a.collectDestructuringTargets(n, state, &discard)
+	default:
+		a.walkNode(n, state)
+	}
+}
+
+// walkSimpleAssignLHS walks the LHS of a simple `=` assignment. The
+// write-target chain (the base identifier reached via PropertyAccess.Expression
+// / ElementAccess.Expression / TS wrappers) is NOT marked as a read. Side
+// expressions (computed indices, etc.) are walked normally.
+func (a *analyzer) walkSimpleAssignLHS(node *ast.Node, state *analysisState) {
+	if node == nil {
+		return
+	}
+	node = ast.SkipParentheses(node)
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		a.walkSimpleAssignLHS(node.AsPropertyAccessExpression().Expression, state)
+	case ast.KindElementAccessExpression:
+		elem := node.AsElementAccessExpression()
+		a.walkSimpleAssignLHS(elem.Expression, state)
+		a.walkNode(elem.ArgumentExpression, state)
+	case ast.KindAsExpression:
+		a.walkSimpleAssignLHS(node.AsAsExpression().Expression, state)
+	case ast.KindTypeAssertionExpression:
+		a.walkSimpleAssignLHS(node.AsTypeAssertion().Expression, state)
+	case ast.KindSatisfiesExpression:
+		a.walkSimpleAssignLHS(node.AsSatisfiesExpression().Expression, state)
+	case ast.KindNonNullExpression:
+		a.walkSimpleAssignLHS(node.AsNonNullExpression().Expression, state)
+	case ast.KindIdentifier:
+		// Base of the write-target chain: do not mark as a read.
+	default:
+		a.walkNode(node, state)
 	}
 }
 
 // stmtAlwaysTerminates returns true if a statement always exits via
-// return/throw/break/continue (so the state from this branch should NOT merge
-// into the continuation). Checks all statements in a block — an early
-// return/throw in the middle means the block terminates even if dead code follows.
+// return/throw.
 func stmtAlwaysTerminates(node *ast.Node) bool {
 	if node == nil {
 		return false
@@ -738,25 +956,17 @@ func (a *analyzer) walkIfStatement(node *ast.Node, state *analysisState) {
 
 		switch {
 		case thenExits && elseExits:
-			// Both branches exit — code after if is unreachable.
 			*state = *thenState
 		case thenExits:
-			// Only then exits — continuation only from else path.
 			*state = *elseState
 		case elseExits:
-			// Only else exits — continuation only from then path.
 			*state = *thenState
 		default:
-			// Neither exits — merge both paths.
 			thenState.merge(elseState)
 			*state = *thenState
 		}
 	} else {
-		if thenExits {
-			// Then-branch always exits — continuation only from the non-taken path.
-			// state already holds the pre-if state (condition was walked).
-		} else {
-			// Then-branch may or may not execute — merge both possibilities.
+		if !thenExits {
 			state.merge(thenState)
 		}
 	}
@@ -777,19 +987,28 @@ func (a *analyzer) walkConditionalExpression(node *ast.Node, state *analysisStat
 	*state = *consequentState
 }
 
-// clauseTerminates checks whether a case/default clause's statements end with
-// break/return/throw (i.e., no fallthrough to the next case).
-func clauseTerminates(statements []*ast.Node) bool {
+// clauseEndKind classifies how a switch clause's statements end.
+type clauseEndKind int
+
+const (
+	clauseEndFallthrough clauseEndKind = iota
+	clauseEndBreak
+	clauseEndExit
+)
+
+func classifyClauseEnd(statements []*ast.Node) clauseEndKind {
 	for _, stmt := range statements {
 		if stmtAlwaysTerminates(stmt) {
-			return true
+			return clauseEndExit
 		}
-		// break/continue also terminate a case clause
-		if stmt.Kind == ast.KindBreakStatement || stmt.Kind == ast.KindContinueStatement {
-			return true
+		if stmt.Kind == ast.KindBreakStatement {
+			return clauseEndBreak
+		}
+		if stmt.Kind == ast.KindContinueStatement {
+			return clauseEndExit
 		}
 	}
-	return false
+	return clauseEndFallthrough
 }
 
 func (a *analyzer) walkSwitchStatement(node *ast.Node, state *analysisState) {
@@ -802,20 +1021,19 @@ func (a *analyzer) walkSwitchStatement(node *ast.Node, state *analysisState) {
 		return
 	}
 
-	// fallthroughState accumulates across cases that don't break/return/throw.
-	// When a case terminates, its state merges into mergedState and fallthroughState resets.
+	swTgt := a.pushBreakTarget("")
+
 	mergedState := state.clone()
 	var fallthroughState *analysisState
+	clauses := caseBlock.Clauses.Nodes
 
-	for _, clause := range caseBlock.Clauses.Nodes {
+	for i, clause := range clauses {
 		caseOrDefault := clause.AsCaseOrDefaultClause()
 		if caseOrDefault == nil {
 			continue
 		}
 
-		// Start from pre-switch state (direct jump to this case).
 		clauseState := state.clone()
-		// If the previous case fell through, merge its accumulated state.
 		if fallthroughState != nil {
 			clauseState.merge(fallthroughState)
 		}
@@ -829,35 +1047,64 @@ func (a *analyzer) walkSwitchStatement(node *ast.Node, state *analysisState) {
 			a.walkStatements(clauseStatements, clauseState)
 		}
 
-		mergedState.merge(clauseState)
-
-		if clauseTerminates(clauseStatements) {
+		switch classifyClauseEnd(clauseStatements) {
+		case clauseEndBreak, clauseEndExit:
 			fallthroughState = nil
-		} else {
+		case clauseEndFallthrough:
+			if i == len(clauses)-1 {
+				mergedState.merge(clauseState)
+			}
 			fallthroughState = clauseState
 		}
 	}
+
+	a.popBreakTargetInto(swTgt, mergedState)
 	*state = *mergedState
 }
 
 func (a *analyzer) walkTryStatement(node *ast.Node, state *analysisState) {
 	tryStmt := node.AsTryStatement()
 
-	tryState := state.clone()
+	tryEnd := state.clone()
 	if tryStmt.TryBlock != nil {
-		a.walkNode(tryStmt.TryBlock, tryState)
+		a.walkNode(tryStmt.TryBlock, tryEnd)
 	}
 
-	// The catch block may be entered at any point during try execution
-	// (an exception can occur after an await). Use the post-try state so
-	// the catch block sees all reads/outdating from the try block.
-	catchState := tryState.clone()
+	tryTerminates := tryStmt.TryBlock != nil && stmtAlwaysTerminates(tryStmt.TryBlock)
+
+	var catchEnd *analysisState
 	if tryStmt.CatchClause != nil {
-		a.walkNode(tryStmt.CatchClause, catchState)
+		if tryTerminates {
+			catchEnd = state.clone()
+		} else {
+			catchEnd = tryEnd.clone()
+		}
+		a.walkNode(tryStmt.CatchClause, catchEnd)
 	}
 
-	tryState.merge(catchState)
-	*state = *tryState
+	var catchTerminates bool
+	if tryStmt.CatchClause != nil {
+		cc := tryStmt.CatchClause.AsCatchClause()
+		if cc.Block != nil {
+			catchTerminates = stmtAlwaysTerminates(cc.Block)
+		}
+	}
+
+	post := newAnalysisState()
+	contributions := 0
+	if !tryTerminates {
+		post.merge(tryEnd)
+		contributions++
+	}
+	if tryStmt.CatchClause != nil && !catchTerminates {
+		post.merge(catchEnd)
+		contributions++
+	}
+	if contributions == 0 {
+		*state = *state.clone()
+	} else {
+		*state = *post
+	}
 
 	if tryStmt.FinallyBlock != nil {
 		a.walkNode(tryStmt.FinallyBlock, state)
@@ -872,16 +1119,21 @@ func (a *analyzer) walkForStatement(node *ast.Node, state *analysisState) {
 	if forStmt.Condition != nil {
 		a.walkNode(forStmt.Condition, state)
 	}
-	a.walkNode(forStmt.Statement, state)
+	bodyState := state.clone()
+	tgt := a.pushBreakTarget("")
+	a.walkNode(forStmt.Statement, bodyState)
+	a.popBreakTargetInto(tgt, state)
+	// Incrementor runs in its own segment whose entry state is fresh.
 	if forStmt.Incrementor != nil {
-		a.walkNode(forStmt.Incrementor, state)
+		a.walkNode(forStmt.Incrementor, newAnalysisState())
 	}
 }
 
 // RequireAtomicUpdatesRule disallows assignments that can lead to race conditions
 // due to usage of `await` or `yield`.
 var RequireAtomicUpdatesRule = rule.Rule{
-	Name: "require-atomic-updates",
+	Name:             "require-atomic-updates",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		allowProperties := false
 		optsMap := utils.GetOptionsMap(options)

--- a/internal/rules/require_atomic_updates/require_atomic_updates_test.go
+++ b/internal/rules/require_atomic_updates/require_atomic_updates_test.go
@@ -53,6 +53,19 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			// ---- Shadowed variable in inner closure ----
 			{Code: `async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }`},
 
+			// ---- Property access name in closure is NOT a variable reference ----
+			// `(item) => item.foo` only references `item`, not outer `foo`.
+			// So outer `foo` is still local-without-escape.
+			{Code: `
+				async function x(list, api) {
+					list.map((item) => item.foo);
+					let foo = 1;
+					if (list.length && foo !== 2) {
+						await api.update({ foo });
+						foo = 2;
+					}
+				}`},
+
 			// ---- Read and write before await (separate statements) ----
 			{Code: `let foo; async function x() { foo = foo + 1; await bar; }`},
 
@@ -211,6 +224,107 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			// ---- for-await-of: no read of outer var before loop ----
 			{Code: `let foo; async function x() { for await (const item of gen) { foo = item; } }`},
 
+			// ---- ESLint quirk: for-of / for-in / for-await-of bodies don't inherit
+			//      pre-loop read state, so an outer read isn't outdated by body awaits. ----
+			{Code: `let foo; function cb() { return foo; }
+				async function x(gen) { foo; for await (const item of gen) { foo = item; } }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function x(arr, hook) { foo; for (const c of arr) { await hook(); foo = 1; } }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function x(arr, hook) { foo; for (const k in arr) { await hook(); foo = 1; } }`},
+
+			// ---- for-of assignment form: bare-identifier target is pure-write ----
+			// ESLint's getWriteExpr breaks at the for-of boundary only WHEN traversing
+			// through a member access. A bare identifier is treated as a pure write,
+			// so `foo` doesn't get marked as read → body await can't outdate it.
+			{Code: `let foo; function cb() { return foo; }
+				async function f(gen, x) { for (foo of gen) { await x; foo = 1; } }`},
+
+			// ---- for-of assignment form: destructure target without pre-read ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(gen) { for ({foo} of gen) {} }`},
+
+			// ---- for-of with plain const binding: no reads in initializer ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(gen, x) { for (const it of gen) { await x; foo = it; } }`},
+
+			// ---- for-loop's update runs in a fresh segment: a simple `foo = await x`
+			//      in the update doesn't see pre-loop reads, so no race is reported. ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; for(;; foo = await x) {} }`},
+
+			// ---- switch where every case exits via return/throw: post-switch
+			//      doesn't inherit any case's outdated state. ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x, n) { foo; switch (n) { case 1: await x; return; case 2: return; } foo = 1; }`},
+
+			// ---- Catch binding shadows outer: inner write doesn't see outer state ----
+			// Also covers: optional catch (no binding) leaves the outer variable
+			// visible, see invalid counterpart below.
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { try { foo; await x; } catch (foo) { foo = 1; } }`},
+
+			// ---- Catch binding destructured: same shadow rule applies ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { try { foo; await x; } catch ({ foo }) { foo = 1; } }`},
+
+			// ---- let/const in a bare block shadow outer for the block duration ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; await x; { let foo = 1; foo = 2; } }`},
+
+			// ---- Block-scoped function / class declarations shadow outer ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; await x; { function foo() {} foo(); } }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; await x; { class foo {} new foo(); } }`},
+
+			// ---- for-loop let shadow covers init / cond / body / update ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; await x; for (let foo = 0; foo < 1; foo++) {} }`},
+
+			// ---- Nested async function is a separate scope ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f() { async function inner() { foo; } }`},
+
+			// ---- namespace with a function export + function RHS: no report
+			//      (function-like RHS skip aligns with ESLint's :expression:exit quirk). ----
+			{Code: `namespace NS { export function foo() {} }
+				function cb() { return NS.foo; }
+				async function f(x: any) { NS.foo; await x; NS.foo = () => {}; }`},
+
+			// ---- RHS is a function/arrow expression: ESLint silently skips the
+			//      outdated check (the :expression:exit fires inside the inner
+			//      function's CodePath whose referenceMap is null). Match it. ----
+			{Code: `let foo: any; function cb() { return foo; }
+				async function f(x: any) { foo; await x; foo = () => {}; }`},
+			{Code: `let foo: any; function cb() { return foo; }
+				async function f(x: any) { foo; await x; foo = function () {}; }`},
+			{Code: `let foo: any; function cb() { return foo; }
+				async function f(x: any) { foo; await x; foo = async () => {}; }`},
+			// Class / object RHS still reports (they don't start a function CodePath).
+			{Code: `let foo = {}; function cb() { return foo; }
+				async function f(x: any) { await x; foo.bar = 1; }`},
+
+			// ---- try that ALWAYS returns: catch entry = pre-try state ----
+			// Outdates produced late in the try don't leak into catch's state.
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; try { await x; return; } catch {} foo = 1; }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { try { foo; await x; return; } catch { foo = 1; } }`},
+
+			// ---- Both try and catch always exit: post-try unreachable ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { try { await x; return; } catch { throw 0; } foo = 1; }`},
+
+			// ---- Member write target where base is NOT read-before-await ----
+			// `await x; foo.bar = 1` has no race because `foo` was never read before await.
+			{Code: `let foo = {}; function cb() { return foo; }
+				async function f(x) { await x; foo.bar = 1; foo = 2; }`},
+
+			// ---- `foo[k] = 1` — the computed key `k` read marks k, clearing its outdated ----
+			{Code: `let foo, k; function cb() { return foo + k; }
+				async function f(x) { k; await x; foo[k] = 1; }`},
+
 			// ---- yield*: still a yield, but local var is safe ----
 			{Code: `function* x() { let foo; foo += yield* gen; }`},
 
@@ -297,6 +411,31 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 					}`,
 				Options: map[string]interface{}{"allowProperties": true},
 			},
+
+			// ---- Loop body awaits don't propagate to post-loop code ----
+			// ESLint per-segment initialization: post-loop sees entry state, not body state.
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; for (let i = 0; i < 10; i++) { await x; } foo = 1; }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; while (x) { await x; } foo = 1; }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; do { await x; } while (x); foo = 1; }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function f(gen) { foo; for (const it of gen) { await it; } foo = 1; }`},
+			{Code: `let foo; function cb() { return foo; }
+				async function f(gen) { foo; for await (const it of gen) {} foo = 1; }`},
+
+			// ---- Update expressions (foo++, --foo) are not tracked as assignments ----
+			{Code: `let foo; function cb() { return foo; } async function f(x) { foo; await x; foo++; }`},
+			{Code: `let foo; function cb() { return foo; } async function f(x) { await x; --foo; }`},
+
+			// ---- Await in LHS base doesn't register the member target ----
+			// `(await ptr).foo = x` — the chain breaks at AwaitExpression, foo isn't tracked.
+			{Code: `let foo; function cb() { return foo; } async function f(ptr, x) { foo; (await ptr).foo = x; }`},
+
+			// ---- Labeled break before await: no race ----
+			{Code: `let foo; function cb() { return foo; }
+				async function f(x) { foo; outer: for (;;) { if (x) break outer; await x; } foo = 1; }`},
 
 			// ---- Exponential time regression test (many branches) ----
 			{Code: `
@@ -797,10 +936,13 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			},
 
 			// ---- TypeScript: type assertion wrapping LHS ----
+			// The type wrapper keeps foo as the write target but ESLint reports
+			// as nonAtomicObjectUpdate with the wrapper text as the value
+			// (since AssignmentExpression.left !== identifier).
 			{
 				Code: `let foo; async function x() { (foo as any) += await bar; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "nonAtomicUpdate"},
+					{MessageId: "nonAtomicObjectUpdate"},
 				},
 			},
 
@@ -935,10 +1077,12 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			},
 
 			// ---- NonNull assertion on LHS ----
+			// Same as type-assertion: ESLint reports the wrapper form as
+			// nonAtomicObjectUpdate since the LHS is not the bare identifier.
 			{
 				Code: `let foo: number | null; async function x() { foo! += await bar; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "nonAtomicUpdate"},
+					{MessageId: "nonAtomicObjectUpdate"},
 				},
 			},
 
@@ -963,21 +1107,6 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 			// ---- void expression wrapping assignment ----
 			{
 				Code: `let foo; async function x() { void (foo += await bar); }`,
-				Errors: []rule_tester.InvalidTestCaseError{
-					{MessageId: "nonAtomicUpdate"},
-				},
-			},
-
-			// ---- for-await-of: read before loop, write inside ----
-			{
-				Code: `
-					let foo;
-					async function x() {
-						foo;
-						for await (const item of gen) {
-							foo = item;
-						}
-					}`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "nonAtomicUpdate"},
 				},
@@ -1270,6 +1399,263 @@ func TestRequireAtomicUpdatesRule(t *testing.T) {
 							case 1: await bar; foo = 1;
 						}
 					}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Element access: computed index on LHS of simple `=` is read ----
+			// `foo[x] = await bar` reads `x`; `x = 1` after must report.
+			{
+				Code: `let x; let foo = {}; function cb() { return x; }
+					async function f(bar) { foo[x] = await bar; x = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Destructuring assignment: object pattern ----
+			{
+				Code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({foo} = src); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// ---- Destructuring assignment: array pattern ----
+			{
+				Code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; [foo] = src; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// ---- Destructuring: aliased target `{a: foo}` ----
+			{
+				Code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({a: foo} = src); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// ---- Destructuring: multiple variables ----
+			{
+				Code: `let foo, bar; function cb() { return foo + bar; } async function f(src, x) { foo; bar; await x; ({foo, bar} = src); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// ---- Destructuring: default with await outdates target ----
+			{
+				Code: `let foo; function cb() { return foo; } async function f(src, x) { foo; ({foo = await x} = src); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// ---- Outer variable still outdated after shadowed inner block ----
+			// Inner `let foo`'s writes don't affect outer foo; the outer write
+			// after the block still sees the outdated state from the earlier await.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { foo; await x; { let foo = 1; foo = 2; } foo = 3; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// Same with if-block containing the shadowing let.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x, cond) { foo; await x; if (cond) { let foo = 1; foo = 2; } foo = 3; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// Block-scoped function declaration shadow: outer write after block reports.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { foo; await x; { function foo() {} foo(); } foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// Block-scoped class declaration shadow.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { foo; await x; { class foo {} new foo(); } foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// for-loop let shadow: outer write after for reports.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { foo; await x; for (let foo = 0; foo < 1; foo++) {} foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// Catch binding shadow: outer write after try/catch reports.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { try { foo; await x; } catch (foo) { foo = 1; } foo = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// TypeScript namespace / module at outer scope creates a value binding
+			// that is tracked as declared.
+			{
+				Code: `namespace NS { export var foo = 1; }
+					function cb() { return NS.foo; }
+					async function f(x: any) { NS.foo; await x; NS.foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// Namespace with a function export, value RHS still reports
+			{
+				Code: `namespace NS { export function foo() {} }
+					function cb() { return NS.foo; }
+					async function f(x: any) { NS.foo; await x; NS.foo = 1 as any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// Nested namespace: outer member read + await + inner member write
+			{
+				Code: `namespace A { export namespace B { export var foo = 1; } }
+					function cb() { return A.B.foo; }
+					async function f(x: any) { A.B.foo; await x; A.B.foo = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+			// declare namespace at outer scope is tracked too
+			{
+				Code: `declare namespace NS { var foo: number; }
+					async function f(x: any) { NS.foo; await x; NS.foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// TS type wrappers on the LHS are transparent for the write-target chain:
+			// `(foo as any) = 1` treats foo as write target (no extra markRead), and
+			// ESLint reports the write itself as nonAtomicObjectUpdate (wrapper text).
+			{
+				Code: `let foo: any; function cb() { return foo; }
+					async function f(x: any) { foo; await x; (foo as any) = 1; foo = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// Non-null assertion directly on simple LHS
+			{
+				Code: `let foo: any; function cb() { return foo; }
+					async function f(x: any) { foo; await x; foo! = 1; foo = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// Optional catch (no binding): `foo` inside catch IS the outer variable.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { try { foo; await x; } catch { foo = 1; } foo = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- for-of declaration with await default in destructure ----
+			// The default `foo + await gen.y` reads foo then awaits, outdating foo
+			// within the loop's body state; the subsequent write reports.
+			{
+				Code: `let foo = 1; function cb() { return foo; }
+					async function f(gen) { for (const { x = foo + await gen.y } of [{}]) { foo = x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// ---- for-of assignment-form destructure with await default ----
+			{
+				Code: `let foo = 1; function cb() { return foo; }
+					async function f(gen) { for ({ x = foo + await gen.y } of [{}]) { foo = x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+			// ---- Compound `foo += await x` in a for-loop update still reports ----
+			// The LHS is a read+write, so `foo` is marked fresh inside the update
+			// segment; the await then outdates it and the implicit write reports.
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { for(;; foo += await x) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Destructuring default with re-read doesn't clear outer outdated ----
+			// Defaults are conditional branches: an outdate from one default
+			// propagates by union, and a re-read inside another default does NOT
+			// clear the outer's outdated flag for that name.
+			{
+				Code: `let foo, bar; function cb() { return foo + bar; }
+					async function f(src, x) { foo; bar; const {a = await x, b = foo + bar} = src; foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Labeled break from nested loop carries state to the labeled
+			//      loop's post-loop point. After `break outer`, post-outer-loop
+			//      sees the state at the break (foo outdated). ----
+			{
+				Code: `let foo; function cb() { return foo; }
+					async function f(x) { outer: for (;;) { for (;;) { foo; await x; break outer; } } foo = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- for-of assignment form: member target base IS read ----
+			// `foo.bar of gen` reads foo (object base). await then outdates foo;
+			// subsequent `foo = 1` reports.
+			{
+				Code: `let foo = {}; function cb() { return foo; }
+					async function f(gen, x) { for (foo.bar of gen) { await x; foo = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Destructuring: rest element ----
+			{
+				Code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({...foo} = src); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicObjectUpdate"},
+				},
+			},
+
+			// ---- Chained assignment `a = b = 1` reports each target ----
+			{
+				Code: `let a, b; function cb() { return a + b; } async function f(x) { a; b; await x; a = b = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonAtomicUpdate"},
+					{MessageId: "nonAtomicUpdate"},
+				},
+			},
+
+			// ---- Non-null assertion on LHS breaks write-target chain ----
+			// ESLint only walks MemberExpression.object; type assertions break the chain,
+			// so `foo` in `foo!.bar = X` is a read (not a write-target base). Thus `foo = 1`
+			// after an await is reported. The `foo!.bar =` line itself is NOT reported
+			// (the chain breaks before reaching the assignment for registration).
+			{
+				Code: `let foo: any; function cb() { return foo; }
+					async function f(bar) { foo!.bar = await bar; foo = 1; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "nonAtomicUpdate"},
 				},

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -53,6 +53,21 @@ func IsNonReferenceIdentifier(node *ast.Node) bool {
 		return false
 	}
 
+	// Property access name: a.b — `b` is a property key, not a variable reference.
+	if parent.Kind == ast.KindPropertyAccessExpression && parent.AsPropertyAccessExpression().Name() == node {
+		return true
+	}
+
+	// Qualified type name: A.B.C (used in types) — right-hand names are not refs.
+	if parent.Kind == ast.KindQualifiedName && parent.AsQualifiedName().Right == node {
+		return true
+	}
+
+	// Meta property: new.target, import.meta — `target`/`meta` are keywords.
+	if parent.Kind == ast.KindMetaProperty {
+		return true
+	}
+
 	// Re-export specifiers: export { x } from 'mod'
 	// All identifiers are source module names, not local references.
 	if parent.Kind == ast.KindExportSpecifier && isReExportSpecifier(parent) {

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-atomic-updates.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-atomic-updates.test.ts.snap
@@ -753,3 +753,646 @@ exports[`require-atomic-updates > invalid 28`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`require-atomic-updates > invalid 29`] = `
+{
+  "code": "let a, b; function cb() { return a + b; } async function f(x) { a; b; await x; a = b = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`a\` might be reassigned based on an outdated value of \`a\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 80,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+    {
+      "message": "Possible race condition: \`b\` might be reassigned based on an outdated value of \`b\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 89,
+          "line": 1,
+        },
+        "start": {
+          "column": 84,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 30`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({foo} = src); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`{foo}\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 93,
+          "line": 1,
+        },
+        "start": {
+          "column": 82,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 31`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(src, x) { foo; await x; [foo] = src; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`[foo]\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 92,
+          "line": 1,
+        },
+        "start": {
+          "column": 81,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 32`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({a: foo} = src); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`{a:foo}\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 1,
+        },
+        "start": {
+          "column": 82,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 33`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(src, x) { foo; ({foo = await x} = src); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`{foo=awaitx}\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 94,
+          "line": 1,
+        },
+        "start": {
+          "column": 73,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 34`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({...foo} = src); }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`{...foo}\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 96,
+          "line": 1,
+        },
+        "start": {
+          "column": 82,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 35`] = `
+{
+  "code": "let foo = 1; function cb() { return foo; } async function f(gen) { for (const { x = foo + await gen.y } of [{}]) { foo = x; } }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 123,
+          "line": 1,
+        },
+        "start": {
+          "column": 116,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 36`] = `
+{
+  "code": "let foo = 1; function cb() { return foo; } async function f(gen) { for ({ x = foo + await gen.y } of [{}]) { foo = x; } }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 117,
+          "line": 1,
+        },
+        "start": {
+          "column": 110,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 37`] = `
+{
+  "code": "let foo = {}; function cb() { return foo; } async function f(gen, x) { for (foo.bar of gen) { await x; foo = 1; } }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 111,
+          "line": 1,
+        },
+        "start": {
+          "column": 104,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 38`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { for(;; foo += await x) {} }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 83,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 39`] = `
+{
+  "code": "let foo, bar; function cb() { return foo + bar; } async function f(src, x) { foo; bar; const {a = await x, b = foo + bar} = src; foo = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 137,
+          "line": 1,
+        },
+        "start": {
+          "column": 130,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 40`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { outer: for (;;) { for (;;) { foo; await x; break outer; } } foo = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 129,
+          "line": 1,
+        },
+        "start": {
+          "column": 122,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 41`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { foo; await x; { let foo = 1; foo = 2; } foo = 3; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 109,
+          "line": 1,
+        },
+        "start": {
+          "column": 102,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 42`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { try { foo; await x; } catch (foo) { foo = 1; } foo = 2; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 116,
+          "line": 1,
+        },
+        "start": {
+          "column": 109,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 43`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { try { foo; await x; } catch { foo = 1; } foo = 2; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 99,
+          "line": 1,
+        },
+        "start": {
+          "column": 92,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 110,
+          "line": 1,
+        },
+        "start": {
+          "column": 103,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 44`] = `
+{
+  "code": "namespace NS { export var foo = 1; } function cb() { return NS.foo; } async function f(x: any) { NS.foo; await x; NS.foo = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`NS.foo\` might be assigned based on an outdated state of \`NS\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 125,
+          "line": 1,
+        },
+        "start": {
+          "column": 115,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 45`] = `
+{
+  "code": "namespace NS { export function foo() {} } function cb() { return NS.foo; } async function f(x: any) { NS.foo; await x; NS.foo = 1 as any; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`NS.foo\` might be assigned based on an outdated state of \`NS\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 137,
+          "line": 1,
+        },
+        "start": {
+          "column": 120,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 46`] = `
+{
+  "code": "namespace A { export namespace B { export var foo = 1; } } function cb() { return A.B.foo; } async function f(x: any) { A.B.foo; await x; A.B.foo = 2; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`A.B.foo\` might be assigned based on an outdated state of \`A\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 150,
+          "line": 1,
+        },
+        "start": {
+          "column": 139,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 47`] = `
+{
+  "code": "let foo: any; function cb() { return foo; } async function f(x: any) { foo; await x; (foo as any) = 1; foo = 2; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`(fooasany)\` might be assigned based on an outdated state of \`foo\`.",
+      "messageId": "nonAtomicObjectUpdate",
+      "range": {
+        "end": {
+          "column": 102,
+          "line": 1,
+        },
+        "start": {
+          "column": 86,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 111,
+          "line": 1,
+        },
+        "start": {
+          "column": 104,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 48`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { foo; await x; { function foo() {} foo(); } foo = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 112,
+          "line": 1,
+        },
+        "start": {
+          "column": 105,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 49`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(x) { foo; await x; for (let foo = 0; foo < 1; foo++) {} foo = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 120,
+          "line": 1,
+        },
+        "start": {
+          "column": 113,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 50`] = `
+{
+  "code": "let x; let foo = {}; function cb() { return x; } async function f(bar) { foo[x] = await bar; x = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`x\` might be reassigned based on an outdated value of \`x\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 99,
+          "line": 1,
+        },
+        "start": {
+          "column": 94,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-atomic-updates > invalid 51`] = `
+{
+  "code": "let foo; function cb() { return foo; } async function f(bar) { foo!.bar = await bar; foo = 1; }",
+  "diagnostics": [
+    {
+      "message": "Possible race condition: \`foo\` might be reassigned based on an outdated value of \`foo\`.",
+      "messageId": "nonAtomicUpdate",
+      "range": {
+        "end": {
+          "column": 93,
+          "line": 1,
+        },
+        "start": {
+          "column": 86,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-atomic-updates",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/require-atomic-updates.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/require-atomic-updates.test.ts
@@ -15,6 +15,61 @@ ruleTester.run('require-atomic-updates', {
     'const foo = []; async function x() { foo[x] += 1;  }',
     'let foo; function* x() { foo = bar + foo; }',
     'async function x() { let foo; bar(() => baz += 1); foo += await amount; }',
+    // Update expressions are not tracked as assignments
+    `let foo; function cb() { return foo; } async function f(x) { foo; await x; foo++; }`,
+    // Await in LHS base doesn't register the member target
+    `let foo; function cb() { return foo; } async function f(ptr, x) { foo; (await ptr).foo = x; }`,
+    // Loop body awaits don't propagate to post-loop code
+    `let foo; function cb() { return foo; }
+     async function f(x) { foo; for (let i = 0; i < 10; i++) { await x; } foo = 1; }`,
+    `let foo; function cb() { return foo; }
+     async function f(x) { foo; while (x) { await x; } foo = 1; }`,
+    `let foo; function cb() { return foo; }
+     async function f(gen) { foo; for await (const it of gen) {} foo = 1; }`,
+    // for-of / for-in / for-await-of bodies don't inherit pre-loop reads
+    `let foo; function cb() { return foo; }
+     async function f(gen) { foo; for await (const item of gen) { foo = item; } }`,
+    `let foo; function cb() { return foo; }
+     async function f(arr, hook) { foo; for (const c of arr) { await hook(); foo = 1; } }`,
+    // for-of assignment form: bare-identifier target is pure write
+    `let foo; function cb() { return foo; }
+     async function f(gen, x) { for (foo of gen) { await x; foo = 1; } }`,
+    // for-of assignment-form destructuring without pre-read
+    `let foo; function cb() { return foo; }
+     async function f(gen) { for ({foo} of gen) {} }`,
+    // for-loop update runs with a fresh segment — simple `=` with await doesn't report
+    `let foo; function cb() { return foo; } async function f(x) { foo; for(;; foo = await x) {} }`,
+    // switch where every case exits via return: post-switch sees no outdated
+    `let foo; function cb() { return foo; } async function f(x, n) { foo; switch (n) { case 1: await x; return; case 2: return; } foo = 1; }`,
+    // RHS arrow/function silently skips check (ESLint quirk)
+    `let foo; function cb() { return foo; } async function f(x) { foo; await x; foo = () => {}; }`,
+    `let foo; function cb() { return foo; } async function f(x) { foo; await x; foo = function () {}; }`,
+    // try-always-returns: catch entry = pre-try state
+    `let foo; function cb() { return foo; } async function f(x) { foo; try { await x; return; } catch {} foo = 1; }`,
+    `let foo; function cb() { return foo; } async function f(x) { try { foo; await x; return; } catch { foo = 1; } }`,
+    // Namespace with a function export, function RHS — no report (function-RHS skip)
+    `namespace NS { export function foo() {} } function cb() { return NS.foo; } async function f(x: any) { NS.foo; await x; NS.foo = () => {}; }`,
+    // Catch binding shadows outer
+    `let foo; function cb() { return foo; }
+     async function f(x) { try { foo; await x; } catch (foo) { foo = 1; } }`,
+    // Block-scoped let shadows outer for the block duration
+    `let foo; function cb() { return foo; }
+     async function f(x) { foo; await x; { let foo = 1; foo = 2; } }`,
+    // for-loop let shadow
+    `let foo; function cb() { return foo; }
+     async function f(x) { foo; await x; for (let foo = 0; foo < 1; foo++) {} }`,
+    // Labeled break before await skips the outdating path
+    `let foo; function cb() { return foo; }
+     async function f(x) { foo; outer: for (;;) { if (x) break outer; await x; } foo = 1; }`,
+    // Property name in a closure does not cause outer variable to escape
+    `async function x(list, api) {
+      list.map((item) => item.foo);
+      let foo = 1;
+      if (list.length && foo !== 2) {
+        await api.update({ foo });
+        foo = 2;
+      }
+    }`,
     'let foo; async function x() { foo = condition ? foo : await bar; }',
     'async function x() { let foo; bar(() => { let foo; blah(foo); }); foo += await result; }',
     'let foo; async function x() { foo = foo + 1; await bar; }',
@@ -183,6 +238,130 @@ ruleTester.run('require-atomic-updates', {
         }
       `,
       options: { allowProperties: true },
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Chained assignment `a = b = 1`
+    {
+      code: `let a, b; function cb() { return a + b; } async function f(x) { a; b; await x; a = b = 1; }`,
+      errors: [
+        { messageId: 'nonAtomicUpdate' },
+        { messageId: 'nonAtomicUpdate' },
+      ],
+    },
+    // Destructuring assignment: object pattern
+    {
+      code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({foo} = src); }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // Destructuring assignment: array pattern
+    {
+      code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; [foo] = src; }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // Destructuring assignment: aliased target
+    {
+      code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({a: foo} = src); }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // Destructuring assignment: default with await
+    {
+      code: `let foo; function cb() { return foo; } async function f(src, x) { foo; ({foo = await x} = src); }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // Destructuring assignment: rest
+    {
+      code: `let foo; function cb() { return foo; } async function f(src, x) { foo; await x; ({...foo} = src); }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // for-of declaration-form destructure default with await
+    {
+      code: `let foo = 1; function cb() { return foo; } async function f(gen) { for (const { x = foo + await gen.y } of [{}]) { foo = x; } }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // for-of assignment-form destructure default with await
+    {
+      code: `let foo = 1; function cb() { return foo; } async function f(gen) { for ({ x = foo + await gen.y } of [{}]) { foo = x; } }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // for-of assignment form: member target base IS a read
+    {
+      code: `let foo = {}; function cb() { return foo; } async function f(gen, x) { for (foo.bar of gen) { await x; foo = 1; } }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Compound `foo += await x` in for-loop update still reports
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { for(;; foo += await x) {} }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Destructure default re-read does NOT clear outer outdated
+    {
+      code: `let foo, bar; function cb() { return foo + bar; } async function f(src, x) { foo; bar; const {a = await x, b = foo + bar} = src; foo = 1; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Labeled break carries state to the labeled loop's post-loop point
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { outer: for (;;) { for (;;) { foo; await x; break outer; } } foo = 1; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Outer foo still outdated after a shadowed inner block
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { foo; await x; { let foo = 1; foo = 2; } foo = 3; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Catch-binding shadow: outer write after try/catch reports
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { try { foo; await x; } catch (foo) { foo = 1; } foo = 2; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Optional catch (no binding): `foo` inside IS outer
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { try { foo; await x; } catch { foo = 1; } foo = 2; }`,
+      errors: [
+        { messageId: 'nonAtomicUpdate' },
+        { messageId: 'nonAtomicUpdate' },
+      ],
+    },
+    // TypeScript namespace at outer scope is tracked as declared
+    {
+      code: `namespace NS { export var foo = 1; } function cb() { return NS.foo; } async function f(x: any) { NS.foo; await x; NS.foo = 1; }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // Namespace with function export, value RHS — still reports
+    {
+      code: `namespace NS { export function foo() {} } function cb() { return NS.foo; } async function f(x: any) { NS.foo; await x; NS.foo = 1 as any; }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // Nested namespace member write
+    {
+      code: `namespace A { export namespace B { export var foo = 1; } } function cb() { return A.B.foo; } async function f(x: any) { A.B.foo; await x; A.B.foo = 2; }`,
+      errors: [{ messageId: 'nonAtomicObjectUpdate' }],
+    },
+    // TS type wrappers on simple LHS report as nonAtomicObjectUpdate
+    {
+      code: `let foo: any; function cb() { return foo; } async function f(x: any) { foo; await x; (foo as any) = 1; foo = 2; }`,
+      errors: [
+        { messageId: 'nonAtomicObjectUpdate' },
+        { messageId: 'nonAtomicUpdate' },
+      ],
+    },
+    // Block-scoped function declaration shadow
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { foo; await x; { function foo() {} foo(); } foo = 1; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // for-loop let shadow: outer write after loop reports
+    {
+      code: `let foo; function cb() { return foo; } async function f(x) { foo; await x; for (let foo = 0; foo < 1; foo++) {} foo = 1; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Element-access index on LHS of simple `=` is still read
+    {
+      code: `let x; let foo = {}; function cb() { return x; } async function f(bar) { foo[x] = await bar; x = 1; }`,
+      errors: [{ messageId: 'nonAtomicUpdate' }],
+    },
+    // Non-null assertion on LHS breaks write-target chain
+    {
+      code: `let foo; function cb() { return foo; } async function f(bar) { foo!.bar = await bar; foo = 1; }`,
       errors: [{ messageId: 'nonAtomicUpdate' }],
     },
   ],


### PR DESCRIPTION
## Summary

Align `require-atomic-updates` with ESLint's upstream implementation — output, options, and semantics. The core change is switching the analyzer from **name-keyed** to **symbol-keyed** state (`map[*ast.Symbol]bool`) via `TypeChecker.GetSymbolAtLocation`. This removes the class of shadowing / aliasing bugs that motivated the rewrite: `item.foo` in a closure no longer taints outer `foo`; block-scoped `let` / catch bindings / for-loop `let` / namespace / enum / import alias / shorthand `{foo}` / TS type wrappers all resolve to distinct symbols and never collide in state.

Rule is marked `RequiresTypeInfo: true` so the linter filters it out cleanly when type info isn't available.

**Key alignment fixes** (all verified case-by-case against ESLint):

- Assignment LHS walked via `walkSimpleAssignLHS` — write-target chain (base identifier + member chain + TS type wrappers) stays unread, side-reads like `x` in `foo[x] = Y` register.
- Destructuring assignment — walk RHS, each default in a cloned branch state, union-merge back. Reports `nonAtomicObjectUpdate` per outdated target; defaults' re-reads don't clear outer outdated.
- Loop body propagation — `while` / `do` / `for(;;)` bodies are clone-and-discard; `for-of` / `for-in` / `for-await-of` bodies start fresh **but** end state union-merges into post-loop (iterator-done edge).
- for-loop incrementor — fresh entry state, independent segment.
- Switch — classify clause end (break / exit / fallthrough); merge only break clauses and last fallthrough into post-switch; labeled `break` routed via a `breakTargets` stack so inner-loop breaks carry state to the labeled target's post-loop point.
- Try / catch / finally — catch entry is pre-try when try always terminates (return / throw), else try-end; post-try merges only non-terminating branches.
- RHS quirk — function / arrow / generator RHS silently skips the outdated check (matches ESLint's inner-CodePath `referenceMap: null` early return).
- TS type-wrapped simple LHS (`(foo as any) = 1`, `foo! = 1`, `(<T>foo) = 1`) — reports as `nonAtomicObjectUpdate` with wrapper text as value; respects `allowProperties: true`.
- `declare global { … }` bindings are treated as unresolved (ESLint's scope analyzer leaves them unresolved too).
- Shorthand-property value resolves via `GetShorthandAssignmentValueSymbol` to the outer binding.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).