### PR TITLE
feat: port rule no-control-regex

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -132,6 +132,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_constant_binary_expression"
 	"github.com/web-infra-dev/rslint/internal/rules/no_constant_condition"
 	"github.com/web-infra-dev/rslint/internal/rules/no_constructor_return"
+	"github.com/web-infra-dev/rslint/internal/rules/no_control_regex"
 	"github.com/web-infra-dev/rslint/internal/rules/no_debugger"
 	"github.com/web-infra-dev/rslint/internal/rules/no_delete_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_args"
@@ -539,6 +540,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-constant-binary-expression", no_constant_binary_expression.NoConstantBinaryExpressionRule)
 	GlobalRuleRegistry.Register("no-constant-condition", no_constant_condition.NoConstantConditionRule)
 	GlobalRuleRegistry.Register("no-constructor-return", no_constructor_return.NoConstructorReturnRule)
+	GlobalRuleRegistry.Register("no-control-regex", no_control_regex.NoControlRegexRule)
 	GlobalRuleRegistry.Register("no-debugger", no_debugger.NoDebuggerRule)
 	GlobalRuleRegistry.Register("no-delete-var", no_delete_var.NoDeleteVarRule)
 	GlobalRuleRegistry.Register("no-dupe-args", no_dupe_args.NoDupeArgsRule)

--- a/internal/rules/no_control_regex/no_control_regex.go
+++ b/internal/rules/no_control_regex/no_control_regex.go
@@ -1,0 +1,166 @@
+package no_control_regex
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-control-regex
+var NoControlRegexRule = rule.Rule{
+	Name: "no-control-regex",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		report := func(node *ast.Node, controlChars []string) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "unexpected",
+				Description: fmt.Sprintf("Unexpected control character(s) in regular expression: %s.", strings.Join(controlChars, ", ")),
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
+				pattern, flags := utils.ExtractRegexPatternAndFlags(node.Text())
+				if chars := collectControlChars(pattern, flags); len(chars) > 0 {
+					report(node, chars)
+				}
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				callExpr := node.AsCallExpression()
+				checkRegExpConstructor(callExpr.Expression, callExpr.Arguments, report)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				newExpr := node.AsNewExpression()
+				checkRegExpConstructor(newExpr.Expression, newExpr.Arguments, report)
+			},
+		}
+	},
+}
+
+func checkRegExpConstructor(
+	callee *ast.Node,
+	args *ast.NodeList,
+	report func(*ast.Node, []string),
+) {
+	callee = ast.SkipParentheses(callee)
+	if callee == nil || callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "RegExp" {
+		return
+	}
+	if args == nil || len(args.Nodes) == 0 {
+		return
+	}
+
+	patternNode := args.Nodes[0]
+	if patternNode.Kind != ast.KindStringLiteral {
+		return
+	}
+	pattern := patternNode.AsStringLiteral().Text
+
+	// ESLint only treats flags as known when the second argument is a string
+	// literal; otherwise flags default to "" (neither u nor v).
+	flags := ""
+	if len(args.Nodes) >= 2 && args.Nodes[1].Kind == ast.KindStringLiteral {
+		flags = args.Nodes[1].AsStringLiteral().Text
+	}
+
+	if chars := collectControlChars(pattern, flags); len(chars) > 0 {
+		report(patternNode, chars)
+	}
+}
+
+// collectControlChars scans a regex pattern and returns each code point in
+// U+0000..U+001F that appears as:
+//   - a raw character,
+//   - a \xHH escape,
+//   - a \uHHHH escape, or
+//   - a \u{H...} escape (only under the u or v flag).
+//
+// Each hit is formatted as `\xHH` (lowercase, 2 digits). Symbolic control
+// escapes (\t, \n, \r, \v, \f, \0, \cX) are NOT reported — matching ESLint.
+//
+// Note on syntax-invalid patterns: ESLint uses @eslint-community/regexpp's
+// validatePattern inside a try/catch, so on a syntax error it keeps the
+// characters collected before the error point and discards anything after.
+// This scanner does not reproduce that behavior — on a malformed pattern it
+// continues scanning to the end, which may over-report control characters
+// that appear after the syntax error. Syntactically-invalid patterns are
+// independently flagged by the `no-invalid-regexp` rule, so in practice a
+// user running both rules sees every issue; the rule attribution differs.
+func collectControlChars(pattern, flags string) []string {
+	uvMode := strings.ContainsAny(flags, "uv")
+
+	var results []string
+	record := func(cp uint64) {
+		results = append(results, fmt.Sprintf(`\x%02x`, cp))
+	}
+
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+
+		if c == '\\' && i+1 < len(pattern) {
+			switch pattern[i+1] {
+			case 'x':
+				// \xHH — 2 hex digits required.
+				if i+3 < len(pattern) {
+					if cp, ok := parseFixedHex(pattern[i+2 : i+4]); ok {
+						if cp <= 0x1f {
+							record(cp)
+						}
+						i += 4
+						continue
+					}
+				}
+			case 'u':
+				// \u{H...} — only recognized under u / v flag.
+				if uvMode && i+2 < len(pattern) && pattern[i+2] == '{' {
+					if closeRel := strings.IndexByte(pattern[i+3:], '}'); closeRel > 0 {
+						if cp, ok := parseFixedHex(pattern[i+3 : i+3+closeRel]); ok {
+							if cp <= 0x1f {
+								record(cp)
+							}
+							i += 3 + closeRel + 1
+							continue
+						}
+					}
+				}
+				// \uHHHH — 4 hex digits.
+				if i+5 < len(pattern) {
+					if cp, ok := parseFixedHex(pattern[i+2 : i+6]); ok {
+						if cp <= 0x1f {
+							record(cp)
+						}
+						i += 6
+						continue
+					}
+				}
+			}
+			// Any other escape (\t, \n, \\, \cI, \0, etc.): consume 2 bytes.
+			i += 2
+			continue
+		}
+
+		if c <= 0x1f {
+			record(uint64(c))
+		}
+		i++
+	}
+
+	return results
+}
+
+// parseFixedHex parses a hex literal. Returns ok=false when the string is
+// empty or contains any non-hex byte.
+func parseFixedHex(s string) (uint64, bool) {
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(s, 16, 32)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/internal/rules/no_control_regex/no_control_regex.md
+++ b/internal/rules/no_control_regex/no_control_regex.md
@@ -1,0 +1,51 @@
+# no-control-regex
+
+## Rule Details
+
+Disallows control characters (U+0000 through U+001F) in regular expressions. Control characters are rarely intended in patterns and usually indicate a typo.
+
+The rule flags:
+
+- Unescaped raw characters in the U+0000–U+001F range
+- `\xHH` escapes with `HH` in `00`–`1F`
+- `\uHHHH` escapes with `HHHH` in `0000`–`001F`
+- `\u{H...}` escapes (under the `u` or `v` flag) resolving to U+0000–U+001F
+
+Symbolic control escapes such as `\t`, `\n`, `\r`, `\v`, `\f`, `\0`, and `\cX` are allowed.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var pattern1 = /\x00/;
+var pattern2 = /\x0C/;
+var pattern3 = /\x1F/;
+var pattern4 = /\u000C/;
+var pattern5 = /\u{C}/u;
+var pattern6 = new RegExp('\x0C');
+var pattern7 = new RegExp('\\x0C');
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var pattern1 = /\x20/;
+var pattern2 = /\u0020/;
+var pattern3 = /\u{20}/u;
+var pattern4 = /\t/;
+var pattern5 = /\n/;
+var pattern6 = new RegExp('\x20');
+var pattern7 = new RegExp('\\t');
+var pattern8 = new RegExp('\\n');
+```
+
+## Differences from ESLint
+
+ESLint's implementation delegates pattern validation to `@eslint-community/regexpp` and wraps it in `try/catch`. On a regex-syntax error, regexpp aborts parsing, so any control characters appearing after the error point are never reported.
+
+This implementation is a linear scanner without a full ES regex parser. On a **syntactically-invalid pattern** it keeps scanning past the error, which may surface control characters ESLint would have suppressed. For valid regex patterns the two implementations produce identical output.
+
+Syntactically-invalid patterns are independently flagged by the [`no-invalid-regexp`](https://eslint.org/docs/latest/rules/no-invalid-regexp) rule, so running both rules together surfaces every relevant issue; only the rule attribution differs on malformed input.
+
+## Original Documentation
+
+- [no-control-regex](https://eslint.org/docs/latest/rules/no-control-regex)

--- a/internal/rules/no_control_regex/no_control_regex_test.go
+++ b/internal/rules/no_control_regex/no_control_regex_test.go
@@ -1,0 +1,540 @@
+// cspell:ignore FFFD callees lookarounds
+package no_control_regex
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestCollectControlChars(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		flags   string
+		want    []string
+	}{
+		// ── Negative cases ──
+		{"no control chars", `abc`, ``, nil},
+		{"empty pattern", ``, ``, nil},
+		{"escaped backslash then x hex", `\\x1f`, ``, nil}, // \\ + literal x1f
+		{"raw char just above range", "\x20", ``, nil},
+		{"raw DEL (above range)", "\x7f", ``, nil},
+
+		// ── \xHH ──
+		{"xHH at zero", `\x00`, ``, []string{`\x00`}},
+		{"xHH at max", `\x1f`, ``, []string{`\x1f`}},
+		{"xHH uppercase hex", `\x1F`, ``, []string{`\x1f`}},
+		{"xHH mixed case", `\x1A`, ``, []string{`\x1a`}},
+		{"xHH just above range", `\x20`, ``, nil},
+		{"xHH ascii letter", `\x61`, ``, nil},
+		{"xHH incomplete (1 digit)", `\x1`, ``, nil},
+		{"xHH empty after x", `\x`, ``, nil},
+		{"xHH non-hex first", `\xG0`, ``, nil},
+		{"xHH non-hex second", `\x0G`, ``, nil},
+		{"xHH multiple", `\x1f\x1e`, ``, []string{`\x1f`, `\x1e`}},
+		{"xHH adjacent plus text", `a\x1fb\x00c`, ``, []string{`\x1f`, `\x00`}},
+		{"xHH with quantifier", `\x1f+`, ``, []string{`\x1f`}},
+		{"xHH inside alternation", `a|\x1f|b`, ``, []string{`\x1f`}},
+
+		// ── \uHHHH ──
+		{"uHHHH control", `\u001F`, ``, []string{`\x1f`}},
+		{"uHHHH control zero", `\u0000`, ``, []string{`\x00`}},
+		{"uHHHH non-control", `\u0020`, ``, nil},
+		{"uHHHH above BMP edge", `\uFFFD`, ``, nil},
+		{"uHHHH incomplete (3 digits)", `\u001`, ``, nil},
+		{"uHHHH non-hex", `\u00GG`, ``, nil},
+		{"uHHHH surrogate (not control)", `\uD83D`, ``, nil},
+
+		// ── \u{H...} under u/v flag ──
+		{"u-brace u: single", `\u{1f}`, `u`, []string{`\x1f`}},
+		{"u-brace u: uppercase", `\u{1F}`, `u`, []string{`\x1f`}},
+		{"u-brace u: leading zeros", `\u{0000001F}`, `u`, []string{`\x1f`}},
+		{"u-brace u: zero", `\u{0}`, `u`, []string{`\x00`}},
+		{"u-brace u: above range", `\u{20}`, `u`, nil},
+		{"u-brace u: far above (BMP)", `\u{FFFF}`, `u`, nil},
+		{"u-brace u: astral plane", `\u{10FFFF}`, `u`, nil},
+		{"u-brace v: single", `\u{1f}`, `v`, []string{`\x1f`}},
+		{"u-brace u: empty braces", `\u{}`, `u`, nil},
+		{"u-brace u: non-hex", `\u{GG}`, `u`, nil},
+		{"u-brace u: unclosed", `\u{1f`, `u`, nil},
+		{"u-brace no flag: treated literally", `\u{1F}`, ``, nil},
+		{"u-brace g flag only: treated literally", `\u{1F}`, `g`, nil},
+		{"u-brace mixed flags with u", `\u{1F}`, `gui`, []string{`\x1f`}},
+		{"u-brace u-flag multiple", `\u{1F}\u{1E}`, `u`, []string{`\x1f`, `\x1e`}},
+
+		// ── Raw control chars in pattern ──
+		{"raw zero", "\x00", ``, []string{`\x00`}},
+		{"raw tab (0x09)", "\x09", ``, []string{`\x09`}},
+		{"raw at range max", "\x1f", ``, []string{`\x1f`}},
+		{"raw mixed", "a\x1fb\x1ec", ``, []string{`\x1f`, `\x1e`}},
+		{"raw consecutive", "\x01\x02\x03", ``, []string{`\x01`, `\x02`, `\x03`}},
+
+		// ── Symbolic escapes — all allowed ──
+		{"symbolic \\t", `\t`, ``, nil},
+		{"symbolic \\n", `\n`, ``, nil},
+		{"symbolic \\r", `\r`, ``, nil},
+		{"symbolic \\v", `\v`, ``, nil},
+		{"symbolic \\f", `\f`, ``, nil},
+		{"symbolic \\0", `\0`, ``, nil},
+		{"symbolic \\b (word boundary)", `\b`, ``, nil},
+		{"symbolic \\cI", `\cI`, ``, nil},
+		{"symbolic \\cJ", `\cJ`, ``, nil},
+		{"symbolic \\d", `\d`, ``, nil},
+		{"symbolic \\w", `\w`, ``, nil},
+		{"symbolic \\s", `\s`, ``, nil},
+		{"mixed symbolic and control", `\t\x1f\n`, ``, []string{`\x1f`}},
+
+		// ── Character classes ──
+		{"class with xHH", `[\x1f]`, ``, []string{`\x1f`}},
+		{"class negated with xHH", `[^\x1f]`, ``, []string{`\x1f`}},
+		{"class range with controls", `[\x00-\x1f]`, ``, []string{`\x00`, `\x1f`}},
+		{"class escaped bracket literal", `\[\x1f\]`, ``, []string{`\x1f`}},
+		{"v-flag nested class control", `[[\u{1F}]]`, `v`, []string{`\x1f`}},
+		{"v-flag set difference", `[\u{1F}--B]`, `v`, []string{`\x1f`}},
+
+		// ── Groups, lookarounds ──
+		{"named capture with control", `(?<a>\x1f)`, ``, []string{`\x1f`}},
+		{"lookbehind with control", `(?<=\x1f)a`, ``, []string{`\x1f`}},
+		{"lookahead with control", `a(?=\x1f)`, ``, []string{`\x1f`}},
+		{"non-capturing group", `(?:\x1f)`, ``, []string{`\x1f`}},
+
+		// ── Trailing backslash (malformed but shouldn't crash) ──
+		{"trailing backslash", `abc\`, ``, nil},
+
+		// ── Combined forms in same pattern ──
+		{"mixed xHH + uHHHH + u-brace", `\x01\u0002\u{3}`, `u`, []string{`\x01`, `\x02`, `\x03`}},
+
+		// ── Surrogate pairs (neither half is a control code point) ──
+		{"surrogate pair as \\uHHHH\\uHHHH", `\uD83D\uDC7F`, ``, nil},
+		{"surrogate pair under u flag", `\uD83D\uDC7F`, `u`, nil},
+
+		// ── Legacy octal escapes — ESLint never reports these ──
+		{"octal \\01", `\01`, ``, nil},
+		{"octal \\07", `\07`, ``, nil},
+		{"octal \\012", `\012`, ``, nil},
+		{"octal preceded by content", `a\01b`, ``, nil},
+
+		// ── Unicode property escape \p{...} — not a control escape ──
+		{"\\p{Letter} under u", `\p{Letter}`, `u`, nil},
+		{"\\P{Letter} under u", `\P{Letter}`, `u`, nil},
+		{"\\p{Script=Latin} under u", `\p{Script=Latin}`, `u`, nil},
+		{"\\p next to control xHH", `\p{Letter}\x1f`, `u`, []string{`\x1f`}},
+
+		// ── Documented divergence from ESLint on syntactically-invalid patterns.
+		// ESLint's collector inherits regexpp's stop-on-error behavior; this
+		// scanner intentionally does not model that (see rule doc). The cases
+		// below pin the current over-reporting behavior so changes are loud.
+		{"malformed: \\u{...} invalid content before control", `\u{NOT_HEX}\x1f`, `u`, []string{`\x1f`}},
+		{"malformed: unclosed [ still collects control inside", `[\x1f`, ``, []string{`\x1f`}},
+		{"malformed: unclosed ( still collects control inside", `(\x1f`, ``, []string{`\x1f`}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := collectControlChars(tt.pattern, tt.flags)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("collectControlChars(%q, %q) = %v, want %v", tt.pattern, tt.flags, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCollectControlChars_AllBoundary exercises every code point in 0x00..0x20
+// across raw, \xHH, \uHHHH forms — the primary boundary for this rule.
+func TestCollectControlChars_AllBoundary(t *testing.T) {
+	for cp := range 0x21 {
+		want := []string{fmt.Sprintf(`\x%02x`, cp)}
+		if cp > 0x1f {
+			want = nil
+		}
+
+		// \xHH
+		if got := collectControlChars(fmt.Sprintf(`\x%02x`, cp), ``); !reflect.DeepEqual(got, want) {
+			t.Errorf("\\x%02x: got %v want %v", cp, got, want)
+		}
+		// \uHHHH
+		if got := collectControlChars(fmt.Sprintf(`\u%04x`, cp), ``); !reflect.DeepEqual(got, want) {
+			t.Errorf("\\u%04x: got %v want %v", cp, got, want)
+		}
+		// \u{H} under u flag
+		if got := collectControlChars(fmt.Sprintf(`\u{%x}`, cp), `u`); !reflect.DeepEqual(got, want) {
+			t.Errorf("\\u{%x} (u flag): got %v want %v", cp, got, want)
+		}
+	}
+	// Raw control characters in pattern (only 0x00..0x1f — 0x20 is a normal space).
+	for cp := range 0x20 {
+		want := []string{fmt.Sprintf(`\x%02x`, cp)}
+		if got := collectControlChars(string(rune(cp)), ``); !reflect.DeepEqual(got, want) {
+			t.Errorf("raw \\x%02x: got %v want %v", cp, got, want)
+		}
+	}
+}
+
+func TestNoControlRegexRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoControlRegexRule,
+		[]rule_tester.ValidTestCase{
+			// ── Baseline: no control chars ──
+			{Code: `var regex = /x1f/`},
+			{Code: `var regex = /\\x1f/`},
+			{Code: `var regex = new RegExp('x1f')`},
+			{Code: `var regex = RegExp('x1f')`},
+			{Code: `new RegExp('[')`},
+			{Code: `RegExp('[')`},
+			{Code: `/\u{20}/u`},
+			{Code: `/\u{1F}/`},
+			{Code: `/\u{1F}/g`},
+			{Code: `new RegExp("\\u{20}", "u")`},
+			{Code: `new RegExp("\\u{1F}")`},
+			{Code: `new RegExp("\\u{1F}", "g")`},
+			{Code: `new RegExp("\\u{1F}", flags)`},
+			{Code: `new RegExp("[\\q{\\u{20}}]", "v")`},
+			{Code: `/[\u{20}--B]/v`},
+			{Code: "new RegExp('\\x20')"},
+
+			// ── Symbolic escapes — all allowed ──
+			{Code: `/\t/`},
+			{Code: `/\n/`},
+			{Code: `/\r/`},
+			{Code: `/\v/`},
+			{Code: `/\f/`},
+			{Code: `/\0/`},
+			{Code: `/\b/`},  // word boundary
+			{Code: `/\cI/`}, // control-I
+			{Code: `/\cJ/`},
+
+			// ── Non-RegExp callees — should not match ──
+			{Code: `foo.RegExp('\x1f')`},
+			{Code: `window.RegExp('\x1f')`},
+			{Code: `this.RegExp('\x1f')`},
+			{Code: `regexp('\x1f')`}, // lowercase, not RegExp
+			{Code: `bar('\x1f')`},
+			{Code: `new (function foo(){})('\x1f')`}, // callee isn't Identifier "RegExp"
+
+			// ── Non-string first argument — constructor path skipped ──
+			{Code: "RegExp(pattern)"},
+			{Code: "RegExp(/x20/)"},      // inner regex has no controls
+			{Code: "RegExp('a' + 'b')"},  // binary expression
+			{Code: "RegExp(cond ? 'a' : 'b')"},
+			{Code: "RegExp(123)"},
+			{Code: "RegExp(null)"},
+			{Code: "RegExp(undefined)"},
+			{Code: "RegExp(`template`)"}, // template literal
+
+			// ── No-args / zero-arg constructor ──
+			{Code: "new RegExp"},
+			{Code: "RegExp()"},
+			{Code: "new RegExp()"},
+
+			// ── Spread first argument — not a StringLiteral, skip ──
+			{Code: "new RegExp(...args)"},
+			{Code: "RegExp(...['\\x1f'])"},
+
+			// ── Surrogate pair (non-control) ──
+			{Code: `/\uD83D\uDC7F/`},
+			{Code: `new RegExp("\\uD83D\\uDC7F")`},
+
+			// ── Legacy octal in regex literal — ESLint does not report these ──
+			// (Note: octal escapes are disallowed in TS string literals, so we
+			// only exercise the regex-literal path here.)
+			{Code: `/\01/`},
+			{Code: `/\012/`},
+
+			// ── \p{...} unicode property — not a control escape ──
+			{Code: `/\p{Letter}/u`},
+			{Code: `new RegExp("\\p{Letter}", "u")`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ── Regex literals: \xHH ──
+			{
+				Code: `var regex = /\x1f/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `var regex = /\x00/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `var regex = /\x0C/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `var regex = /\\\x1f\\x1e/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `var regex = /\\\x1fFOO\\x00/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `var regex = /FOO\\\x1fFOO\\x1f/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			// Regex literal: \uHHHH
+			{
+				Code: `/\u000C/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Regex literal: \u{H} under u flag
+			{
+				Code: `/\u{C}/u`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/\u{1F}/u`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/\u{1F}/gui`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Regex literal: u-flag combined with other escapes
+			{
+				Code: `/\u{1111}*\x1F/u`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Regex literal: v-flag set notation
+			{
+				Code: `/[\u{1F}--B]/v`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Regex literal: named capture + control
+			{
+				Code: `var regex = /(?<a>\x1f)/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `var regex = /(?<\u{1d49c}>.)\x1f/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+
+			// ── Constructor: raw character strings ──
+			{
+				Code: "var regex = new RegExp('\\x1f\\x1e')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: "var regex = new RegExp('\\x1fFOO\\x00')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: "var regex = new RegExp('FOO\\x1fFOO\\x1f')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: "var regex = RegExp('\\x1f')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+				},
+			},
+			// Constructor: \\uHHHH (escaped — interpreted by RegExp parser)
+			{
+				Code: `new RegExp("\\u001F", flags)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `new RegExp("\\u{1111}*\\x1F", "u")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `new RegExp("\\u{1F}", "u")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `new RegExp("\\u{1F}", "gui")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `new RegExp("[\\q{\\u{1F}}]", "v")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+
+			// ── Constructor: parenthesized callee ──
+			{
+				Code: `(RegExp)('\x1f')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code: `((RegExp))('\x1f')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `(new RegExp('\x1f'))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 13},
+				},
+			},
+
+			// ── Multiple expressions: report only the one with control chars ──
+			{
+				Code: `/\x11/; RegExp("foo", "uv");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ── Nesting contexts ──
+			// Inside function call arg
+			{
+				Code: `foo(/\x1f/)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 5},
+				},
+			},
+			// Inside conditional
+			{
+				Code: `cond ? /\x1f/ : null`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			// Inside array literal
+			{
+				Code: `[/\x1f/]`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 2},
+				},
+			},
+			// Inside object literal
+			{
+				Code: `({ re: /\x1f/ })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 8},
+				},
+			},
+			// Inside arrow function body
+			{
+				Code: `const fn = () => /\x1f/;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			// Nested RegExp: inner reports
+			{
+				Code: `RegExp(RegExp('\x1f'))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// In template literal expression
+			{
+				Code: "`${/\\x1f/}`",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 4},
+				},
+			},
+			// IIFE
+			{
+				Code: `(function() { /\x1f/; })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			// Class method body
+			{
+				Code: `class C { m() { /\x1f/; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 17},
+				},
+			},
+			// Default parameter
+			{
+				Code: `function f(x = /\x1f/) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			// For-loop init
+			{
+				Code: `for (let r = /\x1f/;;) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 14},
+				},
+			},
+			// Return statement
+			{
+				Code: `function g() { return /\x1f/; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			// Logical expression
+			{
+				Code: `true && /\x1f/;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 9},
+				},
+			},
+			// Multi-line code — regex on line 2
+			{
+				Code: "var x = 1;\nvar r = /\\x1f/;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 9},
+				},
+			},
+
+			// ── Multiple control chars in one pattern — one diagnostic, joined list ──
+			{
+				Code: `/[\x00-\x1f]/`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -249,6 +249,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/unbound-method.test.ts',
     // './tests/typescript-eslint/rules/unified-signatures.test.ts',
     // './tests/typescript-eslint/rules/use-unknown-in-catch-callback-variable.test.ts',
+    './tests/eslint/rules/no-control-regex.test.ts',
     './tests/eslint/rules/no-empty-character-class.test.ts',
     './tests/eslint/rules/no-fallthrough.test.ts',
     './tests/eslint/rules/no-invalid-regexp.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-control-regex.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-control-regex.test.ts.snap
@@ -1,0 +1,859 @@
+// Rstest Snapshot v1
+
+exports[`no-control-regex > invalid 1`] = `
+{
+  "code": "var regex = /\\x1f/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 2`] = `
+{
+  "code": "var regex = /\\x00/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x00.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 3`] = `
+{
+  "code": "var regex = /\\\\\\x1f\\\\x1e/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 4`] = `
+{
+  "code": "var regex = /\\\\\\x1fFOO\\\\x00/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 5`] = `
+{
+  "code": "var regex = /FOO\\\\\\x1fFOO\\\\x1f/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 6`] = `
+{
+  "code": "/\\u000C/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x0c.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 7`] = `
+{
+  "code": "/\\u{C}/u",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x0c.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 8`] = `
+{
+  "code": "/\\u{1F}/u",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 9`] = `
+{
+  "code": "/\\u{1F}/gui",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 10`] = `
+{
+  "code": "/\\u{1111}*\\x1F/u",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 11`] = `
+{
+  "code": "/[\\u{1F}--B]/v",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 12`] = `
+{
+  "code": "var regex = /(?<a>\\x1f)/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 13`] = `
+{
+  "code": "var regex = /(?<\\u{1d49c}>.)\\x1f/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 14`] = `
+{
+  "code": "var regex = new RegExp('\\x1f\\x1e')",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f, \\x1e.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 15`] = `
+{
+  "code": "var regex = new RegExp('\\x1fFOO\\x00')",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f, \\x00.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 16`] = `
+{
+  "code": "var regex = new RegExp('FOO\\x1fFOO\\x1f')",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f, \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 17`] = `
+{
+  "code": "var regex = RegExp('\\x1f')",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 18`] = `
+{
+  "code": "new RegExp("\\\\u001F", flags)",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 19`] = `
+{
+  "code": "new RegExp("\\\\u{1111}*\\\\x1F", "u")",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 20`] = `
+{
+  "code": "new RegExp("\\\\u{1F}", "u")",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 21`] = `
+{
+  "code": "new RegExp("\\\\u{1F}", "gui")",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 22`] = `
+{
+  "code": "new RegExp("[\\\\q{\\\\u{1F}}]", "v")",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 23`] = `
+{
+  "code": "(RegExp)('\\x1f')",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 24`] = `
+{
+  "code": "((RegExp))('\\x1f')",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 25`] = `
+{
+  "code": "foo(/\\x1f/)",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 26`] = `
+{
+  "code": "[/\\x1f/]",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 27`] = `
+{
+  "code": "({ re: /\\x1f/ })",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 28`] = `
+{
+  "code": "const fn = () => /\\x1f/;",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 29`] = `
+{
+  "code": "RegExp(RegExp('\\x1f'))",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 30`] = `
+{
+  "code": "class C { m() { /\\x1f/; } }",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 31`] = `
+{
+  "code": "function f(x = /\\x1f/) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 32`] = `
+{
+  "code": "/[\\x00-\\x1f]/",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x00, \\x1f.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-control-regex > invalid 33`] = `
+{
+  "code": "/\\x11/; RegExp("foo", "uv");",
+  "diagnostics": [
+    {
+      "message": "Unexpected control character(s) in regular expression: \\x11.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-control-regex",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-control-regex.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-control-regex.test.ts
@@ -1,0 +1,203 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-control-regex', {
+  valid: [
+    // Baseline: no control chars
+    'var regex = /x1f/',
+    String.raw`var regex = /\\x1f/`,
+    "var regex = new RegExp('x1f')",
+    "var regex = RegExp('x1f')",
+    "new RegExp('[')",
+    "RegExp('[')",
+    String.raw`/\u{20}/u`,
+    String.raw`/\u{1F}/`,
+    String.raw`/\u{1F}/g`,
+    String.raw`new RegExp("\\u{20}", "u")`,
+    String.raw`new RegExp("\\u{1F}")`,
+    String.raw`new RegExp("\\u{1F}", "g")`,
+    String.raw`new RegExp("\\u{1F}", flags)`,
+    String.raw`new RegExp("[\\q{\\u{20}}]", "v")`,
+    String.raw`/[\u{20}--B]/v`,
+    // Symbolic escapes — allowed
+    String.raw`/\t/`,
+    String.raw`/\n/`,
+    String.raw`/\r/`,
+    String.raw`/\v/`,
+    String.raw`/\f/`,
+    String.raw`/\0/`,
+    String.raw`/\b/`,
+    String.raw`/\cI/`,
+    // Non-RegExp callees — should not match
+    "foo.RegExp('\\x1f')",
+    "window.RegExp('\\x1f')",
+    "this.RegExp('\\x1f')",
+    "regexp('\\x1f')",
+    "new (function foo(){})('\\x1f')",
+    // Non-string first argument
+    'RegExp(pattern)',
+    'RegExp(/x20/)',
+    "RegExp('a' + 'b')",
+    'RegExp(123)',
+    'RegExp(null)',
+    // No-args
+    'new RegExp',
+    'RegExp()',
+    'new RegExp()',
+    // Spread first argument — not a StringLiteral, skip
+    'new RegExp(...args)',
+    // Surrogate pair (non-control)
+    String.raw`/\uD83D\uDC7F/`,
+    String.raw`new RegExp("\\uD83D\\uDC7F")`,
+    // Legacy octal in regex literal
+    String.raw`/\01/`,
+    String.raw`/\012/`,
+    // \p{...} unicode property
+    String.raw`/\p{Letter}/u`,
+    String.raw`new RegExp("\\p{Letter}", "u")`,
+  ],
+  invalid: [
+    // Regex literals: \xHH
+    {
+      code: String.raw`var regex = /\x1f/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`var regex = /\x00/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`var regex = /\\\x1f\\x1e/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`var regex = /\\\x1fFOO\\x00/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`var regex = /FOO\\\x1fFOO\\x1f/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Regex literal: \uHHHH
+    {
+      code: String.raw`/\u000C/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Regex literal: \u{H} under u/v flag
+    {
+      code: String.raw`/\u{C}/u`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`/\u{1F}/u`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`/\u{1F}/gui`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`/\u{1111}*\x1F/u`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`/[\u{1F}--B]/v`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Regex literal: named capture + control
+    {
+      code: 'var regex = /(?<a>\\x1f)/',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`var regex = /(?<\u{1d49c}>.)\x1f/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Constructor: raw / escaped strings
+    {
+      code: "var regex = new RegExp('\\x1f\\x1e')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "var regex = new RegExp('\\x1fFOO\\x00')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "var regex = new RegExp('FOO\\x1fFOO\\x1f')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "var regex = RegExp('\\x1f')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`new RegExp("\\u001F", flags)`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`new RegExp("\\u{1111}*\\x1F", "u")`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`new RegExp("\\u{1F}", "u")`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`new RegExp("\\u{1F}", "gui")`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`new RegExp("[\\q{\\u{1F}}]", "v")`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Parenthesized callee
+    {
+      code: "(RegExp)('\\x1f')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "((RegExp))('\\x1f')",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Nesting contexts
+    {
+      code: String.raw`foo(/\x1f/)`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`[/\x1f/]`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: String.raw`({ re: /\x1f/ })`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const fn = () => /\\x1f/;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "RegExp(RegExp('\\x1f'))",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class C { m() { /\\x1f/; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'function f(x = /\\x1f/) {}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Character class range of controls — one diagnostic
+    {
+      code: String.raw`/[\x00-\x1f]/`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Multiple statements — only the bad one reports
+    {
+      code: String.raw`/\x11/; RegExp("foo", "uv");`,
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-control-regex` rule from ESLint to rslint.

Disallows control characters (U+0000–U+001F) in regular expressions. The rule flags raw chars in that range, `\xHH` / `\uHHHH` escapes, and `\u{H...}` escapes under the `u`/`v` flag. Symbolic control escapes (`\t`, `\n`, `\r`, `\v`, `\f`, `\0`, `\cX`) are intentionally allowed — matching ESLint.

Implementation is a minimal linear byte scanner (~110 lines of logic). It detects the four escape/raw forms and delegates everything else to single 2-byte escape consumption. For well-formed regex patterns the scanner produces output identical to ESLint.

## Known divergence on malformed patterns

ESLint's implementation uses `@eslint-community/regexpp` and wraps pattern validation in `try/catch`, so on a regex syntax error it discards characters collected after the error point. This implementation does not reproduce that behavior — it keeps scanning past syntax errors, which can surface control characters ESLint would have suppressed. Syntactically-invalid patterns are independently flagged by `no-invalid-regexp`, so running both rules together surfaces every relevant issue; only the rule attribution differs on malformed input. See the rule documentation for details.

## Verification

- Go unit tests: 85+ targeted cases including boundary loop across U+0000..U+0020 × 3 escape forms.
- JS snapshot tests: 33 cases, stable.
- Verified against `rsbuild` (1197 files): 1 error in `packages/core/src/server/ansiHTML.ts`. Output matches ESLint exactly.
- Verified against `rspack` (392 files): 2 errors in `packages/rspack-test-tools/src/case/stats-output.ts` and `packages/rspack/src/stats/DefaultStatsPrinterPlugin.ts`. Output matches ESLint exactly.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-control-regex
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-control-regex.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).