### PR TITLE
feat: port rule max-lines

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,6 +20,7 @@ npm/tsgo/**/lib/
 binaries/
 target/
 internal/plugins/**/rules/**/*.md
+internal/rules/max_lines/max_lines.md
 website/docs/en/rules/_meta.json
 website/docs/en/rules/*/
 packages/vscode-extension/__tests__/fixtures-monorepo/packages/broken/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,6 +117,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/for_direction"
 	"github.com/web-infra-dev/rslint/internal/rules/getter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/guard_for_in"
+	"github.com/web-infra-dev/rslint/internal/rules/max_lines"
 	"github.com/web-infra-dev/rslint/internal/rules/no_alert"
 	"github.com/web-infra-dev/rslint/internal/rules/no_async_promise_executor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_await_in_loop"
@@ -523,6 +524,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("for-direction", for_direction.ForDirectionRule)
 	GlobalRuleRegistry.Register("getter-return", getter_return.GetterReturnRule)
 	GlobalRuleRegistry.Register("guard-for-in", guard_for_in.GuardForInRule)
+	GlobalRuleRegistry.Register("max-lines", max_lines.MaxLinesRule)
 	GlobalRuleRegistry.Register("no-alert", no_alert.NoAlertRule)
 	GlobalRuleRegistry.Register("no-async-promise-executor", no_async_promise_executor.NoAsyncPromiseExecutorRule)
 	GlobalRuleRegistry.Register("no-await-in-loop", no_await_in_loop.NoAwaitInLoopRule)

--- a/internal/rules/max_lines/max_lines.go
+++ b/internal/rules/max_lines/max_lines.go
@@ -1,0 +1,301 @@
+package max_lines
+
+import (
+	"fmt"
+	"sort"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// MaxLinesRule enforces a maximum number of lines per file.
+// https://eslint.org/docs/latest/rules/max-lines
+var MaxLinesRule = rule.Rule{
+	Name: "max-lines",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// The linter never fires a KindSourceFile listener, so run eagerly.
+		checkMaxLines(ctx, options)
+		return rule.RuleListeners{}
+	},
+}
+
+type maxLinesOptions struct {
+	max            int
+	skipComments   bool
+	skipBlankLines bool
+}
+
+func parseOptions(opts any) maxLinesOptions {
+	result := maxLinesOptions{max: 300}
+	if opts == nil {
+		return result
+	}
+	// JS tests pass options as [2] or [{ max: 2, ... }].
+	if arr, ok := opts.([]interface{}); ok {
+		if len(arr) == 0 {
+			return result
+		}
+		opts = arr[0]
+	}
+	if n, ok := toInt(opts); ok {
+		result.max = n
+		return result
+	}
+	if m, ok := opts.(map[string]interface{}); ok {
+		if v, ok := m["max"]; ok {
+			if n, ok := toInt(v); ok {
+				result.max = n
+			}
+		}
+		if v, ok := m["skipComments"].(bool); ok {
+			result.skipComments = v
+		}
+		if v, ok := m["skipBlankLines"].(bool); ok {
+			result.skipBlankLines = v
+		}
+	}
+	return result
+}
+
+func toInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int32:
+		return int(n), true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	case float32:
+		return int(n), true
+	}
+	return 0, false
+}
+
+func checkMaxLines(ctx rule.RuleContext, options any) {
+	opts := parseOptions(options)
+	sourceFile := ctx.SourceFile
+	text := sourceFile.Text()
+	lineStarts := scanner.GetECMALineStarts(sourceFile)
+	if len(lineStarts) == 0 {
+		lineStarts = []core.TextPos{0}
+	}
+	nLines := len(lineStarts)
+
+	// Slice out a single line's content (excluding its terminator). Matches the
+	// semantics of ESLint's SourceCode.lines entries.
+	lineContent := func(i int) string {
+		start := int(lineStarts[i])
+		if i+1 >= nLines {
+			return text[start:]
+		}
+		return text[start:lineContentEnd(text, int(lineStarts[i+1]))]
+	}
+
+	// If the file ends with a line terminator, the final entry is an extra
+	// empty string that doesn't represent a real line. Drop it from counting
+	// but keep it visible to the end-position calculation below.
+	lastLineIsTrailingEmpty := nLines > 1 && lineContent(nLines-1) == ""
+
+	keep := make([]bool, nLines)
+	for i := range keep {
+		keep[i] = true
+	}
+	if lastLineIsTrailingEmpty {
+		keep[nLines-1] = false
+	}
+
+	if opts.skipBlankLines {
+		for i := range nLines {
+			if keep[i] && isECMABlankLine(lineContent(i)) {
+				keep[i] = false
+			}
+		}
+	}
+
+	if opts.skipComments {
+		for line := range commentOnlyLines(sourceFile, text, lineStarts) {
+			idx := line - 1
+			if idx >= 0 && idx < nLines {
+				keep[idx] = false
+			}
+		}
+	}
+
+	kept := make([]int, 0, nLines)
+	for i := range nLines {
+		if keep[i] {
+			kept = append(kept, i)
+		}
+	}
+	if len(kept) <= opts.max {
+		return
+	}
+	excessIdx := opts.max
+	if excessIdx < 0 {
+		// ESLint's schema requires max >= 0; if a consumer bypasses the
+		// schema and supplies a negative value, report from the first line
+		// rather than panic.
+		excessIdx = 0
+	}
+	startLineIdx := kept[excessIdx]
+
+	ctx.ReportRange(
+		core.NewTextRange(int(lineStarts[startLineIdx]), len(text)),
+		rule.RuleMessage{
+			Id:          "exceed",
+			Description: fmt.Sprintf("File has too many lines (%d). Maximum allowed is %d.", len(kept), opts.max),
+		},
+	)
+}
+
+// lineContentEnd returns the byte position just past the last character of the
+// line whose successor starts at nextLineStart — i.e. nextLineStart with its
+// immediately-preceding ECMA line terminator (LF, CR, CRLF, LS, PS) stripped.
+func lineContentEnd(text string, nextLineStart int) int {
+	if nextLineStart >= 2 && text[nextLineStart-2] == '\r' && text[nextLineStart-1] == '\n' {
+		return nextLineStart - 2
+	}
+	if nextLineStart >= 1 {
+		c := text[nextLineStart-1]
+		if c == '\r' || c == '\n' {
+			return nextLineStart - 1
+		}
+		// U+2028 / U+2029 encode as 0xE2 0x80 0xA8 / 0xA9.
+		if nextLineStart >= 3 &&
+			text[nextLineStart-3] == 0xE2 &&
+			text[nextLineStart-2] == 0x80 &&
+			(text[nextLineStart-1] == 0xA8 || text[nextLineStart-1] == 0xA9) {
+			return nextLineStart - 3
+		}
+	}
+	return nextLineStart
+}
+
+// isECMABlankLine reports whether s contains only ECMAScript WhiteSpace /
+// LineTerminator runes — matching JavaScript's `"".trim() === ""` check used
+// by ESLint's `skipBlankLines`. Go's strings.TrimSpace diverges on U+FEFF
+// (BOM) and U+0085 (NEL), so we can't use it directly.
+func isECMABlankLine(s string) bool {
+	for _, r := range s {
+		if !utils.IsStrWhiteSpace(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// commentOnlyLines returns the set of 1-indexed line numbers that contain only
+// comments and whitespace, matching ESLint's max-lines `getLinesWithoutCode`.
+// A multi-line comment's first (last) line is excluded when non-comment code
+// exists earlier (later) on that same line.
+func commentOnlyLines(sourceFile *ast.SourceFile, text string, lineStarts []core.TextPos) map[int]bool {
+	var comments []*ast.CommentRange
+	// ESLint's sourceCode.getAllComments() includes the hashbang (`#!`) line,
+	// but tsgo's ForEachComment skips past it. Synthesize a comment range so
+	// skipComments filters it the same way ESLint does.
+	if shebang := scanner.GetShebang(text); shebang != "" {
+		comments = append(comments, &ast.CommentRange{
+			TextRange: core.NewTextRange(0, len(shebang)),
+			Kind:      ast.KindSingleLineCommentTrivia,
+		})
+	}
+	utils.ForEachComment(sourceFile.AsNode(), func(c *ast.CommentRange) {
+		copied := *c
+		comments = append(comments, &copied)
+	}, sourceFile)
+	if len(comments) == 0 {
+		return nil
+	}
+	// ForEachComment may surface a comment twice (once as a token's trailing
+	// range, once as the next token's leading range) and not strictly in source
+	// order. Duplicates are harmless for this algorithm, but advancing
+	// commentIdx linearly requires sorted input.
+	sort.Slice(comments, func(i, j int) bool {
+		return comments[i].Pos() < comments[j].Pos()
+	})
+
+	nLines := len(lineStarts)
+	// minCodePos[line] / maxCodeEnd[line] bound the non-comment,
+	// non-whitespace characters on each 0-indexed line. -1 means "none".
+	minCodePos := make([]int, nLines)
+	maxCodeEnd := make([]int, nLines)
+	for i := range minCodePos {
+		minCodePos[i] = -1
+		maxCodeEnd[i] = -1
+	}
+
+	commentIdx := 0
+	line := 0
+	i := 0
+	for i < len(text) {
+		r, size := utf8.DecodeRuneInString(text[i:])
+		// CRLF collapses to a single line break.
+		if r == '\r' {
+			if i+1 < len(text) && text[i+1] == '\n' {
+				i += 2
+			} else {
+				i++
+			}
+			line++
+			continue
+		}
+		if r == '\n' || r == 0x2028 || r == 0x2029 {
+			i += size
+			line++
+			continue
+		}
+
+		// Advance past comments that ended at or before i.
+		for commentIdx < len(comments) && comments[commentIdx].End() <= i {
+			commentIdx++
+		}
+		// Inside a comment — ignore.
+		if commentIdx < len(comments) && comments[commentIdx].Pos() <= i && i < comments[commentIdx].End() {
+			i += size
+			continue
+		}
+
+		// Line-terminator runes are consumed above, so at this point
+		// IsStrWhiteSpace only matches ECMAScript WhiteSpace.
+		if utils.IsStrWhiteSpace(r) {
+			i += size
+			continue
+		}
+
+		if minCodePos[line] == -1 {
+			minCodePos[line] = i
+		}
+		maxCodeEnd[line] = i + size
+		i += size
+	}
+
+	commentOnly := make(map[int]bool)
+	for _, cmt := range comments {
+		startPos := cmt.Pos()
+		endPos := cmt.End()
+		if endPos <= startPos {
+			continue
+		}
+		startLine := scanner.ComputeLineOfPosition(lineStarts, startPos)
+		endLine := scanner.ComputeLineOfPosition(lineStarts, endPos-1)
+
+		if mc := minCodePos[startLine]; mc != -1 && mc < startPos {
+			startLine++
+		}
+		if me := maxCodeEnd[endLine]; me != -1 && me > endPos {
+			endLine--
+		}
+		for l := startLine; l <= endLine; l++ {
+			if l >= 0 && l < nLines {
+				commentOnly[l+1] = true
+			}
+		}
+	}
+	return commentOnly
+}

--- a/internal/rules/max_lines/max_lines.md
+++ b/internal/rules/max_lines/max_lines.md
@@ -1,0 +1,87 @@
+# max-lines
+
+Enforce a maximum number of lines per file.
+
+## Rule Details
+
+Large files tend to do a lot of things and can make it hard to follow what's
+going on. This rule caps the number of lines in a file.
+
+With the `{ "max": 3 }` option:
+
+```json
+{
+  "rules": {
+    "max-lines": ["error", 3]
+  }
+}
+```
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+let a,
+    b,
+    c,
+    d;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+let a,
+    b,
+    c;
+```
+
+## Options
+
+This rule accepts a number (the maximum allowed) or an object with the
+following properties:
+
+- `max` (default `300`): the maximum number of lines allowed in a file.
+- `skipBlankLines` (default `false`): ignore lines made up purely of
+  whitespace.
+- `skipComments` (default `false`): ignore lines containing just comments
+  (a comment that shares a line with code does not exclude that line).
+
+### `skipBlankLines`
+
+```json
+{
+  "rules": {
+    "max-lines": ["error", { "max": 2, "skipBlankLines": true }]
+  }
+}
+```
+
+Examples of **correct** code with the above configuration:
+
+```javascript
+var a = 1;
+
+
+var b = 2;
+```
+
+### `skipComments`
+
+```json
+{
+  "rules": {
+    "max-lines": ["error", { "max": 2, "skipComments": true }]
+  }
+}
+```
+
+Examples of **correct** code with the above configuration:
+
+```javascript
+// a header comment
+var a = 1;
+var b = 2;
+```
+
+## Original Documentation
+
+- <https://eslint.org/docs/latest/rules/max-lines>

--- a/internal/rules/max_lines/max_lines_test.go
+++ b/internal/rules/max_lines/max_lines_test.go
@@ -1,0 +1,764 @@
+package max_lines
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestMaxLines exercises three overlapping test corpora in a single run:
+//
+//  1. ESLint parity — ports of cases from eslint/tests/lib/rules/max-lines.js,
+//     asserting identical line / column / endLine / endColumn / messageId.
+//  2. Additional edge cases (negative max, shebang, complex comment/code
+//     interactions, multi-byte column precision, ECMA line terminators).
+//  3. Differential-test corpus — 121 cases whose expected diagnostics were
+//     captured verbatim from real ESLint v9. Any divergence surfaces here.
+//
+// The three groups overlap; that is intentional redundancy — a regression in
+// any single dimension should fire in multiple subtests.
+func TestMaxLines(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&MaxLinesRule,
+		[]rule_tester.ValidTestCase{
+			// ============================================================
+			// 1. ESLint parity — mirrors tests/lib/rules/max-lines.js
+			// ============================================================
+			{Code: `var x;`},
+			{Code: "var xy;\nvar xy;"},
+			{Code: `A`, Options: 1},
+			{Code: "A\n", Options: 1},
+			{Code: "A\r", Options: 1},
+			{Code: "A\r\n", Options: 1},
+			{Code: "var xy;\nvar xy;", Options: 2},
+			{Code: "var xy;\nvar xy;\n", Options: 2},
+			{Code: "var xy;\nvar xy;", Options: map[string]interface{}{"max": 2}},
+			{
+				Code:    "// comment\n",
+				Options: map[string]interface{}{"max": 0, "skipComments": true},
+			},
+			{
+				Code:    "foo;\n /* comment */\n",
+				Options: map[string]interface{}{"max": 1, "skipComments": true},
+			},
+			{
+				Code: strings.Join([]string{
+					"//a single line comment",
+					"var xy;",
+					"var xy;",
+					" /* a multiline",
+					" really really",
+					" long comment*/ ",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+			},
+			{
+				Code: strings.Join([]string{
+					"var x; /* inline comment",
+					" spanning multiple lines */ var z;",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+			},
+			{
+				Code: strings.Join([]string{
+					"var x; /* inline comment",
+					" spanning multiple lines */",
+					"var z;",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+			},
+			{
+				Code:    strings.Join([]string{"var x;", "", "\t", "\t  ", "var y;"}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+			},
+			{
+				Code: strings.Join([]string{
+					"//a single line comment",
+					"var xy;",
+					" ",
+					"var xy;",
+					" ",
+					" /* a multiline",
+					" really really",
+					" long comment*/",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true, "skipBlankLines": true},
+			},
+
+			// ============================================================
+			// 2. Additional edge cases
+			// ============================================================
+
+			// --- ECMA line terminators ---
+			{Code: "var a;\u2028var b;\u2028var c;", Options: 3},
+			{Code: "var a;\u2029var b;\u2029var c;", Options: 3},
+			{Code: "a\nb\r\nc\rd", Options: 4},
+			{Code: "a\nb\u2028c\u2029d", Options: 4},
+
+			// --- Multi-byte source ---
+			{Code: "const 日本語 = 'テスト';\nconst 中文 = '测试';", Options: 2},
+			{Code: "var a = '🎉';\nvar b = '🎊';", Options: 2},
+
+			// --- Comment arrangements ---
+			{Code: "foo; /* a */ /* b */ bar;", Options: 1},
+			{
+				Code:    "var x; // hint\nvar y;",
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+			},
+			{
+				Code:    "/* line1\nline2\nline3 */",
+				Options: map[string]interface{}{"max": 0, "skipComments": true},
+			},
+			{
+				Code:    "/**/\nvar x;",
+				Options: map[string]interface{}{"max": 1, "skipComments": true},
+			},
+			{
+				Code:    "/**\n * doc\n */\nfunction f() { return 1; }",
+				Options: map[string]interface{}{"max": 1, "skipComments": true},
+			},
+			{
+				Code:    "// 🎉 celebrate\nvar x;\nvar y;",
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+			},
+			{
+				Code:    "var x;\n\t\n\v\n\f\nvar y;",
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+			},
+			{
+				Code:    "#!/usr/bin/env node\nvar x;\nvar y;",
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+			},
+			{
+				Code:    "#!/usr/bin/env node\n// regular\nvar x;",
+				Options: map[string]interface{}{"max": 1, "skipComments": true},
+			},
+			// BOM / NBSP on a line is "blank" per JS trim, unlike Go's
+			// strings.TrimSpace — uses utils.IsStrWhiteSpace for alignment.
+			{
+				Code:    "var x;\n\u00A0\u00A0\n\uFEFF\nvar y;",
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+			},
+
+			// --- Nested / realistic code shapes ---
+			{
+				Code:    "class Foo {\n  bar() {\n    return 1;\n  }\n}",
+				Options: 5,
+			},
+			{
+				Code:    "const fns = [\n  () => ({\n    run() { return 1; },\n  }),\n];",
+				Options: 5,
+			},
+			{Code: "var s = `a\nb\nc`;", Options: 3},
+			{
+				Code: strings.Join([]string{
+					"(function () {",
+					"  const x = 1;",
+					"  return x;",
+					"})();",
+				}, "\n"),
+				Options: 4,
+			},
+
+			// --- Options shapes ---
+			{Code: "var x;\nvar y;", Options: 10000},
+			{
+				Code:    strings.Repeat("var x;\n", 10),
+				Options: map[string]interface{}{},
+			},
+			{Code: "var x;\nvar y;", Options: []interface{}{2}},
+			{
+				Code:    "var x;\nvar y;",
+				Options: []interface{}{map[string]interface{}{"max": 2}},
+			},
+			{Code: "var x;\nvar y;", Options: []interface{}{}},
+
+			// ============================================================
+			// 3. Differential-test corpus (verified against ESLint v9)
+			// ============================================================
+			{Code: "", Options: []interface{}{map[string]interface{}{"max": 1}}}, // empty-max-1
+			{Code: "A", Options: []interface{}{map[string]interface{}{"max": 1}}},
+			{Code: "#!/usr/bin/env node", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "#!/usr/bin/env node\nvar x;\nvar y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipComments": true}}},
+			{Code: "#!/usr/bin/env node\n", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "// a", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "/* a */", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "/* line1\nline2\nline3 */", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "/**/\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "foo; /* a */ /* b */ bar;", Options: []interface{}{1}},
+			{Code: "var x;\n// trailing", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "// leading\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "/* a\nb */", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "var x;\n\t\n\v\n\f\nvar y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipBlankLines": true}}},
+			{Code: "var x;\n\u00a0\u00a0\nvar y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipBlankLines": true}}},
+			{Code: "\n\n\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipBlankLines": true}}},
+			{Code: "var x;\n\n\n", Options: []interface{}{map[string]interface{}{"max": 1, "skipBlankLines": true}}},
+			{Code: "const 日本語 = 1;\nconst 中文 = 2;", Options: []interface{}{2}},
+			{Code: "var a = '🎉';\nvar b = '🎊';", Options: []interface{}{2}},
+			{Code: "// 🎉 celebrate\nvar x;\nvar y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipComments": true}}},
+			{Code: "var s = `a\nb\nc`;", Options: []interface{}{3}},
+			{Code: "class Foo {\n  bar() {\n    return 1;\n  }\n}", Options: []interface{}{5}},
+			{Code: "const fns = [\n  () => ({\n    run() { return 1; },\n  }),\n];", Options: []interface{}{5}},
+			{Code: "(function () {\n  const x = 1;\n  return x;\n})();", Options: []interface{}{4}},
+			{Code: "\n\n\n", Options: []interface{}{map[string]interface{}{"max": 0, "skipBlankLines": true}}},
+			{Code: "var x;\nvar y;"},
+			{Code: "var x;\nvar y;", Options: []interface{}{map[string]interface{}{}}},
+			{Code: "// a\n// b\nvar x;", Options: []interface{}{map[string]interface{}{"skipComments": true}}},
+			{Code: "\n\nvar x;", Options: []interface{}{map[string]interface{}{"skipBlankLines": true}}},
+			{Code: "// a\n\n\n// b\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true, "skipBlankLines": true}}},
+			{Code: "var x;\n// comment", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "var x;\n// comment\n", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "var r = /abc/g;", Options: []interface{}{1}},
+			{Code: "a\n\rb", Options: []interface{}{3}},
+			{Code: "a\r\r\nb", Options: []interface{}{3}},
+			{Code: "var x;\nvar y;", Options: []interface{}{2}},
+			{Code: "var x;\n", Options: []interface{}{map[string]interface{}{"max": 1}}},
+			{Code: "\"use strict\";\nvar x;\nvar y;", Options: []interface{}{3}},
+			{Code: "var s = `${\n  a\n  + b\n}`;", Options: []interface{}{4}},
+			{Code: "var aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = 1;", Options: []interface{}{1}},
+			{Code: "\nvar x;\n// comment\n\n", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true, "skipBlankLines": true}}},
+			{Code: "// a\n// b\n// c\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "/* a */\n/* b */\n/* c */\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "/**\n * desc\n */\nfunction f() {}", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "var x;\n\t\t\t\nvar y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipBlankLines": true}}},
+			{Code: "var x;\n\n// c\n\nvar y;\n\n// d\n\nvar z;", Options: []interface{}{map[string]interface{}{"max": 3, "skipComments": true, "skipBlankLines": true}}},
+			{Code: "\uFEFF" + "var x;", Options: []interface{}{1}},
+			{Code: "\ufeff\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipBlankLines": true}}},
+			{Code: "var x;\r", Options: []interface{}{1}},
+			{Code: "var x;\u2028", Options: []interface{}{1}},
+			{Code: "var x;\u2029", Options: []interface{}{1}},
+			{Code: "#!/usr/bin/env -S node --harmony\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "//\n//\n//\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "var x;\u2028\u2028\u2028var y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipBlankLines": true}}},
+			{Code: "/// <reference path=\"foo\" />\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "a\rb", Options: []interface{}{2}},
+			{Code: "var x;\n// comment   \n", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "var x;\n/* a\n*/   ", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "var x;\nvar y;\nvar z;", Options: []interface{}{map[string]interface{}{"max": 300}}},
+			{Code: "a\r\n\rb", Options: []interface{}{3}},
+			{Code: "\n/* comment */\n", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true, "skipBlankLines": true}}},
+			{Code: "//", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "var x;\n\t\nvar y;", Options: []interface{}{map[string]interface{}{"max": 2, "skipBlankLines": true}}},
+			{Code: "var x;\nvar y;\nvar z;\nvar a;\nvar b;\nvar c;\nvar d;\nvar e;\nvar f;\nvar g;", Options: []interface{}{10}},
+			{Code: "// a\n// b\n// c", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "/* a\u2028b */", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}},
+			{Code: "/* a *//* b */\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "/* a */// b\nvar x;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}},
+			{Code: "const x = {\n  a: {\n    b: [\n      {\n        c: () => ({\n          d: 1,\n        }),\n      },\n    ],\n  },\n};", Options: []interface{}{11}},
+			{Code: "var x;"},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ============================================================
+			// 1. ESLint parity — mirrors tests/lib/rules/max-lines.js
+			// ============================================================
+			{
+				Code:    "var xyz;\nvar xyz;\nvar xyz;",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "/* a multiline comment\n that goes to many lines*/\nvar xy;\nvar xy;",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 4, EndColumn: 8},
+				},
+			},
+			{
+				Code:    "//a single line comment\nvar xy;\nvar xy;",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 8},
+				},
+			},
+			{
+				Code:    strings.Join([]string{"var x;", "", "", "", "var y;"}, "\n"),
+				Options: map[string]interface{}{"max": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 5, EndColumn: 7},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"//a single line comment",
+					"var xy;",
+					" ",
+					"var xy;",
+					" ",
+					" /* a multiline",
+					" really really",
+					" long comment*/",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 8, EndColumn: 16},
+				},
+			},
+			{
+				Code:    strings.Join([]string{"var x; // inline comment", "var y;", "var z;"}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var x; /* inline comment",
+					" spanning multiple lines */",
+					"var y;",
+					"var z;",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 7},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"//a single line comment",
+					"var xy;",
+					" ",
+					"var xy;",
+					" ",
+					" /* a multiline",
+					" really really",
+					" long comment*/",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 8, EndColumn: 16},
+				},
+			},
+			{
+				Code:    strings.TrimRight(strings.Repeat("AAAAAAAA\n", 301), " \t\n\r"),
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 301, Column: 1, EndLine: 301, EndColumn: 9},
+				},
+			},
+			{
+				Code:    "",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 1},
+				},
+			},
+			{
+				Code:    " ",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "\n",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "A",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "A\n",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "A\n ",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "A\n ",
+				Options: map[string]interface{}{"max": 1},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "A\n\n",
+				Options: map[string]interface{}{"max": 1},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code:    strings.Join([]string{"var a = 'a'; ", "var x", "var c;", "console.log"}, "\n"),
+				Options: map[string]interface{}{"max": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 4, EndColumn: 12},
+				},
+			},
+			{
+				Code:    "var a = 'a',\nc,\nx;\r",
+				Options: map[string]interface{}{"max": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 4, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "var a = 'a',\nc,\nx;\n",
+				Options: map[string]interface{}{"max": 2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 4, EndColumn: 1},
+				},
+			},
+			{
+				Code:    "\n\nvar a = 'a',\nc,\nx;\n",
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 5, Column: 1, EndLine: 6, EndColumn: 1},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"var x",
+					"var c;",
+					"console.log",
+					"// some block ",
+					"// comments",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 6, EndColumn: 12},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"var x",
+					"var c;",
+					"console.log",
+					"/* block comments */",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 5, EndColumn: 21},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"var x",
+					"var c;",
+					"console.log",
+					"/* block comments */\n",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 6, EndColumn: 1},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"var x",
+					"var c;",
+					"console.log",
+					"/** block \n\n comments */",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 7, EndColumn: 13},
+				},
+			},
+			{
+				Code:    strings.Join([]string{"var a = 'a'; ", "", "", "// comment"}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 4, EndColumn: 11},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"var x",
+					"\n",
+					"var c;",
+					"console.log",
+					"\n",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 5, Column: 1, EndLine: 8, EndColumn: 1},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"\n",
+					"var x",
+					"var c;",
+					"console.log",
+					"\n",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipBlankLines": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 5, Column: 1, EndLine: 8, EndColumn: 1},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"var a = 'a'; ",
+					"//",
+					"var x",
+					"var c;",
+					"console.log",
+					"//",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 6, EndColumn: 3},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"// hello world",
+					"/*hello",
+					" world 2 */",
+					"var a,",
+					"b",
+					"// hh",
+					"c,",
+					"e,",
+					"f;",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 7, Column: 1, EndLine: 9, EndColumn: 3},
+				},
+			},
+			{
+				Code: strings.Join([]string{
+					"",
+					"var x = '';",
+					"",
+					"// comment",
+					"",
+					"var b = '',",
+					"c,",
+					"d,",
+					"e",
+					"",
+					"// comment",
+				}, "\n"),
+				Options: map[string]interface{}{"max": 2, "skipComments": true, "skipBlankLines": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 7, Column: 1, EndLine: 11, EndColumn: 11},
+				},
+			},
+
+			// ============================================================
+			// 2. Additional edge cases
+			// ============================================================
+
+			// --- ECMA line terminators over limit ---
+			{
+				Code:    "var a;\u2028var b;\u2028var c;",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "var a;\u2029var b;\u2029var c;",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "a\nb\r\nc\rd",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "a\nb\u2028c\u2029d",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 2},
+				},
+			},
+
+			// --- Multi-byte content: end column uses UTF-16 units ---
+			{
+				Code:    "const 日本語 = '1';\nconst b = '🎉';\nconst c = '3';",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 15},
+				},
+			},
+
+			// --- Template literal counts physical lines ---
+			{
+				Code:    "var s = `a\nb\nc\nd`;",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 4},
+				},
+			},
+
+			// --- Nested code shapes ---
+			{
+				Code:    "class Foo {\n  bar() {\n    return 1;\n  }\n}",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 5, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "const fns = [\n  () => 1,\n  () => 2,\n  () => 3,\n];",
+				Options: 3,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 5, EndColumn: 3},
+				},
+			},
+
+			// --- Comment interactions ---
+			{
+				Code:    "foo; /* a */ /* b */ bar;\nbar;\nbaz;",
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 5},
+				},
+			},
+			{
+				Code:    "/**/ var x;\nvar y;\nvar z;",
+				Options: map[string]interface{}{"max": 2, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "/* line1\nline2\nline3 */",
+				Options: map[string]interface{}{"max": 0},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 3, EndColumn: 9},
+				},
+			},
+
+			// --- Blank line handling without skipBlankLines ---
+			{
+				Code:    "var a;\n\n\n\n\n\n\n\nvar b;\nvar c;",
+				Options: map[string]interface{}{"max": 3},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 4, Column: 1, EndLine: 10, EndColumn: 7},
+				},
+			},
+
+			// --- Option shapes for invalid cases ---
+			{
+				Code:    "var a;\nvar b;\nvar c;",
+				Options: []interface{}{2},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			{
+				Code:    "var a;\nvar b;\nvar c;",
+				Options: []interface{}{map[string]interface{}{"max": 2}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			// Defensive: negative max is treated like 0 rather than crashing.
+			{
+				Code:    "var a;",
+				Options: map[string]interface{}{"max": -1},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// Hashbang without skipComments counts toward the limit.
+			{
+				Code:    "#!/usr/bin/env node\nvar x;\nvar y;",
+				Options: 2,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+			// Hashbang + skipComments: line 1 filtered, remaining still exceeds.
+			{
+				Code:    "#!/usr/bin/env node\nvar x;\nvar y;",
+				Options: map[string]interface{}{"max": 1, "skipComments": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7},
+				},
+			},
+
+			// ============================================================
+			// 3. Differential-test corpus (verified against ESLint v9)
+			// ============================================================
+			{Code: "", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 1}}},
+			{Code: " ", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 2}}},
+			{Code: "\n", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1}}},
+			{Code: "\r", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1}}},
+			{Code: "\r\n", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1}}},
+			{Code: "\u2028", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1}}},
+			{Code: "\u2029", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 1}}},
+			{Code: "\n\n", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 3, EndColumn: 1}}},
+			{Code: "A", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 2}}},
+			{Code: "var a;\nvar b;\nvar c;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "var a;\rvar b;\rvar c;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "var a;\r\nvar b;\r\nvar c;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "var a;\u2028var b;\u2028var c;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "var a;\u2029var b;\u2029var c;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "a\nb\r\nc\rd", Options: []interface{}{3}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 2}}},
+			{Code: "a\nb\u2028c\u2029d", Options: []interface{}{3}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 2}}},
+			{Code: "#!/usr/bin/env node", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 20}}},
+			{Code: "#!/usr/bin/env node\nvar x;\nvar y;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "#!/usr/bin/env node\n// other\nvar x;", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "// a", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* line1\nline2\nline3 */", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 3, EndColumn: 9}}},
+			{Code: "/* a */ // b\nvar x;", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 7}}},
+			{Code: "foo; /* a */ /* b */ bar;\nbar;\nbaz;", Options: []interface{}{map[string]interface{}{"max": 2, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 5}}},
+			{Code: "var x; // tail\nvar y;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 7}}},
+			{Code: "a /* b\nc */", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 5}}},
+			{Code: "/* a\nb */ c", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 7}}},
+			{Code: "a /* b\nc */ d", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 2, EndColumn: 7}}},
+			{Code: "const 日本語 = '1';\nconst b = '🎉';\nconst c = '3';", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 15}}},
+			{Code: "var s = `a\nb\nc\nd`;", Options: []interface{}{3}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 4}}},
+			{Code: "class Foo {\n  bar() {\n    return 1;\n  }\n}", Options: []interface{}{3}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 4, Column: 1, EndLine: 5, EndColumn: 2}}},
+			{Code: "/* line1\nline2\nline3 */", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 3, EndColumn: 9}}},
+			{Code: "// a\n\n\n// b\nvar x;", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true, "skipBlankLines": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 5, Column: 1, EndLine: 5, EndColumn: 7}}},
+			{Code: "/* a */ var x;\nvar y;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 7}}},
+			{Code: "var x; /* a */\nvar y;", Options: []interface{}{map[string]interface{}{"max": 1, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 7}}},
+			{Code: "a\n\rb", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 2}}},
+			{Code: "a\r\r\nb", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 2}}},
+			{Code: "var x;\nvar y;\nvar z;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "\"use strict\";\nvar x;\nvar y;", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 7}}},
+			{Code: "var s = `${\n  a\n  + b\n}`;", Options: []interface{}{3}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 4, Column: 1, EndLine: 4, EndColumn: 4}}},
+			{Code: "var aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa = 1;", Options: []interface{}{0}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 62}}},
+			{Code: "a\rb", Options: []interface{}{1}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 2}}},
+			{Code: "a\r\n\rb", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 2}}},
+			{Code: "a\r\n\nb", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 2}}},
+			{Code: "\n/* comment */\n", Options: []interface{}{map[string]interface{}{"max": 0, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 3, EndColumn: 1}}},
+			{Code: "//", Options: []interface{}{map[string]interface{}{"max": 0}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 1, Column: 1, EndLine: 1, EndColumn: 3}}},
+			{Code: "var x;\nvar y;\nvar z;\nvar a;\nvar b;\nvar c;\nvar d;\nvar e;\nvar f;\nvar g;", Options: []interface{}{9}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 10, Column: 1, EndLine: 10, EndColumn: 7}}},
+			{Code: "var x; // a\nvar y; // b\nvar z; // c", Options: []interface{}{map[string]interface{}{"max": 2, "skipComments": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 12}}},
+			{Code: "var s = '\u2028';", Options: []interface{}{1}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 3}}},
+			{Code: "var s = '\u2028';", Options: []interface{}{map[string]interface{}{"max": 1, "skipBlankLines": true}}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 2, Column: 1, EndLine: 2, EndColumn: 3}}},
+			{Code: "var x;\nvar y;\nvar z = '日';", Options: []interface{}{2}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 3, Column: 1, EndLine: 3, EndColumn: 13}}},
+			{Code: "const x = {\n  a: {\n    b: [\n      {\n        c: () => ({\n          d: 1,\n        }),\n      },\n    ],\n  },\n};", Options: []interface{}{5}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "exceed", Line: 6, Column: 1, EndLine: 11, EndColumn: 3}}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -265,6 +265,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unmodified-loop-condition.test.ts',
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-bitwise.test.ts',
+    './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-lines.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/max-lines.test.ts.snap
@@ -1,0 +1,1217 @@
+// Rstest Snapshot v1
+
+exports[`max-lines > invalid 1`] = `
+{
+  "code": "var xyz;
+var xyz;
+var xyz;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 2`] = `
+{
+  "code": "/* a multiline comment
+ that goes to many lines*/
+var xy;
+var xy;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 3`] = `
+{
+  "code": "//a single line comment
+var xy;
+var xy;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 4`] = `
+{
+  "code": "var x;
+
+
+
+var y;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (5). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 5`] = `
+{
+  "code": "//a single line comment
+var xy;
+ 
+var xy;
+ 
+ /* a multiline
+ really really
+ long comment*/",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 6`] = `
+{
+  "code": "var x; // inline comment
+var y;
+var z;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 7`] = `
+{
+  "code": "var x; /* inline comment
+ spanning multiple lines */
+var y;
+var z;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 8`] = `
+{
+  "code": "//a single line comment
+var xy;
+ 
+var xy;
+ 
+ /* a multiline
+ really really
+ long comment*/",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (6). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 9`] = `
+{
+  "code": "AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA
+AAAAAAAA",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (301). Maximum allowed is 300.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 301,
+        },
+        "start": {
+          "column": 1,
+          "line": 301,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 10`] = `
+{
+  "code": "",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 11`] = `
+{
+  "code": " ",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 12`] = `
+{
+  "code": "
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 13`] = `
+{
+  "code": "A",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 14`] = `
+{
+  "code": "A
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (1). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 15`] = `
+{
+  "code": "A
+ ",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (2). Maximum allowed is 0.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 16`] = `
+{
+  "code": "A
+ ",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 17`] = `
+{
+  "code": "A
+
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (2). Maximum allowed is 1.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 18`] = `
+{
+  "code": "var a = 'a'; 
+var x
+var c;
+console.log",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 19`] = `
+{
+  "code": "var a = 'a',
+c,
+x;
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 20`] = `
+{
+  "code": "var a = 'a',
+c,
+x;
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 21`] = `
+{
+  "code": "
+
+var a = 'a',
+c,
+x;
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 22`] = `
+{
+  "code": "var a = 'a'; 
+var x
+var c;
+console.log
+// some block 
+// comments",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 23`] = `
+{
+  "code": "var a = 'a'; 
+var x
+var c;
+console.log
+/* block comments */",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 24`] = `
+{
+  "code": "var a = 'a'; 
+var x
+var c;
+console.log
+/* block comments */
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 25`] = `
+{
+  "code": "var a = 'a'; 
+var x
+var c;
+console.log
+/** block 
+
+ comments */",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 7,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 26`] = `
+{
+  "code": "var a = 'a'; 
+
+
+// comment",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (3). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 27`] = `
+{
+  "code": "var a = 'a'; 
+var x
+
+
+var c;
+console.log
+
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 28`] = `
+{
+  "code": "var a = 'a'; 
+
+
+var x
+var c;
+console.log
+
+",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 8,
+        },
+        "start": {
+          "column": 1,
+          "line": 5,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 29`] = `
+{
+  "code": "var a = 'a'; 
+//
+var x
+var c;
+console.log
+//",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (4). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 30`] = `
+{
+  "code": "// hello world
+/*hello
+ world 2 */
+var a,
+b
+// hh
+c,
+e,
+f;",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (5). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 9,
+        },
+        "start": {
+          "column": 1,
+          "line": 7,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`max-lines > invalid 31`] = `
+{
+  "code": "
+var x = '';
+
+// comment
+
+var b = '',
+c,
+d,
+e
+
+// comment",
+  "diagnostics": [
+    {
+      "message": "File has too many lines (5). Maximum allowed is 2.",
+      "messageId": "exceed",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 11,
+        },
+        "start": {
+          "column": 1,
+          "line": 7,
+        },
+      },
+      "ruleName": "max-lines",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/max-lines.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/max-lines.test.ts
@@ -1,0 +1,564 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('max-lines', {
+  valid: [
+    'var x;',
+    'var xy;\nvar xy;',
+    { code: 'A', options: [1] as any },
+    { code: 'A\n', options: [1] as any },
+    { code: 'A\r', options: [1] as any },
+    { code: 'A\r\n', options: [1] as any },
+    { code: 'var xy;\nvar xy;', options: [2] as any },
+    { code: 'var xy;\nvar xy;\n', options: [2] as any },
+    { code: 'var xy;\nvar xy;', options: [{ max: 2 }] as any },
+    {
+      code: '// comment\n',
+      options: [{ max: 0, skipComments: true }] as any,
+    },
+    {
+      code: 'foo;\n /* comment */\n',
+      options: [{ max: 1, skipComments: true }] as any,
+    },
+    {
+      code: [
+        '//a single line comment',
+        'var xy;',
+        'var xy;',
+        ' /* a multiline',
+        ' really really',
+        ' long comment*/ ',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+    },
+    {
+      code: [
+        'var x; /* inline comment',
+        ' spanning multiple lines */ var z;',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+    },
+    {
+      code: [
+        'var x; /* inline comment',
+        ' spanning multiple lines */',
+        'var z;',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+    },
+    {
+      code: ['var x;', '', '\t', '\t  ', 'var y;'].join('\n'),
+      options: [{ max: 2, skipBlankLines: true }] as any,
+    },
+    {
+      code: [
+        '//a single line comment',
+        'var xy;',
+        ' ',
+        'var xy;',
+        ' ',
+        ' /* a multiline',
+        ' really really',
+        ' long comment*/',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true, skipBlankLines: true }] as any,
+    },
+  ],
+  invalid: [
+    {
+      code: 'var xyz;\nvar xyz;\nvar xyz;',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 9,
+        },
+      ],
+    },
+    {
+      code: '/* a multiline comment\n that goes to many lines*/\nvar xy;\nvar xy;',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 4,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: '//a single line comment\nvar xy;\nvar xy;',
+      options: [2] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 8,
+        },
+      ],
+    },
+    {
+      code: ['var x;', '', '', '', 'var y;'].join('\n'),
+      options: [{ max: 2 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 5,
+          endColumn: 7,
+        },
+      ],
+    },
+    {
+      code: [
+        '//a single line comment',
+        'var xy;',
+        ' ',
+        'var xy;',
+        ' ',
+        ' /* a multiline',
+        ' really really',
+        ' long comment*/',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 4,
+          column: 1,
+          endLine: 8,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: ['var x; // inline comment', 'var y;', 'var z;'].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 3,
+          endColumn: 7,
+        },
+      ],
+    },
+    {
+      code: [
+        'var x; /* inline comment',
+        ' spanning multiple lines */',
+        'var y;',
+        'var z;',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 7,
+        },
+      ],
+    },
+    {
+      code: [
+        '//a single line comment',
+        'var xy;',
+        ' ',
+        'var xy;',
+        ' ',
+        ' /* a multiline',
+        ' really really',
+        ' long comment*/',
+      ].join('\n'),
+      options: [{ max: 2, skipBlankLines: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 4,
+          column: 1,
+          endLine: 8,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: 'AAAAAAAA\n'.repeat(301).trim(),
+      options: [{}] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 301,
+          column: 1,
+          endLine: 301,
+          endColumn: 9,
+        },
+      ],
+    },
+    {
+      code: '',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: ' ',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      code: '\n',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'A',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      code: 'A\n',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: 'A\n ',
+      options: [{ max: 0 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      code: 'A\n ',
+      options: [{ max: 1 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 2,
+        },
+      ],
+    },
+    {
+      code: 'A\n\n',
+      options: [{ max: 1 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 2,
+          column: 1,
+          endLine: 3,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: ["var a = 'a'; ", 'var x', 'var c;', 'console.log'].join('\n'),
+      options: [{ max: 2 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 4,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: "var a = 'a',\nc,\nx;\r",
+      options: [{ max: 2 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 4,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: "var a = 'a',\nc,\nx;\n",
+      options: [{ max: 2 }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 4,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: "\n\nvar a = 'a',\nc,\nx;\n",
+      options: [{ max: 2, skipBlankLines: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 5,
+          column: 1,
+          endLine: 6,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        'var x',
+        'var c;',
+        'console.log',
+        '// some block ',
+        '// comments',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 6,
+          endColumn: 12,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        'var x',
+        'var c;',
+        'console.log',
+        '/* block comments */',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 5,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        'var x',
+        'var c;',
+        'console.log',
+        '/* block comments */\n',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 6,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        'var x',
+        'var c;',
+        'console.log',
+        '/** block \n\n comments */',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 7,
+          endColumn: 13,
+        },
+      ],
+    },
+    {
+      code: ["var a = 'a'; ", '', '', '// comment'].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 3,
+          column: 1,
+          endLine: 4,
+          endColumn: 11,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        'var x',
+        '\n',
+        'var c;',
+        'console.log',
+        '\n',
+      ].join('\n'),
+      options: [{ max: 2, skipBlankLines: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 5,
+          column: 1,
+          endLine: 8,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        '\n',
+        'var x',
+        'var c;',
+        'console.log',
+        '\n',
+      ].join('\n'),
+      options: [{ max: 2, skipBlankLines: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 5,
+          column: 1,
+          endLine: 8,
+          endColumn: 1,
+        },
+      ],
+    },
+    {
+      code: [
+        "var a = 'a'; ",
+        '//',
+        'var x',
+        'var c;',
+        'console.log',
+        '//',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 4,
+          column: 1,
+          endLine: 6,
+          endColumn: 3,
+        },
+      ],
+    },
+    {
+      code: [
+        '// hello world',
+        '/*hello',
+        ' world 2 */',
+        'var a,',
+        'b',
+        '// hh',
+        'c,',
+        'e,',
+        'f;',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 7,
+          column: 1,
+          endLine: 9,
+          endColumn: 3,
+        },
+      ],
+    },
+    {
+      code: [
+        '',
+        "var x = '';",
+        '',
+        '// comment',
+        '',
+        "var b = '',",
+        'c,',
+        'd,',
+        'e',
+        '',
+        '// comment',
+      ].join('\n'),
+      options: [{ max: 2, skipComments: true, skipBlankLines: true }] as any,
+      errors: [
+        {
+          messageId: 'exceed',
+          line: 7,
+          column: 1,
+          endLine: 11,
+          endColumn: 11,
+        },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -186,6 +186,8 @@ unrooted
 unstrict
 unstub
 untest
+subtests
+FEFF
 Unwatch
 unwinded
 USERPROFILE


### PR DESCRIPTION
## Summary

Port the `max-lines` rule from ESLint to rslint.

Enforces a maximum number of lines per file, matching ESLint's behavior on all three options (`max`, `skipComments`, `skipBlankLines`). Validated byte-for-byte against ESLint via differential testing on 121 synthetic edge cases plus 84 real-world diagnostics in `web-infra-dev/rsbuild` and `web-infra-dev/rspack`.

Implementation notes:
- Line counting uses `scanner.GetECMALineStarts` (splits on LF / CR / CRLF / LS / PS) to match ESLint's `sourceCode.lines` semantics exactly, including the trailing-empty-line pop when the file ends with a line terminator.
- Comment-only line detection mirrors ESLint's `getLinesWithoutCode` via per-line min/max code positions; equivalent to the token walk but does not depend on ESTree token iteration.
- Hashbang (`#!`) is synthesized into the comments list because `tsgo`'s `ForEachComment` skips past it — otherwise `skipComments` would diverge from ESLint for CLI scripts.
- `skipBlankLines` uses `utils.IsStrWhiteSpace` (ECMA WhiteSpace + LineTerminator, including BOM) rather than `strings.TrimSpace`, matching JavaScript's `String.prototype.trim()`.
- Negative `max` is defensively clamped to 0 to avoid panics on out-of-schema input.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/max-lines
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/max-lines.js
- Test file: https://github.com/eslint/eslint/blob/main/tests/lib/rules/max-lines.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).