### PR TITLE
docs(port-rule): standardize options examples on a standalone JSON config block

### DIFF
--- a/agents/port-rule/references/PORT_RULE.md
+++ b/agents/port-rule/references/PORT_RULE.md
@@ -333,10 +333,22 @@ Examples of **correct** code for this rule:
 var x = { a: 1, b: 2 };
 ```
 
+Examples of **incorrect** code for this rule with `{ "someOption": true }`:
+
+```json
+{ "<rule-name>": ["error", { "someOption": true }] }
+```
+
+```javascript
+// Example
+```
+
 ## Original Documentation
 
 [Link to ESLint documentation]
 ````
+
+**Options in examples**: when a code block demonstrates a specific option combination, precede the `javascript` block with a standalone `json` block containing the rule's config entry — shape: `{ "<rule-name>": ["error", { ...options... }] }`. Let prettier format it (single-line when short, multi-line when the options list grows). Keep the `javascript` block pure source code (no annotations). Do **not** wrap the config entry in a `"rules": { ... }` object (redundant here) and do **not** copy upstream linter directives such as `/* eslint <rule>: [...] */` into the examples.
 
 ### Step 4: Write Go Tests
 

--- a/internal/rules/max_lines/max_lines.md
+++ b/internal/rules/max_lines/max_lines.md
@@ -10,11 +10,7 @@ going on. This rule caps the number of lines in a file.
 With the `{ "max": 3 }` option:
 
 ```json
-{
-  "rules": {
-    "max-lines": ["error", 3]
-  }
-}
+{ "max-lines": ["error", 3] }
 ```
 
 Examples of **incorrect** code for this rule:
@@ -48,11 +44,7 @@ following properties:
 ### `skipBlankLines`
 
 ```json
-{
-  "rules": {
-    "max-lines": ["error", { "max": 2, "skipBlankLines": true }]
-  }
-}
+{ "max-lines": ["error", { "max": 2, "skipBlankLines": true }] }
 ```
 
 Examples of **correct** code with the above configuration:
@@ -67,11 +59,7 @@ var b = 2;
 ### `skipComments`
 
 ```json
-{
-  "rules": {
-    "max-lines": ["error", { "max": 2, "skipComments": true }]
-  }
-}
+{ "max-lines": ["error", { "max": 2, "skipComments": true }] }
 ```
 
 Examples of **correct** code with the above configuration:

--- a/internal/rules/no_bitwise/no_bitwise.md
+++ b/internal/rules/no_bitwise/no_bitwise.md
@@ -64,11 +64,7 @@ Whitelists the listed bitwise operators as exceptions. Only operators exactly ma
 Example configuration:
 
 ```json
-{
-  "rules": {
-    "no-bitwise": ["error", { "allow": ["~"] }]
-  }
-}
+{ "no-bitwise": ["error", { "allow": ["~"] }] }
 ```
 
 Examples of **correct** code with the above configuration:
@@ -87,11 +83,7 @@ When `true`, permits the `x | 0` idiom commonly used to coerce a number to a 32-
 Example configuration:
 
 ```json
-{
-  "rules": {
-    "no-bitwise": ["error", { "int32Hint": true }]
-  }
-}
+{ "no-bitwise": ["error", { "int32Hint": true }] }
 ```
 
 Examples of **correct** code with the above configuration:

--- a/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.md
+++ b/internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.md
@@ -44,9 +44,11 @@ This rule accepts a single options object.
 
 When `true`, the rule also reports redundant boolean casts that are operands of `||` or `&&` when the overall logical expression is used in a boolean context.
 
-```javascript
-/* eslint no-extra-boolean-cast: ["error", { "enforceForLogicalOperands": true }] */
+```json
+{ "no-extra-boolean-cast": ["error", { "enforceForLogicalOperands": true }] }
+```
 
+```javascript
 if (x || !!y) {
 } // reported
 ```
@@ -55,9 +57,11 @@ if (x || !!y) {
 
 A superset of `enforceForLogicalOperands`. Additionally reports redundant casts on the right-hand side of `??`, on the branches of ternaries, and on the last expression of a sequence (`a, b, c`).
 
-```javascript
-/* eslint no-extra-boolean-cast: ["error", { "enforceForInnerExpressions": true }] */
+```json
+{ "no-extra-boolean-cast": ["error", { "enforceForInnerExpressions": true }] }
+```
 
+```javascript
 if (x ?? !!y) {
 } // reported
 if (cond ? Boolean(a) : b) {

--- a/internal/rules/no_param_reassign/no_param_reassign.md
+++ b/internal/rules/no_param_reassign/no_param_reassign.md
@@ -32,9 +32,7 @@ function foo(bar) {
 ## Options
 
 ```json
-{
-  "no-param-reassign": ["error", { "props": false }]
-}
+{ "no-param-reassign": ["error", { "props": false }] }
 ```
 
 ```json
@@ -56,8 +54,11 @@ function foo(bar) {
 
 Examples of **incorrect** code with `{ "props": true }`:
 
+```json
+{ "no-param-reassign": ["error", { "props": true }] }
+```
+
 ```javascript
-/*eslint no-param-reassign: ["error", { "props": true }]*/
 function foo(bar) {
   bar.prop = 'value';
 }
@@ -73,8 +74,16 @@ function foo(bar) {
 
 Examples of **correct** code with `{ "props": true, "ignorePropertyModificationsFor": ["bar"] }`:
 
+```json
+{
+  "no-param-reassign": [
+    "error",
+    { "props": true, "ignorePropertyModificationsFor": ["bar"] }
+  ]
+}
+```
+
 ```javascript
-/*eslint no-param-reassign: ["error", { "props": true, "ignorePropertyModificationsFor": ["bar"] }]*/
 function foo(bar) {
   bar.prop = 'value';
 }

--- a/internal/rules/require_atomic_updates/require_atomic_updates.md
+++ b/internal/rules/require_atomic_updates/require_atomic_updates.md
@@ -50,9 +50,11 @@ async function baz() {
 
 When set to `true`, the rule does not report assignments to properties (only variables).
 
-```javascript
-/* eslint require-atomic-updates: ["error", { "allowProperties": true }] */
+```json
+{ "require-atomic-updates": ["error", { "allowProperties": true }] }
+```
 
+```javascript
 async function foo(obj) {
   if (!obj.done) {
     obj.something = await getSomething(); // OK with allowProperties


### PR DESCRIPTION
## Summary

Standardize how rule docs show option-specific examples: precede the `javascript` example with a standalone `json` block containing the rule's config entry — shape `{ "<rule-name>": ["error", { ...options... }] }`, no redundant `"rules": { ... }` wrapper, and no upstream linter directives (`/* eslint <rule>: [...] */`) copied into JS blocks. Layout (single-line vs. multi-line) follows prettier.

Changes:

- `agents/port-rule/references/PORT_RULE.md` (Step 3 template): extend the doc skeleton with an options-example sub-example and pin down the convention.
- `internal/rules/no_extra_boolean_cast/no_extra_boolean_cast.md`, `internal/rules/no_param_reassign/no_param_reassign.md`, `internal/rules/require_atomic_updates/require_atomic_updates.md`: drop the leftover `/* eslint ... */` directives and adopt the standalone-JSON-block form.
- `internal/rules/no_bitwise/no_bitwise.md`, `internal/rules/max_lines/max_lines.md`: flatten entries that still wrapped the config in `"rules": { ... }`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).