### PR TITLE
feat: port rule no-lone-blocks

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
 	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
+	"github.com/web-infra-dev/rslint/internal/rules/no_lone_blocks"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
@@ -564,6 +565,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-implicit-coercion", no_implicit_coercion.NoImplicitCoercionRule)
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
+	GlobalRuleRegistry.Register("no-lone-blocks", no_lone_blocks.NoLoneBlocksRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-new-func", no_new_func.NoNewFuncRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)

--- a/internal/rules/no_lone_blocks/no_lone_blocks.go
+++ b/internal/rules/no_lone_blocks/no_lone_blocks.go
@@ -1,0 +1,100 @@
+package no_lone_blocks
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-lone-blocks
+var NoLoneBlocksRule = rule.Rule{
+	Name: "no-lone-blocks",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		var loneBlocks []*ast.Node
+
+		report := func(node *ast.Node) {
+			parent := node.Parent
+			id := "redundantBlock"
+			description := "Block is redundant."
+			if parent != nil && (parent.Kind == ast.KindBlock || parent.Kind == ast.KindClassStaticBlockDeclaration) {
+				id = "redundantNestedBlock"
+				description = "Nested block is redundant."
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          id,
+				Description: description,
+			})
+		}
+
+		isLoneBlock := func(node *ast.Node) bool {
+			parent := node.Parent
+			if parent == nil {
+				return false
+			}
+			switch parent.Kind {
+			case ast.KindBlock, ast.KindSourceFile:
+				return true
+			case ast.KindCaseClause, ast.KindDefaultClause:
+				clause := parent.AsCaseOrDefaultClause()
+				if clause == nil || clause.Statements == nil {
+					return false
+				}
+				statements := clause.Statements.Nodes
+				return len(statements) != 1 || statements[0] != node
+			}
+			return false
+		}
+
+		markLoneBlock := func(node *ast.Node) {
+			if len(loneBlocks) == 0 {
+				return
+			}
+			if loneBlocks[len(loneBlocks)-1] == node.Parent {
+				loneBlocks = loneBlocks[:len(loneBlocks)-1]
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindBlock: func(node *ast.Node) {
+				if isLoneBlock(node) {
+					loneBlocks = append(loneBlocks, node)
+				}
+			},
+			rule.ListenerOnExit(ast.KindBlock): func(node *ast.Node) {
+				if len(loneBlocks) > 0 && loneBlocks[len(loneBlocks)-1] == node {
+					loneBlocks = loneBlocks[:len(loneBlocks)-1]
+					report(node)
+					return
+				}
+				parent := node.Parent
+				if parent == nil {
+					return
+				}
+				if parent.Kind == ast.KindBlock {
+					parentBlock := parent.AsBlock()
+					if parentBlock != nil && parentBlock.Statements != nil && len(parentBlock.Statements.Nodes) == 1 {
+						report(node)
+					}
+				}
+			},
+			ast.KindVariableStatement: func(node *ast.Node) {
+				varStmt := node.AsVariableStatement()
+				if varStmt == nil || varStmt.DeclarationList == nil {
+					return
+				}
+				// let, const, using, and await using are block-scoped.
+				if varStmt.DeclarationList.Flags&ast.NodeFlagsBlockScoped != 0 {
+					markLoneBlock(node)
+				}
+			},
+			ast.KindFunctionDeclaration: func(node *ast.Node) {
+				if utils.IsInStrictMode(node, ctx.SourceFile) {
+					markLoneBlock(node)
+				}
+			},
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				markLoneBlock(node)
+			},
+		}
+	},
+}

--- a/internal/rules/no_lone_blocks/no_lone_blocks.md
+++ b/internal/rules/no_lone_blocks/no_lone_blocks.md
@@ -1,0 +1,78 @@
+# no-lone-blocks
+
+## Rule Details
+
+This rule disallows nested (non-function) lone blocks. A lone block is a block that is not part of an `if`, `for`, `while`, `function`, `try`, class static block, or other statement that naturally introduces one. In ES6+, a block can be useful to scope `let`, `const`, `class`, `function`, or `using` declarations — this rule only flags blocks that do not contain such block-scoped bindings.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+{}
+
+{
+  var x = 1;
+}
+
+if (foo) {
+  bar();
+  {
+    baz();
+  }
+}
+
+function foo() {
+  {
+    var x = 1;
+  }
+}
+
+class C {
+  static {
+    {
+      foo();
+    }
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+while (foo) {
+  bar();
+}
+
+if (foo) {
+  if (bar) {
+    baz();
+  }
+}
+
+{
+  let x = 1;
+}
+
+{
+  const y = 2;
+}
+
+{
+  class Bar {}
+}
+
+switch (foo) {
+  case bar: {
+    baz();
+  }
+}
+
+class C {
+  static {
+    foo();
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint rule: no-lone-blocks](https://eslint.org/docs/latest/rules/no-lone-blocks)

--- a/internal/rules/no_lone_blocks/no_lone_blocks_test.go
+++ b/internal/rules/no_lone_blocks/no_lone_blocks_test.go
@@ -1,0 +1,579 @@
+package no_lone_blocks
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLoneBlocksRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLoneBlocksRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Blocks that belong to a containing statement (not lone) ----
+			{Code: `if (foo) { if (bar) { baz(); } }`},
+			{Code: `if (foo) { bar(); } else { baz(); }`},
+			{Code: `if (foo) { bar(); } else if (baz) { qux(); }`},
+			{Code: `do { bar(); } while (foo)`},
+			{Code: `while (foo) { bar(); }`},
+			{Code: `for (let i = 0; i < 10; i++) { bar(); }`},
+			{Code: `for (const x of xs) { bar(); }`},
+			{Code: `for (const x in obj) { bar(); }`},
+			{Code: `async function f() { for await (const x of xs) { bar(); } }`},
+			{Code: `try { foo(); } catch (e) { bar(); }`},
+			{Code: `try { foo(); } catch { bar(); }`},
+			{Code: `try { foo(); } finally { bar(); }`},
+			{Code: `function foo() { while (bar) { baz(); } }`},
+			{Code: `const f = () => { foo(); }`},
+			{Code: `const f = async () => { await foo(); }`},
+			{Code: `class C { method() { foo(); } }`},
+			{Code: `class C { constructor() { foo(); } }`},
+			{Code: `class C { get prop() { return 1; } }`},
+			{Code: `class C { set prop(v) { this._v = v; } }`},
+			{Code: `class C { static method() { foo(); } }`},
+			{Code: `function* gen() { yield 1; }`},
+
+			// ---- Block-level bindings justify a lone block ----
+			{Code: `{ let x = 1; }`},
+			{Code: `{ const x = 1; }`},
+			{Code: `{ class Bar {} }`},
+			{Code: `'use strict'; { function bar() {} }`},
+			{Code: `export {}; { function bar() {} }`},
+			{Code: `{ let x; var y; }`},
+			{Code: `{ var x; let y; }`},
+			{Code: `{ let x; const y = 1; class Z {} }`},
+
+			// ---- Nested lone block, each with its own binding ----
+			{Code: `{ {let y = 1;} let x = 1; }`},
+			{Code: `{ let x = 1; { let y = 2; } }`},
+
+			// ---- Different scopes, same name is fine ----
+			{Code: `function foo() { { const x = 4 } const x = 3 }`},
+
+			// ---- Switch: solo block per clause is allowed ----
+			{Code: `
+switch (foo) {
+    case bar: {
+        baz;
+    }
+}
+`},
+			{Code: `
+switch (foo) {
+    case bar: {
+        baz;
+    }
+    case qux: {
+        boop;
+    }
+}
+`},
+			{Code: `
+switch (foo) {
+    case bar:
+    {
+        baz;
+    }
+}
+`},
+			{Code: `
+switch (foo) {
+    default: {
+        baz;
+    }
+}
+`},
+			{Code: `
+switch (foo) {
+    case bar: {
+        a;
+    }
+    default: {
+        b;
+    }
+}
+`},
+
+			// ---- Class static blocks ----
+			{Code: `class C { static {} }`},
+			{Code: `class C { static { foo; } }`},
+			{Code: `class C { static { foo; bar; } }`},
+			{Code: `class C { static { if (foo) { block; } } }`},
+			{Code: `class C { static { lbl: { block; } } }`},
+			{Code: `class C { static { { let block; } something; } }`},
+			{Code: `class C { static { something; { const block = 1; } } }`},
+			{Code: `class C { static { { function block(){} } something; } }`},
+			{Code: `class C { static { something; { class block {} } } }`},
+
+			// ---- Labeled block at program scope (parent is LabeledStatement, not "lone") ----
+			{Code: `lbl: { foo(); }`},
+			{Code: `lbl: { let x = 1; }`},
+
+			// ---- TS namespace: a block inside a namespace body is not flagged ----
+			// (ESLint's `isLoneBlock` only recognizes BlockStatement/StaticBlock/Program/SwitchCase,
+			// and never flags blocks whose parent is a TSModuleBlock. rslint matches that.)
+			{Code: `namespace N { { foo; } }`},
+			{Code: `namespace N { { let x = 1; } }`},
+
+			// ---- Explicit resource management (`using` / `await using`) ----
+			{Code: `
+{
+    using x = makeDisposable();
+}
+`},
+			{Code: `
+async function f() {
+    {
+        await using x = makeDisposable();
+    }
+    bar();
+}
+`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Trivial program-scope lone blocks ----
+			{
+				Code: `{}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code: `{var x = 1;}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code: `foo(); {} bar();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 8, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// ---- Two sibling lone blocks at program scope ----
+			{
+				Code: `{} {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 3},
+					{MessageId: "redundantBlock", Line: 1, Column: 4, EndLine: 1, EndColumn: 6},
+				},
+			},
+
+			// ---- Lone block nested inside a containing statement body ----
+			{
+				Code: `if (foo) { bar(); {} baz(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 19, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `function foo() { bar(); {} baz(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 25, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code: `while (foo) { {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 15, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code: `for (;;) { {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 12, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `do { {} } while (foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 6, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code: `try { {} } catch {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 7, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code: `try {} catch { {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 16, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code: `try {} finally { {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 18, EndLine: 1, EndColumn: 20},
+				},
+			},
+			{
+				Code: `class C { method() { {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 22, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code: `class C { constructor() { {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 27, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code: `const f = () => { {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 19, EndLine: 1, EndColumn: 21},
+				},
+			},
+
+			// ---- Multi-line lone block: full position assertion ----
+			{
+				Code: "{ \n{ } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 2, Column: 1, EndLine: 2, EndColumn: 4},
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 2, EndColumn: 6},
+				},
+			},
+			{
+				Code: "{\n    var x = 1;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 3, EndColumn: 2},
+				},
+			},
+
+			// ---- Triple nesting: every level reports (exit order: inner -> middle -> outer) ----
+			{
+				Code: `{ { {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 5, EndLine: 1, EndColumn: 7},
+					{MessageId: "redundantNestedBlock", Line: 1, Column: 3, EndLine: 1, EndColumn: 9},
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 11},
+				},
+			},
+
+			// ---- Even in ES6+, a function declaration in a non-strict block does not
+			// justify the block. ----
+			{
+				Code: `{ function bar() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 22},
+				},
+			},
+
+			// ---- A block that only contains a non-binding (labeled statement / type-only /
+			// var / declare) is still redundant. ----
+			{
+				Code: `{ lbl: foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: `{ type X = number; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `{ interface I {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code: `{ declare var x: number; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code: `{ /* comment */ }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Stack semantics: only bindings directly inside a block mark it. ----
+			{
+				// Outer has `let y` (marks outer). Inner has only `var` (does not mark inner).
+				// Inner is reported as redundantNestedBlock; outer is marked and not reported.
+				Code: "{ \n{var x = 1;}\n let y = 2; } {let z = 1;}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 2, Column: 1},
+				},
+			},
+			{
+				// Inner has `let` (marks inner). Outer has only `var` (does not mark outer).
+				// Inner is marked and skipped; outer is reported as redundantBlock.
+				Code: "{ \n{let x = 1;}\n var y = 2; } {let z = 1;}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 1, Column: 1},
+				},
+			},
+			{
+				// Nothing is block-scoped anywhere. Every block reports.
+				Code: "{ \n{var x = 1;}\n var y = 2; }\n {var z = 1;}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 2, Column: 1},
+					{MessageId: "redundantBlock", Line: 1, Column: 1},
+					{MessageId: "redundantBlock", Line: 4, Column: 2},
+				},
+			},
+
+			// ---- Switch: block that is not the sole statement of a case/default clause ----
+			{
+				Code: `
+switch (foo) {
+    case 1:
+        foo();
+        {
+            bar;
+        }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 5, Column: 9},
+				},
+			},
+			{
+				Code: `
+switch (foo) {
+    case 1:
+    {
+        bar;
+    }
+    foo();
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 4, Column: 5},
+				},
+			},
+			{
+				Code: `
+switch (foo) {
+    default:
+        foo();
+        {
+            bar;
+        }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 5, Column: 9},
+				},
+			},
+			{
+				Code: `
+switch (foo) {
+    default:
+    {
+        bar;
+    }
+    foo();
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantBlock", Line: 4, Column: 5},
+				},
+			},
+
+			// ---- Function body containing a single lone block (else-if branch fires) ----
+			{
+				Code: `
+function foo () {
+    {
+        const x = 4;
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 3, Column: 5},
+				},
+			},
+			{
+				Code: `
+function foo () {
+    {
+        var x = 4;
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 3, Column: 5},
+				},
+			},
+
+			// ---- Class static block cases ----
+			{
+				Code: `
+class C {
+    static {
+        if (foo) {
+            {
+                let block;
+            }
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 5, Column: 13},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        if (foo) {
+            {
+                block;
+            }
+            something;
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 5, Column: 13},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            block;
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            let block;
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            const block = 1;
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            function block() {}
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            class block {}
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            var block;
+        }
+        something;
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        something;
+        {
+            var block;
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 5, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        {
+            block;
+        }
+        something;
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 4, Column: 9},
+				},
+			},
+			{
+				Code: `
+class C {
+    static {
+        something;
+        {
+            block;
+        }
+    }
+}
+`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "redundantNestedBlock", Line: 5, Column: 9},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -275,6 +275,7 @@ export default defineConfig({
     './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
+    './tests/eslint/rules/no-lone-blocks.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
     './tests/eslint/rules/object-shorthand.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-lone-blocks.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-lone-blocks.test.ts.snap
@@ -1,0 +1,1386 @@
+// Rstest Snapshot v1
+
+exports[`no-lone-blocks > invalid 1`] = `
+{
+  "code": "{}",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 2`] = `
+{
+  "code": "{var x = 1;}",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 3`] = `
+{
+  "code": "foo(); {} bar();",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 4`] = `
+{
+  "code": "{} {}",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 5`] = `
+{
+  "code": "if (foo) { bar(); {} baz(); }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 6`] = `
+{
+  "code": "function foo() { bar(); {} baz(); }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 7`] = `
+{
+  "code": "while (foo) { {} }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 8`] = `
+{
+  "code": "for (;;) { {} }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 9`] = `
+{
+  "code": "do { {} } while (foo)",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 10`] = `
+{
+  "code": "try { {} } catch {}",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 11`] = `
+{
+  "code": "try {} catch { {} }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 12`] = `
+{
+  "code": "try {} finally { {} }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 13`] = `
+{
+  "code": "class C { method() { {} } }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 14`] = `
+{
+  "code": "class C { constructor() { {} } }",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 15`] = `
+{
+  "code": "const f = () => { {} };",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 16`] = `
+{
+  "code": "{ 
+{ } }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 17`] = `
+{
+  "code": "{
+    var x = 1;
+}",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 18`] = `
+{
+  "code": "{ { {} } }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 19`] = `
+{
+  "code": "{ function bar() {} }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 20`] = `
+{
+  "code": "{ lbl: foo(); }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 21`] = `
+{
+  "code": "{ type X = number; }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 22`] = `
+{
+  "code": "{ interface I {} }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 23`] = `
+{
+  "code": "{ declare var x: number; }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 24`] = `
+{
+  "code": "{ /* comment */ }",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 25`] = `
+{
+  "code": "{ 
+{var x = 1;}
+ let y = 2; } {let z = 1;}",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 26`] = `
+{
+  "code": "{ 
+{let x = 1;}
+ var y = 2; } {let z = 1;}",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 27`] = `
+{
+  "code": "{ 
+{var x = 1;}
+ var y = 2; }
+ {var z = 1;}",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 2,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 28`] = `
+{
+  "code": "
+switch (foo) {
+    case 1:
+        foo();
+        {
+            bar;
+        }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 29`] = `
+{
+  "code": "
+switch (foo) {
+    case 1:
+    {
+        bar;
+    }
+    foo();
+}
+",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 30`] = `
+{
+  "code": "
+switch (foo) {
+    default:
+        foo();
+        {
+            bar;
+        }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 31`] = `
+{
+  "code": "
+switch (foo) {
+    default:
+    {
+        bar;
+    }
+    foo();
+}
+",
+  "diagnostics": [
+    {
+      "message": "Block is redundant.",
+      "messageId": "redundantBlock",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 6,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 32`] = `
+{
+  "code": "
+function foo () {
+    {
+        const x = 4;
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 33`] = `
+{
+  "code": "
+function foo () {
+    {
+        var x = 4;
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 5,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 34`] = `
+{
+  "code": "
+class C {
+    static {
+        if (foo) {
+            {
+                let block;
+            }
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 7,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 35`] = `
+{
+  "code": "
+class C {
+    static {
+        if (foo) {
+            {
+                block;
+            }
+            something;
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 7,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 36`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            block;
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 37`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            let block;
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 38`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            const block = 1;
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 39`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            function block() {}
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 40`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            class block {}
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 41`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            var block;
+        }
+        something;
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 42`] = `
+{
+  "code": "
+class C {
+    static {
+        something;
+        {
+            var block;
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 43`] = `
+{
+  "code": "
+class C {
+    static {
+        {
+            block;
+        }
+        something;
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 6,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-lone-blocks > invalid 44`] = `
+{
+  "code": "
+class C {
+    static {
+        something;
+        {
+            block;
+        }
+    }
+}
+",
+  "diagnostics": [
+    {
+      "message": "Nested block is redundant.",
+      "messageId": "redundantNestedBlock",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 7,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-lone-blocks",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-lone-blocks.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-lone-blocks.test.ts
@@ -1,0 +1,479 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-lone-blocks', {
+  valid: [
+    // Blocks that belong to a containing statement (not lone).
+    'if (foo) { if (bar) { baz(); } }',
+    'if (foo) { bar(); } else { baz(); }',
+    'if (foo) { bar(); } else if (baz) { qux(); }',
+    'do { bar(); } while (foo)',
+    'while (foo) { bar(); }',
+    'for (let i = 0; i < 10; i++) { bar(); }',
+    'for (const x of xs) { bar(); }',
+    'for (const x in obj) { bar(); }',
+    'async function f() { for await (const x of xs) { bar(); } }',
+    'try { foo(); } catch (e) { bar(); }',
+    'try { foo(); } catch { bar(); }',
+    'try { foo(); } finally { bar(); }',
+    'function foo() { while (bar) { baz(); } }',
+    'const f = () => { foo(); }',
+    'const f = async () => { await foo(); }',
+    'class C { method() { foo(); } }',
+    'class C { constructor() { foo(); } }',
+    'class C { get prop() { return 1; } }',
+    'class C { set prop(v) { this._v = v; } }',
+    'class C { static method() { foo(); } }',
+    'function* gen() { yield 1; }',
+
+    // Block-level bindings justify a lone block.
+    '{ let x = 1; }',
+    '{ const x = 1; }',
+    '{ class Bar {} }',
+    "'use strict'; { function bar() {} }",
+    'export {}; { function bar() {} }',
+    '{ let x; var y; }',
+    '{ var x; let y; }',
+    '{ let x; const y = 1; class Z {} }',
+
+    // Nested lone block, each with its own binding.
+    '{ {let y = 1;} let x = 1; }',
+    '{ let x = 1; { let y = 2; } }',
+
+    // Different scopes, same name is fine.
+    'function foo() { { const x = 4 } const x = 3 }',
+
+    // Switch: solo block per clause is allowed.
+    `
+switch (foo) {
+    case bar: {
+        baz;
+    }
+}
+`,
+    `
+switch (foo) {
+    case bar: {
+        baz;
+    }
+    case qux: {
+        boop;
+    }
+}
+`,
+    `
+switch (foo) {
+    case bar:
+    {
+        baz;
+    }
+}
+`,
+    `
+switch (foo) {
+    default: {
+        baz;
+    }
+}
+`,
+    `
+switch (foo) {
+    case bar: {
+        a;
+    }
+    default: {
+        b;
+    }
+}
+`,
+
+    // Class static blocks.
+    'class C { static {} }',
+    'class C { static { foo; } }',
+    'class C { static { foo; bar; } }',
+    'class C { static { if (foo) { block; } } }',
+    'class C { static { lbl: { block; } } }',
+    'class C { static { { let block; } something; } }',
+    'class C { static { something; { const block = 1; } } }',
+    'class C { static { { function block(){} } something; } }',
+    'class C { static { something; { class block {} } } }',
+
+    // Labeled block at program scope.
+    'lbl: { foo(); }',
+    'lbl: { let x = 1; }',
+
+    // TS namespace — a block inside a namespace body is not flagged (ESLint parity).
+    'namespace N { { foo; } }',
+    'namespace N { { let x = 1; } }',
+
+    // `using` / `await using` declarations.
+    `
+{
+    using x = makeDisposable();
+}
+`,
+    `
+async function f() {
+    {
+        await using x = makeDisposable();
+    }
+    bar();
+}
+`,
+  ],
+  invalid: [
+    // Trivial program-scope lone blocks.
+    {
+      code: '{}',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: '{var x = 1;}',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: 'foo(); {} bar();',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+
+    // Two sibling lone blocks at program scope.
+    {
+      code: '{} {}',
+      errors: [
+        { messageId: 'redundantBlock' },
+        { messageId: 'redundantBlock' },
+      ],
+    },
+
+    // Lone block nested inside a containing statement body.
+    {
+      code: 'if (foo) { bar(); {} baz(); }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'function foo() { bar(); {} baz(); }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'while (foo) { {} }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'for (;;) { {} }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'do { {} } while (foo)',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'try { {} } catch {}',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'try {} catch { {} }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'try {} finally { {} }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'class C { method() { {} } }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'class C { constructor() { {} } }',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: 'const f = () => { {} };',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+
+    // Multi-line lone block (position captured by snapshot).
+    {
+      code: '{ \n{ } }',
+      errors: [
+        { messageId: 'redundantBlock' },
+        { messageId: 'redundantNestedBlock' },
+      ],
+    },
+    {
+      code: '{\n    var x = 1;\n}',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+
+    // Triple nesting.
+    {
+      code: '{ { {} } }',
+      errors: [
+        { messageId: 'redundantBlock' },
+        { messageId: 'redundantNestedBlock' },
+        { messageId: 'redundantNestedBlock' },
+      ],
+    },
+
+    // Non-block-level binding does not justify the block.
+    {
+      code: '{ function bar() {} }',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+
+    // Block containing only a non-binding is still redundant.
+    {
+      code: '{ lbl: foo(); }',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: '{ type X = number; }',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: '{ interface I {} }',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: '{ declare var x: number; }',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: '{ /* comment */ }',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+
+    // Stack semantics: only bindings directly inside a block mark it.
+    {
+      code: '{ \n{var x = 1;}\n let y = 2; } {let z = 1;}',
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: '{ \n{let x = 1;}\n var y = 2; } {let z = 1;}',
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: '{ \n{var x = 1;}\n var y = 2; }\n {var z = 1;}',
+      errors: [
+        { messageId: 'redundantBlock' },
+        { messageId: 'redundantNestedBlock' },
+        { messageId: 'redundantBlock' },
+      ],
+    },
+
+    // Switch: block that is not the sole statement of a case/default clause.
+    {
+      code: `
+switch (foo) {
+    case 1:
+        foo();
+        {
+            bar;
+        }
+}
+`,
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: `
+switch (foo) {
+    case 1:
+    {
+        bar;
+    }
+    foo();
+}
+`,
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: `
+switch (foo) {
+    default:
+        foo();
+        {
+            bar;
+        }
+}
+`,
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+    {
+      code: `
+switch (foo) {
+    default:
+    {
+        bar;
+    }
+    foo();
+}
+`,
+      errors: [{ messageId: 'redundantBlock' }],
+    },
+
+    // Function body containing a single lone block (else-if branch fires).
+    {
+      code: `
+function foo () {
+    {
+        const x = 4;
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+function foo () {
+    {
+        var x = 4;
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+
+    // Class static block cases.
+    {
+      code: `
+class C {
+    static {
+        if (foo) {
+            {
+                let block;
+            }
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        if (foo) {
+            {
+                block;
+            }
+            something;
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            block;
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            let block;
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            const block = 1;
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            function block() {}
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            class block {}
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            var block;
+        }
+        something;
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        something;
+        {
+            var block;
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        {
+            block;
+        }
+        something;
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+    {
+      code: `
+class C {
+    static {
+        something;
+        {
+            block;
+        }
+    }
+}
+`,
+      errors: [{ messageId: 'redundantNestedBlock' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-lone-blocks` rule from ESLint to rslint.

The rule flags redundant stand-alone blocks — blocks that are not part of an `if`/`for`/`while`/`function`/`try`/class-static-block or other statement that naturally introduces one. In ES6+, a block is still considered useful when it scopes `let`, `const`, `class`, `function` (in strict mode), or `using`/`await using` declarations; only blocks without such block-scoped bindings are reported.

Behavior parity verified against the upstream ESLint test suite, plus extended tests for real-world container positions (`if`/`else`, `for`/`for-of`/`for-in`/`for-await`, `do-while`, `try`/`catch`/`finally`, arrow / method / constructor / getter / setter / generator bodies), sibling and triple-nested lone blocks, switch `default` clause variants, TypeScript namespace regression, labeled blocks, blocks containing only non-binding content (`type`/`interface`/`declare`/labeled/comment), and multi-line `Line`/`Column`/`EndLine`/`EndColumn` position assertions (56 valid + 45 invalid Go cases).

Differential validation against ESLint `no-lone-blocks` on rsbuild (1165 files) and rspack (534 files): 0 findings on both sides, matching rslint's output.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-lone-blocks
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-lone-blocks.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).