### PR TITLE
feat: port rule accessor-pairs

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,6 +109,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/unified_signatures"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/use_unknown_in_catch_callback_variable"
 	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/rules/accessor_pairs"
 	"github.com/web-infra-dev/rslint/internal/rules/array_callback_return"
 	"github.com/web-infra-dev/rslint/internal/rules/constructor_super"
 	"github.com/web-infra-dev/rslint/internal/rules/default_case"
@@ -517,6 +518,7 @@ func registerAllEslintImportPluginRules() {
 
 // registerAllCoreEslintRules registers core ESLint rules
 func registerAllCoreEslintRules() {
+	GlobalRuleRegistry.Register("accessor-pairs", accessor_pairs.AccessorPairsRule)
 	GlobalRuleRegistry.Register("array-callback-return", array_callback_return.ArrayCallbackReturnRule)
 	GlobalRuleRegistry.Register("constructor-super", constructor_super.ConstructorSuperRule)
 	GlobalRuleRegistry.Register("default-case", default_case.DefaultCaseRule)

--- a/internal/rule_tester/rule_tester.go
+++ b/internal/rule_tester/rule_tester.go
@@ -31,7 +31,10 @@ type ValidTestCase struct {
 }
 
 type InvalidTestCaseError struct {
-	MessageId   string                      `json:"messageId"`
+	MessageId string `json:"messageId"`
+	// Message, if non-empty, must match the diagnostic's formatted message
+	// exactly. Leave empty to skip the text assertion.
+	Message     string                      `json:"message,omitempty"`
 	Line        int                         `json:"line"`
 	Column      int                         `json:"column"`
 	EndLine     int                         `json:"endLine"`
@@ -244,6 +247,10 @@ func RunRuleTester(rootDir string, tsconfigPath string, t *testing.T, r *rule.Ru
 
 				if expected.MessageId != diagnostic.Message.Id {
 					t.Errorf("Invalid message id %v. Expected %v", diagnostic.Message.Id, expected.MessageId)
+				}
+
+				if expected.Message != "" && expected.Message != diagnostic.Message.Description {
+					t.Errorf("Invalid message text %q. Expected %q", diagnostic.Message.Description, expected.Message)
 				}
 
 				lineIndex, columnIndex := scanner.GetECMALineAndUTF16CharacterOfPosition(diagnostic.SourceFile, diagnostic.Range.Pos())

--- a/internal/rules/accessor_pairs/accessor_pairs.go
+++ b/internal/rules/accessor_pairs/accessor_pairs.go
@@ -1,0 +1,426 @@
+package accessor_pairs
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type Options struct {
+	GetWithoutSet          bool
+	SetWithoutGet          bool
+	EnforceForClassMembers bool
+	EnforceForTSTypes      bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{
+		GetWithoutSet:          false,
+		SetWithoutGet:          true,
+		EnforceForClassMembers: true,
+		EnforceForTSTypes:      false,
+	}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["getWithoutSet"].(bool); ok {
+			opts.GetWithoutSet = v
+		}
+		if v, ok := optsMap["setWithoutGet"].(bool); ok {
+			opts.SetWithoutGet = v
+		}
+		if v, ok := optsMap["enforceForClassMembers"].(bool); ok {
+			opts.EnforceForClassMembers = v
+		}
+		if v, ok := optsMap["enforceForTSTypes"].(bool); ok {
+			opts.EnforceForTSTypes = v
+		}
+	}
+	return opts
+}
+
+type containerKind int
+
+const (
+	containerObjectLiteral containerKind = iota
+	containerClass
+	containerType
+)
+
+// keyKind distinguishes how an accessor's key is compared. A static key never
+// matches a private or dynamic key even when their textual forms coincide —
+// mirroring ESLint's three-way split between `getStaticPropertyName`, the
+// single-token list of a `PrivateIdentifier`, and the token-list comparison
+// of an arbitrary computed expression.
+type keyKind int
+
+const (
+	keyStatic  keyKind = iota // identifier / string / numeric / bigint / computed-with-literal
+	keyPrivate                // `#name` — distinct equivalence class from string `'#name'`
+	keyDynamic                // non-static computed expression — compared structurally
+)
+
+type accessorKey struct {
+	kind keyKind
+	// For keyStatic: the normalized name (e.g. `"100"` for `1e2`, `"a"` for `'a'`).
+	// For keyPrivate: the private-identifier text (already includes `#`).
+	// Unused for keyDynamic.
+	text string
+	// For keyDynamic: the computed expression, already unwrapped with
+	// [ast.SkipParentheses]. nil for keyStatic / keyPrivate.
+	expr *ast.Node
+}
+
+type accessorGroup struct {
+	key      accessorKey
+	isStatic bool
+	getters  []*ast.Node
+	setters  []*ast.Node
+}
+
+// makeKey derives a comparable key for an accessor.
+//   - Static-resolvable names (identifier, string / numeric / bigint literal,
+//     or a computed expression whose value is one of those literals) collapse
+//     into `keyStatic` and are compared by their normalized text — so
+//     `a`, `'a'`, `['a']`, and `` [`a`] `` all group together, and `1e2`
+//     matches `100` / `'100'` / `['100']`.
+//   - `PrivateIdentifier` keys (`#a`) form their own `keyPrivate` class,
+//     separate from a string key `'#a'`.
+//   - Everything else is `keyDynamic`, compared structurally via
+//     [utils.AreNodesStructurallyEqual] — so `[a + b]` and `[a+b]` match
+//     (whitespace is not part of the AST) while `[a + b]` and `[a - b]` do
+//     not, and `[a.b]` and `[a?.b]` do not.
+func makeKey(node *ast.Node) accessorKey {
+	nameNode := node.Name()
+	if nameNode == nil {
+		return accessorKey{kind: keyDynamic}
+	}
+	if nameNode.Kind == ast.KindPrivateIdentifier {
+		return accessorKey{kind: keyPrivate, text: nameNode.AsPrivateIdentifier().Text}
+	}
+	if name, ok := utils.GetStaticPropertyName(nameNode); ok {
+		return accessorKey{kind: keyStatic, text: name}
+	}
+	expr := nameNode
+	if nameNode.Kind == ast.KindComputedPropertyName {
+		expr = nameNode.AsComputedPropertyName().Expression
+	}
+	return accessorKey{kind: keyDynamic, expr: ast.SkipParentheses(expr)}
+}
+
+func keysEqual(sf *ast.SourceFile, a, b accessorKey) bool {
+	if a.kind != b.kind {
+		return false
+	}
+	switch a.kind {
+	case keyStatic, keyPrivate:
+		return a.text == b.text
+	case keyDynamic:
+		return computedKeysEqual(sf, a.expr, b.expr)
+	}
+	return false
+}
+
+// computedKeysEqual reports whether two computed-key expressions are
+// structurally equivalent, mirroring ESLint's token-level comparison
+// (`sourceCode.getTokens(node.key)` with `areEqualTokenLists`). Unlike
+// the general-purpose [utils.AreNodesStructurallyEqual] — which treats
+// `0x1` and `1` as the same number — this walker goes through
+// [scanner.GetSourceTextOfNodeFromSourceFile] for numeric and bigint
+// literals so their raw source form is compared, keeping parity with
+// ESLint even when tsgo's parser normalizes literal texts.
+//
+// Parentheses are transparent at every level (matching ESLint, whose
+// ESTree parser elides parens entirely). All other kinds compare by
+// their Kind plus, for leaves, the text stored on the AST node; for
+// composite nodes, by the ordered list of non-nil children returned
+// from [ast.Node.ForEachChild].
+func computedKeysEqual(sf *ast.SourceFile, a, b *ast.Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	a = ast.SkipParentheses(a)
+	b = ast.SkipParentheses(b)
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case ast.KindIdentifier:
+		return a.AsIdentifier().Text == b.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return a.AsPrivateIdentifier().Text == b.AsPrivateIdentifier().Text
+	case ast.KindStringLiteral:
+		return a.AsStringLiteral().Text == b.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return a.AsNoSubstitutionTemplateLiteral().Text == b.AsNoSubstitutionTemplateLiteral().Text
+	case ast.KindTemplateHead, ast.KindTemplateMiddle, ast.KindTemplateTail,
+		ast.KindRegularExpressionLiteral:
+		return a.Text() == b.Text()
+	case ast.KindNumericLiteral, ast.KindBigIntLiteral:
+		return scanner.GetSourceTextOfNodeFromSourceFile(sf, a, false) ==
+			scanner.GetSourceTextOfNodeFromSourceFile(sf, b, false)
+	}
+	var aKids, bKids []*ast.Node
+	a.ForEachChild(func(c *ast.Node) bool {
+		aKids = append(aKids, c)
+		return false
+	})
+	b.ForEachChild(func(c *ast.Node) bool {
+		bKids = append(bKids, c)
+		return false
+	})
+	if len(aKids) != len(bKids) {
+		return false
+	}
+	for i := range aKids {
+		if !computedKeysEqual(sf, aKids[i], bKids[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// checkList examines accessors in a list and reports any that lack a pair.
+// For class containers, `distinguishStatic` should be true — static and
+// instance members with the same name are independent pairs, and grouping
+// by (name, isStatic) preserves source order of the final reports.
+func checkList(ctx rule.RuleContext, members []*ast.Node, opts Options, kind containerKind, distinguishStatic bool) {
+	var groups []*accessorGroup
+
+	for _, m := range members {
+		isGetter := m.Kind == ast.KindGetAccessor
+		isSetter := m.Kind == ast.KindSetAccessor
+		if !isGetter && !isSetter {
+			continue
+		}
+		key := makeKey(m)
+		isStatic := distinguishStatic && ast.IsStatic(m)
+		var group *accessorGroup
+		for _, g := range groups {
+			if g.isStatic == isStatic && keysEqual(ctx.SourceFile, g.key, key) {
+				group = g
+				break
+			}
+		}
+		if group == nil {
+			group = &accessorGroup{key: key, isStatic: isStatic}
+			groups = append(groups, group)
+		}
+		if isGetter {
+			group.getters = append(group.getters, m)
+		} else {
+			group.setters = append(group.setters, m)
+		}
+	}
+
+	for _, g := range groups {
+		if opts.SetWithoutGet && len(g.setters) > 0 && len(g.getters) == 0 {
+			for _, s := range g.setters {
+				reportAccessor(ctx, s, kind, "Getter")
+			}
+		}
+		if opts.GetWithoutSet && len(g.getters) > 0 && len(g.setters) == 0 {
+			for _, g2 := range g.getters {
+				reportAccessor(ctx, g2, kind, "Setter")
+			}
+		}
+	}
+}
+
+// reportAccessor emits a diagnostic for an accessor that is missing its pair.
+// missingKind is "Getter" or "Setter" (the accessor that is absent); node is
+// the existing accessor whose counterpart is missing.
+func reportAccessor(ctx rule.RuleContext, node *ast.Node, container containerKind, missingKind string) {
+	existingKind := "setter"
+	if node.Kind == ast.KindGetAccessor {
+		existingKind = "getter"
+	}
+
+	var prefix string
+	switch container {
+	case containerClass:
+		prefix = "class "
+		if ast.IsStatic(node) {
+			prefix += "static "
+		}
+		nameNode := node.Name()
+		if nameNode != nil && nameNode.Kind == ast.KindPrivateIdentifier {
+			prefix += "private "
+		}
+	case containerType:
+		prefix = "type "
+	}
+
+	nameNode := node.Name()
+	var namePart string
+	if nameNode != nil {
+		if nameNode.Kind == ast.KindPrivateIdentifier {
+			// PrivateIdentifier.Text already includes the leading '#'; no quotes.
+			namePart = " " + nameNode.AsPrivateIdentifier().Text
+		} else if name, ok := utils.GetStaticPropertyName(nameNode); ok {
+			namePart = fmt.Sprintf(" '%s'", name)
+		}
+	}
+
+	var msgIdSuffix string
+	switch container {
+	case containerObjectLiteral:
+		msgIdSuffix = "ObjectLiteral"
+	case containerClass:
+		msgIdSuffix = "Class"
+	case containerType:
+		msgIdSuffix = "Type"
+	}
+
+	ctx.ReportRange(
+		utils.GetFunctionHeadLoc(ctx.SourceFile, node),
+		rule.RuleMessage{
+			Id:          fmt.Sprintf("missing%sIn%s", missingKind, msgIdSuffix),
+			Description: fmt.Sprintf("%s is not present for %s%s%s.", missingKind, prefix, existingKind, namePart),
+		},
+	)
+}
+
+// reportPropertyDescriptor emits a diagnostic for a property descriptor
+// object literal that declares only one of `get`/`set`.
+func reportPropertyDescriptor(ctx rule.RuleContext, node *ast.Node, missingKind string) {
+	ctx.ReportNode(node, rule.RuleMessage{
+		Id:          fmt.Sprintf("missing%sInPropertyDescriptor", missingKind),
+		Description: missingKind + " is not present in property descriptor.",
+	})
+}
+
+// isPropertyDescriptor reports whether an ObjectLiteralExpression sits in a
+// position that makes it a property descriptor.
+//
+// Recognized shapes:
+//   - `Object.defineProperty(obj, key, <here>)`
+//   - `Reflect.defineProperty(obj, key, <here>)`
+//   - `Object.defineProperties(obj, { foo: <here> })`
+//   - `Object.create(proto,           { foo: <here> })`
+func isPropertyDescriptor(node *ast.Node) bool {
+	if utils.IsArgumentOfSpecificCall(node, 2, "Object", "defineProperty") ||
+		utils.IsArgumentOfSpecificCall(node, 2, "Reflect", "defineProperty") {
+		return true
+	}
+	// Inner `{get/set: ...}` of a descriptor map: walk up to the outer
+	// ObjectLiteralExpression and check if IT is the arg[1] of create /
+	// defineProperties.
+	parent := node.Parent
+	if parent == nil || parent.Kind != ast.KindPropertyAssignment {
+		return false
+	}
+	grandparent := parent.Parent
+	if grandparent == nil || grandparent.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	return utils.IsArgumentOfSpecificCall(grandparent, 1, "Object", "create") ||
+		utils.IsArgumentOfSpecificCall(grandparent, 1, "Object", "defineProperties")
+}
+
+// checkObjectLiteral collects accessor properties and checks pairs.
+func checkObjectLiteral(ctx rule.RuleContext, node *ast.Node, opts Options) {
+	obj := node.AsObjectLiteralExpression()
+	if obj == nil || obj.Properties == nil {
+		return
+	}
+	checkList(ctx, obj.Properties.Nodes, opts, containerObjectLiteral, false)
+}
+
+// checkDescriptorObject reports when a property descriptor declares only
+// `get` or only `set`. Descriptors use regular value-position properties
+// (NOT getter / setter syntax), so accessor-kind entries are ignored. All
+// three "init" shapes with a non-computed identifier key contribute:
+//   - `{ set: fn }`        — PropertyAssignment
+//   - `{ set(v) {} }`      — MethodDeclaration (method shorthand)
+//   - `{ set }`            — ShorthandPropertyAssignment
+//
+// `{ "set": fn }` and `{ [set]: fn }` are NOT recognized (matches ESLint:
+// the string-keyed and computed forms require `!p.computed && key.name`).
+func checkDescriptorObject(ctx rule.RuleContext, node *ast.Node, opts Options) {
+	obj := node.AsObjectLiteralExpression()
+	if obj == nil || obj.Properties == nil {
+		return
+	}
+	names := map[string]bool{}
+	for _, p := range obj.Properties.Nodes {
+		switch p.Kind {
+		case ast.KindPropertyAssignment,
+			ast.KindMethodDeclaration,
+			ast.KindShorthandPropertyAssignment:
+			// fall through
+		default:
+			continue
+		}
+		nameNode := p.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			continue
+		}
+		names[nameNode.AsIdentifier().Text] = true
+	}
+	hasGet := names["get"]
+	hasSet := names["set"]
+	if opts.SetWithoutGet && hasSet && !hasGet {
+		reportPropertyDescriptor(ctx, node, "Getter")
+	}
+	if opts.GetWithoutSet && hasGet && !hasSet {
+		reportPropertyDescriptor(ctx, node, "Setter")
+	}
+}
+
+// checkClassBody examines class members. Static and instance members with
+// the same name form independent pairs, but we iterate in source order and
+// distinguish groups by (name, isStatic) so reports land in source order.
+func checkClassBody(ctx rule.RuleContext, node *ast.Node, opts Options) {
+	checkList(ctx, node.Members(), opts, containerClass, true)
+}
+
+// checkTypeMembers handles InterfaceDeclaration and TypeLiteral members.
+func checkTypeMembers(ctx rule.RuleContext, members []*ast.Node, opts Options) {
+	checkList(ctx, members, opts, containerType, false)
+}
+
+// https://eslint.org/docs/latest/rules/accessor-pairs
+var AccessorPairsRule = rule.Rule{
+	Name: "accessor-pairs",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		if !opts.SetWithoutGet && !opts.GetWithoutSet {
+			return rule.RuleListeners{}
+		}
+
+		listeners := rule.RuleListeners{
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				checkObjectLiteral(ctx, node, opts)
+				if isPropertyDescriptor(node) {
+					checkDescriptorObject(ctx, node, opts)
+				}
+			},
+		}
+
+		if opts.EnforceForClassMembers {
+			listeners[ast.KindClassDeclaration] = func(node *ast.Node) {
+				checkClassBody(ctx, node, opts)
+			}
+			listeners[ast.KindClassExpression] = func(node *ast.Node) {
+				checkClassBody(ctx, node, opts)
+			}
+		}
+
+		if opts.EnforceForTSTypes {
+			listeners[ast.KindInterfaceDeclaration] = func(node *ast.Node) {
+				checkTypeMembers(ctx, node.Members(), opts)
+			}
+			listeners[ast.KindTypeLiteral] = func(node *ast.Node) {
+				checkTypeMembers(ctx, node.Members(), opts)
+			}
+		}
+
+		return listeners
+	},
+}

--- a/internal/rules/accessor_pairs/accessor_pairs.md
+++ b/internal/rules/accessor_pairs/accessor_pairs.md
@@ -1,0 +1,52 @@
+# accessor-pairs
+
+Enforce getter and setter pairs in objects and classes.
+
+## Rule Details
+
+By default the rule flags setters declared without a matching getter. It can
+optionally flag getters declared without a matching setter, and also extends
+to class bodies and TypeScript type-literal / interface members.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const obj = {
+  set a(value) {
+    this.val = value;
+  },
+};
+
+const obj2 = { d: 1 };
+Object.defineProperty(obj2, 'c', {
+  set: function (value) {
+    this.val = value;
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const obj = {
+  set a(value) {
+    this.val = value;
+  },
+  get a() {
+    return this.val;
+  },
+};
+```
+
+## Options
+
+All options are boolean with the following defaults:
+
+- `setWithoutGet` (default `true`): report setters without a matching getter.
+- `getWithoutSet` (default `false`): report getters without a matching setter.
+- `enforceForClassMembers` (default `true`): apply to class declarations and expressions.
+- `enforceForTSTypes` (default `false`): apply to TypeScript type literals and interfaces.
+
+## Original Documentation
+
+- ESLint rule: https://eslint.org/docs/latest/rules/accessor-pairs

--- a/internal/rules/accessor_pairs/accessor_pairs_test.go
+++ b/internal/rules/accessor_pairs/accessor_pairs_test.go
@@ -1,0 +1,1683 @@
+package accessor_pairs
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestAccessorPairsRule(t *testing.T) {
+	bothOpts := map[string]interface{}{"setWithoutGet": true, "getWithoutSet": true}
+	setOnlyOpts := map[string]interface{}{"setWithoutGet": true, "getWithoutSet": false}
+	getOnlyOpts := map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true}
+	noneOpts := map[string]interface{}{"setWithoutGet": false, "getWithoutSet": false}
+	classBoth := map[string]interface{}{"setWithoutGet": true, "getWithoutSet": true, "enforceForClassMembers": true}
+	classOff := map[string]interface{}{"setWithoutGet": true, "getWithoutSet": true, "enforceForClassMembers": false}
+	tsOnly := map[string]interface{}{"enforceForTSTypes": true}
+	tsGetAlso := map[string]interface{}{"enforceForTSTypes": true, "getWithoutSet": true}
+
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&AccessorPairsRule,
+		[]rule_tester.ValidTestCase{
+			// Destructuring — not object literals semantically, not flagged
+			{Code: `var { get: foo } = bar; ({ set: foo } = bar);`, Options: bothOpts},
+			{Code: `var { set } = foo; ({ get } = foo);`, Options: bothOpts},
+
+			// Default: getWithoutSet=false, so lone getter is valid
+			{Code: `var o = { get a() {} }`},
+			{Code: `var o = { get a() {} }`, Options: map[string]interface{}{}},
+
+			// No accessors
+			{Code: `var o = {};`, Options: bothOpts},
+			{Code: `var o = { a: 1 };`, Options: bothOpts},
+			{Code: `var o = { a };`, Options: bothOpts},
+			{Code: `var o = { a: get };`, Options: bothOpts},
+			{Code: `var o = { a: set };`, Options: bothOpts},
+			{Code: `var o = { get: function(){} };`, Options: bothOpts},
+			{Code: `var o = { set: function(foo){} };`, Options: bothOpts},
+			{Code: `var o = { get };`, Options: bothOpts},
+			{Code: `var o = { set };`, Options: bothOpts},
+			{Code: `var o = { [get]: function() {} };`, Options: bothOpts},
+			{Code: `var o = { [set]: function(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get() {} };`, Options: bothOpts},
+			{Code: `var o = { set(foo) {} };`, Options: bothOpts},
+
+			// Both options disabled
+			{Code: `var o = { get a() {} };`, Options: noneOpts},
+			{Code: `var o = { set a(foo) {} };`, Options: noneOpts},
+			{Code: `var o = { get a() {} };`, Options: setOnlyOpts},
+			{Code: `var o = { set a(foo) {} };`, Options: getOnlyOpts},
+
+			// Valid pairs
+			{Code: `var o = { get a() {}, set a(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { set a(foo) {}, get a() {} };`, Options: bothOpts},
+			{Code: `var o = { get 'a'() {}, set 'a'(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, set 'a'(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get ['abc']() {}, set ['abc'](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [1e2]() {}, set 100(foo) {} };`, Options: bothOpts},
+			{Code: "var o = { get abc() {}, set [`abc`](foo) {} };", Options: bothOpts},
+			{Code: `var o = { get ['123']() {}, set 123(foo) {} };`, Options: bothOpts},
+
+			// Valid pairs with computed expressions (token-level equality)
+			{Code: `var o = { get [a]() {}, set [a](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [a]() {}, set [(a)](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [(a)]() {}, set [a](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [a]() {}, set [ a ](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [/*comment*/a/*comment*/]() {}, set [a](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [f()]() {}, set [f()](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [f(a)]() {}, set [f(a)](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [a + b]() {}, set [a + b](foo) {} };`, Options: bothOpts},
+			{Code: "var o = { get [`${a}`]() {}, set [`${a}`](foo) {} };", Options: bothOpts},
+
+			// Multiple valid pairs
+			{Code: `var o = { get a() {}, set a(foo) {}, get b() {}, set b(bar) {} };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, set c(foo) {}, set a(bar) {}, get b() {}, get c() {}, set b(baz) {} };`, Options: bothOpts},
+
+			// Valid pairs mixed with other elements
+			{Code: `var o = { get a() {}, set a(foo) {}, b: bar };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, b, set a(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, ...b, set a(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, set a(foo) {}, ...a };`, Options: bothOpts},
+
+			// Duplicate keys — each kind found → valid
+			{Code: `var o = { get a() {}, get a() {}, set a(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, set a(foo) {}, get a() {} };`, Options: bothOpts},
+			{Code: `var o = { get a() {}, get a() {} };`, Options: setOnlyOpts},
+			{Code: `var o = { set a(foo) {}, set a(foo) {} };`, Options: getOnlyOpts},
+			{Code: `var o = { get a() {}, set a(foo) {}, a };`, Options: bothOpts},
+			{Code: `var o = { a, get a() {}, set a(foo) {} };`, Options: bothOpts},
+
+			// Property descriptors — complete pairs or non-descriptor calls
+			{Code: "var o = {a: 1};\n Object.defineProperty(o, 'b', \n{set: function(value) {\n val = value; \n},\n get: function() {\n return val; \n} \n});"},
+			{Code: `var o = {set: function() {}}`},
+			{Code: `Object.defineProperties(obj, {set: {value: function() {}}});`},
+			{Code: `Object.create(null, {set: {value: function() {}}});`},
+			{Code: `var o = {get: function() {}}`, Options: map[string]interface{}{"getWithoutSet": true}},
+			{Code: `var o = {[set]: function() {}}`},
+			{Code: `var set = 'value'; Object.defineProperty(obj, 'foo', {[set]: function(value) {}});`},
+
+			// Classes — default (no errors without enforceForClassMembers or with options off)
+			{Code: `class A { get a() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class A { get #a() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class A { set a(foo) {} }`, Options: map[string]interface{}{"enforceForClassMembers": false}},
+			{Code: `class A { get a() {} set b(foo) {} static get c() {} static set d(bar) {} }`, Options: classOff},
+			{Code: `(class A { get a() {} set b(foo) {} static get c() {} static set d(bar) {} });`, Options: classOff},
+
+			// Class — individual options disabled
+			{Code: `class A { get a() {} }`, Options: map[string]interface{}{"setWithoutGet": true, "getWithoutSet": false, "enforceForClassMembers": true}},
+			{Code: `class A { set a(foo) {} }`, Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true}},
+			{Code: `class A { static get a() {} }`, Options: map[string]interface{}{"setWithoutGet": true, "getWithoutSet": false, "enforceForClassMembers": true}},
+			{Code: `class A { static set a(foo) {} }`, Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true}},
+			{Code: `A = class { set a(foo) {} };`, Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true}},
+			{Code: `class A { get a() {} set b(foo) {} static get c() {} static set d(bar) {} }`, Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": false, "enforceForClassMembers": true}},
+
+			// Class — no accessors
+			{Code: `class A {}`, Options: classBoth},
+			{Code: `(class {})`, Options: classBoth},
+			{Code: `class A { constructor () {} }`, Options: classBoth},
+			{Code: `class A { a() {} }`, Options: classBoth},
+			{Code: `class A { static a() {} 'b'() {} }`, Options: classBoth},
+			{Code: `class A { [a]() {} }`, Options: classBoth},
+			{Code: `A = class { a() {} static a() {} b() {} static c() {} }`, Options: classBoth},
+
+			// Class — valid pairs
+			{Code: `class A { get a() {} set a(foo) {} }`, Options: classBoth},
+			{Code: `class A { set a(foo) {} get a() {} }`, Options: classBoth},
+			{Code: `class A { static get a() {} static set a(foo) {} }`, Options: classBoth},
+			{Code: `class A { static set a(foo) {} static get a() {} }`, Options: classBoth},
+			{Code: `(class { set a(foo) {} get a() {} });`, Options: classBoth},
+			{Code: `class A { get 'a'() {} set ['a'](foo) {} }`, Options: classBoth},
+			{Code: "class A { set [`a`](foo) {} get a() {} }", Options: classBoth},
+			{Code: `class A { get 'a'() {} set a(foo) {} }`, Options: classBoth},
+			{Code: `A = class { static get 1e2() {} static set [100](foo) {} };`, Options: classBoth},
+			{Code: `class A { get [a]() {} set [a](foo) {} }`, Options: classBoth},
+			{Code: `A = class { set [(f())](foo) {} get [(f())]() {} };`, Options: classBoth},
+			{Code: `class A { static set [f(a)](foo) {} static get [f(a)]() {} }`, Options: classBoth},
+
+			// Multiple valid pairs in same class
+			{Code: `class A { get a() {} set b(foo) {} set a(bar) {} get b() {} }`, Options: classBoth},
+			{Code: `class A { get a() {} set a(bar) {} b() {} set c(foo) {} get c() {} }`, Options: classBoth},
+			{Code: `(class { get a() {} static set a(foo) {} set a(bar) {} static get a() {} });`, Options: classBoth},
+
+			// Class — valid mixed with other members
+			{Code: `class A { get a() {} b() {} set a(foo) {} }`, Options: classBoth},
+			{Code: `class A { set a(foo) {} get a() {} b() {} }`, Options: classBoth},
+			{Code: `class A { a() {} get b() {} c() {} set b(foo) {} d() {} }`, Options: classBoth},
+			{Code: `class A { get a() {} set a(foo) {} static a() {} }`, Options: classBoth},
+			{Code: `A = class { static get a() {} static b() {} static set a(foo) {} };`, Options: classBoth},
+			{Code: `A = class { static set a(foo) {} static get a() {} a() {} };`, Options: classBoth},
+
+			// Class — duplicate keys
+			{Code: `class A { get a() {} get a() {} set a(foo) {} }`, Options: classBoth},
+			{Code: `class A { get [a]() {} set [a](foo) {} set [a](foo) {} }`, Options: classBoth},
+			{Code: "class A { get a() {} set 'a'(foo) {} get [`a`]() {} }", Options: classBoth},
+			{Code: `A = class { get a() {} set a(foo) {} a() {} }`, Options: classBoth},
+			{Code: `A = class { a() {} get a() {} set a(foo) {} }`, Options: classBoth},
+			{Code: `class A { static set a(foo) {} static set a(foo) {} static get a() {} }`, Options: classBoth},
+			{Code: `class A { static get a() {} static set a(foo) {} static get a() {} }`, Options: classBoth},
+			{Code: `class A { static set a(foo) {} static get a() {} static a() {} }`, Options: classBoth},
+			{Code: `class A { get a() {} a() {} set a(foo) {} }`, Options: classBoth},
+			{Code: `class A { static set a(foo) {} static a() {} static get a() {} }`, Options: classBoth},
+
+			// TS — default off, lone setter/getter in types is valid
+			{Code: `interface I { get prop(): any }`},
+			{Code: `type T = { set prop(value: any): void }`},
+			{Code: `interface I { get prop(): any, set prop(value: any): void }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `type T = { get prop(): any, set prop(value: any): void }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { get prop(): any, between: true, set prop(value: any): void }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { set prop(value: any): void, get prop(): any }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { set prop(value: any): void, get 'prop'(): any }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I {}`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { (...args): void }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { new(...args): unknown }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { prop: () => any }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `interface I { method(): any }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+			{Code: `type T = { get prop(): any }`, Options: map[string]interface{}{"enforceForTSTypes": true}},
+
+			// ---- Structural matching of computed keys ----
+
+			// Whitespace inside the key expression is not part of the AST → match.
+			{Code: `var o = { get [a+b]() {}, set [a + b](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [a  +  b]() {}, set [a+b](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [f ( a , b )]() {}, set [f(a,b)](foo) {} };`, Options: bothOpts},
+			// Comments inside the key are skipped too.
+			{Code: `var o = { get [/*x*/ a /*y*/ + b]() {}, set [a + b](foo) {} };`, Options: bothOpts},
+			// Nested parens at every level.
+			{Code: `var o = { get [((a + b))]() {}, set [a + b](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [(a) + (b)]() {}, set [a + b](foo) {} };`, Options: bothOpts},
+			// Property / element access with same static name.
+			{Code: `var o = { get [a.b]() {}, set [a.b](foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [a[0]]() {}, set [a[0]](foo) {} };`, Options: bothOpts},
+
+			// ---- Numeric / bigint normalization on static keys ----
+
+			{Code: `var o = { get 0x10() {}, set 16(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get [0x10]() {}, set 16(foo) {} };`, Options: bothOpts},
+			{Code: `var o = { get 1.0() {}, set 1(foo) {} };`, Options: bothOpts},
+			// Normalized against an identifier name "Infinity" — NOT expected to match
+			// (identifier vs numeric overflow is a subtle edge case and ESLint doesn't
+			// guarantee it either, so we don't test the cross-form here).
+
+			// ---- Private identifier forms their own equivalence class ----
+
+			// `#a` and `'#a'` are separate keys — each forms its own unmatched group.
+			// See invalid section for the negative assertion.
+			{Code: `class A { get #a() {} set #a(foo) {} }`, Options: classBoth},
+			{Code: `class A { get '#a'() {} set '#a'(foo) {} }`, Options: classBoth},
+
+			// ---- Class: static and instance of the same name are independent pairs ----
+
+			{Code: `class A { get a() {} set a(v) {} static get a() {} static set a(v) {} }`, Options: classBoth},
+
+			// ---- Nested object literals & classes are processed independently ----
+
+			{Code: `const x = { outer: { get a() {}, set a(v) {} } };`, Options: bothOpts},
+			{Code: `class A { method() { return { get a() {}, set a(v) {} }; } }`, Options: classBoth},
+			{Code: `class A { method() { return class B { get a() {} set a(v) {} }; } }`, Options: classBoth},
+
+			// ---- Descriptor calls are NOT treated as descriptors in nested positions ----
+
+			// `{set: ...}` is inside a conditional → not arg[2] of defineProperty.
+			// The outer call is unrecognized but the inner object still exists as a
+			// plain object literal (no accessor kinds → no report).
+			{Code: `Object.defineProperty(o, 'k', cond ? {set: function(){}} : {});`, Options: bothOpts},
+			// Wrapped in another call — not a direct arg of defineProperty.
+			{Code: `Object.defineProperty(o, 'k', wrap({set: function(){}}));`, Options: bothOpts},
+			// `{set: ...}` is the VALUE of a property assignment whose grandparent is
+			// NOT a descriptor-map argument.
+			{Code: `const x = { bag: { set: function(){} } };`, Options: bothOpts},
+
+			// ---- Runtime descriptors passed via variables are opaque to the rule ----
+
+			{Code: `const d = {set: function(v){}}; Object.defineProperty(o, 'k', d);`, Options: bothOpts},
+
+			// ---- Shadowed Object shouldn't affect syntactic recognition ----
+			// (We mirror ESLint: text-only match, no scope resolution. Documented.)
+			{Code: `{ const Object = null; Object.defineProperty(o, 'k', {get() {}, set(v) {}}); }`, Options: bothOpts},
+
+			// ---- Reserved-word property names ----
+
+			// Bare reserved words land on Identifier → static name works.
+			{Code: `var o = { get null() {}, set null(v) {} };`, Options: bothOpts},
+			{Code: `var o = { get true() {}, set true(v) {} };`, Options: bothOpts},
+			{Code: `var o = { get undefined() {}, set undefined(v) {} };`, Options: bothOpts},
+			// [null] / [true] / [false] in computed form collapse to the same static name.
+			{Code: `var o = { get null() {}, set [null](v) {} };`, Options: bothOpts},
+			{Code: `var o = { get true() {}, set [true](v) {} };`, Options: bothOpts},
+			{Code: `var o = { get false() {}, set [false](v) {} };`, Options: bothOpts},
+
+			// ---- Descriptor: method shorthand / shorthand property / mix ----
+
+			// Method shorthand forms a complete descriptor.
+			{Code: `Object.defineProperty(o, 'k', {get() { return 1; }, set(v) {}});`, Options: bothOpts},
+			// Shorthand property — `set` is a variable that holds the function.
+			{Code: `var get, set; Object.defineProperty(o, 'k', {get, set});`, Options: bothOpts},
+			// Mixed: one property-assignment + one method-shorthand.
+			{Code: `Object.defineProperty(o, 'k', {get: function() {}, set(v) {}});`, Options: bothOpts},
+
+			// ---- Bracket caller form ----
+
+			// Well-known callers via element access with static string.
+			{Code: "Reflect['defineProperty'](o, 'k', {get: function() {}, set: function(v) {}});", Options: bothOpts},
+			{Code: "Object['defineProperties'](o, {k: {get: function() {}, set: function(v) {}}});", Options: bothOpts},
+			{Code: "Object['create'](null, {k: {get: function() {}, set: function(v) {}}});", Options: bothOpts},
+			// Optional chain + bracket: `Reflect?.['defineProperty']`.
+			{Code: "Reflect?.['defineProperty'](o, 'k', {get: function() {}, set: function(v) {}});", Options: bothOpts},
+
+			// ---- Regex computed key cross-form with string key ----
+
+			// `[/a/]` and string `'/a/'` both normalize to static name "/a/".
+			{Code: `var o = { get '/a/'() {}, set [/a/](v) {} };`, Options: bothOpts},
+
+		},
+		[]rule_tester.InvalidTestCase{
+			// Default — setter without getter
+			{
+				Code: `var o = { set a(value) {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:    `var o = { set a(value) {} };`,
+				Options: setOnlyOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:    `var o = { set a(value) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:    `var o = { get a() {} };`,
+				Options: getOnlyOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:    `var o = { get a() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:    `var o = { get a() {} };`,
+				Options: map[string]interface{}{"getWithoutSet": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+
+			// Various getter keys
+			{
+				Code:    `var o = { get abc() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get 'abc'() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get 123() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get 1e2() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get ['abc']() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    "var o = { get [`abc`]() {} };",
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get [abc]() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get [f(abc)]() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `var o = { get [a + b]() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+
+			// Various setter keys
+			{
+				Code:    `var o = { set [a + b](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+
+			// Different keys
+			{
+				Code:    `var o = { get a() {}, set b(foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `var o = { set a(foo) {}, get b() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:    `var o = { get 1() {}, set b(foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `var o = { get [a]() {}, set [b](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:    `var o = { get [a]() {}, set a(foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:    `var o = { get a() {}, set [a](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `var o = { get [a + b]() {}, set [a - b](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 29},
+				},
+			},
+
+			// Multiple invalid of same and different kinds
+			{
+				Code:    `var o = { get a() {}, get b() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `var o = { set a(foo) {}, set b(bar) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 26},
+				},
+			},
+
+			// Separate object literals
+			{
+				Code:    `var o1 = { get a() {} }, o2 = { set a(foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 12},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 33},
+				},
+			},
+
+			// Duplicate keys that remain unpaired
+			{
+				Code:    `var o = { get a() {}, get a() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `var o = { set a(foo) {}, set a(foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 26},
+				},
+			},
+
+			// With spread / other properties
+			{
+				Code:    `var o = { a, get b() {}, c };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:    `var o = { get a() {}, ...b };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+				},
+			},
+
+			// Full location tests (Line + Column + EndLine + EndColumn)
+			{
+				Code:    `var o = { get b() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:    "var o = {\n  set [\n a](foo) {} };",
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 2, Column: 3, EndLine: 3, EndColumn: 4},
+				},
+			},
+
+			// Property descriptors
+			{
+				Code: "var o = {d: 1};\n Object.defineProperty(o, 'c', \n{set: function(value) {\n val = value; \n} \n});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code: `Reflect.defineProperty(obj, 'foo', {set: function(value) {}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code: `Object.defineProperties(obj, {foo: {set: function(value) {}}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code: `Object.create(null, {foo: {set: function(value) {}}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			// Optional chaining
+			{
+				Code: "var o = {d: 1};\n Object?.defineProperty(o, 'c', \n{set: function(value) {\n val = value; \n} \n});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code: `Reflect?.defineProperty(obj, 'foo', {set: function(value) {}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code: `(Object?.defineProperty)(o, 'c', {set: function(value) {}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+
+			// Classes — default settings
+			{
+				Code: `class A { set a(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+			{
+				Code:    `class A { get a() {} set b(foo) {} }`,
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+			{
+				Code:    `class A { get a() {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass"},
+				},
+			},
+			{
+				Code:    `class A { static get a() {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass"},
+				},
+			},
+			{
+				Code:    `class A { static set a(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+			{
+				Code:    `A = class { get a() {} set b(foo) {} };`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass"},
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+
+			// Class — private identifiers
+			{
+				Code: `class A { set #a(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+			{
+				Code: `class A { static set #a(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+
+			// Class — different keys with column positions
+			{
+				Code:    `class A { get a() {} set b(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code:    `A = class { static get a() {} static set b(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 31},
+				},
+			},
+
+			// Class — prototype and static with same key
+			{
+				Code:    `class A { get a() {} static set a(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 22},
+				},
+			},
+
+			// Class — duplicates
+			{
+				Code:    `class A { get a() {} get a() {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code:    `class A { set a(foo) {} set a(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 25},
+				},
+			},
+
+			// Class — full location
+			{
+				Code:    `class A { get a() {} };`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code:    "A = class {\n  set [\n a](foo) {} };",
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 2, Column: 3, EndLine: 3, EndColumn: 4},
+				},
+			},
+			{
+				Code:    `class A { static get b() {} };`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// Class — mixed ESLint cases
+			{
+				Code:    `class A { get a() {} } class B { set a(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 34},
+				},
+			},
+
+			// TS types
+			{
+				Code: `({ set prop(value) {} });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+			{
+				Code:    `interface I { set prop(value: any): any }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `interface I { set prop(value: any): any, get other(): any }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `interface I { set prop(value: any): any, prop(): any }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `interface I { get prop(): any } interface J { set prop(value: any): void }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `type T = { set prop(value: any): any }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `function fn(): { set prop(value: any): any } { return null as any }`,
+				Options: tsOnly,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType"},
+				},
+			},
+			{
+				Code:    `type T = { get prop(): any }`,
+				Options: tsGetAlso,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInType"},
+				},
+			},
+
+			// ---- Structural mismatches (computed keys) ----
+
+			// Same operands, different operator.
+			{
+				Code:    `var o = { get [a + b]() {}, set [a - b](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 29},
+				},
+			},
+			// Optional chain vs regular access — structurally different.
+			{
+				Code:    `var o = { get [a.b]() {}, set [a?.b](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+			// PropertyAccess vs ElementAccess — different Kind.
+			{
+				Code:    `var o = { get [a.b]() {}, set [a['b']](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+			// Template tail text differs.
+			{
+				Code:    "var o = { get [`${a}`]() {}, set [`${a} `](foo) {} };",
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+			// Raw numeric literal form differs (`0x1` vs `1`) — ESLint does a
+			// token-level compare, and we route numeric literals through
+			// scanner.GetSourceTextOfNodeFromSourceFile so the original source
+			// form is preserved despite tsgo's parse-time normalization.
+			{
+				Code:    `var o = { get [a + 0x1]() {}, set [a + 1](v) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+			// Arg count differs.
+			{
+				Code:    `var o = { get [f(a)]() {}, set [f(a, b)](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+
+			// ---- Static vs dynamic/private cross-form (never match) ----
+
+			// Static `a` vs dynamic `[a.b]` — different kinds.
+			{
+				Code:    `var o = { get a() {}, set [a.b](foo) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+			// Private `#a` vs string `'#a'` — separate equivalence classes.
+			{
+				Code:    `class A { get #a() {} set '#a'(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `class A { get '#a'() {} set #a(foo) {} }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- Numeric normalization still matches across forms ----
+
+			// Hex literal key paired with decimal identifier key.
+			{
+				Code:    `var o = { get 0x10() {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					// Key normalizes to "16" — report for missing setter on "16".
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+
+			// ---- Nested ObjectLiteralExpression is checked independently ----
+
+			{
+				Code:    `const x = { outer: { get a() {} } };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+				},
+			},
+			// Outer class has a pair; nested class has only a setter.
+			{
+				Code:    `class Outer { get a() {} set a(v) {} method() { return class Inner { set a(v) {} }; } }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass"},
+				},
+			},
+			// Object literal inside class method body.
+			{
+				Code:    `class A { m() { return { set a(v) {} }; } }`,
+				Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+
+			// ---- Descriptor-shape recognition ----
+
+			// Spread in descriptor: treated syntactically, only named properties are
+			// considered — so {...d, set: ...} still counts as "set without get".
+			{
+				Code:    `Object.defineProperty(o, 'k', {...d, set: function(v) {}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			// Doubly-nested descriptor maps: only the inner {set:...} is a descriptor.
+			{
+				Code:    `Object.defineProperties(obj, {foo: {set: function(v){}}, bar: {get: function(){}}});`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+					{MessageId: "missingSetterInPropertyDescriptor"},
+				},
+			},
+			// Parenthesized Object.defineProperties callee with optional chain.
+			{
+				Code:    `(Object?.defineProperties)(obj, {foo: {set: function(v){}}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+
+			// ---- Descriptor: method shorthand only reports correctly ----
+
+			{
+				Code: `Object.defineProperty(o, 'k', {set(v) {}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code:    `Object.defineProperty(o, 'k', {get() { return 1; }});`,
+				Options: map[string]interface{}{"setWithoutGet": true, "getWithoutSet": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInPropertyDescriptor"},
+				},
+			},
+			// Shorthand property — only `set` is declared.
+			{
+				Code: `var set; Object.defineProperty(o, 'k', {set});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+
+			// ---- Bracket caller form (reports) ----
+
+			{
+				Code: "Reflect['defineProperty'](o, 'k', {set: function(v) {}});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+			{
+				Code: "Object['defineProperties'](o, {k: {set: function(v) {}}});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor"},
+				},
+			},
+
+			// ---- Reserved-word computed key mismatch ----
+
+			// `[true]` vs `[false]` → different static names, both flagged.
+			{
+				Code:    `var o = { get [true]() {}, set [false](v) {} };`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral"},
+					{MessageId: "missingGetterInObjectLiteral"},
+				},
+			},
+
+			// =====================================================
+			// Full parity pass with ESLint's test suite (rest of cases).
+			// Grouped in the same order as lib/tests/lib/rules/accessor-pairs.js.
+			// =====================================================
+
+			// ---- Object literals: various setter keys ----
+
+			{Code: `var o = { set abc(foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set 'abc'(foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set 123(foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set 1e2(foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set ['abc'](foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: "var o = { set [`abc`](foo) {} };", Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set [123](foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set [abc](foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { set [f(abc)](foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral"}}},
+			{Code: `var o = { get [123]() {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral"}}},
+
+			// ---- Different keys with numeric / whitespace / empty / null ----
+
+			{
+				Code: `var o = { get a() {}, set 1(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `var o = { get a() {}, set 'a '(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `var o = { get ' a'() {}, set 'a'(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `var o = { get ''() {}, set ' '(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `var o = { get ''() {}, set null(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: "var o = { get [`a`]() {}, set b(foo) {} };", Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: "var o = { get [`${0} `]() {}, set [`${0}`](foo) {} };", Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 31},
+				},
+			},
+
+			// ---- Four-error combination ----
+
+			{
+				Code: `var o = { get a() {}, set b(foo) {}, set c(foo) {}, get d() {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 38},
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 53},
+				},
+			},
+
+			// ---- Per object literal (reverse) ----
+
+			{
+				Code: `var o1 = { set a(foo) {} }, o2 = { get a() {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 12},
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- Valid+invalid combinations ----
+
+			{
+				Code: `var o = { get a() {}, get b() {}, set b(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11}},
+			},
+			{
+				Code: `var o = { get b() {}, get a() {}, set b(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 23}},
+			},
+			{
+				Code: `var o = { get b() {}, set b(foo) {}, get a() {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 38}},
+			},
+			{
+				Code: `var o = { set a(foo) {}, get b() {}, set b(bar) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11}},
+			},
+			{
+				Code: `var o = { get b() {}, set a(foo) {}, set b(bar) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 23}},
+			},
+			{
+				Code: `var o = { get b() {}, set b(bar) {}, set a(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 38}},
+			},
+			{
+				Code: `var o = { get v1() {}, set i1(foo) {}, get v2() {}, set v2(bar) {}, get i2() {}, set v1(baz) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 24},
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 69},
+				},
+			},
+
+			// ---- Other elements don't affect ----
+
+			{
+				Code: `var o = { a, get b() {}, c, set d(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 14},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 29},
+				},
+			},
+			{Code: `var o = { get a() {}, a:1 };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11}}},
+			{Code: `var o = { a, get a() {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 14}}},
+			{Code: `var o = { set a(foo) {}, a:1 };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11}}},
+			{Code: `var o = { a, set a(foo) {} };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 14}}},
+			{Code: `var o = { get a() {}, ...a };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 11}}},
+			{Code: `var o = { set a(foo) {}, ...a };`, Options: bothOpts, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 11}}},
+
+			// ---- Property descriptors: full optional-chain + parenthesized matrix ----
+
+			{Code: `Object?.defineProperties(obj, {foo: {set: function(v) {}}});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInPropertyDescriptor"}}},
+			{Code: `Object?.create(null, {foo: {set: function(v) {}}});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInPropertyDescriptor"}}},
+			{Code: `(Reflect?.defineProperty)(obj, 'foo', {set: function(v) {}});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInPropertyDescriptor"}}},
+			{Code: `(Object?.create)(null, {foo: {set: function(v) {}}});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInPropertyDescriptor"}}},
+
+			// ---- Classes: default / enforceForClassMembers:true echo ----
+
+			{Code: `class A { set a(foo) {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `class A { set a(foo) {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `A = class { get a() {} };`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `class A { set a(value) {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `class A { static set a(value) {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `A = class { set a(value) {} };`, Options: map[string]interface{}{"enforceForClassMembers": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `(class A { static set a(value) {} });`, Options: map[string]interface{}{"enforceForClassMembers": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+
+			// ---- Class private-identifier forms ----
+
+			{Code: `class A { set '#a'(foo) {} }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `class A { static set '#a'(foo) {} }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+
+			// ---- Class: options don't affect each other ----
+
+			{
+				Code:    `class A { set a(value) {} }`,
+				Options: map[string]interface{}{"setWithoutGet": true, "getWithoutSet": false, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}},
+			},
+			{
+				Code:    `A = class { static set a(value) {} };`,
+				Options: classBoth,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}},
+			},
+			{
+				Code:    `let foo = class A { get a() {} };`,
+				Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+			{
+				Code:    `class A { static get a() {} };`,
+				Options: classBoth,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+			{
+				Code:    `(class { get a() {} });`,
+				Options: map[string]interface{}{"getWithoutSet": true, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+			{
+				Code:    `class A { get '#a'() {} };`,
+				Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+			{
+				Code:    `class A { get #a() {} };`,
+				Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+			{
+				Code:    `class A { static get '#a'() {} };`,
+				Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+			{
+				Code:    `class A { static get #a() {} };`,
+				Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}},
+			},
+
+			// ---- Class: various kinds of keys ----
+
+			{Code: `class A { get abc() {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `A = class { static set 'abc'(foo) {} };`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `(class { get 123() {} });`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `class A { static get 1e2() {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `A = class { get ['abc']() {} };`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: "class A { set [`abc`](foo) {} }", Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `class A { static get [123]() {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `class A { get [abc]() {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `class A { static get [f(abc)]() {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+			{Code: `A = class { set [a + b](foo) {} };`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass"}}},
+			{Code: `class A { get ['constructor']() {} }`, Options: classBoth, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass"}}},
+
+			// ---- Class: different keys (names & positions) ----
+
+			{
+				Code: `A = class { set a(foo) {} get b() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class A { get a() {} set b(foo) {} }`, Options: map[string]interface{}{"setWithoutGet": false, "getWithoutSet": true, "enforceForClassMembers": true},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 11}},
+			},
+			{
+				Code: `class A { get a() {} set b(foo) {} }`, Options: map[string]interface{}{"setWithoutGet": true, "getWithoutSet": false, "enforceForClassMembers": true},
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 22}},
+			},
+			{
+				Code: `class A { get 'a '() {} set 'a'(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `class A { get 'a'() {} set 1(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `class A { get 1() {} set 2(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `class A { get ''() {} set null(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `class A { get a() {} set [a](foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `class A { get [a]() {} set [b](foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `class A { get [a]() {} set [a++](foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `class A { get [a + b]() {} set [a - b](foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 28},
+				},
+			},
+
+			// ---- Class: prototype vs static with same key ----
+
+			{
+				Code: `A = class { static get a() {} set a(foo) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `class A { set [a](foo) {} static get [a]() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class A { static set [a](foo) {} get [a]() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 34},
+				},
+			},
+
+			// ---- Class: multiple invalid ----
+
+			{
+				Code: `A = class { get a() {} get [b]() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `class A { get [a]() {} get [b]() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `A = class { set a(foo) {} set b(bar) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class A { static get a() {} static get b() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `A = class { static set a(foo) {} static set b(bar) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 34},
+				},
+			},
+			{
+				Code: `class A { static get a() {} set b(foo) {} static set c(bar) {} get d() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 29},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 43},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 64},
+				},
+			},
+
+			// ---- Class: per-class scoping ----
+
+			{
+				Code: `A = class { set a(foo) {} }, class { get a() {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: `A = class { get a() {} }, { set a(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingGetterInObjectLiteral", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `A = { get a() {} }, class { set a(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Line: 1, Column: 7},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 29},
+				},
+			},
+
+			// ---- Class: valid+invalid combinations ----
+
+			{
+				Code: `class A { get a() {} get b() {} set b(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 11}},
+			},
+			{
+				Code: `A = class { get b() {} get a() {} set b(foo) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 24}},
+			},
+			{
+				Code: `class A { set b(foo) {} get b() {} set a(bar) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 36}},
+			},
+			{
+				Code: `A = class { static get b() {} set a(foo) {} static set b(bar) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 31}},
+			},
+			{
+				Code: `class A { static set a(foo) {} get b() {} set b(bar) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 11}},
+			},
+			{
+				Code: `class A { get b() {} static get a() {} set b(bar) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 22}},
+			},
+			{
+				Code: `class A { static set b(foo) {} static get a() {} static get b() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 32}},
+			},
+			{
+				Code: `class A { get [v1](){} static set i1(foo){} static set v2(bar){} get [i2](){} static get i3(){} set [v1](baz){} static get v2(){} set i4(quux){} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 24},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 66},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 79},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 131},
+				},
+			},
+
+			// ---- Class: duplicate keys all reported ----
+
+			{
+				Code: `A = class { set a(foo) {} set a(foo) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `A = class { static get a() {} static get a() {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 13},
+					{MessageId: "missingSetterInClass", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `class A { set a(foo) {} set a(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Line: 1, Column: 11},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- Class: other elements don't affect ----
+
+			{
+				Code: `class A { a() {} get b() {} c() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 18}},
+			},
+			{
+				Code: `A = class { a() {} get b() {} c() {} set d(foo) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Line: 1, Column: 20},
+					{MessageId: "missingGetterInClass", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: `class A { static a() {} get b() {} static c() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 25}},
+			},
+			{
+				Code: `class A { a() {} get a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 18}},
+			},
+			{
+				Code: `A = class { static a() {} set a(foo) {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 27}},
+			},
+			{
+				Code: `class A { a() {} static get b() {} c() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 18}},
+			},
+			{
+				Code: `A = class { static a() {} static set b(foo) {} static c() {} d() {} };`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 27}},
+			},
+			{
+				Code: `class A { a() {} static get a() {} a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingSetterInClass", Line: 1, Column: 18}},
+			},
+			{
+				Code: `class A { static set a(foo) {} static a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "missingGetterInClass", Line: 1, Column: 11}},
+			},
+
+			// =====================================================
+			// Message-text parity pass — verifies the full formatted
+			// output byte-for-byte against ESLint's messages.
+			// =====================================================
+
+			// Object literal: identifier name.
+			{
+				Code: `var o = { set a(value) {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Message: "Getter is not present for setter 'a'."},
+				},
+			},
+			{
+				Code: `var o = { get a() {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Message: "Setter is not present for getter 'a'."},
+				},
+			},
+			// Object literal: numeric normalization.
+			{
+				Code: `var o = { set 1e2(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Message: "Getter is not present for setter '100'."},
+				},
+			},
+			{
+				Code: `var o = { get 0x10() {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Message: "Setter is not present for getter '16'."},
+				},
+			},
+			// Object literal: string name.
+			{
+				Code: `var o = { set 'abc'(foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Message: "Getter is not present for setter 'abc'."},
+				},
+			},
+			// Object literal: computed dynamic — no name.
+			{
+				Code: `var o = { get [abc]() {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInObjectLiteral", Message: "Setter is not present for getter."},
+				},
+			},
+			{
+				Code: `var o = { set [a + b](foo) {} };`, Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInObjectLiteral", Message: "Getter is not present for setter."},
+				},
+			},
+
+			// Class: identifier.
+			{
+				Code: `class A { set a(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class setter 'a'."},
+				},
+			},
+			{
+				Code: `class A { get a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Message: "Setter is not present for class getter 'a'."},
+				},
+			},
+			// Class: static.
+			{
+				Code: `class A { static set a(foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class static setter 'a'."},
+				},
+			},
+			{
+				Code: `class A { static get a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Message: "Setter is not present for class static getter 'a'."},
+				},
+			},
+			// Class: static + numeric normalization.
+			{
+				Code: `class A { static get 1e2() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Message: "Setter is not present for class static getter '100'."},
+				},
+			},
+			// Class: private (no quotes, `#a`).
+			{
+				Code: `class A { set #a(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class private setter #a."},
+				},
+			},
+			{
+				Code: `class A { get #a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Message: "Setter is not present for class private getter #a."},
+				},
+			},
+			// Class: static private.
+			{
+				Code: `class A { static set #a(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class static private setter #a."},
+				},
+			},
+			{
+				Code: `class A { static get #a() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Message: "Setter is not present for class static private getter #a."},
+				},
+			},
+			// Class: string that looks like private (WITH quotes, NOT private).
+			{
+				Code: `class A { set '#a'(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class setter '#a'."},
+				},
+			},
+			{
+				Code: `class A { static set '#a'(foo) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class static setter '#a'."},
+				},
+			},
+			// Class: computed dynamic — no name.
+			{
+				Code: `class A { set [a + b](foo) {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInClass", Message: "Getter is not present for class setter."},
+				},
+			},
+			{
+				Code: `class A { static get [f(x)]() {} }`, Options: classBoth,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInClass", Message: "Setter is not present for class static getter."},
+				},
+			},
+
+			// Property descriptor — no name substitution, fixed text.
+			{
+				Code: `Object.defineProperty(o, 'k', {set: function(v) {}});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInPropertyDescriptor", Message: "Getter is not present in property descriptor."},
+				},
+			},
+			{
+				Code:    `Object.defineProperty(o, 'k', {get: function() {}});`,
+				Options: bothOpts,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInPropertyDescriptor", Message: "Setter is not present in property descriptor."},
+				},
+			},
+
+			// TS: interface / type literal.
+			{
+				Code: `interface I { set prop(value: any): any }`, Options: map[string]interface{}{"enforceForTSTypes": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType", Message: "Getter is not present for type setter 'prop'."},
+				},
+			},
+			{
+				Code: `type T = { get prop(): any }`, Options: map[string]interface{}{"enforceForTSTypes": true, "getWithoutSet": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingSetterInType", Message: "Setter is not present for type getter 'prop'."},
+				},
+			},
+			// TS computed key in an interface: ESLint emits `'null'` as the name
+			// (a @typescript-eslint/parser quirk where `getStaticValue` coerces
+			// an Identifier in a computed position to null → String(null)).
+			// rslint reports with no name, which is semantically more correct.
+			// Locked in here so future refactors can't silently change it.
+			{
+				Code:    `interface I { set [prop](value: any): any }`,
+				Options: map[string]interface{}{"enforceForTSTypes": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingGetterInType", Message: "Getter is not present for type setter."},
+				},
+			},
+
+			// ---- Ambient / abstract accessor without body ----
+
+			// No body → `GetFunctionHeadLoc` falls through to `findOpenParenPos`,
+			// which still finds the `(` of the parameter list. ESLint tests
+			// don't exercise this, so we lock in our behavior here.
+			{
+				Code: `declare class A { set a(foo: number); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingGetterInClass",
+						Message:   "Getter is not present for class setter 'a'.",
+						// "set a" occupies columns 19–23; range ends at the `(` at col 24.
+						Line: 1, Column: 19, EndLine: 1, EndColumn: 24,
+					},
+				},
+			},
+			{
+				Code: `abstract class A { abstract set a(foo: number); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingGetterInClass",
+						Message:   "Getter is not present for class setter 'a'.",
+						// "abstract set a" occupies columns 20–33; range ends at `(` col 34.
+						Line: 1, Column: 20, EndLine: 1, EndColumn: 34,
+					},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/this_binding.go
+++ b/internal/utils/this_binding.go
@@ -174,13 +174,13 @@ func isCallbackWithThisArg(call *ast.CallExpression, callback *ast.Node) bool {
 	args := call.Arguments.Nodes
 
 	// Reflect.apply(callback, thisArg, args)
-	if isSpecificMemberAccess(call.Expression, "Reflect", "apply") {
+	if IsSpecificMemberAccess(call.Expression, "Reflect", "apply") {
 		return len(args) >= 3 && args[0] == callback && !IsNullOrUndefined(args[1])
 	}
 
 	// Array.from(iterable, callback, thisArg) / Array.fromAsync(...)
-	if isSpecificMemberAccess(call.Expression, "Array", "from") ||
-		isSpecificMemberAccess(call.Expression, "Array", "fromAsync") {
+	if IsSpecificMemberAccess(call.Expression, "Array", "from") ||
+		IsSpecificMemberAccess(call.Expression, "Array", "fromAsync") {
 		return len(args) >= 3 && args[1] == callback && !IsNullOrUndefined(args[2])
 	}
 
@@ -197,16 +197,3 @@ func isCallbackWithThisArg(call *ast.CallExpression, callback *ast.Node) bool {
 	return false
 }
 
-// isSpecificMemberAccess checks if node is Object.method pattern.
-func isSpecificMemberAccess(node *ast.Node, objectName, methodName string) bool {
-	if node == nil || !ast.IsPropertyAccessExpression(node) {
-		return false
-	}
-	prop := node.AsPropertyAccessExpression()
-	name := prop.Name()
-	if name == nil || name.Text() != methodName {
-		return false
-	}
-	obj := ast.SkipParentheses(prop.Expression)
-	return obj != nil && ast.IsIdentifier(obj) && obj.AsIdentifier().Text == objectName
-}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -806,6 +806,12 @@ func GetStaticPropertyName(nameNode *ast.Node) (string, bool) {
 			return expr.AsNoSubstitutionTemplateLiteral().Text, true
 		case ast.KindNullKeyword:
 			return "null", true
+		case ast.KindTrueKeyword:
+			return "true", true
+		case ast.KindFalseKeyword:
+			return "false", true
+		case ast.KindRegularExpressionLiteral:
+			return expr.AsRegularExpressionLiteral().Text, true
 		}
 		return "", false
 	default:
@@ -1236,4 +1242,143 @@ func VisitDestructuringIdentifiers(node *ast.Node, fn func(*ast.Node)) {
 		}
 		return false
 	})
+}
+
+// IsSpecificMemberAccess reports whether `node` is a member access of the
+// form `<objectName>.<methodName>`. Both dot (`Object.defineProperty`) and
+// bracket-with-static-string (`Object['defineProperty']`) forms are matched,
+// each transparently unwrapping parentheses (e.g. `(Object).defineProperty`)
+// and optional chaining (`Object?.defineProperty`, `Object?.['defineProperty']`).
+// Mirrors ESLint's `astUtils.isSpecificMemberAccess`.
+func IsSpecificMemberAccess(node *ast.Node, objectName, methodName string) bool {
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	var obj *ast.Node
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		pae := node.AsPropertyAccessExpression()
+		name := pae.Name()
+		if name == nil || !ast.IsIdentifier(name) || name.AsIdentifier().Text != methodName {
+			return false
+		}
+		obj = pae.Expression
+	case ast.KindElementAccessExpression:
+		eae := node.AsElementAccessExpression()
+		argText, ok := GetStaticExpressionValue(ast.SkipParentheses(eae.ArgumentExpression))
+		if !ok || argText != methodName {
+			return false
+		}
+		obj = eae.Expression
+	default:
+		return false
+	}
+	obj = ast.SkipParentheses(obj)
+	return obj != nil && ast.IsIdentifier(obj) && obj.AsIdentifier().Text == objectName
+}
+
+// AreNodesStructurallyEqual reports whether two AST subtrees have identical
+// syntactic shape and leaf values, transparently unwrapping
+// ParenthesizedExpression on both sides at every level. Useful for rules that
+// compare computed keys, duplicate case expressions, or any pattern that must
+// be evaluated at the source-syntax level rather than by semantic reference
+// identity (for which see [IsSameReference]).
+//
+// Leaf comparison:
+//   - Identifier / PrivateIdentifier: `.Text` equality.
+//   - StringLiteral / NoSubstitutionTemplateLiteral / TemplateHead / Middle /
+//     Tail / RegularExpressionLiteral: textual equality.
+//   - NumericLiteral: normalized numeric value equality (e.g. `0x10` == `16`).
+//   - BigIntLiteral: normalized bigint value equality (e.g. `0x1n` == `1n`).
+//   - All other kinds (keyword tokens, punctuation tokens, composite nodes):
+//     Kind must match, and the non-nil children visited by [ast.Node.ForEachChild]
+//     must be pairwise structurally equal in order.
+//
+// Comments and whitespace are not part of the AST and are therefore ignored
+// (so `a+b` and `a + b` compare equal). Optional chaining IS preserved
+// (`a.b` != `a?.b`). Type-only syntax (`as T`, `<T>x`, `x!`, `x satisfies T`)
+// is compared as-is — callers that want to see through it should strip it
+// first via [ast.SkipOuterExpressions] before calling this helper.
+func AreNodesStructurallyEqual(a, b *ast.Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	a = ast.SkipParentheses(a)
+	b = ast.SkipParentheses(b)
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	switch a.Kind {
+	case ast.KindIdentifier:
+		return a.AsIdentifier().Text == b.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return a.AsPrivateIdentifier().Text == b.AsPrivateIdentifier().Text
+	case ast.KindStringLiteral:
+		return a.AsStringLiteral().Text == b.AsStringLiteral().Text
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return a.AsNoSubstitutionTemplateLiteral().Text == b.AsNoSubstitutionTemplateLiteral().Text
+	case ast.KindNumericLiteral:
+		// Note: tsgo already normalizes numeric literals at parse time
+		// (`0x1` / `1e2` / `1.0` are all stored as their decimal form).
+		// Normalize again to be explicit about the intent; two literals
+		// that differ only in source form (e.g. `0x1` vs `1`) are treated
+		// as equal here. This is slightly more forgiving than ESLint's
+		// token-level comparison, which would see them as distinct — but
+		// the raw source form is not recoverable from the tsgo AST
+		// without a *SourceFile, which we deliberately don't take.
+		return NormalizeNumericLiteral(a.AsNumericLiteral().Text) ==
+			NormalizeNumericLiteral(b.AsNumericLiteral().Text)
+	case ast.KindBigIntLiteral:
+		return NormalizeBigIntLiteral(a.AsBigIntLiteral().Text) ==
+			NormalizeBigIntLiteral(b.AsBigIntLiteral().Text)
+	case ast.KindTemplateHead, ast.KindTemplateMiddle, ast.KindTemplateTail,
+		ast.KindRegularExpressionLiteral:
+		return a.Text() == b.Text()
+	}
+	// Composite / pure-token kinds: compare children pairwise. Token kinds
+	// without children (operators, keywords) fall through the empty loop and
+	// return true, which is correct — Kind already uniquely identifies them.
+	var aKids, bKids []*ast.Node
+	a.ForEachChild(func(c *ast.Node) bool {
+		aKids = append(aKids, c)
+		return false
+	})
+	b.ForEachChild(func(c *ast.Node) bool {
+		bKids = append(bKids, c)
+		return false
+	})
+	if len(aKids) != len(bKids) {
+		return false
+	}
+	for i := range aKids {
+		if !AreNodesStructurallyEqual(aKids[i], bKids[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsArgumentOfSpecificCall reports whether `node` sits at argument position
+// `index` of a call to `<objectName>.<methodName>(...)` — covering optional
+// chaining and parenthesized callee expressions, e.g. `(Object?.defineProperty)(...)`.
+// This is the common shape for detecting property-descriptor arguments in
+// `Object.defineProperty` / `Reflect.defineProperty`, mutation targets in
+// `Object.assign`, and similar well-known API calls.
+func IsArgumentOfSpecificCall(node *ast.Node, index int, objectName, methodName string) bool {
+	if node == nil || node.Parent == nil || node.Parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := node.Parent.AsCallExpression()
+	if call.Arguments == nil {
+		return false
+	}
+	args := call.Arguments.Nodes
+	if index < 0 || index >= len(args) || args[index] != node {
+		return false
+	}
+	return IsSpecificMemberAccess(call.Expression, objectName, methodName)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -27,6 +27,7 @@ export default defineConfig({
     './tests/cli/type-check/ignores-suppression.test.ts',
 
     // eslint
+    './tests/eslint/rules/accessor-pairs.test.ts',
     './tests/eslint/rules/default-case.test.ts',
     './tests/eslint/rules/no-case-declarations.test.ts',
     './tests/eslint/rules/no-console.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/accessor-pairs.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/accessor-pairs.test.ts.snap
@@ -1,0 +1,560 @@
+// Rstest Snapshot v1
+
+exports[`accessor-pairs > invalid 1`] = `
+{
+  "code": "var o = { set a(value) {} };",
+  "diagnostics": [
+    {
+      "message": "Getter is not present for setter 'a'.",
+      "messageId": "missingGetterInObjectLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 2`] = `
+{
+  "code": "var o = { get a() {} };",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for getter 'a'.",
+      "messageId": "missingSetterInObjectLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 3`] = `
+{
+  "code": "var o = { get a() {}, set b(foo) {} };",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for getter 'a'.",
+      "messageId": "missingSetterInObjectLiteral",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+    {
+      "message": "Getter is not present for setter 'b'.",
+      "messageId": "missingGetterInObjectLiteral",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 4`] = `
+{
+  "code": "var o = { get [a]() {}, set [b](foo) {} };",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for getter.",
+      "messageId": "missingSetterInObjectLiteral",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+    {
+      "message": "Getter is not present for setter.",
+      "messageId": "missingGetterInObjectLiteral",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 5`] = `
+{
+  "code": "var o = {d: 1};
+ Object.defineProperty(o, 'c', 
+{set: function(value) {
+ val = value; 
+} 
+});",
+  "diagnostics": [
+    {
+      "message": "Getter is not present in property descriptor.",
+      "messageId": "missingGetterInPropertyDescriptor",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 6,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 6`] = `
+{
+  "code": "Reflect.defineProperty(obj, 'foo', {set: function(value) {}});",
+  "diagnostics": [
+    {
+      "message": "Getter is not present in property descriptor.",
+      "messageId": "missingGetterInPropertyDescriptor",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 7`] = `
+{
+  "code": "Object.defineProperties(obj, {foo: {set: function(value) {}}});",
+  "diagnostics": [
+    {
+      "message": "Getter is not present in property descriptor.",
+      "messageId": "missingGetterInPropertyDescriptor",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 8`] = `
+{
+  "code": "Object.create(null, {foo: {set: function(value) {}}});",
+  "diagnostics": [
+    {
+      "message": "Getter is not present in property descriptor.",
+      "messageId": "missingGetterInPropertyDescriptor",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 9`] = `
+{
+  "code": "Object?.defineProperty(obj, 'foo', {set: function(value) {}});",
+  "diagnostics": [
+    {
+      "message": "Getter is not present in property descriptor.",
+      "messageId": "missingGetterInPropertyDescriptor",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 10`] = `
+{
+  "code": "(Object?.defineProperty)(obj, 'foo', {set: function(value) {}});",
+  "diagnostics": [
+    {
+      "message": "Getter is not present in property descriptor.",
+      "messageId": "missingGetterInPropertyDescriptor",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 11`] = `
+{
+  "code": "class A { set a(foo) {} }",
+  "diagnostics": [
+    {
+      "message": "Getter is not present for class setter 'a'.",
+      "messageId": "missingGetterInClass",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 12`] = `
+{
+  "code": "class A { get a() {} }",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for class getter 'a'.",
+      "messageId": "missingSetterInClass",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 13`] = `
+{
+  "code": "class A { static set a(foo) {} }",
+  "diagnostics": [
+    {
+      "message": "Getter is not present for class static setter 'a'.",
+      "messageId": "missingGetterInClass",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 14`] = `
+{
+  "code": "class A { get a() {} set b(foo) {} }",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for class getter 'a'.",
+      "messageId": "missingSetterInClass",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+    {
+      "message": "Getter is not present for class setter 'b'.",
+      "messageId": "missingGetterInClass",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 15`] = `
+{
+  "code": "class A { get a() {} static set a(foo) {} }",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for class getter 'a'.",
+      "messageId": "missingSetterInClass",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+    {
+      "message": "Getter is not present for class static setter 'a'.",
+      "messageId": "missingGetterInClass",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 16`] = `
+{
+  "code": "class A { set #a(foo) {} }",
+  "diagnostics": [
+    {
+      "message": "Getter is not present for class private setter #a.",
+      "messageId": "missingGetterInClass",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 17`] = `
+{
+  "code": "interface I { set prop(value: any): any }",
+  "diagnostics": [
+    {
+      "message": "Getter is not present for type setter 'prop'.",
+      "messageId": "missingGetterInType",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 18`] = `
+{
+  "code": "type T = { set prop(value: any): any }",
+  "diagnostics": [
+    {
+      "message": "Getter is not present for type setter 'prop'.",
+      "messageId": "missingGetterInType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`accessor-pairs > invalid 19`] = `
+{
+  "code": "type T = { get prop(): any }",
+  "diagnostics": [
+    {
+      "message": "Setter is not present for type getter 'prop'.",
+      "messageId": "missingSetterInType",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "accessor-pairs",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/accessor-pairs.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/accessor-pairs.test.ts
@@ -1,0 +1,257 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('accessor-pairs', {
+  valid: [
+    // Destructuring patterns — not flagged
+    {
+      code: 'var { get: foo } = bar; ({ set: foo } = bar);',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+    {
+      code: 'var { set } = foo; ({ get } = foo);',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+
+    // Default: getWithoutSet=false, so lone getter is OK
+    'var o = { get a() {} }',
+    { code: 'var o = { get a() {} }', options: [{}] as any },
+
+    // Both options disabled
+    {
+      code: 'var o = { get a() {} };',
+      options: [{ setWithoutGet: false, getWithoutSet: false }] as any,
+    },
+    {
+      code: 'var o = { set a(foo) {} };',
+      options: [{ setWithoutGet: false, getWithoutSet: false }] as any,
+    },
+
+    // Valid pairs
+    {
+      code: 'var o = { get a() {}, set a(foo) {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+    {
+      code: 'var o = { set a(foo) {}, get a() {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+    {
+      code: "var o = { get 'a'() {}, set 'a'(foo) {} };",
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+    {
+      code: 'var o = { get [a]() {}, set [a](foo) {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+    {
+      code: 'var o = { get [(a)]() {}, set [a](foo) {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+    {
+      code: 'var o = { get [f(a)]() {}, set [f(a)](foo) {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+    },
+
+    // Property descriptors — complete pairs or non-descriptor calls
+    "var o = {a: 1};\n Object.defineProperty(o, 'b', \n{set: function(value) {\n val = value; \n},\n get: function() {\n return val; \n} \n});",
+    'var o = {set: function() {}}',
+    'Object.defineProperties(obj, {set: {value: function() {}}});',
+    'Object.create(null, {set: {value: function() {}}});',
+
+    // Classes — default (no errors without options)
+    {
+      code: 'class A { get a() {} }',
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: 'class A { get #a() {} }',
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: 'class A { set a(foo) {} }',
+      options: [{ enforceForClassMembers: false }] as any,
+    },
+    {
+      code: 'class A { get a() {} set a(foo) {} }',
+      options: [
+        {
+          setWithoutGet: true,
+          getWithoutSet: true,
+          enforceForClassMembers: true,
+        },
+      ] as any,
+    },
+    {
+      code: 'class A { static get a() {} static set a(foo) {} }',
+      options: [
+        {
+          setWithoutGet: true,
+          getWithoutSet: true,
+          enforceForClassMembers: true,
+        },
+      ] as any,
+    },
+
+    // TS — default off
+    'interface I { get prop(): any }',
+    'type T = { set prop(value: any): void }',
+    {
+      code: 'interface I { get prop(): any, set prop(value: any): void }',
+      options: [{ enforceForTSTypes: true }] as any,
+    },
+    {
+      code: 'type T = { get prop(): any, set prop(value: any): void }',
+      options: [{ enforceForTSTypes: true }] as any,
+    },
+    { code: 'interface I {}', options: [{ enforceForTSTypes: true }] as any },
+    {
+      code: 'interface I { method(): any }',
+      options: [{ enforceForTSTypes: true }] as any,
+    },
+  ],
+  invalid: [
+    // Default — setter without getter
+    {
+      code: 'var o = { set a(value) {} };',
+      errors: [{ messageId: 'missingGetterInObjectLiteral' }],
+    },
+    {
+      code: 'var o = { get a() {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+      errors: [{ messageId: 'missingSetterInObjectLiteral' }],
+    },
+
+    // Different keys
+    {
+      code: 'var o = { get a() {}, set b(foo) {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+      errors: [
+        { messageId: 'missingSetterInObjectLiteral' },
+        { messageId: 'missingGetterInObjectLiteral' },
+      ],
+    },
+
+    // Computed different keys
+    {
+      code: 'var o = { get [a]() {}, set [b](foo) {} };',
+      options: [{ setWithoutGet: true, getWithoutSet: true }] as any,
+      errors: [
+        { messageId: 'missingSetterInObjectLiteral' },
+        { messageId: 'missingGetterInObjectLiteral' },
+      ],
+    },
+
+    // Property descriptors
+    {
+      code: "var o = {d: 1};\n Object.defineProperty(o, 'c', \n{set: function(value) {\n val = value; \n} \n});",
+      errors: [{ messageId: 'missingGetterInPropertyDescriptor' }],
+    },
+    {
+      code: "Reflect.defineProperty(obj, 'foo', {set: function(value) {}});",
+      errors: [{ messageId: 'missingGetterInPropertyDescriptor' }],
+    },
+    {
+      code: 'Object.defineProperties(obj, {foo: {set: function(value) {}}});',
+      errors: [{ messageId: 'missingGetterInPropertyDescriptor' }],
+    },
+    {
+      code: 'Object.create(null, {foo: {set: function(value) {}}});',
+      errors: [{ messageId: 'missingGetterInPropertyDescriptor' }],
+    },
+
+    // Optional chaining on descriptor-creating calls
+    {
+      code: "Object?.defineProperty(obj, 'foo', {set: function(value) {}});",
+      errors: [{ messageId: 'missingGetterInPropertyDescriptor' }],
+    },
+    {
+      code: "(Object?.defineProperty)(obj, 'foo', {set: function(value) {}});",
+      errors: [{ messageId: 'missingGetterInPropertyDescriptor' }],
+    },
+
+    // Class — default (setWithoutGet only)
+    {
+      code: 'class A { set a(foo) {} }',
+      errors: [{ messageId: 'missingGetterInClass' }],
+    },
+    {
+      code: 'class A { get a() {} }',
+      options: [
+        {
+          setWithoutGet: true,
+          getWithoutSet: true,
+          enforceForClassMembers: true,
+        },
+      ] as any,
+      errors: [{ messageId: 'missingSetterInClass' }],
+    },
+    {
+      code: 'class A { static set a(foo) {} }',
+      options: [
+        {
+          setWithoutGet: true,
+          getWithoutSet: true,
+          enforceForClassMembers: true,
+        },
+      ] as any,
+      errors: [{ messageId: 'missingGetterInClass' }],
+    },
+
+    // Class — different keys
+    {
+      code: 'class A { get a() {} set b(foo) {} }',
+      options: [
+        {
+          setWithoutGet: true,
+          getWithoutSet: true,
+          enforceForClassMembers: true,
+        },
+      ] as any,
+      errors: [
+        { messageId: 'missingSetterInClass' },
+        { messageId: 'missingGetterInClass' },
+      ],
+    },
+
+    // Class — same key on static vs instance is not a pair
+    {
+      code: 'class A { get a() {} static set a(foo) {} }',
+      options: [
+        {
+          setWithoutGet: true,
+          getWithoutSet: true,
+          enforceForClassMembers: true,
+        },
+      ] as any,
+      errors: [
+        { messageId: 'missingSetterInClass' },
+        { messageId: 'missingGetterInClass' },
+      ],
+    },
+
+    // Class — private identifier
+    {
+      code: 'class A { set #a(foo) {} }',
+      errors: [{ messageId: 'missingGetterInClass' }],
+    },
+
+    // TS types
+    {
+      code: 'interface I { set prop(value: any): any }',
+      options: [{ enforceForTSTypes: true }] as any,
+      errors: [{ messageId: 'missingGetterInType' }],
+    },
+    {
+      code: 'type T = { set prop(value: any): any }',
+      options: [{ enforceForTSTypes: true }] as any,
+      errors: [{ messageId: 'missingGetterInType' }],
+    },
+    {
+      code: 'type T = { get prop(): any }',
+      options: [{ enforceForTSTypes: true, getWithoutSet: true }] as any,
+      errors: [{ messageId: 'missingSetterInType' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `accessor-pairs` rule from ESLint to rslint.

The rule enforces getter/setter pairs in objects, classes, and (optionally) TypeScript interfaces and type literals. Supports all four ESLint options: `setWithoutGet` (default true), `getWithoutSet` (default false), `enforceForClassMembers` (default true), `enforceForTSTypes` (default false).

Behavior is verified against the full ESLint test suite (~400 test cases across Go unit tests, including message-text assertions for every formatted variant — static/private/static-private modifiers, numeric normalization, no-name computed reports, property descriptor fixed text). Differential-tested on the rspack codebase: 68 reports, 100% file+line+column+message match with the upstream ESLint rule run against the same files.

Additions touching shared code:

- `utils.IsSpecificMemberAccess(node, object, method)` — promoted from a private helper, extended to handle optional chaining, parenthesized forms, and bracket access (`Reflect['defineProperty']`).
- `utils.IsArgumentOfSpecificCall(node, index, object, method)` — new; covers the common \"is this the N-th argument of \`Object.defineProperty\`-style calls\" pattern used here, in `getter_return`, and in `no_import_assign`.
- `utils.AreNodesStructurallyEqual(a, b)` — new general-purpose structural AST equality helper.
- `utils.GetStaticPropertyName` — extended to recognize `[true]` / `[false]` / `[/regex/]` in computed keys (matches ESLint's `String(prop.value)` semantics).
- `rule_tester.InvalidTestCaseError.Message` — new optional field for exact-message assertions.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/accessor-pairs
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/accessor-pairs.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).