### PR TITLE
feat: port rule no-octal

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
+	"github.com/web-infra-dev/rslint/internal/rules/no_octal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_octal_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_param_reassign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
@@ -570,6 +571,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-restricted-imports", no_restricted_imports.NoRestrictedImportsRule)
 	GlobalRuleRegistry.Register("no-multi-str", no_multi_str.NoMultiStrRule)
 	GlobalRuleRegistry.Register("no-nested-ternary", no_nested_ternary.NoNestedTernaryRule)
+	GlobalRuleRegistry.Register("no-octal", no_octal.NoOctalRule)
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)
 	GlobalRuleRegistry.Register("no-param-reassign", no_param_reassign.NoParamReassignRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)

--- a/internal/rules/no_octal/no_octal.go
+++ b/internal/rules/no_octal/no_octal.go
@@ -1,0 +1,35 @@
+package no_octal
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-octal
+var NoOctalRule = rule.Rule{
+	Name: "no-octal",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindNumericLiteral: func(node *ast.Node) {
+				// tsgo normalizes NumericLiteral.Text at parse time (e.g. "01234" -> "668"),
+				// so we must read the raw source to distinguish a legacy octal from a decimal.
+				raw := utils.TrimmedNodeText(ctx.SourceFile, node)
+				if isOctalLiteralRaw(raw) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "noOctal",
+						Description: "Octal literals should not be used.",
+					})
+				}
+			},
+		}
+	},
+}
+
+// isOctalLiteralRaw reports whether a NumericLiteral's raw source text denotes a
+// legacy octal literal or a leading-zero decimal (e.g. `08`, `09.1`).
+// Matches ESLint's `^0\d` check on `node.raw` — hex (`0x`), modern octal (`0o`),
+// binary (`0b`), and fractional literals (`0.1`) are excluded by construction.
+func isOctalLiteralRaw(raw string) bool {
+	return len(raw) >= 2 && raw[0] == '0' && raw[1] >= '0' && raw[1] <= '9'
+}

--- a/internal/rules/no_octal/no_octal.md
+++ b/internal/rules/no_octal/no_octal.md
@@ -1,0 +1,37 @@
+# no-octal
+
+## Rule Details
+
+Disallows octal literals — integer numerals whose source form starts with a leading
+zero followed by another digit (e.g. `071`, `00`, `08`). Octal numeric literals were
+deprecated in ECMAScript 5 and are forbidden in strict mode; the leading-zero notation
+has also been a long-standing source of confusion (`08` is decimal 8, but `017` is
+decimal 15). Prefer the explicit `0o...` octal notation introduced in ES2015.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const num = 071;
+const result = 5 + 07;
+const leadingDigit = 08;
+const leadingDecimal = 09.1;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+const num = "071";
+const hex = 0x1234;
+const binary = 0b101;
+const modernOctal = 0o17;
+const zero = 0;
+const decimal = 0.1;
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-octal

--- a/internal/rules/no_octal/no_octal_test.go
+++ b/internal/rules/no_octal/no_octal_test.go
@@ -1,0 +1,97 @@
+package no_octal
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestIsOctalLiteralRaw(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected bool
+	}{
+		// ---- ESLint upstream invalid cases (legacy octal + leading-zero decimal) ----
+		{name: "01234", raw: "01234", expected: true},
+		{name: "07", raw: "07", expected: true},
+		{name: "00", raw: "00", expected: true},
+		{name: "08 (leading-zero decimal)", raw: "08", expected: true},
+		{name: "09.1", raw: "09.1", expected: true},
+		{name: "09e1", raw: "09e1", expected: true},
+		{name: "09.1e1", raw: "09.1e1", expected: true},
+		{name: "018", raw: "018", expected: true},
+		{name: "019.1", raw: "019.1", expected: true},
+		{name: "019e1", raw: "019e1", expected: true},
+		{name: "019.1e1", raw: "019.1e1", expected: true},
+
+		// ---- ESLint upstream valid cases ----
+		{name: "0", raw: "0", expected: false},
+		{name: "0.1", raw: "0.1", expected: false},
+		{name: "0.5e1", raw: "0.5e1", expected: false},
+		{name: "0x1234", raw: "0x1234", expected: false},
+		{name: "0X5", raw: "0X5", expected: false},
+
+		// ---- Modern literal forms (correctly excluded) ----
+		{name: "0o17", raw: "0o17", expected: false},
+		{name: "0O17", raw: "0O17", expected: false},
+		{name: "0b101", raw: "0b101", expected: false},
+		{name: "0B101", raw: "0B101", expected: false},
+
+		// ---- Plain decimals ----
+		{name: "1", raw: "1", expected: false},
+		{name: "123", raw: "123", expected: false},
+		{name: "1.5", raw: "1.5", expected: false},
+		{name: "1e5", raw: "1e5", expected: false},
+		{name: ".5", raw: ".5", expected: false},
+
+		// ---- Boundary: too short to be 0-prefixed ----
+		{name: "empty", raw: "", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isOctalLiteralRaw(tt.raw); got != tt.expected {
+				t.Errorf("isOctalLiteralRaw(%q) = %v, want %v", tt.raw, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNoOctalRule(t *testing.T) {
+	// Invalid cases cannot be exercised via the tsconfig-bound rule_tester because
+	// the TypeScript parser rejects octal literals (TS1121) and leading-zero
+	// decimals (TS1489) as syntactic errors, preventing program creation.
+	// Detection logic is covered by TestIsOctalLiteralRaw; production files use the
+	// lenient fallback program, where the listener fires normally.
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoOctalRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: `var a = 'hello world';`},
+			{Code: `0x1234`},
+			{Code: `0X5;`},
+			{Code: `a = 0;`},
+			{Code: `0.1`},
+			{Code: `0.5e1`},
+
+			// ---- Modern literal forms that share a leading zero ----
+			{Code: `0o17`},
+			{Code: `0O17`},
+			{Code: `0b101`},
+			{Code: `0B101`},
+			{Code: `0n`},
+
+			// ---- Plain decimals ----
+			{Code: `123`},
+			{Code: `1.5`},
+			{Code: `1e5`},
+			{Code: `.5`},
+		},
+		[]rule_tester.InvalidTestCase{},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -278,6 +278,7 @@ export default defineConfig({
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
     './tests/eslint/rules/object-shorthand.test.ts',
+    './tests/eslint/rules/no-octal.test.ts',
     './tests/eslint/rules/no-octal-escape.test.ts',
     './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/no-octal.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-octal.test.ts
@@ -1,0 +1,24 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-octal', {
+  valid: [
+    "var a = 'hello world';",
+    '0x1234',
+    '0X5;',
+    'a = 0;',
+    '0.1',
+    '0.5e1',
+    '0o17',
+    '0O17',
+    '0b101',
+    '0B101',
+  ],
+  // Invalid cases cannot be tested through the JS test framework because the
+  // TypeScript parser reports octal literals (TS1121) and leading-zero decimals
+  // (TS1489) as syntax errors, preventing program creation. The detection logic
+  // is comprehensively tested via Go unit tests (TestIsOctalLiteralRaw in
+  // no_octal_test.go).
+  invalid: [],
+});


### PR DESCRIPTION
## Summary

Port the `no-octal` rule from ESLint to rslint.

Disallows legacy octal literals (`071`) and leading-zero decimals (`08`, `09.1`) —
numerals whose source form starts with a leading zero followed by another digit.
ECMAScript 5 deprecated this notation; the explicit `0o...` form is preferred.

The rule listens on `KindNumericLiteral`, reads the raw source text via
`utils.TrimmedNodeText` (because tsgo normalizes `NumericLiteral.Text` at parse
time), and reports `noOctal` when the raw matches `^0\d` — byte-identical to
ESLint's `/^0\d/u.test(node.raw)` check.

### Notes on reachability

tsgo's parser rejects legacy octal literals (TS1121) and leading-zero decimals
(TS1489) as syntactic errors at parse time. As a result:

- Under tsconfig-bound paths (strict), program creation fails before rules run,
  so the rule only effectively fires on gap files (matched by config \`files\` but
  outside any tsconfig). This mirrors the existing \`no-octal-escape\` port.
- Invalid test cases are covered by direct unit tests on the \`isOctalLiteralRaw\`
  helper rather than through the rule_tester, for the same reason.

End-to-end verification against a gap file confirmed position (\`1:11\` / \`2:11\`)
and message text match ESLint; running the rule across rsbuild (1197 files) and
rspack (392 files) added no measurable overhead.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-octal
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-octal.js
- Test file: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-octal.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).