### PR TITLE
feat: port rule no-label-var

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
+	"github.com/web-infra-dev/rslint/internal/rules/no_label_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_lone_blocks"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
@@ -561,6 +562,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-extend-native", no_extend_native.NoExtendNativeRule)
 	GlobalRuleRegistry.Register("no-extra-bind", no_extra_bind.NoExtraBindRule)
 	GlobalRuleRegistry.Register("no-extra-label", no_extra_label.NoExtraLabelRule)
+	GlobalRuleRegistry.Register("no-label-var", no_label_var.NoLabelVarRule)
 	GlobalRuleRegistry.Register("no-labels", no_labels.NoLabelsRule)
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)
 	GlobalRuleRegistry.Register("no-global-assign", no_global_assign.NoGlobalAssignRule)

--- a/internal/rules/no_label_var/no_label_var.go
+++ b/internal/rules/no_label_var/no_label_var.go
@@ -1,0 +1,61 @@
+package no_label_var
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-label-var
+//
+// Strategy: hybrid. ESLint's `getVariableByName` walks the scope chain all the
+// way to the global scope, catching both file-local declarations and globals
+// from `env`/`globals`. We approximate it with two complementary checks:
+//
+//  1. utils.IsShadowed — fast, works without type info; covers every binding
+//     declared inside the current source file (var/let/const, function, class,
+//     enum, namespace, import, parameter, catch, for-init, function-expression
+//     name, hoisted vars).
+//  2. ctx.TypeChecker.GetSymbolsInScope — when type info is available, also
+//     catches globals provided by the tsconfig `lib` (e.g. `window`, `Promise`,
+//     `console`). Differs from ESLint's `env`/`globals` config and does not
+//     read `/* global foo */` comments — see the rule docs for details.
+//
+// On a JS file with no tsconfig only step 1 runs, so the rule still catches
+// the dominant case (label clashing with a sibling declaration).
+var NoLabelVarRule = rule.Rule{
+	Name: "no-label-var",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		report := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "identifierClashWithLabel",
+				Description: "Found identifier with same name as label.",
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindLabeledStatement: func(node *ast.Node) {
+				ls := node.AsLabeledStatement()
+				if ls == nil || ls.Label == nil {
+					return
+				}
+				name := ls.Label.Text()
+
+				if utils.IsShadowed(node, name) {
+					report(node)
+					return
+				}
+
+				if ctx.TypeChecker == nil {
+					return
+				}
+				for _, sym := range ctx.TypeChecker.GetSymbolsInScope(node, ast.SymbolFlagsValue) {
+					if sym != nil && sym.Name == name {
+						report(node)
+						return
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_label_var/no_label_var.md
+++ b/internal/rules/no_label_var/no_label_var.md
@@ -1,0 +1,50 @@
+# no-label-var
+
+## Rule Details
+
+This rule aims to create clearer code by disallowing the bad practice of creating a label that shares a name with a variable that is in scope.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x = foo;
+function bar() {
+x:
+  for (;;) {
+    break x;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// The variable that has the same name as the label is not in scope.
+
+function foo() {
+  var q = t;
+}
+
+function bar() {
+q:
+  for (;;) {
+    break q;
+  }
+}
+```
+
+## Options
+
+This rule has no options.
+
+## Differences from ESLint
+
+- `/* global foo */` directive comments are not recognized — labels colliding
+  with names declared only via these comments are not reported.
+- On files without type information, only declarations written in the file are
+  checked; clashes with built-in globals (`Promise`, `Array`, …) are not
+  reported in that case.
+
+## Original Documentation
+
+- [ESLint rule: no-label-var](https://eslint.org/docs/latest/rules/no-label-var)

--- a/internal/rules/no_label_var/no_label_var_test.go
+++ b/internal/rules/no_label_var/no_label_var_test.go
@@ -1,0 +1,246 @@
+package no_label_var
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLabelVarRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLabelVarRule,
+
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream ESLint suite ----
+			{Code: `function bar() { q: for(;;) { break q; } } function foo () { var q = t; }`},
+			{Code: `function bar() { var x = foo; q: for(;;) { break q; } }`},
+
+			// ---- Top-level / sibling-scope ----
+			{Code: `q: for(;;) { break q; }`},
+			{Code: `function bar() { a: for(;;) { b: for(;;) { break b; } } }`},
+			{Code: `function bar(y) { q: for(;;) { break q; } }`},
+			{Code: `for (let i = 0; i < 1; i++) { q: for(;;) { break q; } }`},
+			{Code: `for (const k in obj) { q: for(;;) { break q; } }`},
+			{Code: `for (const v of arr) { q: for(;;) { break q; } }`},
+
+			// ---- TS type-only declarations should NOT clash (only values count) ----
+			{Code: `interface X {} X: for(;;) { break X; }`},
+			{Code: `type X = number; X: for(;;) { break X; }`},
+			// NOTE: `import type` is intentionally NOT in the valid list — utils.IsShadowed
+			// does not distinguish type-only imports from value imports, so it triggers.
+			// See the matching invalid case below.
+
+			// ---- Nested label inside iteration; outer var has different name ----
+			{Code: `var x = 1; function f() { y: for(;;) { break y; } }`},
+
+			// ---- Catch parameter has different name ----
+			{Code: `try {} catch (e) { q: for(;;) { break q; } }`},
+
+			// ---- Method / arrow / generator scopes don't leak names ----
+			{Code: `class C { m() { q: for(;;) { break q; } } }`},
+			{Code: `const fn = (a) => { q: for(;;) { break q; } };`},
+			{Code: `function* gen() { q: for(;;) { break q; } }`},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream ESLint suite (with explicit message + position) ----
+			{
+				Code: `var x = foo; function bar() { x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Message: "Found identifier with same name as label.", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `function bar() { var x = foo; x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `function bar(x) { x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- Local-binding clashes (strategy A path) ----
+			// let / const in same block
+			{
+				Code: `function bar() { let x = 1; x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `function bar() { const x = 1; x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 31},
+				},
+			},
+			// Sibling function declaration in the same block
+			{
+				Code: `function bar() { function x() {} x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 34},
+				},
+			},
+			// Class declaration at module scope
+			{
+				Code: "class X {}\nX: for(;;) { break X; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 2, Column: 1},
+				},
+			},
+			// Destructuring parameter
+			{
+				Code: `function bar({ x }) { x: for(;;) { break x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 23},
+				},
+			},
+			// Catch binding (simple)
+			{
+				Code: `try {} catch (e) { e: for(;;) { break e; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 20},
+				},
+			},
+			// Catch binding (destructured)
+			{
+				Code: `try {} catch ({ a }) { a: for(;;) { break a; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 24},
+				},
+			},
+			// for-statement let init
+			{
+				Code: `for (let i = 0; i < 1; i++) { i: for(;;) { break i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 31},
+				},
+			},
+			// for-of let init
+			{
+				Code: `for (let v of arr) { v: for(;;) { break v; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 22},
+				},
+			},
+			// for-in const init
+			{
+				Code: `for (const k in obj) { k: for(;;) { break k; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 24},
+				},
+			},
+			// Hoisted var declared further down the same function body
+			{
+				Code: `function f() { x: for(;;) { break x; } { var x = 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 16},
+				},
+			},
+			// Label name equals enclosing function declaration name
+			{
+				Code: `function foo() { foo: for(;;) { break foo; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 18},
+				},
+			},
+			// Label name equals named function expression name
+			{
+				Code: `(function fee() { fee: for(;;) { break fee; } })()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 19},
+				},
+			},
+			// Default import
+			{
+				Code: `import x from 'mod'; x: for(;;) { break x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 22},
+				},
+			},
+			// Named import
+			{
+				Code: `import { x } from 'mod'; x: for(;;) { break x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 26},
+				},
+			},
+			// Namespace import
+			{
+				Code: `import * as x from 'mod'; x: for(;;) { break x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 27},
+				},
+			},
+			// Renamed named import
+			{
+				Code: `import { y as x } from 'mod'; x: for(;;) { break x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 31},
+				},
+			},
+			// Type-only import: utils.IsShadowed does not differentiate type-only
+			// from value imports, so this is reported. Lock current behavior.
+			{
+				Code: `import type { X } from 'mod'; X: for(;;) { break X; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 31},
+				},
+			},
+			// TS enum (runtime value)
+			{
+				Code: `enum X { A } X: for(;;) { break X; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 14},
+				},
+			},
+			// TS namespace with a value export (runtime value)
+			{
+				Code: `namespace N { export const x = 1; } N: for(;;) { break N; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 37},
+				},
+			},
+			// Nested labels: outer label clashes with module-level var
+			{
+				Code: `var a = 1; function f() { a: for(;;) { b: for(;;) { break b; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 27},
+				},
+			},
+
+			// ---- Globals from tsgo lib (strategy B path; requires TypeChecker) ----
+			{
+				Code: `window: for (;;) { break window; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `console: for (;;) { break console; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise: for (;;) { break Promise; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Array: for (;;) { break Array; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "identifierClashWithLabel", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -275,6 +275,7 @@ export default defineConfig({
     './tests/eslint/rules/no-alert.test.ts',
     './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
+    './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-label-var.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-label-var.test.ts.snap
@@ -1,0 +1,730 @@
+// Rstest Snapshot v1
+
+exports[`no-label-var > invalid 1`] = `
+{
+  "code": "var x = foo; function bar() { x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 2`] = `
+{
+  "code": "function bar() { var x = foo; x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 3`] = `
+{
+  "code": "function bar(x) { x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 4`] = `
+{
+  "code": "function bar() { let x = 1; x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 5`] = `
+{
+  "code": "function bar() { const x = 1; x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 6`] = `
+{
+  "code": "function bar() { function x() {} x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 7`] = `
+{
+  "code": "class X {}
+X: for(;;) { break X; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 8`] = `
+{
+  "code": "function bar({ x }) { x: for(;;) { break x; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 9`] = `
+{
+  "code": "try {} catch (e) { e: for(;;) { break e; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 10`] = `
+{
+  "code": "try {} catch ({ a }) { a: for(;;) { break a; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 11`] = `
+{
+  "code": "for (let i = 0; i < 1; i++) { i: for(;;) { break i; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 12`] = `
+{
+  "code": "for (let v of arr) { v: for(;;) { break v; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 13`] = `
+{
+  "code": "for (const k in obj) { k: for(;;) { break k; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 14`] = `
+{
+  "code": "function f() { x: for(;;) { break x; } { var x = 1; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 15`] = `
+{
+  "code": "function foo() { foo: for(;;) { break foo; } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 16`] = `
+{
+  "code": "(function fee() { fee: for(;;) { break fee; } })()",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 17`] = `
+{
+  "code": "import x from 'mod'; x: for(;;) { break x; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 18`] = `
+{
+  "code": "import { x } from 'mod'; x: for(;;) { break x; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 19`] = `
+{
+  "code": "import * as x from 'mod'; x: for(;;) { break x; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 20`] = `
+{
+  "code": "import { y as x } from 'mod'; x: for(;;) { break x; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 21`] = `
+{
+  "code": "import type { X } from 'mod'; X: for(;;) { break X; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 22`] = `
+{
+  "code": "enum X { A } X: for(;;) { break X; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 23`] = `
+{
+  "code": "namespace N { export const x = 1; } N: for(;;) { break N; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 24`] = `
+{
+  "code": "var a = 1; function f() { a: for(;;) { b: for(;;) { break b; } } }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 25`] = `
+{
+  "code": "Promise: for (;;) { break Promise; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 26`] = `
+{
+  "code": "Array: for (;;) { break Array; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 27`] = `
+{
+  "code": "Math: for (;;) { break Math; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-label-var > invalid 28`] = `
+{
+  "code": "Symbol: for (;;) { break Symbol; }",
+  "diagnostics": [
+    {
+      "message": "Found identifier with same name as label.",
+      "messageId": "identifierClashWithLabel",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-label-var",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-label-var.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-label-var.test.ts
@@ -1,0 +1,154 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-label-var', {
+  valid: [
+    // ---- Upstream ESLint suite ----
+    'function bar() { q: for(;;) { break q; } } function foo () { var q = t; }',
+    'function bar() { var x = foo; q: for(;;) { break q; } }',
+
+    // ---- Top-level / sibling-scope ----
+    'q: for(;;) { break q; }',
+    'function bar() { a: for(;;) { b: for(;;) { break b; } } }',
+    'function bar(y) { q: for(;;) { break q; } }',
+    'for (let i = 0; i < 1; i++) { q: for(;;) { break q; } }',
+    'for (const k in obj) { q: for(;;) { break q; } }',
+    'for (const v of arr) { q: for(;;) { break q; } }',
+
+    // ---- TS type-only declarations should NOT clash (only values count) ----
+    'interface X {} X: for(;;) { break X; }',
+    'type X = number; X: for(;;) { break X; }',
+
+    // ---- Nested label inside iteration; outer var has different name ----
+    'var x = 1; function f() { y: for(;;) { break y; } }',
+
+    // ---- Catch parameter has different name ----
+    'try {} catch (e) { q: for(;;) { break q; } }',
+
+    // ---- Method / arrow / generator scopes don't leak names ----
+    'class C { m() { q: for(;;) { break q; } } }',
+    'const fn = (a) => { q: for(;;) { break q; } };',
+    'function* gen() { q: for(;;) { break q; } }',
+  ],
+  invalid: [
+    // ---- Upstream ESLint suite ----
+    {
+      code: 'var x = foo; function bar() { x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 31 }],
+    },
+    {
+      code: 'function bar() { var x = foo; x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 31 }],
+    },
+    {
+      code: 'function bar(x) { x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 19 }],
+    },
+
+    // ---- Local-binding clashes (strategy A path) ----
+    {
+      code: 'function bar() { let x = 1; x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 29 }],
+    },
+    {
+      code: 'function bar() { const x = 1; x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 31 }],
+    },
+    {
+      code: 'function bar() { function x() {} x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 34 }],
+    },
+    {
+      code: 'class X {}\nX: for(;;) { break X; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 2, column: 1 }],
+    },
+    {
+      code: 'function bar({ x }) { x: for(;;) { break x; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 23 }],
+    },
+    {
+      code: 'try {} catch (e) { e: for(;;) { break e; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 20 }],
+    },
+    {
+      code: 'try {} catch ({ a }) { a: for(;;) { break a; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 24 }],
+    },
+    {
+      code: 'for (let i = 0; i < 1; i++) { i: for(;;) { break i; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 31 }],
+    },
+    {
+      code: 'for (let v of arr) { v: for(;;) { break v; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 22 }],
+    },
+    {
+      code: 'for (const k in obj) { k: for(;;) { break k; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 24 }],
+    },
+    {
+      code: 'function f() { x: for(;;) { break x; } { var x = 1; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 16 }],
+    },
+    {
+      code: 'function foo() { foo: for(;;) { break foo; } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 18 }],
+    },
+    {
+      code: '(function fee() { fee: for(;;) { break fee; } })()',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 19 }],
+    },
+    {
+      code: "import x from 'mod'; x: for(;;) { break x; }",
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 22 }],
+    },
+    {
+      code: "import { x } from 'mod'; x: for(;;) { break x; }",
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 26 }],
+    },
+    {
+      code: "import * as x from 'mod'; x: for(;;) { break x; }",
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 27 }],
+    },
+    {
+      code: "import { y as x } from 'mod'; x: for(;;) { break x; }",
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 31 }],
+    },
+    {
+      code: "import type { X } from 'mod'; X: for(;;) { break X; }",
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 31 }],
+    },
+    {
+      code: 'enum X { A } X: for(;;) { break X; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 14 }],
+    },
+    {
+      code: 'namespace N { export const x = 1; } N: for(;;) { break N; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 37 }],
+    },
+    {
+      code: 'var a = 1; function f() { a: for(;;) { b: for(;;) { break b; } } }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 27 }],
+    },
+
+    // ---- Globals from tsgo lib (strategy B path; requires TypeChecker) ----
+    // Use ES standard built-ins so the assertion holds without `lib: ["dom"]`.
+    {
+      code: 'Promise: for (;;) { break Promise; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 1 }],
+    },
+    {
+      code: 'Array: for (;;) { break Array; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 1 }],
+    },
+    {
+      code: 'Math: for (;;) { break Math; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 1 }],
+    },
+    {
+      code: 'Symbol: for (;;) { break Symbol; }',
+      errors: [{ messageId: 'identifierClashWithLabel', line: 1, column: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-label-var` rule from ESLint to rslint.

The rule disallows labeled statements whose label name clashes with a variable
in scope. Implemented with a hybrid resolution strategy:

1. `utils.IsShadowed` covers every binding declared inside the source file
   (`var` / `let` / `const`, function / class, parameters with destructuring,
   catch bindings, `for` / `for-in` / `for-of` `let`/`const` init, default /
   named / namespace / renamed / type-only imports, TS `enum`, TS `namespace`,
   named function expression, hoisted `var`).
2. When `ctx.TypeChecker` is available, `GetSymbolsInScope(node, SymbolFlagsValue)`
   additionally catches built-in globals provided by the tsconfig `lib`
   (`window`, `console`, `Promise`, `Array`, …).

Validated by enabling the rule (with a temporary "report every LabeledStatement"
debug variant) on rsbuild and rspack: both repos contain zero labeled
statements, so no real-world hits — confirmed via a dedicated smoke fixture
that all three trigger paths fire correctly.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-label-var
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-label-var.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).