### PR TITLE
feat: port rule no-extend-native

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -20,7 +20,7 @@ npm/tsgo/**/lib/
 binaries/
 target/
 internal/plugins/**/rules/**/*.md
-internal/rules/max_lines/max_lines.md
+internal/rules/**/*.md
 website/docs/en/rules/_meta.json
 website/docs/en/rules/*/
 packages/vscode-extension/__tests__/fixtures-monorepo/packages/broken/

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,6 +144,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_empty_pattern"
 	"github.com/web-infra-dev/rslint/internal/rules/no_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_ex_assign"
+	"github.com/web-infra-dev/rslint/internal/rules/no_extend_native"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
@@ -552,6 +553,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-empty-pattern", no_empty_pattern.NoEmptyPatternRule)
 	GlobalRuleRegistry.Register("no-eval", no_eval.NoEvalRule)
 	GlobalRuleRegistry.Register("no-ex-assign", no_ex_assign.NoExAssignRule)
+	GlobalRuleRegistry.Register("no-extend-native", no_extend_native.NoExtendNativeRule)
 	GlobalRuleRegistry.Register("no-extra-bind", no_extra_bind.NoExtraBindRule)
 	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)

--- a/internal/rules/no_extend_native/no_extend_native.go
+++ b/internal/rules/no_extend_native/no_extend_native.go
@@ -1,0 +1,196 @@
+package no_extend_native
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// nativeBuiltins lists ECMAScript globals whose first letter is uppercase.
+// Mirrors ESLint's `Object.keys(astUtils.ECMASCRIPT_GLOBALS).filter(b => b[0].toUpperCase() === b[0])`,
+// where `ECMASCRIPT_GLOBALS = globals[`es${LATEST_ECMA_VERSION}`]` from the
+// `globals` package. Generated from `globals.es2027` to stay byte-for-byte
+// in sync with upstream ESLint.
+var nativeBuiltins = map[string]bool{
+	"AggregateError": true, "Array": true, "ArrayBuffer": true, "Atomics": true,
+	"BigInt": true, "BigInt64Array": true, "BigUint64Array": true, "Boolean": true,
+	"DataView": true, "Date": true,
+	"Error": true, "EvalError": true,
+	"FinalizationRegistry": true, "Float16Array": true, "Float32Array": true, "Float64Array": true, "Function": true,
+	"Infinity": true, "Int16Array": true, "Int32Array": true, "Int8Array": true, "Intl": true, "Iterator": true,
+	"JSON": true,
+	"Map": true, "Math": true,
+	"NaN": true, "Number": true,
+	"Object": true,
+	"Promise": true, "Proxy": true,
+	"RangeError": true, "ReferenceError": true, "Reflect": true, "RegExp": true,
+	"Set": true, "SharedArrayBuffer": true, "String": true, "Symbol": true, "SyntaxError": true,
+	"TypeError": true,
+	"URIError": true, "Uint16Array": true, "Uint32Array": true, "Uint8Array": true, "Uint8ClampedArray": true,
+	"WeakMap": true, "WeakRef": true, "WeakSet": true,
+}
+
+type options struct {
+	exceptions map[string]bool
+}
+
+func parseOptions(opts any) options {
+	result := options{exceptions: make(map[string]bool)}
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap != nil {
+		if exceptions, ok := optsMap["exceptions"].([]interface{}); ok {
+			for _, e := range exceptions {
+				if s, ok := e.(string); ok {
+					result.exceptions[s] = true
+				}
+			}
+		}
+	}
+	return result
+}
+
+// isAssignmentOperator reports whether the given binary operator is a
+// (compound) assignment, including logical assignments.
+func isAssignmentOperator(kind ast.Kind) bool {
+	switch kind {
+	case ast.KindEqualsToken,
+		ast.KindPlusEqualsToken,
+		ast.KindMinusEqualsToken,
+		ast.KindAsteriskEqualsToken,
+		ast.KindAsteriskAsteriskEqualsToken,
+		ast.KindSlashEqualsToken,
+		ast.KindPercentEqualsToken,
+		ast.KindLessThanLessThanEqualsToken,
+		ast.KindGreaterThanGreaterThanEqualsToken,
+		ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
+		ast.KindAmpersandEqualsToken,
+		ast.KindBarEqualsToken,
+		ast.KindCaretEqualsToken,
+		ast.KindAmpersandAmpersandEqualsToken,
+		ast.KindBarBarEqualsToken,
+		ast.KindQuestionQuestionEqualsToken:
+		return true
+	}
+	return false
+}
+
+// memberObject returns the object expression of a property/element access node,
+// or nil if the node is not a member access.
+func memberObject(node *ast.Node) *ast.Node {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		return node.AsPropertyAccessExpression().Expression
+	case ast.KindElementAccessExpression:
+		return node.AsElementAccessExpression().Expression
+	}
+	return nil
+}
+
+// staticMemberName returns the static property name of a member access, or
+// ("", false) if it cannot be determined statically.
+func staticMemberName(node *ast.Node) (string, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		name := node.AsPropertyAccessExpression().Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text, true
+		}
+	case ast.KindElementAccessExpression:
+		return utils.GetStaticExpressionValue(ast.SkipParentheses(node.AsElementAccessExpression().ArgumentExpression))
+	}
+	return "", false
+}
+
+// skipParensUp walks up from `node` through ParenthesizedExpression parents.
+func skipParensUp(node *ast.Node) *ast.Node {
+	for node.Parent != nil && node.Parent.Kind == ast.KindParenthesizedExpression {
+		node = node.Parent
+	}
+	return node
+}
+
+// https://eslint.org/docs/latest/rules/no-extend-native
+var NoExtendNativeRule = rule.Rule{
+	Name: "no-extend-native",
+	Run: func(ctx rule.RuleContext, opts any) rule.RuleListeners {
+		o := parseOptions(opts)
+
+		return rule.RuleListeners{
+			ast.KindIdentifier: func(node *ast.Node) {
+				name := node.Text()
+				if !nativeBuiltins[name] || o.exceptions[name] {
+					return
+				}
+
+				// In tsgo, parentheses are explicit nodes — `(Object).prototype.p`
+				// wraps the identifier in a ParenthesizedExpression. Walk up
+				// through any wrapping parens before checking the member access.
+				identExpr := skipParensUp(node)
+				parent := identExpr.Parent
+				if parent == nil {
+					return
+				}
+
+				// `identExpr` must be the object of a member access whose property is `prototype`.
+				obj := memberObject(parent)
+				if obj != identExpr {
+					return
+				}
+				propName, ok := staticMemberName(parent)
+				if !ok || propName != "prototype" {
+					return
+				}
+
+				if utils.IsShadowed(node, name) {
+					return
+				}
+
+				// Walk up through any wrapping parentheses to find the next significant parent.
+				prototypeAccess := skipParensUp(parent)
+				next := prototypeAccess.Parent
+				if next == nil {
+					return
+				}
+
+				// Case 1: assignment to a property of the prototype.
+				// e.g. `Object.prototype.p = 0`, `(Object?.prototype).p = 0`,
+				//      `Array.prototype.p &&= 0`.
+				if memberObject(next) == prototypeAccess {
+					memberAccess := skipParensUp(next)
+					assign := memberAccess.Parent
+					if assign != nil && assign.Kind == ast.KindBinaryExpression {
+						bin := assign.AsBinaryExpression()
+						if bin.OperatorToken != nil &&
+							isAssignmentOperator(bin.OperatorToken.Kind) &&
+							bin.Left == memberAccess {
+							ctx.ReportNode(assign, rule.RuleMessage{
+								Id:          "unexpected",
+								Description: fmt.Sprintf("%s prototype is read only, properties should not be added.", name),
+							})
+							return
+						}
+					}
+				}
+
+				// Case 2: first argument of `Object.defineProperty` /
+				// `Object.defineProperties`.
+				if next.Kind == ast.KindCallExpression {
+					call := next.AsCallExpression()
+					if call.Arguments == nil || len(call.Arguments.Nodes) == 0 ||
+						call.Arguments.Nodes[0] != prototypeAccess {
+						return
+					}
+					if utils.IsSpecificMemberAccess(call.Expression, "Object", "defineProperty") ||
+						utils.IsSpecificMemberAccess(call.Expression, "Object", "defineProperties") {
+						ctx.ReportNode(next, rule.RuleMessage{
+							Id:          "unexpected",
+							Description: fmt.Sprintf("%s prototype is read only, properties should not be added.", name),
+						})
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_extend_native/no_extend_native.go
+++ b/internal/rules/no_extend_native/no_extend_native.go
@@ -1,8 +1,6 @@
 package no_extend_native
 
 import (
-	"fmt"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -167,7 +165,7 @@ var NoExtendNativeRule = rule.Rule{
 							bin.Left == memberAccess {
 							ctx.ReportNode(assign, rule.RuleMessage{
 								Id:          "unexpected",
-								Description: fmt.Sprintf("%s prototype is read only, properties should not be added.", name),
+								Description: name + " prototype is read only, properties should not be added.",
 							})
 							return
 						}
@@ -186,7 +184,7 @@ var NoExtendNativeRule = rule.Rule{
 						utils.IsSpecificMemberAccess(call.Expression, "Object", "defineProperties") {
 						ctx.ReportNode(next, rule.RuleMessage{
 							Id:          "unexpected",
-							Description: fmt.Sprintf("%s prototype is read only, properties should not be added.", name),
+							Description: name + " prototype is read only, properties should not be added.",
 						})
 					}
 				}

--- a/internal/rules/no_extend_native/no_extend_native.md
+++ b/internal/rules/no_extend_native/no_extend_native.md
@@ -1,0 +1,64 @@
+# no-extend-native
+
+Disallows directly modifying the prototype of native built-in objects (`Object`,
+`Array`, `Function`, `String`, `Number`, `Boolean`, `Symbol`, `Map`, `Set`,
+`Promise`, `Error`, `RegExp`, `Date`, `BigInt`, `WeakRef`,
+`FinalizationRegistry`, etc.).
+
+## Rule Details
+
+Extending native prototypes is generally regarded as a bad practice because it
+breaks assumptions other code makes about builtins, can collide with future
+language additions, and is invisible to the rest of the program until it is
+triggered at runtime.
+
+The rule reports two extension patterns:
+
+1. Direct assignment, including compound and logical assignments:
+   `Builtin.prototype.foo = ...`, `Builtin.prototype.foo ??= ...`.
+2. `Object.defineProperty(Builtin.prototype, ...)` and
+   `Object.defineProperties(Builtin.prototype, ...)`.
+
+References to the builtin that are shadowed by a local declaration in scope
+(e.g. `function foo() { var Object = function () {}; Object.prototype.p = 0 }`)
+are not reported.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Object.prototype.a = "a";
+Object.defineProperty(Array.prototype, "times", { value: 999 });
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// Modifications to user-defined objects are allowed.
+x.prototype.p = 0;
+
+// Property access on the constructor (not on its prototype) is allowed.
+Object.toString.bind = 0;
+```
+
+## Options
+
+```json
+{
+  "no-extend-native": ["error", { "exceptions": ["Object"] }]
+}
+```
+
+| Option       | Type                | Default | Description                                                                |
+| ------------ | ------------------- | ------- | -------------------------------------------------------------------------- |
+| `exceptions` | `string[]` (unique) | `[]`    | Names of built-in objects whose prototype is allowed to be extended.       |
+
+With `{ "exceptions": ["Object"] }`, the following becomes valid:
+
+```javascript
+Object.prototype.g = 0;
+```
+
+## Original Documentation
+
+- [ESLint rule documentation](https://eslint.org/docs/latest/rules/no-extend-native)
+- [Source code](https://github.com/eslint/eslint/blob/main/lib/rules/no-extend-native.js)

--- a/internal/rules/no_extend_native/no_extend_native_test.go
+++ b/internal/rules/no_extend_native/no_extend_native_test.go
@@ -1,0 +1,339 @@
+package no_extend_native
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExtendNativeRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoExtendNativeRule,
+		// Valid cases — mirrors ESLint's `tests/lib/rules/no-extend-native.js`.
+		[]rule_tester.ValidTestCase{
+			{Code: `x.prototype.p = 0`},
+			{Code: `x.prototype['p'] = 0`},
+			{Code: `Object.p = 0`},
+			{Code: `Object.toString.bind = 0`},
+			{Code: `Object['toString'].bind = 0`},
+			{Code: `Object.defineProperty(x, 'p', {value: 0})`},
+			{Code: `Object.defineProperties(x, {p: {value: 0}})`},
+			{Code: `global.Object.prototype.toString = 0`},
+			{Code: `this.Object.prototype.toString = 0`},
+			{Code: `with(Object) { prototype.p = 0; }`},
+			{Code: `o = Object; o.prototype.toString = 0`},
+			{Code: `eval('Object.prototype.toString = 0')`},
+
+			// `parseFloat` is a lowercase-first ECMAScript global and so is not
+			// considered a "native" builtin by this rule.
+			{Code: `parseFloat.prototype.x = 1`},
+
+			// Exception option allows extending Object's prototype.
+			{
+				Code:    `Object.prototype.g = 0`,
+				Options: map[string]interface{}{"exceptions": []interface{}{"Object"}},
+			},
+
+			// `Object.prototype` appears as the *index* of a member access, not
+			// as the assignment target.
+			{Code: `obj[Object.prototype] = 0`},
+
+			// https://github.com/eslint/eslint/issues/4438
+			{Code: `Object.defineProperty()`},
+			{Code: `Object.defineProperties()`},
+
+			// https://github.com/eslint/eslint/issues/8461 — locally shadowed
+			// references are not reported.
+			{Code: `function foo() { var Object = function() {}; Object.prototype.p = 0 }`},
+			{Code: `{ let Object = function() {}; Object.prototype.p = 0 }`},
+
+			// ---- Extra valid coverage ----
+			// Pure read of prototype, not a write.
+			{Code: `var x = Object.prototype`},
+			{Code: `var x = Object.prototype.p`},
+			{Code: `console.log(Object.prototype.p)`},
+
+			// `Reflect.defineProperty` is not flagged — the rule only targets
+			// `Object.defineProperty` and `Object.defineProperties`.
+			{Code: `Reflect.defineProperty(Array.prototype, 'p', {value: 0})`},
+
+			// Removing a property is not "adding" one.
+			{Code: `delete Object.prototype.p`},
+
+			// Increment/decrement are UpdateExpressions, not AssignmentExpressions.
+			{Code: `Object.prototype.p++`},
+			{Code: `--Object.prototype.p`},
+
+			// Assigning to `prototype` itself (not to a property of it) is a
+			// different operation; ESLint deliberately does not report it here.
+			{Code: `(Object.prototype) = 0`},
+
+			// TypeScript type assertion wrapping the builtin reference.
+			{Code: `(Object as any).prototype.p = 0`},
+		},
+		// Invalid cases — mirrors ESLint's `tests/lib/rules/no-extend-native.js`.
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `Object.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `BigInt.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `WeakRef.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `FinalizationRegistry.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `AggregateError.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Function.prototype['p'] = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `String['prototype'].p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Number['prototype']['p'] = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object.defineProperty(Array.prototype, 'p', {value: 0})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object.defineProperties(Array.prototype, {p: {value: 0}})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object.defineProperties(Array.prototype, {p: {value: 0}, q: {value: 0}})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `Number['prototype']['p'] = 0`,
+				Options: map[string]interface{}{"exceptions": []interface{}{"Object"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object.prototype.p = 0; Object.prototype.q = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `function foo() { Object.prototype.p = 0 }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+
+			// ---- Optional chaining ----
+			{
+				Code: `(Object?.prototype).p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object.defineProperty(Object?.prototype, 'p', { value: 0 })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object?.defineProperty(Object.prototype, 'p', { value: 0 })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(Object?.defineProperty)(Object.prototype, 'p', { value: 0 })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Logical assignments ----
+			{
+				Code: `Array.prototype.p &&= 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Array.prototype.p ||= 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Array.prototype.p ??= 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Extra coverage ----
+			// Multi-line assignment — message position covers the whole assignment.
+			{
+				Code: "Object\n  .prototype\n  .p = 0",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1, EndLine: 3, EndColumn: 9},
+				},
+			},
+			// Compound (non-logical) assignment.
+			{
+				Code: `String.prototype.p += 'x'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Exception option does NOT apply to other builtins.
+			{
+				Code:    `Array.prototype.p = 0`,
+				Options: map[string]interface{}{"exceptions": []interface{}{"Object"}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Message text assertion for the `unexpected` messageId.
+			{
+				Code: `Object.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "Object prototype is read only, properties should not be added.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+
+			// ---- Parenthesized identifier (tsgo-only quirk) ----
+			// ESLint's ESTree treats parens as transparent; tsgo wraps them
+			// in a ParenthesizedExpression node. Both forms must still fire.
+			{
+				Code: `(Object).prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `((Object)).prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Object.defineProperty((Array).prototype, 'p', {value: 0})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Builtin coverage ----
+			{
+				Code: `Symbol.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Map.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `WeakMap.prototype.p = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Chained assignment — both sides report ----
+			{
+				Code: `Object.prototype.p = Array.prototype.q = 0`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- Template literal as static key ----
+			{
+				Code: "Object[`prototype`].p = 0",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "Object.prototype[`p`] = 0",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Options schema ----
+			// Empty options object behaves like the default (no exceptions).
+			{
+				Code:    `Object.prototype.p = 0`,
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+			// Explicit empty exceptions list also matches the default.
+			{
+				Code:    `Object.prototype.p = 0`,
+				Options: map[string]interface{}{"exceptions": []interface{}{}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -47,6 +47,7 @@ export default defineConfig({
     './tests/eslint/rules/no-caller.test.ts',
 
     './tests/eslint/rules/default-case-last.test.ts',
+    './tests/eslint/rules/no-extend-native.test.ts',
     './tests/eslint/rules/no-extra-bind.test.ts',
     './tests/eslint/rules/no-func-assign.test.ts',
     './tests/eslint/rules/no-global-assign.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extend-native.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extend-native.test.ts.snap
@@ -1,0 +1,733 @@
+// Rstest Snapshot v1
+
+exports[`no-extend-native > invalid 1`] = `
+{
+  "code": "Object.prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 2`] = `
+{
+  "code": "BigInt.prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "BigInt prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 3`] = `
+{
+  "code": "WeakRef.prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "WeakRef prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 4`] = `
+{
+  "code": "FinalizationRegistry.prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "FinalizationRegistry prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 5`] = `
+{
+  "code": "AggregateError.prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "AggregateError prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 6`] = `
+{
+  "code": "Function.prototype['p'] = 0",
+  "diagnostics": [
+    {
+      "message": "Function prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 7`] = `
+{
+  "code": "String['prototype'].p = 0",
+  "diagnostics": [
+    {
+      "message": "String prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 8`] = `
+{
+  "code": "Number['prototype']['p'] = 0",
+  "diagnostics": [
+    {
+      "message": "Number prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 9`] = `
+{
+  "code": "Object.defineProperty(Array.prototype, 'p', {value: 0})",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 10`] = `
+{
+  "code": "Object.defineProperties(Array.prototype, {p: {value: 0}})",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 11`] = `
+{
+  "code": "Object.defineProperties(Array.prototype, {p: {value: 0}, q: {value: 0}})",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 12`] = `
+{
+  "code": "Number['prototype']['p'] = 0",
+  "diagnostics": [
+    {
+      "message": "Number prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 13`] = `
+{
+  "code": "Object.prototype.p = 0; Object.prototype.q = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 14`] = `
+{
+  "code": "function foo() { Object.prototype.p = 0 }",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 15`] = `
+{
+  "code": "(Object?.prototype).p = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 16`] = `
+{
+  "code": "Object.defineProperty(Object?.prototype, 'p', { value: 0 })",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 17`] = `
+{
+  "code": "Object?.defineProperty(Object.prototype, 'p', { value: 0 })",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 18`] = `
+{
+  "code": "(Object?.defineProperty)(Object.prototype, 'p', { value: 0 })",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 19`] = `
+{
+  "code": "Array.prototype.p &&= 0",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 20`] = `
+{
+  "code": "Array.prototype.p ||= 0",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 21`] = `
+{
+  "code": "Array.prototype.p ??= 0",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 22`] = `
+{
+  "code": "(Object).prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 23`] = `
+{
+  "code": "((Object)).prototype.p = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 24`] = `
+{
+  "code": "Object.defineProperty((Array).prototype, 'p', {value: 0})",
+  "diagnostics": [
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 25`] = `
+{
+  "code": "Object.prototype.p = Array.prototype.q = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+    {
+      "message": "Array prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 26`] = `
+{
+  "code": "Object[\`prototype\`].p = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extend-native > invalid 27`] = `
+{
+  "code": "Object.prototype[\`p\`] = 0",
+  "diagnostics": [
+    {
+      "message": "Object prototype is read only, properties should not be added.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extend-native",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-extend-native.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-extend-native.test.ts
@@ -1,0 +1,155 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-extend-native', {
+  valid: [
+    'x.prototype.p = 0',
+    "x.prototype['p'] = 0",
+    'Object.p = 0',
+    'Object.toString.bind = 0',
+    "Object['toString'].bind = 0",
+    "Object.defineProperty(x, 'p', {value: 0})",
+    'Object.defineProperties(x, {p: {value: 0}})',
+    'global.Object.prototype.toString = 0',
+    'this.Object.prototype.toString = 0',
+    'with(Object) { prototype.p = 0; }',
+    'o = Object; o.prototype.toString = 0',
+    "eval('Object.prototype.toString = 0')",
+    'parseFloat.prototype.x = 1',
+    {
+      code: 'Object.prototype.g = 0',
+      options: { exceptions: ['Object'] },
+    },
+    'obj[Object.prototype] = 0',
+
+    // https://github.com/eslint/eslint/issues/4438
+    'Object.defineProperty()',
+    'Object.defineProperties()',
+
+    // https://github.com/eslint/eslint/issues/8461
+    'function foo() { var Object = function() {}; Object.prototype.p = 0 }',
+    '{ let Object = function() {}; Object.prototype.p = 0 }',
+  ],
+  invalid: [
+    {
+      code: 'Object.prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'BigInt.prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'WeakRef.prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'FinalizationRegistry.prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'AggregateError.prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Function.prototype['p'] = 0",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "String['prototype'].p = 0",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Number['prototype']['p'] = 0",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Object.defineProperty(Array.prototype, 'p', {value: 0})",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'Object.defineProperties(Array.prototype, {p: {value: 0}})',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'Object.defineProperties(Array.prototype, {p: {value: 0}, q: {value: 0}})',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Number['prototype']['p'] = 0",
+      options: { exceptions: ['Object'] },
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'Object.prototype.p = 0; Object.prototype.q = 0',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: 'function foo() { Object.prototype.p = 0 }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Optional chaining
+    {
+      code: '(Object?.prototype).p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Object.defineProperty(Object?.prototype, 'p', { value: 0 })",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Object?.defineProperty(Object.prototype, 'p', { value: 0 })",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "(Object?.defineProperty)(Object.prototype, 'p', { value: 0 })",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Logical assignments
+    {
+      code: 'Array.prototype.p &&= 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'Array.prototype.p ||= 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'Array.prototype.p ??= 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Parenthesized identifier (tsgo wraps parens as a node; ESTree doesn't).
+    {
+      code: '(Object).prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '((Object)).prototype.p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "Object.defineProperty((Array).prototype, 'p', {value: 0})",
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Chained assignment — both sides report.
+    {
+      code: 'Object.prototype.p = Array.prototype.q = 0',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+
+    // Template literal as static property key.
+    {
+      code: 'Object[`prototype`].p = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'Object.prototype[`p`] = 0',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-extend-native` rule from ESLint to rslint. The rule disallows extending native built-in prototypes (\`Object\`, \`Array\`, \`String\`, …) via direct assignment, compound/logical assignment, or \`Object.defineProperty\` / \`Object.defineProperties\`.

Built-in list is generated from \`globals.es2027\` to stay byte-for-byte in sync with upstream ESLint (49 entries). Exception list option (\`exceptions: string[]\`) and message format (\`unexpected\`) match ESLint exactly.

Differential validation against ESLint on a 12-pattern sample (paren / optional-chain / bracket / template-literal / logical-assignment / chained-assignment / shadowing / etc.) yields zero diff in line/column/message. Verified on \`rsbuild\` and \`rspack\` source trees.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-extend-native
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-extend-native.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).