### PR TITLE
feat: port rule react/jsx-no-bind

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_filename_extension"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_bind"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_multi_spaces"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
@@ -26,6 +27,7 @@ func GetAllRules() []rule.Rule {
 		jsx_filename_extension.JsxFilenameExtensionRule,
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,
+		jsx_no_bind.JsxNoBindRule,
 		jsx_props_no_multi_spaces.JsxPropsNoMultiSpacesRule,
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -1,6 +1,8 @@
 package reactutil
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 )
 
@@ -46,4 +48,68 @@ func GetJsxPropName(node *ast.Node) string {
 		return node.AsIdentifier().Text
 	}
 	return ""
+}
+
+// GetJsxParentElement returns the JsxOpeningElement or JsxSelfClosingElement that
+// owns the given JsxAttribute (or JsxSpreadAttribute), or nil if not applicable.
+func GetJsxParentElement(attr *ast.Node) *ast.Node {
+	if attr == nil || attr.Parent == nil {
+		return nil
+	}
+	grandParent := attr.Parent.Parent
+	if grandParent == nil {
+		return nil
+	}
+	switch grandParent.Kind {
+	case ast.KindJsxOpeningElement, ast.KindJsxSelfClosingElement:
+		return grandParent
+	}
+	return nil
+}
+
+// GetJsxTagName returns the tag-name node of a JsxOpeningElement or
+// JsxSelfClosingElement, or nil for other kinds.
+func GetJsxTagName(element *ast.Node) *ast.Node {
+	if element == nil {
+		return nil
+	}
+	switch element.Kind {
+	case ast.KindJsxOpeningElement:
+		return element.AsJsxOpeningElement().TagName
+	case ast.KindJsxSelfClosingElement:
+		return element.AsJsxSelfClosingElement().TagName
+	}
+	return nil
+}
+
+// IsDOMComponent reports whether a JSX opening/self-closing element refers to
+// an intrinsic (DOM) element like <div> or <svg:path>, rather than a user
+// component like <Foo> or <foo.Bar>.
+//
+// Mirrors ESLint-plugin-react's `jsxUtil.isDOMComponent`: a tag name is
+// intrinsic iff its string form starts with a lowercase letter and contains
+// no ".". Property-access tag names (<foo.bar>) are user components.
+func IsDOMComponent(element *ast.Node) bool {
+	tagName := GetJsxTagName(element)
+	if tagName == nil {
+		return false
+	}
+	var text string
+	switch tagName.Kind {
+	case ast.KindIdentifier:
+		text = tagName.AsIdentifier().Text
+	case ast.KindJsxNamespacedName:
+		ns := tagName.AsJsxNamespacedName()
+		if ns.Namespace == nil || ns.Name() == nil {
+			return false
+		}
+		text = ns.Namespace.AsIdentifier().Text + ":" + ns.Name().AsIdentifier().Text
+	default:
+		return false
+	}
+	if text == "" || strings.Contains(text, ".") {
+		return false
+	}
+	first := text[0]
+	return first >= 'a' && first <= 'z'
 }

--- a/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.go
+++ b/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.go
@@ -1,0 +1,253 @@
+package jsx_no_bind
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Violation kinds correspond to ESLint messageIds. The `bindExpression` kind
+// (ES `::` proposal) is omitted because TypeScript does not parse it.
+const (
+	kindBindCall  = "bindCall"
+	kindArrowFunc = "arrowFunc"
+	kindFunc      = "func"
+)
+
+// violationOrder controls lookup priority when a JSX attribute value is an
+// identifier that appears under multiple tracked kinds in the same block.
+var violationOrder = []string{kindArrowFunc, kindBindCall, kindFunc}
+
+// unwrap strips parentheses, which ESTree does not represent as nodes but the
+// TypeScript AST does. Other TS-only wrappers (`as T`, `expr!`, `satisfies T`,
+// `<T>expr`, partially-emitted) are intentionally left visible to match the
+// original ESLint rule's behavior under typescript-eslint.
+func unwrap(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	return ast.SkipParentheses(node)
+}
+
+type options struct {
+	allowArrowFunctions bool
+	allowBind           bool
+	allowFunctions      bool
+	ignoreRefs          bool
+	ignoreDOMComponents bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowArrowFunctions"].(bool); ok {
+		opts.allowArrowFunctions = v
+	}
+	if v, ok := optsMap["allowBind"].(bool); ok {
+		opts.allowBind = v
+	}
+	if v, ok := optsMap["allowFunctions"].(bool); ok {
+		opts.allowFunctions = v
+	}
+	if v, ok := optsMap["ignoreRefs"].(bool); ok {
+		opts.ignoreRefs = v
+	}
+	if v, ok := optsMap["ignoreDOMComponents"].(bool); ok {
+		opts.ignoreDOMComponents = v
+	}
+	return opts
+}
+
+func message(id string) rule.RuleMessage {
+	var desc string
+	switch id {
+	case kindBindCall:
+		desc = "JSX props should not use .bind()"
+	case kindArrowFunc:
+		desc = "JSX props should not use arrow functions"
+	case kindFunc:
+		desc = "JSX props should not use functions"
+	}
+	return rule.RuleMessage{Id: id, Description: desc}
+}
+
+var JsxNoBindRule = rule.Rule{
+	Name: "react/jsx-no-bind",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		// blockVariableNameSets tracks, per enclosing Block (keyed by node
+		// position), the names of const-bound variables and local function
+		// declarations whose value is a banned expression kind.
+		blockVariableNameSets := map[int]map[string]map[string]bool{}
+
+		initBlock := func(blockPos int) {
+			if _, ok := blockVariableNameSets[blockPos]; ok {
+				return
+			}
+			blockVariableNameSets[blockPos] = map[string]map[string]bool{
+				kindArrowFunc: {},
+				kindBindCall:  {},
+				kindFunc:      {},
+			}
+		}
+
+		var getNodeViolationType func(node *ast.Node) string
+		getNodeViolationType = func(node *ast.Node) string {
+			node = unwrap(node)
+			if node == nil {
+				return ""
+			}
+			if !opts.allowBind && node.Kind == ast.KindCallExpression {
+				callee := unwrap(node.AsCallExpression().Expression)
+				if callee != nil && callee.Kind == ast.KindPropertyAccessExpression {
+					nameNode := callee.AsPropertyAccessExpression().Name()
+					if nameNode != nil && nameNode.Kind == ast.KindIdentifier && nameNode.AsIdentifier().Text == "bind" {
+						return kindBindCall
+					}
+				}
+			}
+			if node.Kind == ast.KindConditionalExpression {
+				ce := node.AsConditionalExpression()
+				if t := getNodeViolationType(ce.Condition); t != "" {
+					return t
+				}
+				if t := getNodeViolationType(ce.WhenTrue); t != "" {
+					return t
+				}
+				return getNodeViolationType(ce.WhenFalse)
+			}
+			if !opts.allowArrowFunctions && node.Kind == ast.KindArrowFunction {
+				return kindArrowFunc
+			}
+			if !opts.allowFunctions && (node.Kind == ast.KindFunctionExpression || node.Kind == ast.KindFunctionDeclaration) {
+				return kindFunc
+			}
+			return ""
+		}
+
+		// blockAncestors returns the enclosing Block nodes from innermost to
+		// outermost, matching ESLint's getBlockStatementAncestors().
+		blockAncestors := func(node *ast.Node) []*ast.Node {
+			var result []*ast.Node
+			for cur := node.Parent; cur != nil; cur = cur.Parent {
+				if cur.Kind == ast.KindBlock {
+					result = append(result, cur)
+				}
+			}
+			return result
+		}
+
+		reportVariableViolation := func(attrNode *ast.Node, name string, blockPos int) bool {
+			sets, ok := blockVariableNameSets[blockPos]
+			if !ok {
+				return false
+			}
+			for _, violationType := range violationOrder {
+				if sets[violationType][name] {
+					ctx.ReportNode(attrNode, message(violationType))
+					return true
+				}
+			}
+			return false
+		}
+
+		findVariableViolation := func(attrNode *ast.Node, name string) {
+			for _, block := range blockAncestors(attrNode) {
+				if reportVariableViolation(attrNode, name, block.Pos()) {
+					return
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindBlock: func(node *ast.Node) {
+				initBlock(node.Pos())
+			},
+
+			ast.KindFunctionDeclaration: func(node *ast.Node) {
+				ancestors := blockAncestors(node)
+				if len(ancestors) == 0 {
+					return
+				}
+				violation := getNodeViolationType(node)
+				if violation == "" {
+					return
+				}
+				nameNode := node.AsFunctionDeclaration().Name()
+				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+					return
+				}
+				blockPos := ancestors[0].Pos()
+				initBlock(blockPos)
+				blockVariableNameSets[blockPos][violation][nameNode.AsIdentifier().Text] = true
+			},
+
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				varDecl := node.AsVariableDeclaration()
+				if varDecl.Initializer == nil {
+					return
+				}
+				// Only `const` bindings, matching ESLint.
+				declList := node.Parent
+				if declList == nil || declList.Kind != ast.KindVariableDeclarationList {
+					return
+				}
+				if declList.Flags&ast.NodeFlagsConst == 0 {
+					return
+				}
+				// `for (const x of ...)` and friends: the declaration lives inside a
+				// `For*Statement`, not a `VariableStatement`. Skip, because ESLint only
+				// tracks true block-scoped const bindings.
+				if declList.Parent == nil || declList.Parent.Kind != ast.KindVariableStatement {
+					return
+				}
+				ancestors := blockAncestors(node)
+				if len(ancestors) == 0 {
+					return
+				}
+				violation := getNodeViolationType(varDecl.Initializer)
+				if violation == "" {
+					return
+				}
+				nameNode := varDecl.Name()
+				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+					return
+				}
+				blockPos := ancestors[0].Pos()
+				initBlock(blockPos)
+				blockVariableNameSets[blockPos][violation][nameNode.AsIdentifier().Text] = true
+			},
+
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				attr := node.AsJsxAttribute()
+				nameNode := attr.Name()
+				if opts.ignoreRefs && nameNode != nil && nameNode.Kind == ast.KindIdentifier && nameNode.AsIdentifier().Text == "ref" {
+					return
+				}
+				initializer := attr.Initializer
+				if initializer == nil || initializer.Kind != ast.KindJsxExpression {
+					return
+				}
+				expr := unwrap(initializer.AsJsxExpression().Expression)
+				if expr == nil {
+					return
+				}
+				if opts.ignoreDOMComponents && reactutil.IsDOMComponent(reactutil.GetJsxParentElement(node)) {
+					return
+				}
+				if expr.Kind == ast.KindIdentifier {
+					findVariableViolation(node, expr.AsIdentifier().Text)
+					return
+				}
+				if violation := getNodeViolationType(expr); violation != "" {
+					ctx.ReportNode(node, message(violation))
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.md
+++ b/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind.md
@@ -1,0 +1,64 @@
+# react/jsx-no-bind
+
+Disallow `.bind()` or arrow functions in JSX props.
+
+## Rule Details
+
+A new function (or an arrow function) is created on every render when `.bind()` or an inline function expression is used as a JSX prop. Passing a new function reference can trigger unnecessary re-renders in memoized consumers or cause effects to re-run.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Foo onClick={this._handleClick.bind(this)} />
+```
+
+```jsx
+<Foo onClick={() => console.log('Hello!')} />
+```
+
+```jsx
+function onClick() { console.log('Hello!'); }
+<Foo onClick={onClick} />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Foo onClick={this._handleClick} />
+```
+
+## Rule Options
+
+```json
+{
+  "react/jsx-no-bind": ["error", {
+    "allowArrowFunctions": false,
+    "allowBind": false,
+    "allowFunctions": false,
+    "ignoreRefs": false,
+    "ignoreDOMComponents": false
+  }]
+}
+```
+
+- `allowArrowFunctions`: allow arrow function expressions as JSX prop values.
+- `allowBind`: allow `.bind()` calls as JSX prop values.
+- `allowFunctions`: allow function expressions/declarations as JSX prop values.
+- `ignoreRefs`: skip checks on `ref` props.
+- `ignoreDOMComponents`: skip checks on DOM components (lowercase tags like `<div>`).
+
+## Differences from ESLint
+
+- The ES bind operator (`::`, e.g. `<div foo={::this.onChange} />`) is not supported. Empirically verified: TypeScript's parser rejects the `::` token as a syntax error, so such code never reaches the rule. Consequently the `bindExpression` messageId is not produced.
+
+## Known Limitations (matches ESLint)
+
+- Identifiers used inside conditional expressions are not resolved against tracked declarations, so `<Foo onClick={cond ? tracked : other} />` does not flag `tracked`.
+- Only `const` declarations are tracked; `let` / `var` bindings are ignored even when initialized to an arrow / bind / function.
+- Forward references (JSX used before the declaration in source order) are not reported.
+- A non-violating inner `const` does not shadow a violating outer one; JSX inside the inner scope still reports the outer violation.
+- TypeScript-only wrappers (`as T`, `<T>expr`, `expr!`, `expr satisfies T`) are opaque to the rule, matching ESLint's behavior under the `@typescript-eslint/parser`: for example `<Foo onClick={(() => 1) as Handler} />` is **not** flagged. Plain parentheses around an expression *are* transparent because ESTree does not represent them as nodes.
+
+## Original Documentation
+
+- [eslint-plugin-react/jsx-no-bind](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md)

--- a/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind_test.go
+++ b/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind_test.go
@@ -1,0 +1,717 @@
+package jsx_no_bind
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoBindRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoBindRule, []rule_tester.ValidTestCase{
+		// ---------- 1. Plain identifiers & non-banned expressions ----------
+		{Code: `var x = <div onClick={this._handleClick}></div>`, Tsx: true},
+		{Code: `var x = <Foo onClick={this._handleClick} />`, Tsx: true},
+		{Code: `var x = <div meaningOfLife={42}></div>`, Tsx: true},
+		{Code: `var x = <div onClick={getHandler()}></div>`, Tsx: true},
+		{Code: `var x = <div onClick={obj.method}></div>`, Tsx: true},
+		// `foo()` (not `.bind()`) is not flagged
+		{Code: `var x = <div onClick={foo()}></div>`, Tsx: true},
+		// Bracket-access bind (ESLint requires `.bind`, not `['bind']`)
+		{Code: `var x = <div onClick={foo['bind'](this)}></div>`, Tsx: true},
+		// Logical expressions are not checked (matches ESLint)
+		{Code: `var x = <div onClick={cond && handler}></div>`, Tsx: true},
+		{Code: `var x = <div onClick={cond || handler}></div>`, Tsx: true},
+		{Code: `var x = <div onClick={handler ?? fallback}></div>`, Tsx: true},
+		// JSX spread attribute is not checked
+		{Code: `var x = <div {...props}></div>`, Tsx: true},
+		// JSX child expression is not checked
+		{Code: `var x = <div>{() => 1}</div>`, Tsx: true},
+
+		// ---------- 2. ignoreRefs ----------
+		{Code: `var x = <div ref={c => (this._input = c)}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreRefs": true}},
+		{Code: `var x = <div ref={this._refCallback.bind(this)}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreRefs": true}},
+		{Code: `var x = <div ref={function (c) { this._input = c; }}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreRefs": true}},
+
+		// ---------- 3. allow* options ----------
+		{Code: `var x = <div onClick={this._handleClick.bind(this)}></div>`, Tsx: true, Options: map[string]interface{}{"allowBind": true}},
+		{Code: `var x = <div onClick={() => alert("1337")}></div>`, Tsx: true, Options: map[string]interface{}{"allowArrowFunctions": true}},
+		{Code: `var x = <div onClick={async () => alert("1337")}></div>`, Tsx: true, Options: map[string]interface{}{"allowArrowFunctions": true}},
+		{Code: `var x = <div onClick={function () { alert("1337"); }}></div>`, Tsx: true, Options: map[string]interface{}{"allowFunctions": true}},
+		{Code: `var x = <div onClick={function* () { alert("1337"); }}></div>`, Tsx: true, Options: map[string]interface{}{"allowFunctions": true}},
+		{Code: `var x = <div onClick={async function () { alert("1337"); }}></div>`, Tsx: true, Options: map[string]interface{}{"allowFunctions": true}},
+
+		// ---------- 4. ignoreDOMComponents ----------
+		{Code: `var x = <div onClick={this._handleClick.bind(this)}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
+		{Code: `var x = <div onClick={() => alert("1337")}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
+		{Code: `var x = <div onClick={function () { alert("1337"); }}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
+		// Namespaced DOM element is also intrinsic
+		{Code: `var x = <svg:path onClick={() => 1} />`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
+
+		// ---------- 5. Bind-not-used-for-JSX-prop ----------
+		{
+			Code: `
+				class Hello extends Component {
+					render() {
+						this.onTap.bind(this);
+						return true;
+					}
+				}
+			`,
+			Tsx: true,
+		},
+		{
+			Code: `
+				class Hello extends Component {
+					render() {
+						const click = this.onTap.bind(this);
+						return <div onClick={onClick}>Hello</div>;
+					}
+				};
+			`,
+			Tsx: true,
+		},
+		{
+			Code: `
+				class Hello extends Component {
+					render() {
+						return (<div>{
+							this.props.list.map(this.wrap.bind(this, "span"))
+						}</div>);
+					}
+				};
+			`,
+			Tsx: true,
+		},
+		// Arrow as map callback (a JSX child, not a prop)
+		{
+			Code: `
+				class Hello extends Component {
+					render() {
+						return (<div>{
+							this.props.list.map(item => <item hello="true"/>)
+						}</div>);
+					}
+				};
+			`,
+			Tsx: true,
+		},
+
+		// ---------- 6. Non-const / non-identifier bindings are not tracked ----------
+		{
+			// let with arrow init — NOT tracked
+			Code: `
+				function C() {
+					let click = () => 1;
+					return <div onClick={click}>Hello</div>;
+				}
+			`,
+			Tsx: true,
+		},
+		{
+			// var with arrow init — NOT tracked
+			Code: `
+				function C() {
+					var click = () => 1;
+					return <div onClick={click}>Hello</div>;
+				}
+			`,
+			Tsx: true,
+		},
+		{
+			// Destructured const — name is not an Identifier, NOT tracked
+			Code: `
+				function C() {
+					const { click } = obj;
+					return <div onClick={click}>Hello</div>;
+				}
+			`,
+			Tsx: true,
+		},
+		{
+			// Uninitialized variable should not crash
+			Code: `
+				class Hello extends Component {
+					render() {
+						let click;
+						return <div onClick={onClick}>Hello</div>;
+					}
+				}
+			`,
+			Tsx: true,
+		},
+
+		// ---------- 7. Top-level / cross-scope ----------
+		{
+			// Top-level function declarations are NOT tracked
+			Code: `
+				function click() { return true; }
+				class Hello23 extends React.Component {
+					renderDiv() {
+						return <div onClick={click}>Hello</div>;
+					}
+				};
+			`,
+			Tsx: true,
+		},
+		{
+			// for-of const binding is not tracked
+			Code: `
+				function C() {
+					for (const handler of handlers) {
+						return <div onClick={handler} />;
+					}
+				}
+			`,
+			Tsx: true,
+		},
+		{
+			// for-in const binding is not tracked
+			Code: `
+				function C() {
+					for (const key in handlers) {
+						return <div onClick={handlers[key]} />;
+					}
+				}
+			`,
+			Tsx: true,
+		},
+
+		// ---------- 8. TS-only wrappers are opaque (matches ESLint behavior under
+		// typescript-eslint; TSAsExpression/TSNonNullExpression/TSSatisfiesExpression
+		// are distinct AST nodes the rule doesn't recurse into) ----------
+		{
+			// `as T` wrapping an arrow is not recognized → not flagged
+			Code: `var x = <div onClick={(() => 1) as any}></div>`,
+			Tsx:  true,
+		},
+		{
+			// Non-null on an arrow is not recognized → not flagged
+			Code: `var x = <div onClick={(() => 1)!}></div>`,
+			Tsx:  true,
+		},
+		{
+			// `satisfies T` wrapping an arrow is not recognized → not flagged
+			Code: `var x = <div onClick={(() => 1) satisfies any}></div>`,
+			Tsx:  true,
+		},
+		{
+			// `as T` on the result of .bind() is opaque → not flagged
+			Code: `var x = <div onClick={this.h.bind(this) as any}></div>`,
+			Tsx:  true,
+		},
+		{
+			// Non-null on an identifier of a tracked arrow is opaque → not flagged
+			Code: `
+function C() {
+	const handler = () => 1;
+	return <div onClick={handler!}>Hello</div>;
+}
+			`,
+			Tsx: true,
+		},
+
+		// ---------- 9. Scope isolation across siblings ----------
+		{
+			// A const arrow in an unrelated function doesn't leak into siblings
+			Code: `
+				function A() {
+					const click = () => 1;
+					return true;
+				}
+				function B() {
+					return <div onClick={click}>Hello</div>;
+				}
+			`,
+			Tsx: true,
+		},
+
+		// ---------- 10. IIFE returning a function is a CallExpression result, not .bind ----------
+		{
+			// Value is the call's return value, not itself a violating expression
+			Code: `var x = <div onClick={(() => handler)()}></div>`,
+			Tsx:  true,
+		},
+
+		// ---------- 11. Async generators with allowFunctions ----------
+		{
+			Code:    `var x = <div onClick={async function* () { yield 1; }}></div>`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---------- 10. Direct violations ----------
+		{
+			Code: `var x = <div onClick={this._handleClick.bind(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={someGlobalFunction.bind(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={window.lol.bind(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div ref={this._refCallback.bind(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={() => alert("1337")}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={async () => alert("1337")}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div ref={c => (this._input = c)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={function () { alert("1337"); }}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "func", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={function* () { alert("1337"); }}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "func", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={async function () { alert("1337"); }}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "func", Line: 1, Column: 14},
+			},
+		},
+
+		// ---------- 11. Parentheses are invisible (ESTree parity) ----------
+		{
+			// Parenthesized arrow in attribute value
+			Code: `var x = <div onClick={(() => 1)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 14},
+			},
+		},
+		{
+			// Parenthesized .bind() callee — callee parens are stripped
+			Code: `var x = <div onClick={(this.h.bind)(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			// Parenthesized const initializer
+			Code: `
+function C() {
+	const click = (() => 1);
+	return <div onClick={click}>Hello</div>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 4, Column: 14},
+			},
+		},
+
+		// ---------- 12. Conditional expressions ----------
+		{
+			Code: `var x = <div onClick={cond ? onClick.bind(this) : handleClick()}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `var x = <div onClick={cond ? handleClick() : this.onClick.bind(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			// Nested ternary — recursion finds the arrow in the inner WhenTrue
+			Code: `var x = <div onClick={a ? (b ? () => 1 : c) : d}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 14},
+			},
+		},
+		{
+			// Ternary condition itself is a .bind()
+			Code: `var x = <div onClick={returningBoolean.bind(this) ? handleClick() : onClick()}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+
+		// ---------- 13. ignoreDOMComponents ----------
+		{
+			// User component is still flagged
+			Code:    `var x = <Foo onClick={this._handleClick.bind(this)} />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreDOMComponents": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+		{
+			// Property-access tag name is NOT a DOM component
+			Code:    `var x = <foo.Bar onClick={() => 1} />`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreDOMComponents": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 18},
+			},
+		},
+
+		// ---------- 14. Variable tracking in function / method / arrow bodies ----------
+		{
+			Code: `
+class Hello23 extends React.Component {
+	render() {
+		const click = this.someMethod.bind(this);
+		return <div onClick={click}>Hello</div>;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 5, Column: 15},
+			},
+		},
+		{
+			Code: `
+class Hello23 extends React.Component {
+	render() {
+		const click = () => true;
+		return <div onClick={click}>Hello</div>;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+		{
+			Code: `
+class Hello23 extends React.Component {
+	render() {
+		const click = function () { return true; };
+		return <div onClick={click}>Hello</div>;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "func", Line: 5, Column: 15},
+			},
+		},
+		{
+			// Class-field arrow body is itself a Block scope
+			Code: `
+class Hello23 extends React.Component {
+	renderDiv = () => {
+		const click = this.doSomething.bind(this, "no");
+		return <div onClick={click}>Hello</div>;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 5, Column: 15},
+			},
+		},
+		{
+			// Local FunctionDeclaration inside a method body
+			Code: `
+class Hello23 extends React.Component {
+	renderDiv() {
+		function click() { return true; }
+		return <div onClick={click}>Hello</div>;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "func", Line: 5, Column: 15},
+			},
+		},
+
+		// ---------- 15. Nested blocks & innermost-first resolution ----------
+		{
+			// Inner block shadows outer: innermost hit wins (bindCall for inner,
+			// arrowFunc for outer)
+			Code: `
+class Hello23 extends React.Component {
+	renderDiv() {
+		const click = () => true;
+		const renderStuff = () => {
+			const click = this.doSomething.bind(this, "hey");
+			return <div onClick={click} />;
+		};
+		return <div onClick={click}>Hello</div>;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 7, Column: 16},
+				{MessageId: "arrowFunc", Line: 9, Column: 15},
+			},
+		},
+		{
+			// Closures across function boundaries: outer decl is found from inner body
+			Code: `
+function outer() {
+	const click = () => 1;
+	function inner() {
+		return <div onClick={click}>Hello</div>;
+	}
+	inner();
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+		{
+			// If-block as an independent scope
+			Code: `
+function C() {
+	if (cond) {
+		const handler = () => 1;
+		return <div onClick={handler}>Hello</div>;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+		{
+			// For-loop body as its own block
+			Code: `
+function C() {
+	for (let i = 0; i < 1; i++) {
+		const handler = () => 1;
+		return <div onClick={handler}>Hello</div>;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+
+		// ---------- 16. JSX nested inside JSX — multiple reports ----------
+		{
+			// Outer arrow prop is flagged AND inner bind prop is flagged
+			Code: `var x = <Outer onClick={() => <Inner baz={fn.bind(this)} />}></Outer>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 16},
+				{MessageId: "bindCall", Line: 1, Column: 38},
+			},
+		},
+
+		// ---------- 17. Multiple VariableDeclarations in one list ----------
+		{
+			Code: `
+function C() {
+	const a = () => 1, b = this.x.bind(this);
+	return <><div onClick={a} /><div onClick={b} /></>;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 4, Column: 16},
+				{MessageId: "bindCall", Line: 4, Column: 35},
+			},
+		},
+
+		// ---------- 18. Non-violating inner shadow still flags outer (ESLint parity) ----------
+		{
+			// Inner `const click = handler;` (non-violating) does NOT override
+			// the outer `click = () => 1` tracking — matches ESLint's behavior.
+			Code: `
+function C() {
+	const click = () => 1;
+	if (cond) {
+		const click = normalHandler;
+		return <div onClick={click}>Hello</div>;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 6, Column: 15},
+			},
+		},
+
+		// ---------- 19. ref without ignoreRefs — flagged like any other prop ----------
+		{
+			Code: `var x = <div ref={() => 1}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 1, Column: 14},
+			},
+		},
+
+		// ---------- 20. Optional chain `?.bind()` ----------
+		{
+			Code: `var x = <div onClick={foo?.bind(this)}></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "bindCall", Line: 1, Column: 14},
+			},
+		},
+
+		// ---------- 21. Const initialized with a conditional whose branch violates ----------
+		{
+			// First non-empty violation from the ternary is the tracked kind.
+			Code: `
+function C() {
+	const click = cond ? () => 1 : other;
+	return <div onClick={click} />;
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 4, Column: 14},
+			},
+		},
+
+		// ---------- 22. catch-clause body is its own block ----------
+		{
+			Code: `
+function C() {
+	try {} catch (err) {
+		const handler = () => 1;
+		return <div onClick={handler} />;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+
+		// ---------- 23. Object method shorthand body is a tracked block ----------
+		{
+			Code: `
+const obj = {
+	render() {
+		const handler = () => 1;
+		return <div onClick={handler} />;
+	}
+};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+
+		// ---------- 24. Constructor body is a tracked block ----------
+		{
+			Code: `
+class C {
+	constructor() {
+		const handler = () => 1;
+		this.el = <div onClick={handler} />;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 18},
+			},
+		},
+
+		// ---------- 25. Getter body tracked ----------
+		{
+			Code: `
+class C {
+	get el() {
+		const handler = () => 1;
+		return <div onClick={handler} />;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+
+		// ---------- 26. Raw (free-standing) block creates its own scope ----------
+		{
+			Code: `
+function C() {
+	{
+		const handler = () => 1;
+		return <div onClick={handler} />;
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 5, Column: 15},
+			},
+		},
+
+		// ---------- 27. Switch case with braced block ----------
+		{
+			Code: `
+function C(x) {
+	switch (x) {
+		case 1: {
+			const handler = () => 1;
+			return <div onClick={handler} />;
+		}
+	}
+}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "arrowFunc", Line: 6, Column: 16},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -79,6 +79,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-filename-extension.test.ts',
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-bind.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-bind.test.ts
@@ -1,0 +1,177 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-bind', {} as never, {
+  valid: [
+    { code: `var x = <div onClick={this._handleClick}></div>;` },
+    { code: `var x = <Foo onClick={this._handleClick} />;` },
+    { code: `var x = <div meaningOfLife={42}></div>;` },
+    { code: `var x = <div onClick={getHandler()}></div>;` },
+
+    // ignoreRefs
+    {
+      code: `var x = <div ref={c => (this._input = c)}></div>;`,
+      options: [{ ignoreRefs: true }],
+    },
+    {
+      code: `var x = <div ref={this._refCallback.bind(this)}></div>;`,
+      options: [{ ignoreRefs: true }],
+    },
+
+    // allowBind
+    {
+      code: `var x = <div onClick={this._handleClick.bind(this)}></div>;`,
+      options: [{ allowBind: true }],
+    },
+
+    // allowArrowFunctions
+    {
+      code: `var x = <div onClick={() => alert("1337")}></div>;`,
+      options: [{ allowArrowFunctions: true }],
+    },
+
+    // allowFunctions
+    {
+      code: `var x = <div onClick={function () { alert("1337"); }}></div>;`,
+      options: [{ allowFunctions: true }],
+    },
+
+    // ignoreDOMComponents
+    {
+      code: `var x = <div onClick={this._handleClick.bind(this)}></div>;`,
+      options: [{ ignoreDOMComponents: true }],
+    },
+    {
+      code: `var x = <div onClick={() => alert("1337")}></div>;`,
+      options: [{ ignoreDOMComponents: true }],
+    },
+
+    // Not attached to JSX
+    {
+      code: `
+        class Hello extends Component {
+          render() {
+            const click = this.onTap.bind(this);
+            return <div onClick={onClick}>Hello</div>;
+          }
+        }
+      `,
+    },
+
+    // Uninitialized variable should not crash
+    {
+      code: `
+        class Hello extends Component {
+          render() {
+            let click;
+            return <div onClick={onClick}>Hello</div>;
+          }
+        }
+      `,
+    },
+
+    // Top-level function declarations are not tracked
+    {
+      code: `
+        function click() { return true; }
+        class Hello23 extends React.Component {
+          renderDiv() {
+            return <div onClick={click}>Hello</div>;
+          }
+        }
+      `,
+    },
+  ],
+
+  invalid: [
+    {
+      code: `var x = <div onClick={this._handleClick.bind(this)}></div>;`,
+      errors: [{ messageId: 'bindCall' }],
+    },
+    {
+      code: `var x = <div onClick={someGlobalFunction.bind(this)}></div>;`,
+      errors: [{ messageId: 'bindCall' }],
+    },
+    {
+      code: `var x = <div ref={this._refCallback.bind(this)}></div>;`,
+      errors: [{ messageId: 'bindCall' }],
+    },
+    {
+      code: `var x = <div onClick={() => alert("1337")}></div>;`,
+      errors: [{ messageId: 'arrowFunc' }],
+    },
+    {
+      code: `var x = <div onClick={async () => alert("1337")}></div>;`,
+      errors: [{ messageId: 'arrowFunc' }],
+    },
+    {
+      code: `var x = <div onClick={function () { alert("1337"); }}></div>;`,
+      errors: [{ messageId: 'func' }],
+    },
+    {
+      code: `var x = <div onClick={async function () { alert("1337"); }}></div>;`,
+      errors: [{ messageId: 'func' }],
+    },
+    {
+      code: `var x = <div onClick={cond ? onClick.bind(this) : handleClick()}></div>;`,
+      errors: [{ messageId: 'bindCall' }],
+    },
+    // ignoreDOMComponents: user components still flagged
+    {
+      code: `var x = <Foo onClick={this._handleClick.bind(this)} />;`,
+      options: [{ ignoreDOMComponents: true }],
+      errors: [{ messageId: 'bindCall' }],
+    },
+    // Variable tracking
+    {
+      code: `
+        class Hello23 extends React.Component {
+          render() {
+            const click = this.someMethod.bind(this);
+            return <div onClick={click}>Hello</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'bindCall' }],
+    },
+    {
+      code: `
+        class Hello23 extends React.Component {
+          render() {
+            const click = () => true;
+            return <div onClick={click}>Hello</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'arrowFunc' }],
+    },
+    {
+      code: `
+        class Hello23 extends React.Component {
+          renderDiv() {
+            function click() { return true; }
+            return <div onClick={click}>Hello</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'func' }],
+    },
+    // Nested blocks
+    {
+      code: `
+        class Hello23 extends React.Component {
+          renderDiv() {
+            const click = () => true;
+            const renderStuff = () => {
+              const click = this.doSomething.bind(this, "hey");
+              return <div onClick={click} />;
+            };
+            return <div onClick={click}>Hello</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'bindCall' }, { messageId: 'arrowFunc' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-bind` rule from [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md) to rslint.

The rule disallows `.bind()` calls and function literals (arrow / function expression / function declaration) as JSX prop values, which would otherwise create a new reference on every render and defeat memoization / trigger hook dependency changes. It also tracks `const` bindings and local function declarations inside a render block so that a banned value assigned to a variable and then passed through still gets reported.

All five ESLint options are supported: `allowArrowFunctions`, `allowBind`, `allowFunctions`, `ignoreRefs`, `ignoreDOMComponents`.

### Differences from ESLint

- The ES bind operator (`::`) is not supported — empirically verified that TypeScript's parser rejects the `::` token as a syntax error, so such code never reaches the rule. Consequently the `bindExpression` messageId is not produced.

### Validation against real-world codebases

Cross-checked against the upstream ESLint rule on `rsbuild` and `rspack`; the two produce identical diagnostics (file / line / column / messageId):

| Repo | Hit |
|---|---|
| rsbuild | `website/theme/components/Hero.tsx:16:7 arrowFunc` |
| rspack | `packages/create-rspack/template-react-ts/src/App.tsx:17:31 arrowFunc` |

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-bind.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).