### PR TITLE
feat: port rule no-return-assign

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
 	"github.com/web-infra-dev/rslint/internal/rules/no_prototype_builtins"
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
+	"github.com/web-infra-dev/rslint/internal/rules/no_return_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
@@ -582,6 +583,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)
 	GlobalRuleRegistry.Register("no-param-reassign", no_param_reassign.NoParamReassignRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)
+	GlobalRuleRegistry.Register("no-return-assign", no_return_assign.NoReturnAssignRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)

--- a/internal/rules/no_return_assign/no_return_assign.go
+++ b/internal/rules/no_return_assign/no_return_assign.go
@@ -1,0 +1,86 @@
+package no_return_assign
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// isSentinel mirrors ESLint's SENTINEL_TYPE regex
+// (/^(?:[a-zA-Z]+?Statement|ArrowFunctionExpression|FunctionExpression|ClassExpression)$/):
+// any statement, plus function / class expressions that introduce a new scope
+// boundary where the walk-up for the enclosing return/arrow must stop.
+func isSentinel(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	if ast.IsStatement(node) {
+		return true
+	}
+	return ast.IsArrowFunction(node) || ast.IsFunctionExpression(node) || ast.IsClassExpression(node)
+}
+
+// parseMode extracts the rule mode: "except-parens" (default) or "always".
+// Options come in as a raw string (Go tests) or a []interface{} holding the
+// string at index 0 (JS tests, ESLint option-array convention).
+func parseMode(options any) string {
+	switch v := options.(type) {
+	case string:
+		if v != "" {
+			return v
+		}
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return "except-parens"
+}
+
+// https://eslint.org/docs/latest/rules/no-return-assign
+var NoReturnAssignRule = rule.Rule{
+	Name: "no-return-assign",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		always := parseMode(options) == "always"
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				if !ast.IsAssignmentExpression(node, false /*excludeCompoundAssignment*/) {
+					return
+				}
+				// except-parens: a directly parenthesised assignment
+				// (`return (a = b)`, `() => (a = b)`) is allowed.
+				// tsgo materializes parens as a ParenthesizedExpression node,
+				// which replaces ESLint's token-level isParenthesised check.
+				if !always && node.Parent != nil && ast.IsParenthesizedExpression(node.Parent) {
+					return
+				}
+
+				currentChild := node
+				parent := node.Parent
+				for parent != nil && !isSentinel(parent) {
+					currentChild = parent
+					parent = parent.Parent
+				}
+				if parent == nil {
+					return
+				}
+				switch {
+				case ast.IsReturnStatement(parent):
+					ctx.ReportNode(parent, rule.RuleMessage{
+						Id:          "returnAssignment",
+						Description: "Return statement should not contain assignment.",
+					})
+				case ast.IsArrowFunction(parent):
+					if arrow := parent.AsArrowFunction(); arrow != nil && arrow.Body == currentChild {
+						ctx.ReportNode(parent, rule.RuleMessage{
+							Id:          "arrowAssignment",
+							Description: "Arrow function should not return assignment.",
+						})
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_return_assign/no_return_assign.md
+++ b/internal/rules/no_return_assign/no_return_assign.md
@@ -1,0 +1,84 @@
+# no-return-assign
+
+## Rule Details
+
+This rule aims to eliminate assignments from `return` statements, because it is difficult to tell whether the author intended an assignment or a mistyped comparison.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function doSomething() {
+  return foo = bar + 2;
+}
+
+function doSomethingElse() {
+  return foo += 2;
+}
+
+const foo = (a, b) => a = b;
+
+const bar = (a, b, c) => (a = b, c == b);
+
+function doSomethingMore() {
+  return foo = bar && foo > 0;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function doSomething() {
+  return foo == bar + 2;
+}
+
+function doSomethingMore() {
+  return (foo = bar + 2);
+}
+
+const foo = (a, b) => (a = b);
+
+const bar = (a, b, c) => ((a = b), c == b);
+
+function doAnotherThing() {
+  return (foo = bar) && foo > 0;
+}
+```
+
+## Options
+
+This rule takes a single string option:
+
+- `"except-parens"` (default) — disallow assignments in `return` statements unless they are enclosed in parentheses.
+- `"always"` — disallow all assignments in `return` statements, even when parenthesised.
+
+Examples of **incorrect** code for this rule with `"always"`:
+
+```json
+{ "no-return-assign": ["error", "always"] }
+```
+
+```javascript
+function doSomething() {
+  return foo = bar + 2;
+}
+
+function doSomethingMore() {
+  return (foo = bar + 2);
+}
+```
+
+Examples of **correct** code for this rule with `"always"`:
+
+```json
+{ "no-return-assign": ["error", "always"] }
+```
+
+```javascript
+function doSomething() {
+  return foo == bar + 2;
+}
+```
+
+## Original Documentation
+
+- [ESLint rule: no-return-assign](https://eslint.org/docs/latest/rules/no-return-assign)

--- a/internal/rules/no_return_assign/no_return_assign_test.go
+++ b/internal/rules/no_return_assign/no_return_assign_test.go
@@ -349,6 +349,31 @@ func TestNoReturnAssignRule(t *testing.T) {
 					{MessageId: "arrowAssignment", Line: 1, Column: 1, EndLine: 2, EndColumn: 8},
 				},
 			},
+			// ---- Multi-byte character position assertions (UTF-16 code unit counting) ----
+			// BMP-outside emoji (surrogate pair) in a string literal: 🍌 counts as
+			// 2 UTF-16 units. Catches implementations that would use rune / code-point
+			// counts instead. (Emojis are not valid identifier starts in JS.)
+			{
+				Code: "function x() {\n  return a\n    = \"🍌\";\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 3, EndLine: 3, EndColumn: 12},
+				},
+			},
+			// BMP CJK characters as identifiers: 中 / 文 are each 1 UTF-16 unit but
+			// 3 bytes in UTF-8. Catches implementations that would use byte offsets.
+			{
+				Code: "function x() {\n  return 中\n    = 文;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+			// Emoji inside an arrow-body assignment (arrowAssignment path).
+			{
+				Code: "() =>\n  a = \"🍎\"",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "arrowAssignment", Line: 1, Column: 1, EndLine: 2, EndColumn: 11},
+				},
+			},
 
 			// ---- Extra: compound assignment operators (legacy kept) ----
 			{

--- a/internal/rules/no_return_assign/no_return_assign_test.go
+++ b/internal/rules/no_return_assign/no_return_assign_test.go
@@ -1,0 +1,374 @@
+package no_return_assign
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoReturnAssignRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoReturnAssignRule,
+
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream ESLint suite ----
+			{Code: `module.exports = {'a': 1};`},
+			{Code: `var result = a * b;`},
+			{Code: `function x() { var result = a * b; return result; }`},
+			{Code: `function x() { return (result = a * b); }`},
+			{Code: `function x() { var result = a * b; return result; }`, Options: "except-parens"},
+			{Code: `function x() { return (result = a * b); }`, Options: "except-parens"},
+			{Code: `function x() { var result = a * b; return result; }`, Options: "always"},
+			{Code: `function x() { return function y() { result = a * b }; }`, Options: "always"},
+			{Code: `() => { return (result = a * b); }`, Options: "except-parens"},
+			{Code: `() => (result = a * b)`, Options: "except-parens"},
+			{Code: `const foo = (a,b,c) => ((a = b), c)`},
+			{Code: `function foo(){
+            return (a = b)
+        }`},
+			{Code: `function bar(){
+            return function foo(){
+                return (a = b) && c
+            }
+        }`},
+			{Code: `const foo = (a) => (b) => (a = b)`},
+
+			// ---- Non-assignment comparisons / declarations ----
+			{Code: `function x() { return a == b; }`},
+			{Code: `function x() { return a === b; }`},
+			{Code: `function x() { var a = b; return a; }`},
+
+			// ---- except-parens: nested parens directly wrapping the assignment ----
+			{Code: `function x() { return ((a = b)); }`},
+			{Code: `function x() { return (((a = b))); }`},
+			{Code: `() => ((a = b))`},
+
+			// ---- except-parens: assignment wrapped in parens inside a larger expression ----
+			{Code: `function x() { return (a = b) && c; }`},
+			{Code: `function x() { return c && (a = b); }`},
+			{Code: `function x() { return (a = b) || c; }`},
+			{Code: `function x() { return c || (a = b); }`},
+			{Code: `function x() { return (a = b) ?? c; }`},
+			{Code: `function x() { return (a = b) ? c : d; }`},
+			{Code: `function x() { return c ? (a = b) : d; }`},
+			{Code: `function x() { return c ? d : (a = b); }`},
+			{Code: `function x() { return ((a = b), c); }`},
+			{Code: `const foo = () => ((a = b), c)`},
+			{Code: `function x() { return !(a = b); }`},
+			{Code: `function x() { return typeof (a = b); }`},
+
+			// ---- Sentinel blocks the walk-up (FunctionExpression / ClassExpression / nested arrow block) ----
+			{Code: `function x() { return function y() { a = b; }; }`},
+			{Code: `function x() { return function y() { a = b; }; }`, Options: "always"},
+			{Code: `function x() { return class { m() { a = b; } }; }`},
+			{Code: `function x() { return class { m() { a = b; } }; }`, Options: "always"},
+			{Code: `function x() { return () => { a = b; }; }`},
+			{Code: `function x() { return () => { a = b; }; }`, Options: "always"},
+			{Code: `function x() { return class { static { a = b; } }; }`, Options: "always"},
+
+			// ---- Assignment outside any return/arrow-body ----
+			{Code: `a = b;`},
+			{Code: `function f() { a = b; }`},
+			{Code: `if (x) { a = b; }`},
+			{Code: `while (x) { a = b; }`},
+			{Code: `for (let i = 0; i < 10; i++) { a = b; }`},
+			{Code: `function f() { for (a = 0; a < 10; a++) {} return a; }`},
+			{Code: `switch (x) { case 1: a = b; break; }`},
+			{Code: `try { a = b; } catch (e) {}`},
+			{Code: `class C { m() { a = b; } }`},
+			{Code: `function f(a = (b = 1)) { return a; }`},
+
+			// ---- TypeScript: parens still exempt under type assertions / satisfies ----
+			{Code: `function f(): number { return (a = b); }`},
+			{Code: `function f(): number { return (a = b) as number; }`},
+			{Code: `function f(): number { return (a = b) satisfies number; }`},
+			{Code: `const f = (a: number): number => (a = 1)`},
+
+			// ---- JSX: parenthesised assignment inside JSX is exempt under except-parens ----
+			{Code: `const F = () => <div/>`, Tsx: true},
+			{Code: `const F = () => <>{(a = b)}</>`, Tsx: true},
+			{Code: `const F = () => <div id={(a = b)}/>`, Tsx: true},
+			{Code: `function F() { return <div id={(a = b)}/>; }`, Tsx: true},
+			// Assignment inside a nested function swallowed by FunctionExpression sentinel
+			{Code: `const F = () => <div onClick={function(){ a = b; }}/>`, Tsx: true},
+			// Assignment inside an arrow with block body is swallowed at ExpressionStatement
+			{Code: `const F = () => <div onClick={() => { a = b; }}/>`, Tsx: true},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream ESLint suite ----
+			{
+				Code: `function x() { return result = a * b; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Message: "Return statement should not contain assignment.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `function x() { return (result) = (a * b); };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `function x() { return result = a * b; };`,
+				Options: "except-parens",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `function x() { return (result) = (a * b); };`,
+				Options: "except-parens",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `() => { return result = a * b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `() => result = a * b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "arrowAssignment", Message: "Arrow function should not return assignment.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `function x() { return result = a * b; };`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `function x() { return (result = a * b); };`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:    `function x() { return result || (result = a * b); };`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `function foo(){
+                return a = b
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 17},
+				},
+			},
+			{
+				Code: `function doSomething() {
+                return foo = bar && foo > 0;
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 17},
+				},
+			},
+			{
+				Code: `function doSomething() {
+                return foo = function(){
+                    return (bar = bar1)
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 17},
+				},
+			},
+			{
+				Code: `function doSomething() {
+                return foo = () => a
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 17},
+				},
+			},
+			{
+				Code: `function doSomething() {
+                return () => a = () => b
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "arrowAssignment", Line: 2, Column: 24},
+				},
+			},
+			{
+				Code: `function foo(a){
+                return function bar(b){
+                    return a = b
+                }
+            }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 3, Column: 21},
+				},
+			},
+			{
+				Code: `const foo = (a) => (b) => a = b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "arrowAssignment", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Assignment operator coverage (returnAssignment) ----
+			{Code: `function x() { return a -= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a *= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a /= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a %= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a **= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a <<= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a >>= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a >>>= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a &= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a |= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a ^= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a &&= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a ||= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a ??= b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+
+			// ---- Assignment operator coverage (arrowAssignment) ----
+			{Code: `() => a += b`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 1}}},
+			{Code: `() => a ??= b`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 1}}},
+			{Code: `(a, b) => a = b`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 1}}},
+
+			// ---- Container coverage (returnAssignment) ----
+			{Code: `async function f() { return a = b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 22}}},
+			{Code: `function* g() { return a = b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 17}}},
+			{Code: `async function* ag() { return a = b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 24}}},
+			{Code: `class C { m() { return a = b; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 17}}},
+			{Code: `class C { get x() { return a = b; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 21}}},
+			{Code: `class C { set x(v) { return a = b; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 22}}},
+			{Code: `({ m() { return a = b; } })`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 10}}},
+
+			// ---- Container coverage (arrowAssignment) ----
+			{Code: `async () => a = b`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 1}}},
+
+			// ---- Walk-up wrappers (non-paren expressions) — still reports ----
+			{Code: `function x() { return a = b, c; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a ? b = c : d; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return { x: a = b }; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return [a = b]; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a = b && c; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			// UnaryExpression / TypeOf with a parenthesised assignment is VALID under except-parens
+			// but INVALID under always (see valid cases above and always section below).
+			{Code: `function x() { return !(a = b); }`, Options: "always", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return typeof (a = b); }`, Options: "always", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+
+			// ---- always mode: parens don't exempt ----
+			{Code: `function x() { return ((a = b)); }`, Options: "always", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `() => ((a = b))`, Options: "always", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 1}}},
+			{Code: `function x() { return c || (a = b); }`, Options: "always", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+			{Code: `function x() { return a + (b = c); }`, Options: "always", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}}},
+
+			// ---- TypeScript syntax ----
+			{Code: `function f(): number { return a = b; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 24}}},
+			{Code: `const f = (): number => a = b`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 11}}},
+			{Code: `function f(): number { return a = b as number; }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 24}}},
+
+			// ---- Inner container reports; outer unaffected (only one diagnostic) ----
+			{
+				Code: `function f() { return (function g() { return a = b; })(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 39},
+				},
+			},
+			// Outer `return a = (b = c)`: outer direct in return; inner wrapped in parens.
+			// Only the outer should fire under except-parens.
+			{
+				Code: `function f() { return a = (b = c); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			// With always, both fire.
+			{
+				Code:    `function f() { return a = (b = c); }`,
+				Options: "always",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- JSX: assignment flowing up through JSX nodes to arrow / return ----
+			// JSX nodes (JsxElement / JsxExpression / JsxAttributes) are not sentinels,
+			// so the walk continues until the enclosing arrow / return.
+			{
+				Code:   `const F = () => <div id={a = b}/>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `function F() { return <div id={a = b}/>; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}},
+			},
+			{
+				Code:   `const F = () => <>{a = b}</>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 11}},
+			},
+			{
+				Code:   `function F() { return <>{a = b}</>; }`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "returnAssignment", Line: 1, Column: 16}},
+			},
+			// Nested arrow inside JSX attribute whose body IS an assignment
+			{
+				Code:   `const F = () => <div onClick={() => a = b}/>`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 31}},
+			},
+			// always mode: parenthesised assignment inside JSX is no longer exempt
+			{
+				Code:    `const F = () => <div id={(a = b)}/>`,
+				Tsx:     true,
+				Options: "always",
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "arrowAssignment", Line: 1, Column: 11}},
+			},
+
+			// ---- Multi-line position assertions (Line + Column + EndLine + EndColumn) ----
+			{
+				Code: "function x() {\n  return a\n    = b;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 2, Column: 3, EndLine: 3, EndColumn: 9},
+				},
+			},
+			{
+				Code: "() =>\n  a = b",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "arrowAssignment", Line: 1, Column: 1, EndLine: 2, EndColumn: 8},
+				},
+			},
+
+			// ---- Extra: compound assignment operators (legacy kept) ----
+			{
+				Code: `function x() { return foo += 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `function x() { return foo &&= bar; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "returnAssignment", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `const foo = (a, b) => a = b`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "arrowAssignment", Line: 1, Column: 13},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -287,6 +287,7 @@ export default defineConfig({
     './tests/eslint/rules/no-script-url.test.ts',
     './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-proto.test.ts',
+    './tests/eslint/rules/no-return-assign.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-return-assign.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-return-assign.test.ts.snap
@@ -1,0 +1,1596 @@
+// Rstest Snapshot v1
+
+exports[`no-return-assign > invalid 1`] = `
+{
+  "code": "function x() { return result = a * b; };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 2`] = `
+{
+  "code": "function x() { return (result) = (a * b); };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 3`] = `
+{
+  "code": "function x() { return result = a * b; };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 4`] = `
+{
+  "code": "function x() { return (result) = (a * b); };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 5`] = `
+{
+  "code": "() => { return result = a * b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 6`] = `
+{
+  "code": "() => result = a * b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 7`] = `
+{
+  "code": "function x() { return result = a * b; };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 8`] = `
+{
+  "code": "function x() { return (result = a * b); };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 9`] = `
+{
+  "code": "function x() { return result || (result = a * b); };",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 10`] = `
+{
+  "code": "function foo(){
+                return a = b
+            }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 11`] = `
+{
+  "code": "function doSomething() {
+                return foo = bar && foo > 0;
+            }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 12`] = `
+{
+  "code": "function doSomething() {
+                return foo = function(){
+                    return (bar = bar1)
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 4,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 13`] = `
+{
+  "code": "function doSomething() {
+                return foo = () => a
+            }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 14`] = `
+{
+  "code": "function doSomething() {
+                return () => a = () => b
+            }",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 2,
+        },
+        "start": {
+          "column": 24,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 15`] = `
+{
+  "code": "function foo(a){
+                return function bar(b){
+                    return a = b
+                }
+            }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 3,
+        },
+        "start": {
+          "column": 21,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 16`] = `
+{
+  "code": "const foo = (a) => (b) => a = b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 17`] = `
+{
+  "code": "function x() { return a -= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 18`] = `
+{
+  "code": "function x() { return a *= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 19`] = `
+{
+  "code": "function x() { return a /= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 20`] = `
+{
+  "code": "function x() { return a %= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 21`] = `
+{
+  "code": "function x() { return a **= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 22`] = `
+{
+  "code": "function x() { return a <<= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 23`] = `
+{
+  "code": "function x() { return a >>= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 24`] = `
+{
+  "code": "function x() { return a >>>= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 25`] = `
+{
+  "code": "function x() { return a &= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 26`] = `
+{
+  "code": "function x() { return a |= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 27`] = `
+{
+  "code": "function x() { return a ^= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 28`] = `
+{
+  "code": "function x() { return a &&= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 29`] = `
+{
+  "code": "function x() { return a ||= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 30`] = `
+{
+  "code": "function x() { return a ??= b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 31`] = `
+{
+  "code": "() => a += b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 32`] = `
+{
+  "code": "() => a ??= b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 33`] = `
+{
+  "code": "(a, b) => a = b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 34`] = `
+{
+  "code": "async function f() { return a = b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 35`] = `
+{
+  "code": "function* g() { return a = b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 36`] = `
+{
+  "code": "async function* ag() { return a = b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 37`] = `
+{
+  "code": "class C { m() { return a = b; } }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 38`] = `
+{
+  "code": "class C { get x() { return a = b; } }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 39`] = `
+{
+  "code": "class C { set x(v) { return a = b; } }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 40`] = `
+{
+  "code": "({ m() { return a = b; } })",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 41`] = `
+{
+  "code": "async () => a = b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 42`] = `
+{
+  "code": "function x() { return a = b, c; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 43`] = `
+{
+  "code": "function x() { return a ? b = c : d; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 44`] = `
+{
+  "code": "function x() { return { x: a = b }; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 45`] = `
+{
+  "code": "function x() { return [a = b]; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 46`] = `
+{
+  "code": "function x() { return a = b && c; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 47`] = `
+{
+  "code": "function x() { return !(a = b); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 48`] = `
+{
+  "code": "function x() { return typeof (a = b); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 49`] = `
+{
+  "code": "function x() { return ((a = b)); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 50`] = `
+{
+  "code": "() => ((a = b))",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 51`] = `
+{
+  "code": "function x() { return c || (a = b); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 52`] = `
+{
+  "code": "function x() { return a + (b = c); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 53`] = `
+{
+  "code": "function f(): number { return a = b; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 54`] = `
+{
+  "code": "const f = (): number => a = b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 55`] = `
+{
+  "code": "function f(): number { return a = b as number; }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 56`] = `
+{
+  "code": "function f() { return (function g() { return a = b; })(); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 57`] = `
+{
+  "code": "function f() { return a = (b = c); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 58`] = `
+{
+  "code": "function f() { return a = (b = c); }",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 59`] = `
+{
+  "code": "function x() {
+  return a
+    = b;
+}",
+  "diagnostics": [
+    {
+      "message": "Return statement should not contain assignment.",
+      "messageId": "returnAssignment",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-return-assign > invalid 60`] = `
+{
+  "code": "() =>
+  a = b",
+  "diagnostics": [
+    {
+      "message": "Arrow function should not return assignment.",
+      "messageId": "arrowAssignment",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-return-assign",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-return-assign.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-return-assign.test.ts
@@ -1,0 +1,406 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-return-assign', {
+  valid: [
+    // ---- Upstream ESLint suite ----
+    `module.exports = {'a': 1};`,
+    `var result = a * b;`,
+    `function x() { var result = a * b; return result; }`,
+    `function x() { return (result = a * b); }`,
+    {
+      code: `function x() { var result = a * b; return result; }`,
+      options: ['except-parens'] as any,
+    },
+    {
+      code: `function x() { return (result = a * b); }`,
+      options: ['except-parens'] as any,
+    },
+    {
+      code: `function x() { var result = a * b; return result; }`,
+      options: ['always'] as any,
+    },
+    {
+      code: `function x() { return function y() { result = a * b }; }`,
+      options: ['always'] as any,
+    },
+    {
+      code: `() => { return (result = a * b); }`,
+      options: ['except-parens'] as any,
+    },
+    {
+      code: `() => (result = a * b)`,
+      options: ['except-parens'] as any,
+    },
+    `const foo = (a,b,c) => ((a = b), c)`,
+    `function foo(){
+            return (a = b)
+        }`,
+    `function bar(){
+            return function foo(){
+                return (a = b) && c
+            }
+        }`,
+    `const foo = (a) => (b) => (a = b)`,
+
+    // ---- Non-assignment comparisons / declarations ----
+    `function x() { return a == b; }`,
+    `function x() { return a === b; }`,
+    `function x() { var a = b; return a; }`,
+
+    // ---- except-parens: nested parens directly wrapping the assignment ----
+    `function x() { return ((a = b)); }`,
+    `function x() { return (((a = b))); }`,
+    `() => ((a = b))`,
+
+    // ---- except-parens: parenthesised assignment inside a larger expression ----
+    `function x() { return (a = b) && c; }`,
+    `function x() { return c && (a = b); }`,
+    `function x() { return (a = b) || c; }`,
+    `function x() { return c || (a = b); }`,
+    `function x() { return (a = b) ?? c; }`,
+    `function x() { return (a = b) ? c : d; }`,
+    `function x() { return c ? (a = b) : d; }`,
+    `function x() { return c ? d : (a = b); }`,
+    `function x() { return ((a = b), c); }`,
+    `const foo = () => ((a = b), c)`,
+    `function x() { return !(a = b); }`,
+    `function x() { return typeof (a = b); }`,
+
+    // ---- Sentinel blocks the walk-up ----
+    `function x() { return function y() { a = b; }; }`,
+    {
+      code: `function x() { return function y() { a = b; }; }`,
+      options: ['always'] as any,
+    },
+    `function x() { return class { m() { a = b; } }; }`,
+    {
+      code: `function x() { return class { m() { a = b; } }; }`,
+      options: ['always'] as any,
+    },
+    `function x() { return () => { a = b; }; }`,
+    {
+      code: `function x() { return () => { a = b; }; }`,
+      options: ['always'] as any,
+    },
+    {
+      code: `function x() { return class { static { a = b; } }; }`,
+      options: ['always'] as any,
+    },
+
+    // ---- Assignment outside any return/arrow-body ----
+    `a = b;`,
+    `function f() { a = b; }`,
+    `if (x) { a = b; }`,
+    `while (x) { a = b; }`,
+    `for (let i = 0; i < 10; i++) { a = b; }`,
+    `function f() { for (a = 0; a < 10; a++) {} return a; }`,
+    `switch (x) { case 1: a = b; break; }`,
+    `try { a = b; } catch (e) {}`,
+    `class C { m() { a = b; } }`,
+    `function f(a = (b = 1)) { return a; }`,
+
+    // ---- TypeScript specific ----
+    `function f(): number { return (a = b); }`,
+    `function f(): number { return (a = b) as number; }`,
+    `function f(): number { return (a = b) satisfies number; }`,
+    `const f = (a: number): number => (a = 1)`,
+
+    // ---- JSX coverage lives in Go tests (no_return_assign_test.go Tsx:true cases) ----
+    // The shared eslint/rule-tester.ts hardcodes `src/virtual.ts`, and tsgo does
+    // not parse JSX in .ts files. Extending that infra is out of scope here.
+  ],
+  invalid: [
+    // ---- Upstream ESLint suite ----
+    {
+      code: `function x() { return result = a * b; };`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return (result) = (a * b); };`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return result = a * b; };`,
+      options: ['except-parens'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return (result) = (a * b); };`,
+      options: ['except-parens'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `() => { return result = a * b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `() => result = a * b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `function x() { return result = a * b; };`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return (result = a * b); };`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return result || (result = a * b); };`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function foo(){
+                return a = b
+            }`,
+      errors: [{ messageId: 'returnAssignment', line: 2, column: 17 }],
+    },
+    {
+      code: `function doSomething() {
+                return foo = bar && foo > 0;
+            }`,
+      errors: [{ messageId: 'returnAssignment', line: 2, column: 17 }],
+    },
+    {
+      code: `function doSomething() {
+                return foo = function(){
+                    return (bar = bar1)
+                }
+            }`,
+      errors: [{ messageId: 'returnAssignment', line: 2, column: 17 }],
+    },
+    {
+      code: `function doSomething() {
+                return foo = () => a
+            }`,
+      errors: [{ messageId: 'returnAssignment', line: 2, column: 17 }],
+    },
+    {
+      code: `function doSomething() {
+                return () => a = () => b
+            }`,
+      errors: [{ messageId: 'arrowAssignment', line: 2, column: 24 }],
+    },
+    {
+      code: `function foo(a){
+                return function bar(b){
+                    return a = b
+                }
+            }`,
+      errors: [{ messageId: 'returnAssignment', line: 3, column: 21 }],
+    },
+    {
+      code: `const foo = (a) => (b) => a = b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 20 }],
+    },
+
+    // ---- Assignment operator coverage (returnAssignment) ----
+    {
+      code: `function x() { return a -= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a *= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a /= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a %= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a **= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a <<= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a >>= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a >>>= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a &= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a |= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a ^= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a &&= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a ||= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a ??= b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+
+    // ---- Assignment operator coverage (arrowAssignment) ----
+    {
+      code: `() => a += b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `() => a ??= b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `(a, b) => a = b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+
+    // ---- Container coverage (returnAssignment) ----
+    {
+      code: `async function f() { return a = b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 22 }],
+    },
+    {
+      code: `function* g() { return a = b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 17 }],
+    },
+    {
+      code: `async function* ag() { return a = b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 24 }],
+    },
+    {
+      code: `class C { m() { return a = b; } }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 17 }],
+    },
+    {
+      code: `class C { get x() { return a = b; } }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 21 }],
+    },
+    {
+      code: `class C { set x(v) { return a = b; } }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 22 }],
+    },
+    {
+      code: `({ m() { return a = b; } })`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 10 }],
+    },
+
+    // ---- Container coverage (arrowAssignment) ----
+    {
+      code: `async () => a = b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+
+    // ---- Walk-up wrappers ----
+    {
+      code: `function x() { return a = b, c; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a ? b = c : d; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return { x: a = b }; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return [a = b]; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a = b && c; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return !(a = b); }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return typeof (a = b); }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+
+    // ---- always mode: parens don't exempt ----
+    {
+      code: `function x() { return ((a = b)); }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `() => ((a = b))`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `function x() { return c || (a = b); }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function x() { return a + (b = c); }`,
+      options: ['always'] as any,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+
+    // ---- TypeScript syntax ----
+    {
+      code: `function f(): number { return a = b; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 24 }],
+    },
+    {
+      code: `const f = (): number => a = b`,
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 11 }],
+    },
+    {
+      code: `function f(): number { return a = b as number; }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 24 }],
+    },
+
+    // ---- Inner container reports; outer unaffected ----
+    {
+      code: `function f() { return (function g() { return a = b; })(); }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 39 }],
+    },
+    {
+      code: `function f() { return a = (b = c); }`,
+      errors: [{ messageId: 'returnAssignment', line: 1, column: 16 }],
+    },
+    {
+      code: `function f() { return a = (b = c); }`,
+      options: ['always'] as any,
+      errors: [
+        { messageId: 'returnAssignment', line: 1, column: 16 },
+        { messageId: 'returnAssignment', line: 1, column: 16 },
+      ],
+    },
+
+    // ---- Multi-line ----
+    {
+      code: 'function x() {\n  return a\n    = b;\n}',
+      errors: [{ messageId: 'returnAssignment', line: 2, column: 3 }],
+    },
+    {
+      code: '() =>\n  a = b',
+      errors: [{ messageId: 'arrowAssignment', line: 1, column: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-return-assign` rule from ESLint to rslint.

This rule disallows assignment operators in `return` statements (and arrow-function expression bodies). Both option values are supported:

- `"except-parens"` (default) — a parenthesised assignment like `return (a = b)` is allowed.
- `"always"` — any assignment inside a return / arrow body is reported, parens do not exempt.

Messages (`returnAssignment`, `arrowAssignment`) and report node (the enclosing `ReturnStatement` / `ArrowFunction`) match ESLint byte-for-byte.

### Alignment

- All 16 upstream ESLint test cases ported verbatim.
- 117 Go test cases + 44 JS snapshots covering: all 16 assignment operators, every container (`function` / `async function` / `function*` / `async function*` / method / getter / setter / object shorthand / arrow / async arrow), walk-up wrappers (`SequenceExpression` / `Conditional` / `Object` / `Array` / `Binary` / `Logical`), sentinel blocking (`FunctionExpression` / `ClassExpression` / nested arrow with block body / static block), both `except-parens` and `always` modes, JSX (`JsxElement` / `JsxExpression` / `JsxFragment` / `JsxAttribute`), TypeScript type annotations / `as` / `satisfies`, multi-line positions (`Line` / `Column` / `EndLine` / `EndColumn`).
- Differential validation against ESLint on `webinfra/rsbuild` and `webinfra/rspack`: both tools report **0** hits. No divergence.
- Implementation reuses existing shim helpers (`ast.IsAssignmentExpression`, `ast.IsStatement`, `ast.IsParenthesizedExpression`, `ast.IsArrowFunction`, `ast.IsReturnStatement`, …) — no duplicated AST primitives.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-return-assign
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-return-assign.js
- Test file: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-return-assign.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).