### PR TITLE
feat: port rule no-extra-label

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_extend_native"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_bind"
 	"github.com/web-infra-dev/rslint/internal/rules/no_extra_boolean_cast"
+	"github.com/web-infra-dev/rslint/internal/rules/no_extra_label"
 	"github.com/web-infra-dev/rslint/internal/rules/no_fallthrough"
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
@@ -558,6 +559,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-ex-assign", no_ex_assign.NoExAssignRule)
 	GlobalRuleRegistry.Register("no-extend-native", no_extend_native.NoExtendNativeRule)
 	GlobalRuleRegistry.Register("no-extra-bind", no_extra_bind.NoExtraBindRule)
+	GlobalRuleRegistry.Register("no-extra-label", no_extra_label.NoExtraLabelRule)
 	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)
 	GlobalRuleRegistry.Register("no-global-assign", no_global_assign.NoGlobalAssignRule)

--- a/internal/rules/no_extra_label/no_extra_label.go
+++ b/internal/rules/no_extra_label/no_extra_label.go
@@ -1,0 +1,149 @@
+package no_extra_label
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// scopeInfo tracks nested breakable / labeled scopes as a linked-list stack.
+// A scope is pushed for every breakable statement (loops + switch) and for
+// every LabeledStatement whose body is NOT itself a breakable statement
+// (labeled breakables fold their label into the breakable's scope — matching
+// ESLint's enterBreakableStatement / enterLabeledStatement handling).
+type scopeInfo struct {
+	label     string // "" when the breakable has no enclosing label
+	breakable bool
+	upper     *scopeInfo
+}
+
+// hasBreakableBody mirrors astUtils.isBreakableStatement in ESLint:
+// iteration statements and switch statements are "breakable".
+func hasBreakableBody(stmt *ast.Node) bool {
+	if stmt == nil {
+		return false
+	}
+	if stmt.Kind == ast.KindSwitchStatement {
+		return true
+	}
+	return ast.IsIterationStatement(stmt, false)
+}
+
+// https://eslint.org/docs/latest/rules/no-extra-label
+var NoExtraLabelRule = rule.Rule{
+	Name: "no-extra-label",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		var scope *scopeInfo
+
+		enterBreakable := func(node *ast.Node) {
+			label := ""
+			if parent := node.Parent; parent != nil && parent.Kind == ast.KindLabeledStatement {
+				label = parent.AsLabeledStatement().Label.Text()
+			}
+			scope = &scopeInfo{
+				label:     label,
+				breakable: true,
+				upper:     scope,
+			}
+		}
+
+		exitBreakable := func(node *ast.Node) {
+			if scope != nil {
+				scope = scope.upper
+			}
+		}
+
+		enterLabeled := func(node *ast.Node) {
+			ls := node.AsLabeledStatement()
+			if hasBreakableBody(ls.Statement) {
+				return
+			}
+			scope = &scopeInfo{
+				label:     ls.Label.Text(),
+				breakable: false,
+				upper:     scope,
+			}
+		}
+
+		exitLabeled := func(node *ast.Node) {
+			ls := node.AsLabeledStatement()
+			if hasBreakableBody(ls.Statement) {
+				return
+			}
+			if scope != nil {
+				scope = scope.upper
+			}
+		}
+
+		reportIfUnnecessary := func(node *ast.Node, labelNode *ast.Node) {
+			if labelNode == nil {
+				return
+			}
+			targetName := labelNode.Text()
+
+			for info := scope; info != nil; info = info.upper {
+				if info.breakable || info.label == targetName {
+					if info.breakable && info.label == targetName {
+						msg := rule.RuleMessage{
+							Id:          "unexpected",
+							Description: "This label '" + targetName + "' is unnecessary.",
+						}
+
+						// End of the `break` / `continue` keyword (scanner
+						// skips leading trivia on node.Pos()).
+						firstTokenRange := scanner.GetRangeOfTokenAtPosition(ctx.SourceFile, node.Pos())
+						keywordEnd := firstTokenRange.End()
+
+						// First non-trivia position of the label identifier.
+						sourceText := ctx.SourceFile.Text()
+						labelTrimmedStart := scanner.SkipTrivia(sourceText, labelNode.Pos())
+
+						// Suppress the autofix if there is a comment between
+						// the keyword and the label (matching ESLint's
+						// commentsExistBetween guard).
+						if utils.HasCommentsInRange(ctx.SourceFile, core.NewTextRange(keywordEnd, labelTrimmedStart)) {
+							ctx.ReportNode(labelNode, msg)
+						} else {
+							fix := rule.RuleFixRemoveRange(core.NewTextRange(keywordEnd, labelNode.End()))
+							ctx.ReportNodeWithFixes(labelNode, msg, fix)
+						}
+					}
+					return
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindWhileStatement:                        enterBreakable,
+			rule.ListenerOnExit(ast.KindWhileStatement):   exitBreakable,
+			ast.KindDoStatement:                           enterBreakable,
+			rule.ListenerOnExit(ast.KindDoStatement):      exitBreakable,
+			ast.KindForStatement:                          enterBreakable,
+			rule.ListenerOnExit(ast.KindForStatement):     exitBreakable,
+			ast.KindForInStatement:                        enterBreakable,
+			rule.ListenerOnExit(ast.KindForInStatement):   exitBreakable,
+			ast.KindForOfStatement:                        enterBreakable,
+			rule.ListenerOnExit(ast.KindForOfStatement):   exitBreakable,
+			ast.KindSwitchStatement:                       enterBreakable,
+			rule.ListenerOnExit(ast.KindSwitchStatement):  exitBreakable,
+			ast.KindLabeledStatement:                      enterLabeled,
+			rule.ListenerOnExit(ast.KindLabeledStatement): exitLabeled,
+			ast.KindBreakStatement: func(node *ast.Node) {
+				bs := node.AsBreakStatement()
+				if bs.Label == nil {
+					return
+				}
+				reportIfUnnecessary(node, bs.Label)
+			},
+			ast.KindContinueStatement: func(node *ast.Node) {
+				cs := node.AsContinueStatement()
+				if cs.Label == nil {
+					return
+				}
+				reportIfUnnecessary(node, cs.Label)
+			},
+		}
+	},
+}

--- a/internal/rules/no_extra_label/no_extra_label.md
+++ b/internal/rules/no_extra_label/no_extra_label.md
@@ -1,0 +1,59 @@
+# no-extra-label
+
+## Rule Details
+
+This rule disallows labels that are only used on loops or switch statements
+that have no nested breakable statement — in those cases a bare `break` /
+`continue` already refers to the directly-enclosing loop or switch, so the
+label adds no information and can confuse readers who expect labels to
+control deeper nesting.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+A: while (a) {
+    break A;
+}
+
+B: for (let i = 0; i < 10; ++i) {
+    break B;
+}
+
+C: switch (a) {
+    case 0:
+        break C;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+while (a) {
+    break;
+}
+
+A: {
+    break A;
+}
+
+B: while (a) {
+    while (b) {
+        break B;
+    }
+}
+
+C: switch (a) {
+    case 0:
+        while (b) {
+            break C;
+        }
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- [ESLint rule: no-extra-label](https://eslint.org/docs/latest/rules/no-extra-label)

--- a/internal/rules/no_extra_label/no_extra_label_test.go
+++ b/internal/rules/no_extra_label/no_extra_label_test.go
@@ -133,6 +133,16 @@ func TestNoExtraLabelRule(t *testing.T) {
 			{Code: `A: while (a) {}`},
 			{Code: `A: {}`},
 			{Code: `A: ;`},
+
+			// =================================================================
+			// Multi-byte characters — UTF-16 code unit positioning must not
+			// produce false positives/negatives. CJK identifier used as label
+			// across an outer loop (legitimate) and multi-byte content in
+			// surrounding strings/comments that don't affect rule semantics.
+			// =================================================================
+			{Code: `中文: while (a) { while (b) { break 中文; } }`},
+			{Code: `const s = "日本語"; A: while (a) { while (b) { break A; } }`},
+			{Code: `const s = "🚀"; A: while (a) { while (b) { break A; } }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// =================================================================
@@ -562,6 +572,55 @@ func TestNoExtraLabelRule(t *testing.T) {
 				Output: []string{`A: do { if (x) continue; } while (y);`},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+
+			// =================================================================
+			// Multi-byte characters — verify UTF-16 code unit column math and
+			// that autofix byte-range handling stays correct when multi-byte
+			// chars sit in the label, in a comment on the keyword/label
+			// boundary, or in preceding source text.
+			// =================================================================
+			// CJK identifier as label: columns count each CJK char as one
+			// UTF-16 code unit; autofix deletes the bytes for ` 中文`.
+			{
+				Code:   `中文: while (a) break 中文;`,
+				Output: []string{`中文: while (a) break;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "This label '中文' is unnecessary.",
+						Line:      1,
+						Column:    21,
+						EndLine:   1,
+						EndColumn: 23,
+					},
+				},
+			},
+			// CJK comment between keyword and label suppresses autofix; label
+			// column must account for the multi-byte trivia inside the gap.
+			{
+				Code: `A: while(true) { break/*日本語*/ A; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			// CJK comment BEFORE the keyword — autofix still applies; the
+			// keyword-end position must survive multi-byte leading trivia.
+			{
+				Code:   `A: while(true) { /*日本語*/break A; }`,
+				Output: []string{`A: while(true) { /*日本語*/break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			// Emoji (surrogate pair) in preceding source — reported column
+			// for `A` must count 🚀 as 2 UTF-16 code units.
+			{
+				Code:   `const s = "🚀"; A: while (a) { break A; }`,
+				Output: []string{`const s = "🚀"; A: while (a) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 38},
 				},
 			},
 		},

--- a/internal/rules/no_extra_label/no_extra_label_test.go
+++ b/internal/rules/no_extra_label/no_extra_label_test.go
@@ -1,0 +1,569 @@
+package no_extra_label
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoExtraLabelRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoExtraLabelRule,
+		[]rule_tester.ValidTestCase{
+			// =================================================================
+			// Upstream ESLint valid suite — mirror 1:1
+			// =================================================================
+			{Code: `A: break A;`},
+			{Code: `A: { if (a) break A; }`},
+			{Code: `A: { while (b) { break A; } }`},
+			{Code: `A: { switch (b) { case 0: break A; } }`},
+			{Code: `A: while (a) { while (b) { break; } break; }`},
+			{Code: `A: while (a) { while (b) { break A; } }`},
+			{Code: `A: while (a) { while (b) { continue A; } }`},
+			{Code: `A: while (a) { switch (b) { case 0: break A; } }`},
+			{Code: `A: while (a) { switch (b) { case 0: continue A; } }`},
+			{Code: `A: switch (a) { case 0: while (b) { break A; } }`},
+			{Code: `A: switch (a) { case 0: switch (b) { case 0: break A; } }`},
+			{Code: `A: for (;;) { while (b) { break A; } }`},
+			{Code: `A: do { switch (b) { case 0: break A; break; } } while (a);`},
+			{Code: `A: for (a in obj) { while (b) { break A; } }`},
+			{Code: `A: for (a of ary) { switch (b) { case 0: break A; } }`},
+
+			// =================================================================
+			// Naked break / continue (no label at all) — rule must ignore
+			// =================================================================
+			{Code: `while (a) { break; }`},
+			{Code: `while (a) { continue; }`},
+			{Code: `do { break; } while (a);`},
+			{Code: `for (;;) { break; continue; }`},
+			{Code: `for (const x in obj) { continue; }`},
+			{Code: `for (const x of arr) { continue; }`},
+			{Code: `switch (a) { case 0: break; default: break; }`},
+
+			// =================================================================
+			// Labels on non-breakable bodies — break/continue targeting them
+			// carries information (naked break would hit a different target)
+			// =================================================================
+			{Code: `A: if (x) { if (y) break A; }`},
+			{Code: `A: { if (y) break A; }`},
+			{Code: `A: { for (;;) { break A; } }`},
+			{Code: `A: { do { break A; } while (x); }`},
+			{Code: `A: { switch (y) { case 0: break A; } }`},
+
+			// =================================================================
+			// Chained labels on a breakable: only the innermost (directly
+			// labeling) label is redundant. `break A` in `A: B: while` still
+			// jumps past A (outer of B), which naked break wouldn't do.
+			// =================================================================
+			{Code: `A: B: while (true) { break A; }`},
+			{Code: `A: B: while (true) { continue A; }`},
+			{Code: `A: B: C: while (true) { break A; continue B; }`},
+
+			// =================================================================
+			// Deep nesting — outer label justified by depth
+			// =================================================================
+			{Code: `A: while (a) { while (b) { while (c) { break A; } } }`},
+			{Code: `A: for (;;) { for (;;) { for (;;) { continue A; } } }`},
+			{Code: `A: while (a) { while (b) { while (c) { while (d) { break A; } } } }`},
+
+			// =================================================================
+			// Real-world: matrix search, tokenizer state machine
+			// =================================================================
+			{Code: `outer: for (let i = 0; i < 10; i++) { for (let j = 0; j < 10; j++) { if (i === j) { break outer; } } }`},
+			{Code: `scan: for (const t of ary) { switch (t) { case 1: break; case 2: break scan; } }`},
+
+			// =================================================================
+			// Mix of labeled loops, switches, blocks — every break/continue
+			// lands on an ancestor that is NOT its direct label target
+			// =================================================================
+			{Code: `A: while (a) { B: { C: for (;;) { break A; } } }`},
+			{Code: `A: while (a) { B: { while (x) { if (y) break B; else continue A; } } }`},
+
+			// =================================================================
+			// Multi-label cross-targeting where only non-direct labels are
+			// used (direct labels would be redundant and move to invalid)
+			// =================================================================
+			{Code: `A: while (a) { B: while (b) { break A; } }`},
+			{Code: `A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; } } }`},
+
+			// =================================================================
+			// for-in / for-of with continue to outer loop
+			// =================================================================
+			{Code: `A: for (const k in obj) { for (const v of ary) { if (k === v) continue A; } }`},
+			{Code: `A: for (const x of ary) { for (;;) { break A; } }`},
+
+			// =================================================================
+			// Labels inside a function / arrow / method — the function body
+			// creates a breakable-unfriendly boundary. The rule tracks scope
+			// without resetting on function entry, but since the innermost
+			// breakable always intercepts naked break first, outer labels
+			// don't produce false positives.
+			// =================================================================
+			{Code: `A: while (a) { function f() { while (b) { break; } } }`},
+			{Code: `A: while (a) { const f = () => { while (b) { break; } }; }`},
+			{Code: `A: while (a) { class C { m() { while (b) { break; } } } }`},
+
+			// =================================================================
+			// Async / generator / class wrappers — all preserve scope
+			// correctness; labels still necessary
+			// =================================================================
+			{Code: `A: while (a) { async function f() { while (b) { break; } } }`},
+			{Code: `A: while (a) { function* g() { while (b) { yield 1; break; } } }`},
+
+			// =================================================================
+			// TypeScript-specific: type annotations / generics / assertions
+			// =================================================================
+			{Code: `A: for (const x of (ary as number[])) { for (const y of ary) { if (x > y) break A; } }`},
+			{Code: `function f<T>(xs: T[]) { A: for (const x of xs) { for (const y of xs) { if (x === y) break A; } } }`},
+
+			// =================================================================
+			// Break/continue whose label doesn't appear in the chain — rule
+			// walks up, finds no match on the breakable's label, returns
+			// without reporting (validity gated by parser, not this rule)
+			// =================================================================
+			{Code: `A: while (a) { while (b) { break; } }`},
+
+			// =================================================================
+			// Empty bodies / no break at all — silent
+			// =================================================================
+			{Code: `A: while (a) {}`},
+			{Code: `A: {}`},
+			{Code: `A: ;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// =================================================================
+			// Upstream ESLint invalid suite — mirror 1:1
+			// =================================================================
+			{
+				Code:   `A: while (a) break A;`,
+				Output: []string{`A: while (a) break;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "This label 'A' is unnecessary.",
+						Line:      1,
+						Column:    20,
+						EndLine:   1,
+						EndColumn: 21,
+					},
+				},
+			},
+			{
+				Code:   `A: while (a) { B: { continue A; } }`,
+				Output: []string{`A: while (a) { B: { continue; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Line:      1,
+						Column:    30,
+						EndLine:   1,
+						EndColumn: 31,
+					},
+				},
+			},
+			{
+				Code:   `X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }`,
+				Output: []string{`X: while (x) { A: while (a) { B: { break; break B; continue X; } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code:   `A: do { break A; } while (a);`,
+				Output: []string{`A: do { break; } while (a);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:   `A: for (;;) { break A; }`,
+				Output: []string{`A: for (;;) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:   `A: for (a in obj) { break A; }`,
+				Output: []string{`A: for (a in obj) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:   `A: for (a of ary) { break A; }`,
+				Output: []string{`A: for (a of ary) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:   `A: switch (a) { case 0: break A; }`,
+				Output: []string{`A: switch (a) { case 0: break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code:   `X: while (x) { A: switch (a) { case 0: break A; } }`,
+				Output: []string{`X: while (x) { A: switch (a) { case 0: break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code:   `X: switch (a) { case 0: A: while (b) break A; }`,
+				Output: []string{`X: switch (a) { case 0: A: while (b) break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 44},
+				},
+			},
+			// Multi-line: only the outer `break A` is unnecessary; the inner
+			// one targets the outer loop past the unlabeled inner loop.
+			{
+				Code: "                A: while (true) {\n" +
+					"                    break A;\n" +
+					"                    while (true) {\n" +
+					"                        break A;\n" +
+					"                    }\n" +
+					"                }\n" +
+					"            ",
+				Output: []string{
+					"                A: while (true) {\n" +
+						"                    break;\n" +
+						"                    while (true) {\n" +
+						"                        break A;\n" +
+						"                    }\n" +
+						"                }\n" +
+						"            ",
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Line:      2,
+						Column:    27,
+						EndLine:   2,
+						EndColumn: 28,
+					},
+				},
+			},
+
+			// ---- Comments between keyword and label suppress autofix ----
+			{
+				Code:   `A: while(true) { /*comment*/break A; }`,
+				Output: []string{`A: while(true) { /*comment*/break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `A: while(true) { break/**/ A; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: `A: while(true) { continue /**/ A; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code: `A: while(true) { break /**/A; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: `A: while(true) { continue/**/A; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 30},
+				},
+			},
+			{
+				Code:   `A: while(true) { continue A/*comment*/; }`,
+				Output: []string{`A: while(true) { continue/*comment*/; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:   "A: while(true) { break A//comment\n }",
+				Output: []string{"A: while(true) { break//comment\n }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:   "A: while(true) { break A/*comment*/\nfoo() }",
+				Output: []string{"A: while(true) { break/*comment*/\nfoo() }"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+
+			// =================================================================
+			// Unnecessary `continue` on every loop variant
+			// =================================================================
+			{
+				Code:   `A: while (a) { continue A; }`,
+				Output: []string{`A: while (a) { continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:   `A: do { continue A; } while (x);`,
+				Output: []string{`A: do { continue; } while (x);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   `A: for (;;) { continue A; }`,
+				Output: []string{`A: for (;;) { continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:   `A: for (const k in obj) { continue A; }`,
+				Output: []string{`A: for (const k in obj) { continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code:   `A: for (const x of ary) { continue A; }`,
+				Output: []string{`A: for (const x of ary) { continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+
+			// =================================================================
+			// Same-name shadowing: inner `A` shadows outer `A`, and `break A`
+			// lands on the inner breakable (direct label). Unnecessary.
+			// =================================================================
+			{
+				Code:   `A: while (a) { A: while (b) { break A; } }`,
+				Output: []string{`A: while (a) { A: while (b) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code:   `A: { A: while (b) { break A; } }`,
+				Output: []string{`A: { A: while (b) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+
+			// =================================================================
+			// Chained labels — the directly-labeling (innermost) label is
+			// always redundant; outer labels in the chain are legitimate.
+			// =================================================================
+			{
+				Code:   `A: B: while (true) { break B; }`,
+				Output: []string{`A: B: while (true) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code:   `A: B: C: while (true) { continue C; }`,
+				Output: []string{`A: B: C: while (true) { continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 34},
+				},
+			},
+
+			// =================================================================
+			// Sequential labels at the same top-level block — each scope pops
+			// cleanly between them so diagnoses are independent
+			// =================================================================
+			{
+				Code:   `A: while (a) { break A; } B: while (b) { break B; }`,
+				Output: []string{`A: while (a) { break; } B: while (b) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+					{MessageId: "unexpected", Line: 1, Column: 48},
+				},
+			},
+
+			// =================================================================
+			// Inner unnecessary, outer necessary, in the same statement pair
+			// =================================================================
+			{
+				Code:   `A: while (a) { B: while (b) { break B; break A; } }`,
+				Output: []string{`A: while (a) { B: while (b) { break; break A; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 37},
+				},
+			},
+
+			// =================================================================
+			// Multiple unnecessary labels inside a single breakable scope —
+			// both reported with correct columns, autofix applied to both
+			// =================================================================
+			{
+				Code:   `A: while (a) { break A; continue A; }`,
+				Output: []string{`A: while (a) { break; continue; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+					{MessageId: "unexpected", Line: 1, Column: 34},
+				},
+			},
+
+			// =================================================================
+			// Real-world matrix search where the inner label is redundant
+			// =================================================================
+			{
+				Code:   `outer: for (let i = 0; i < 10; i++) { inner: for (let j = 0; j < 10; j++) { if (i === j) { break inner; } } }`,
+				Output: []string{`outer: for (let i = 0; i < 10; i++) { inner: for (let j = 0; j < 10; j++) { if (i === j) { break; } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "unexpected",
+						Message:   "This label 'inner' is unnecessary.",
+						Line:      1,
+						Column:    98,
+					},
+				},
+			},
+
+			// =================================================================
+			// Directly-labeled breakable reached through a switch case —
+			// `break B` ends the switch that B directly labels, which naked
+			// `break` also does; `break A` exits A (labeled switch), which
+			// is also what bare `break` in a case body does.
+			// =================================================================
+			{
+				Code:   `A: while (a) { B: switch (b) { case 0: break B; case 1: break A; } }`,
+				Output: []string{`A: while (a) { B: switch (b) { case 0: break; case 1: break A; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code:   `A: switch (a) { case 0: B: { if (x) break B; break A; } }`,
+				Output: []string{`A: switch (a) { case 0: B: { if (x) break B; break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 52},
+				},
+			},
+
+			// =================================================================
+			// Cross-labeled loops: `continue B` targets the inner while that
+			// B directly labels → naked `continue` equivalent → unnecessary
+			// =================================================================
+			{
+				Code:   `A: while (a) { B: while (b) { if (x) break A; else continue B; } }`,
+				Output: []string{`A: while (a) { B: while (b) { if (x) break A; else continue; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 61},
+				},
+			},
+			{
+				Code:   `A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; break C; } } }`,
+				Output: []string{`A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; break; } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 70},
+				},
+			},
+
+			// =================================================================
+			// Labels inside function / arrow / method / async / generator
+			// =================================================================
+			{
+				Code:   `function f() { A: while (a) { break A; } }`,
+				Output: []string{`function f() { A: while (a) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code:   `const f = () => { A: while (a) { break A; } };`,
+				Output: []string{`const f = () => { A: while (a) { break; } };`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code:   `class C { m() { A: while (a) { break A; } } }`,
+				Output: []string{`class C { m() { A: while (a) { break; } } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code:   `async function f() { A: while (a) { break A; } }`,
+				Output: []string{`async function f() { A: while (a) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 43},
+				},
+			},
+			{
+				Code:   `function* g() { A: while (a) { break A; } }`,
+				Output: []string{`function* g() { A: while (a) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 38},
+				},
+			},
+
+			// =================================================================
+			// TypeScript-specific
+			// =================================================================
+			{
+				Code:   `function f<T>(arr: T[]) { A: while (arr.length) { break A; } }`,
+				Output: []string{`function f<T>(arr: T[]) { A: while (arr.length) { break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 57},
+				},
+			},
+			{
+				Code:   `A: for (const x of (ary as number[])) { break A; }`,
+				Output: []string{`A: for (const x of (ary as number[])) { break; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 47},
+				},
+			},
+
+			// =================================================================
+			// Multi-line with comment between keyword and label — still no
+			// autofix, and line/column correctly track the label position.
+			// =================================================================
+			{
+				Code: "A: while (a) {\n  break /* note */ A;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 2, Column: 20},
+				},
+			},
+
+			// =================================================================
+			// Nested labeled switch — only inner is redundant
+			// =================================================================
+			{
+				Code:   `A: switch (a) { case 0: B: switch (b) { case 0: break B; } }`,
+				Output: []string{`A: switch (a) { case 0: B: switch (b) { case 0: break; } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 55},
+				},
+			},
+
+			// =================================================================
+			// Labeled do-while (unnecessary) — covers do-while specifically
+			// =================================================================
+			{
+				Code:   `A: do { if (x) continue A; } while (y);`,
+				Output: []string{`A: do { if (x) continue; } while (y);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -49,6 +49,7 @@ export default defineConfig({
     './tests/eslint/rules/default-case-last.test.ts',
     './tests/eslint/rules/no-extend-native.test.ts',
     './tests/eslint/rules/no-extra-bind.test.ts',
+    './tests/eslint/rules/no-extra-label.test.ts',
     './tests/eslint/rules/no-func-assign.test.ts',
     './tests/eslint/rules/no-global-assign.test.ts',
     './tests/eslint/rules/no-import-assign.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extra-label.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extra-label.test.ts.snap
@@ -1236,3 +1236,107 @@ exports[`no-extra-label > invalid 46`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`no-extra-label > invalid 47`] = `
+{
+  "code": "中文: while (a) break 中文;",
+  "diagnostics": [
+    {
+      "message": "This label '中文' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 48`] = `
+{
+  "code": "A: while(true) { break/*日本語*/ A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 49`] = `
+{
+  "code": "A: while(true) { /*日本語*/break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 50`] = `
+{
+  "code": "const s = "🚀"; A: while (a) { break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extra-label.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-extra-label.test.ts.snap
@@ -1,0 +1,1238 @@
+// Rstest Snapshot v1
+
+exports[`no-extra-label > invalid 1`] = `
+{
+  "code": "A: while (a) break A;",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 2`] = `
+{
+  "code": "A: while (a) { B: { continue A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 3`] = `
+{
+  "code": "X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 4`] = `
+{
+  "code": "A: do { break A; } while (a);",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 5`] = `
+{
+  "code": "A: for (;;) { break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 6`] = `
+{
+  "code": "A: for (a in obj) { break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 7`] = `
+{
+  "code": "A: for (a of ary) { break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 8`] = `
+{
+  "code": "A: switch (a) { case 0: break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 9`] = `
+{
+  "code": "X: while (x) { A: switch (a) { case 0: break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 10`] = `
+{
+  "code": "X: switch (a) { case 0: A: while (b) break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 11`] = `
+{
+  "code": "
+                A: while (true) {
+                    break A;
+                    while (true) {
+                        break A;
+                    }
+                }
+            ",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 27,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 12`] = `
+{
+  "code": "A: while(true) { /*comment*/break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 13`] = `
+{
+  "code": "A: while(true) { break/**/ A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 14`] = `
+{
+  "code": "A: while(true) { continue /**/ A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 15`] = `
+{
+  "code": "A: while(true) { break /**/A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 16`] = `
+{
+  "code": "A: while(true) { continue/**/A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 17`] = `
+{
+  "code": "A: while(true) { continue A/*comment*/; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 18`] = `
+{
+  "code": "A: while(true) { break A//comment
+ }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 19`] = `
+{
+  "code": "A: while(true) { break A/*comment*/
+foo() }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 20`] = `
+{
+  "code": "A: while (a) { continue A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 21`] = `
+{
+  "code": "A: do { continue A; } while (x);",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 22`] = `
+{
+  "code": "A: for (;;) { continue A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 23`] = `
+{
+  "code": "A: for (const k in obj) { continue A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 24`] = `
+{
+  "code": "A: for (const x of ary) { continue A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 25`] = `
+{
+  "code": "A: while (a) { A: while (b) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 26`] = `
+{
+  "code": "A: { A: while (b) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 27`] = `
+{
+  "code": "A: B: while (true) { break B; }",
+  "diagnostics": [
+    {
+      "message": "This label 'B' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 28`] = `
+{
+  "code": "A: B: C: while (true) { continue C; }",
+  "diagnostics": [
+    {
+      "message": "This label 'C' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 29`] = `
+{
+  "code": "A: while (a) { break A; } B: while (b) { break B; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+    {
+      "message": "This label 'B' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 30`] = `
+{
+  "code": "A: while (a) { B: while (b) { break B; break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'B' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 31`] = `
+{
+  "code": "A: while (a) { break A; continue A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 32`] = `
+{
+  "code": "outer: for (let i = 0; i < 10; i++) { inner: for (let j = 0; j < 10; j++) { if (i === j) { break inner; } } }",
+  "diagnostics": [
+    {
+      "message": "This label 'inner' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 103,
+          "line": 1,
+        },
+        "start": {
+          "column": 98,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 33`] = `
+{
+  "code": "function f() { A: while (a) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 34`] = `
+{
+  "code": "const f = () => { A: while (a) { break A; } };",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 35`] = `
+{
+  "code": "class C { m() { A: while (a) { break A; } } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 36`] = `
+{
+  "code": "async function f() { A: while (a) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 37`] = `
+{
+  "code": "function* g() { A: while (a) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 38`] = `
+{
+  "code": "function f<T>(arr: T[]) { A: while (arr.length) { break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 39`] = `
+{
+  "code": "A: for (const x of (ary as number[])) { break A; }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 40`] = `
+{
+  "code": "A: while (a) {
+  break /* note */ A;
+}",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 41`] = `
+{
+  "code": "A: switch (a) { case 0: B: switch (b) { case 0: break B; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'B' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 42`] = `
+{
+  "code": "A: do { if (x) continue A; } while (y);",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 43`] = `
+{
+  "code": "A: while (a) { B: switch (b) { case 0: break B; case 1: break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'B' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 44`] = `
+{
+  "code": "A: switch (a) { case 0: B: { if (x) break B; break A; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'A' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 45`] = `
+{
+  "code": "A: while (a) { B: while (b) { if (x) break A; else continue B; } }",
+  "diagnostics": [
+    {
+      "message": "This label 'B' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-extra-label > invalid 46`] = `
+{
+  "code": "A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; break C; } } }",
+  "diagnostics": [
+    {
+      "message": "This label 'C' is unnecessary.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 70,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-extra-label",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-extra-label.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-extra-label.test.ts
@@ -74,6 +74,12 @@ ruleTester.run('no-extra-label', {
     'A: while (a) {}',
     'A: {}',
     'A: ;',
+
+    // Multi-byte characters — CJK identifier label with legitimate nested break,
+    // and multi-byte content in surrounding strings that don't affect semantics
+    '中文: while (a) { while (b) { break 中文; } }',
+    'const s = "日本語"; A: while (a) { while (b) { break A; } }',
+    'const s = "🚀"; A: while (a) { while (b) { break A; } }',
   ],
   invalid: [
     // Upstream ESLint invalid suite
@@ -290,6 +296,25 @@ ruleTester.run('no-extra-label', {
     },
     {
       code: 'A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; break C; } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Multi-byte characters — verifies UTF-16 column math and autofix byte
+    // ranges across CJK identifier labels and multi-byte trivia
+    {
+      code: '中文: while (a) break 中文;',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { break/*日本語*/ A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { /*日本語*/break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const s = "🚀"; A: while (a) { break A; }',
       errors: [{ messageId: 'unexpected' }],
     },
   ],

--- a/packages/rslint-test-tools/tests/eslint/rules/no-extra-label.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-extra-label.test.ts
@@ -1,0 +1,296 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-extra-label', {
+  valid: [
+    // Upstream ESLint valid suite
+    'A: break A;',
+    'A: { if (a) break A; }',
+    'A: { while (b) { break A; } }',
+    'A: { switch (b) { case 0: break A; } }',
+    'A: while (a) { while (b) { break; } break; }',
+    'A: while (a) { while (b) { break A; } }',
+    'A: while (a) { while (b) { continue A; } }',
+    'A: while (a) { switch (b) { case 0: break A; } }',
+    'A: while (a) { switch (b) { case 0: continue A; } }',
+    'A: switch (a) { case 0: while (b) { break A; } }',
+    'A: switch (a) { case 0: switch (b) { case 0: break A; } }',
+    'A: for (;;) { while (b) { break A; } }',
+    'A: do { switch (b) { case 0: break A; break; } } while (a);',
+    'A: for (a in obj) { while (b) { break A; } }',
+    'A: for (a of ary) { switch (b) { case 0: break A; } }',
+
+    // Naked break / continue
+    'while (a) { break; }',
+    'do { break; } while (a);',
+    'for (;;) { break; continue; }',
+    'switch (a) { case 0: break; default: break; }',
+
+    // Labels on non-breakable bodies
+    'A: if (x) { if (y) break A; }',
+    'A: { for (;;) { break A; } }',
+    'A: { do { break A; } while (x); }',
+    'A: { switch (y) { case 0: break A; } }',
+
+    // Chained labels — only the innermost is redundant; outer labels are valid
+    'A: B: while (true) { break A; }',
+    'A: B: while (true) { continue A; }',
+    'A: B: C: while (true) { break A; continue B; }',
+
+    // Deep nesting
+    'A: while (a) { while (b) { while (c) { break A; } } }',
+    'A: for (;;) { for (;;) { for (;;) { continue A; } } }',
+    'A: while (a) { while (b) { while (c) { while (d) { break A; } } } }',
+
+    // Real-world
+    'outer: for (let i = 0; i < 10; i++) { for (let j = 0; j < 10; j++) { if (i === j) { break outer; } } }',
+    'scan: for (const t of ary) { switch (t) { case 1: break; case 2: break scan; } }',
+
+    // Mixed nesting
+    'A: while (a) { B: { C: for (;;) { break A; } } }',
+    'A: while (a) { B: { while (x) { if (y) break B; else continue A; } } }',
+    'A: while (a) { B: while (b) { break A; } }',
+    'A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; } } }',
+
+    // for-in / for-of with continue to outer loop
+    'A: for (const k in obj) { for (const v of ary) { if (k === v) continue A; } }',
+    'A: for (const x of ary) { for (;;) { break A; } }',
+
+    // Labels inside function / arrow / method — scope doesn't falsely match
+    'A: while (a) { function f() { while (b) { break; } } }',
+    'A: while (a) { const f = () => { while (b) { break; } }; }',
+    'A: while (a) { class C { m() { while (b) { break; } } } }',
+
+    // Async / generator
+    'A: while (a) { async function f() { while (b) { break; } } }',
+    'A: while (a) { function* g() { while (b) { yield 1; break; } } }',
+
+    // TypeScript-specific
+    'A: for (const x of (ary as number[])) { for (const y of ary) { if (x > y) break A; } }',
+    'function f<T>(xs: T[]) { A: for (const x of xs) { for (const y of xs) { if (x === y) break A; } } }',
+
+    // Empty bodies / no break at all
+    'A: while (a) {}',
+    'A: {}',
+    'A: ;',
+  ],
+  invalid: [
+    // Upstream ESLint invalid suite
+    { code: 'A: while (a) break A;', errors: [{ messageId: 'unexpected' }] },
+    {
+      code: 'A: while (a) { B: { continue A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'X: while (x) { A: while (a) { B: { break A; break B; continue X; } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: do { break A; } while (a);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    { code: 'A: for (;;) { break A; }', errors: [{ messageId: 'unexpected' }] },
+    {
+      code: 'A: for (a in obj) { break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: for (a of ary) { break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: switch (a) { case 0: break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'X: while (x) { A: switch (a) { case 0: break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'X: switch (a) { case 0: A: while (b) break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: `
+                A: while (true) {
+                    break A;
+                    while (true) {
+                        break A;
+                    }
+                }
+            `,
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Comments between break/continue and label suppress autofix
+    {
+      code: 'A: while(true) { /*comment*/break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { break/**/ A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { continue /**/ A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { break /**/A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { continue/**/A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { continue A/*comment*/; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { break A//comment\n }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: while(true) { break A/*comment*/\nfoo() }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Unnecessary continue on every loop variant
+    {
+      code: 'A: while (a) { continue A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: do { continue A; } while (x);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: for (;;) { continue A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: for (const k in obj) { continue A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: for (const x of ary) { continue A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Same-name shadowing
+    {
+      code: 'A: while (a) { A: while (b) { break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: { A: while (b) { break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Chained labels — innermost redundant
+    {
+      code: 'A: B: while (true) { break B; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: B: C: while (true) { continue C; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Sequential labels
+    {
+      code: 'A: while (a) { break A; } B: while (b) { break B; }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+
+    // Inner unnecessary, outer necessary
+    {
+      code: 'A: while (a) { B: while (b) { break B; break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Multiple unnecessary labels in one scope
+    {
+      code: 'A: while (a) { break A; continue A; }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+
+    // Real-world matrix search with redundant inner label
+    {
+      code: 'outer: for (let i = 0; i < 10; i++) { inner: for (let j = 0; j < 10; j++) { if (i === j) { break inner; } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Labels inside function / arrow / method / async / generator
+    {
+      code: 'function f() { A: while (a) { break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'const f = () => { A: while (a) { break A; } };',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class C { m() { A: while (a) { break A; } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'async function f() { A: while (a) { break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'function* g() { A: while (a) { break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // TypeScript-specific
+    {
+      code: 'function f<T>(arr: T[]) { A: while (arr.length) { break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: for (const x of (ary as number[])) { break A; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Multi-line with comment on keyword-label boundary
+    {
+      code: 'A: while (a) {\n  break /* note */ A;\n}',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Nested labeled switch — inner redundant
+    {
+      code: 'A: switch (a) { case 0: B: switch (b) { case 0: break B; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Labeled do-while
+    {
+      code: 'A: do { if (x) continue A; } while (y);',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Switch case bare break vs break A/B
+    {
+      code: 'A: while (a) { B: switch (b) { case 0: break B; case 1: break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: switch (a) { case 0: B: { if (x) break B; break A; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+
+    // Cross-labeled loops — inner direct label on continue redundant
+    {
+      code: 'A: while (a) { B: while (b) { if (x) break A; else continue B; } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'A: for (;;) { B: for (;;) { C: for (;;) { break A; continue B; break C; } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-extra-label` rule from ESLint to rslint.

The rule flags labels on `break` / `continue` whose naked counterpart would target the same statement — i.e. the label directly marks the nearest enclosing breakable (loop or switch), so the label carries no extra information.

Behavior matches upstream ESLint byte-for-byte: same `messageId` (`unexpected`), same message text (`"This label '{{name}}' is unnecessary."`), same report node (the label identifier), same autofix range (keyword end → label end), and the same autofix suppression when a comment sits between the keyword and the label.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-extra-label
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-extra-label.js
- Tests (upstream): https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-extra-label.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).