### PR TITLE
feat: port rule no-prototype-builtins

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -170,6 +170,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_octal_escape"
 	"github.com/web-infra-dev/rslint/internal/rules/no_param_reassign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
+	"github.com/web-infra-dev/rslint/internal/rules/no_prototype_builtins"
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
@@ -607,6 +608,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
+	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/no_prototype_builtins/no_prototype_builtins.go
+++ b/internal/rules/no_prototype_builtins/no_prototype_builtins.go
@@ -1,0 +1,155 @@
+package no_prototype_builtins
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var disallowedProps = map[string]struct{}{
+	"hasOwnProperty":       {},
+	"isPrototypeOf":        {},
+	"propertyIsEnumerable": {},
+}
+
+// isAfterOptional walks the member/call chain leftward from node, returning
+// true if any link owns a `?.` token. Parentheses are unwrapped on each step
+// so a chain hidden inside `(...)` (tsgo's stand-in for ESTree's
+// ChainExpression, e.g. `(foo?.hasOwnProperty)('bar')`) is also caught —
+// ESLint handles that case via a separate ChainExpression check, but on the
+// tsgo AST the same short-circuiting concern folds into one walk.
+func isAfterOptional(node *ast.Node) bool {
+	for node != nil {
+		node = ast.SkipParentheses(node)
+		if node == nil {
+			return false
+		}
+		if ast.IsOptionalChainRoot(node) {
+			return true
+		}
+		switch node.Kind {
+		case ast.KindCallExpression:
+			node = node.AsCallExpression().Expression
+		case ast.KindPropertyAccessExpression:
+			node = node.AsPropertyAccessExpression().Expression
+		case ast.KindElementAccessExpression:
+			node = node.AsElementAccessExpression().Expression
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// isCommaBinaryExpression reports whether node is a BinaryExpression with the
+// comma operator — tsgo's encoding of ESTree's SequenceExpression, which is the
+// only operand that ESLint's precedence check wraps in `(...)`.
+func isCommaBinaryExpression(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := node.AsBinaryExpression()
+	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken
+}
+
+// https://eslint.org/docs/latest/rules/no-prototype-builtins
+var NoPrototypeBuiltinsRule = rule.Rule{
+	Name: "no-prototype-builtins",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				callExpr := node.AsCallExpression()
+				if callExpr == nil || callExpr.Expression == nil {
+					return
+				}
+
+				callee := ast.SkipParentheses(callExpr.Expression)
+				if callee == nil {
+					return
+				}
+
+				var reportNode *ast.Node
+				switch callee.Kind {
+				case ast.KindPropertyAccessExpression:
+					reportNode = callee.AsPropertyAccessExpression().Name()
+				case ast.KindElementAccessExpression:
+					reportNode = callee.AsElementAccessExpression().ArgumentExpression
+				default:
+					return
+				}
+				if reportNode == nil {
+					return
+				}
+
+				propName, ok := utils.AccessExpressionStaticName(callee)
+				if !ok {
+					return
+				}
+				if _, forbidden := disallowedProps[propName]; !forbidden {
+					return
+				}
+
+				msg := rule.RuleMessage{
+					Id:          "prototypeBuildIn",
+					Description: fmt.Sprintf("Do not access Object.prototype method '%s' from target object.", propName),
+				}
+
+				// No suggestion when the chain may short-circuit, or when the
+				// global `Object` is shadowed and can't be referenced as-is.
+				if isAfterOptional(node) || utils.IsShadowed(node, "Object") {
+					ctx.ReportNode(reportNode, msg)
+					return
+				}
+
+				obj := utils.AccessExpressionObject(callee)
+				if obj == nil {
+					ctx.ReportNode(reportNode, msg)
+					return
+				}
+
+				unwrappedObj := ast.SkipParentheses(obj)
+				if unwrappedObj == nil {
+					ctx.ReportNode(reportNode, msg)
+					return
+				}
+
+				objText := utils.TrimmedNodeText(ctx.SourceFile, unwrappedObj)
+				if isCommaBinaryExpression(unwrappedObj) {
+					objText = "(" + objText + ")"
+				}
+
+				text := ctx.SourceFile.Text()
+				openParenPos := scanner.SkipTrivia(text, callExpr.Expression.End())
+				if openParenPos >= len(text) || text[openParenPos] != '(' {
+					ctx.ReportNode(reportNode, msg)
+					return
+				}
+
+				delim := ", "
+				if callExpr.Arguments == nil || len(callExpr.Arguments.Nodes) == 0 {
+					delim = ""
+				}
+
+				suggestion := rule.RuleSuggestion{
+					Message: rule.RuleMessage{
+						Id:          "callObjectPrototype",
+						Description: fmt.Sprintf("Call Object.prototype.%s explicitly.", propName),
+					},
+					FixesArr: []rule.RuleFix{
+						rule.RuleFixReplace(ctx.SourceFile, callee, "Object.prototype."+propName+".call"),
+						rule.RuleFixReplaceRange(
+							core.NewTextRange(openParenPos+1, openParenPos+1),
+							objText+delim,
+						),
+					},
+				}
+
+				ctx.ReportNodeWithSuggestions(reportNode, msg, suggestion)
+			},
+		}
+	},
+}

--- a/internal/rules/no_prototype_builtins/no_prototype_builtins.md
+++ b/internal/rules/no_prototype_builtins/no_prototype_builtins.md
@@ -1,0 +1,34 @@
+# no-prototype-builtins
+
+## Rule Details
+
+This rule disallows calling `Object.prototype` methods directly on object
+instances. In particular, it flags calls to `hasOwnProperty`, `isPrototypeOf`,
+and `propertyIsEnumerable` invoked as members of a target object. Such calls
+can break on objects created with `Object.create(null)` (which do not inherit
+from `Object.prototype`) or on objects that define shadowing properties with
+the same names.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var hasBarProperty = foo.hasOwnProperty('bar');
+var isPrototypeOfBar = foo.isPrototypeOf(bar);
+var barIsEnumerable = foo.propertyIsEnumerable('bar');
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var hasBarProperty = Object.prototype.hasOwnProperty.call(foo, 'bar');
+var isPrototypeOfBar = Object.prototype.isPrototypeOf.call(foo, bar);
+var barIsEnumerable = {}.propertyIsEnumerable.call(foo, 'bar');
+```
+
+## Options
+
+This rule has no options.
+
+## Original Documentation
+
+- ESLint rule: https://eslint.org/docs/latest/rules/no-prototype-builtins

--- a/internal/rules/no_prototype_builtins/no_prototype_builtins_test.go
+++ b/internal/rules/no_prototype_builtins/no_prototype_builtins_test.go
@@ -1,0 +1,297 @@
+// cspell:ignore Enumerabl
+
+package no_prototype_builtins
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoPrototypeBuiltinsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoPrototypeBuiltinsRule,
+		// Valid cases - ported from ESLint
+		[]rule_tester.ValidTestCase{
+			{Code: `Object.prototype.hasOwnProperty.call(foo, 'bar')`},
+			{Code: `Object.prototype.isPrototypeOf.call(foo, 'bar')`},
+			{Code: `Object.prototype.propertyIsEnumerable.call(foo, 'bar')`},
+			{Code: `Object.prototype.hasOwnProperty.apply(foo, ['bar'])`},
+			{Code: `Object.prototype.isPrototypeOf.apply(foo, ['bar'])`},
+			{Code: `Object.prototype.propertyIsEnumerable.apply(foo, ['bar'])`},
+			{Code: `foo.hasOwnProperty`},
+			{Code: `foo.hasOwnProperty.bar()`},
+			{Code: `foo(hasOwnProperty)`},
+			{Code: `hasOwnProperty(foo, 'bar')`},
+			{Code: `isPrototypeOf(foo, 'bar')`},
+			{Code: `propertyIsEnumerable(foo, 'bar')`},
+			{Code: `({}.hasOwnProperty.call(foo, 'bar'))`},
+			{Code: `({}.isPrototypeOf.call(foo, 'bar'))`},
+			{Code: `({}.propertyIsEnumerable.call(foo, 'bar'))`},
+			{Code: `({}.hasOwnProperty.apply(foo, ['bar']))`},
+			{Code: `({}.isPrototypeOf.apply(foo, ['bar']))`},
+			{Code: `({}.propertyIsEnumerable.apply(foo, ['bar']))`},
+			// Computed access with non-string/identifier key: not a disallowed name.
+			{Code: `foo[hasOwnProperty]('bar')`},
+			// Different casing: not one of the forbidden names.
+			{Code: `foo['HasOwnProperty']('bar')`},
+			// Template with extra char is not the forbidden name.
+			{Code: "foo[`isPrototypeOff`]('bar')"},
+			// Optional chain + not-quite-the-forbidden-name.
+			{Code: `foo?.['propertyIsEnumerabl']('bar')`},
+			// Numeric / null keys aren't the forbidden names.
+			{Code: `foo[1]('bar')`},
+			{Code: `foo[null]('bar')`},
+			// Private name is not a Object.prototype method name.
+			{Code: `class C { #hasOwnProperty; foo() { obj.#hasOwnProperty('bar'); } }`},
+
+			// Out of scope — dynamic keys that happen to spell the forbidden name
+			// at runtime still aren't statically resolvable.
+			{Code: `foo['hasOwn' + 'Property']('bar')`},
+			{Code: "foo[`hasOwnProperty${''}`]('bar')"},
+		},
+		// Invalid cases - ported from ESLint
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `foo.hasOwnProperty('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Message:   "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.hasOwnProperty.call(foo, 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo.isPrototypeOf('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 18,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.isPrototypeOf.call(foo, 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo.propertyIsEnumerable('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 25,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.propertyIsEnumerable.call(foo, 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo.bar.hasOwnProperty('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    9,
+						EndLine:   1,
+						EndColumn: 23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.hasOwnProperty.call(foo.bar, 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo.bar.baz.isPrototypeOf('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    13,
+						EndLine:   1,
+						EndColumn: 26,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.isPrototypeOf.call(foo.bar.baz, 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo['hasOwnProperty']('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.hasOwnProperty.call(foo, 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: "foo[`isPrototypeOf`]('bar').baz",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    5,
+						EndLine:   1,
+						EndColumn: 20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.isPrototypeOf.call(foo, 'bar').baz`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `foo.bar["propertyIsEnumerable"]('baz')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Line:      1,
+						Column:    9,
+						EndLine:   1,
+						EndColumn: 31,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.propertyIsEnumerable.call(foo.bar, 'baz')`,
+							},
+						},
+					},
+				},
+			},
+			// Can't suggest Object.prototype when Object is shadowed.
+			{
+				Code: `(function(Object) {return foo.hasOwnProperty('bar');})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+
+			// Optional chaining
+			{
+				Code: `foo?.hasOwnProperty('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			{
+				Code: `foo?.bar.hasOwnProperty('baz')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			{
+				Code: `foo.hasOwnProperty?.('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			// hasOwnProperty is inside a chain whose optional link is before it:
+			// the call may short-circuit, so we cannot suggest a rewrite.
+			{
+				Code: `foo?.hasOwnProperty('bar').baz`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			// Optional link is AFTER the call — the fix is safe.
+			{
+				Code: `foo.hasOwnProperty('bar')?.baz`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.hasOwnProperty.call(foo, 'bar')?.baz`,
+							},
+						},
+					},
+				},
+			},
+			// SequenceExpression as object: ESLint wraps it in parens; on tsgo
+			// the parens are already in the AST, so the same text lands as-is.
+			{
+				Code: `(a,b).hasOwnProperty('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "prototypeBuildIn",
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "callObjectPrototype",
+								Output:    `Object.prototype.hasOwnProperty.call((a,b), 'bar')`,
+							},
+						},
+					},
+				},
+			},
+			// Parens around an optional chain: may still short-circuit.
+			{
+				Code: `(foo?.hasOwnProperty)('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			{
+				Code: `(foo?.hasOwnProperty)?.('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			{
+				Code: `foo?.['hasOwnProperty']('bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+			{
+				Code: "(foo?.[`hasOwnProperty`])('bar')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "prototypeBuildIn"},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -267,6 +267,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',
+    './tests/eslint/rules/no-prototype-builtins.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',
     './tests/eslint/rules/valid-typeof.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-prototype-builtins.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-prototype-builtins.test.ts.snap
@@ -1,0 +1,495 @@
+// Rstest Snapshot v1
+
+exports[`no-prototype-builtins > invalid 1`] = `
+{
+  "code": "foo.hasOwnProperty('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 2`] = `
+{
+  "code": "foo.isPrototypeOf('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'isPrototypeOf' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 3`] = `
+{
+  "code": "foo.propertyIsEnumerable('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'propertyIsEnumerable' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 4`] = `
+{
+  "code": "foo.bar.hasOwnProperty('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 5`] = `
+{
+  "code": "foo.bar.baz.isPrototypeOf('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'isPrototypeOf' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 6`] = `
+{
+  "code": "foo['hasOwnProperty']('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 7`] = `
+{
+  "code": "foo[\`isPrototypeOf\`]('bar').baz",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'isPrototypeOf' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 8`] = `
+{
+  "code": "foo.bar["propertyIsEnumerable"]('baz')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'propertyIsEnumerable' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 9`] = `
+{
+  "code": "(function(Object) {return foo.hasOwnProperty('bar');})",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 10`] = `
+{
+  "code": "foo?.hasOwnProperty('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 11`] = `
+{
+  "code": "foo?.bar.hasOwnProperty('baz')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 12`] = `
+{
+  "code": "foo.hasOwnProperty?.('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 13`] = `
+{
+  "code": "foo?.hasOwnProperty('bar').baz",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 14`] = `
+{
+  "code": "foo.hasOwnProperty('bar')?.baz",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 15`] = `
+{
+  "code": "(a,b).hasOwnProperty('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 16`] = `
+{
+  "code": "(foo?.hasOwnProperty)('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 17`] = `
+{
+  "code": "(foo?.hasOwnProperty)?.('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 18`] = `
+{
+  "code": "foo?.['hasOwnProperty']('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-prototype-builtins > invalid 19`] = `
+{
+  "code": "(foo?.[\`hasOwnProperty\`])('bar')",
+  "diagnostics": [
+    {
+      "message": "Do not access Object.prototype method 'hasOwnProperty' from target object.",
+      "messageId": "prototypeBuildIn",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-prototype-builtins",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-prototype-builtins.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-prototype-builtins.test.ts
@@ -1,0 +1,178 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-prototype-builtins', {
+  valid: [
+    "Object.prototype.hasOwnProperty.call(foo, 'bar')",
+    "Object.prototype.isPrototypeOf.call(foo, 'bar')",
+    "Object.prototype.propertyIsEnumerable.call(foo, 'bar')",
+    "Object.prototype.hasOwnProperty.apply(foo, ['bar'])",
+    "Object.prototype.isPrototypeOf.apply(foo, ['bar'])",
+    "Object.prototype.propertyIsEnumerable.apply(foo, ['bar'])",
+    'foo.hasOwnProperty',
+    'foo.hasOwnProperty.bar()',
+    'foo(hasOwnProperty)',
+    "hasOwnProperty(foo, 'bar')",
+    "isPrototypeOf(foo, 'bar')",
+    "propertyIsEnumerable(foo, 'bar')",
+    "({}.hasOwnProperty.call(foo, 'bar'))",
+    "({}.isPrototypeOf.call(foo, 'bar'))",
+    "({}.propertyIsEnumerable.call(foo, 'bar'))",
+    "({}.hasOwnProperty.apply(foo, ['bar']))",
+    "({}.isPrototypeOf.apply(foo, ['bar']))",
+    "({}.propertyIsEnumerable.apply(foo, ['bar']))",
+    "foo[hasOwnProperty]('bar')",
+    "foo['HasOwnProperty']('bar')",
+    "foo[`isPrototypeOff`]('bar')",
+    "foo?.['propertyIsEnumerabl']('bar')",
+    "foo[1]('bar')",
+    "foo[null]('bar')",
+    "class C { #hasOwnProperty; foo() { obj.#hasOwnProperty('bar'); } }",
+    "foo['hasOwn' + 'Property']('bar')",
+    "foo[`hasOwnProperty${''}`]('bar')",
+  ],
+  invalid: [
+    {
+      code: "foo.hasOwnProperty('bar')",
+      errors: [
+        {
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 19,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "foo.isPrototypeOf('bar')",
+      errors: [
+        {
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 18,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "foo.propertyIsEnumerable('bar')",
+      errors: [
+        {
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 25,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "foo.bar.hasOwnProperty('bar')",
+      errors: [
+        {
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 23,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "foo.bar.baz.isPrototypeOf('bar')",
+      errors: [
+        {
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 26,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "foo['hasOwnProperty']('bar')",
+      errors: [
+        {
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 21,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "foo[`isPrototypeOf`]('bar').baz",
+      errors: [
+        {
+          line: 1,
+          column: 5,
+          endLine: 1,
+          endColumn: 20,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: `foo.bar["propertyIsEnumerable"]('baz')`,
+      errors: [
+        {
+          line: 1,
+          column: 9,
+          endLine: 1,
+          endColumn: 31,
+          messageId: 'prototypeBuildIn',
+        },
+      ],
+    },
+    {
+      code: "(function(Object) {return foo.hasOwnProperty('bar');})",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    // Optional chaining
+    {
+      code: "foo?.hasOwnProperty('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "foo?.bar.hasOwnProperty('baz')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "foo.hasOwnProperty?.('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "foo?.hasOwnProperty('bar').baz",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "foo.hasOwnProperty('bar')?.baz",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "(a,b).hasOwnProperty('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "(foo?.hasOwnProperty)('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "(foo?.hasOwnProperty)?.('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "foo?.['hasOwnProperty']('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+    {
+      code: "(foo?.[`hasOwnProperty`])('bar')",
+      errors: [{ messageId: 'prototypeBuildIn' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-prototype-builtins` rule from ESLint to rslint.

Disallow direct calls to `Object.prototype` built-ins (`hasOwnProperty`, `isPrototypeOf`, `propertyIsEnumerable`) on a target object, since those calls break on `Object.create(null)` instances and are vulnerable to shadowing by own properties of the same name. The rule covers property access, computed / template-literal keys, and optional chaining, and offers an `Object.prototype.<method>.call(...)` suggestion — suppressed when the chain may short-circuit or when the global `Object` is shadowed at the call site.

Verified against two real codebases with the new binary:

- `rsbuild` (1197 files): 0 warnings (grep confirms no violations in scope).
- `rspack` (392 files): 2 warnings, both on `Compiler.prototype.hasOwnProperty(p)` in `packages/rspack-test-tools/src/compiler.ts:53` / `:97`. No false positives (valid `Object.prototype.hasOwnProperty.call(...)` forms and non-call identifier reads were not flagged).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-prototype-builtins
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-prototype-builtins.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).