### PR TITLE
feat: port rule no-self-compare

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -179,6 +179,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_return_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
+	"github.com/web-infra-dev/rslint/internal/rules/no_self_compare"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
@@ -586,6 +587,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-return-assign", no_return_assign.NoReturnAssignRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
+	GlobalRuleRegistry.Register("no-self-compare", no_self_compare.NoSelfCompareRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
 	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)

--- a/internal/rules/no_self_compare/no_self_compare.go
+++ b/internal/rules/no_self_compare/no_self_compare.go
@@ -1,0 +1,40 @@
+package no_self_compare
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-self-compare
+var NoSelfCompareRule = rule.Rule{
+	Name: "no-self-compare",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if bin == nil || bin.OperatorToken == nil {
+					return
+				}
+				switch bin.OperatorToken.Kind {
+				case ast.KindEqualsEqualsEqualsToken,
+					ast.KindEqualsEqualsToken,
+					ast.KindExclamationEqualsEqualsToken,
+					ast.KindExclamationEqualsToken,
+					ast.KindGreaterThanToken,
+					ast.KindLessThanToken,
+					ast.KindGreaterThanEqualsToken,
+					ast.KindLessThanEqualsToken:
+				default:
+					return
+				}
+				if utils.HasSameTokens(ctx.SourceFile, bin.Left, bin.Right) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "comparingToSelf",
+						Description: "Comparing to itself is potentially pointless.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_self_compare/no_self_compare.md
+++ b/internal/rules/no_self_compare/no_self_compare.md
@@ -1,0 +1,44 @@
+# no-self-compare
+
+## Rule Details
+
+Disallows comparing a value to itself using any of the equality or relational operators (`===`, `==`, `!==`, `!=`, `>`, `<`, `>=`, `<=`). Such a comparison is typically a typo (the programmer likely meant a different operand) and is either always true, always false, or always `NaN`-sensitive, so the check is pointless.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var x = 10;
+if (x === x) {
+}
+
+if (x !== x) {
+}
+
+if (foo.bar().baz.qux >= foo.bar().baz.qux) {
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var x = 10;
+var y = 10;
+if (x === y) {
+}
+
+if (foo.bar.baz === foo.bar.qux) {
+}
+
+class C {
+  #field;
+  foo() {
+    // Property access via private identifier and bracket string literal
+    // are structurally distinct and allowed.
+    return this.#field === this["#field"];
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint no-self-compare](https://eslint.org/docs/latest/rules/no-self-compare)

--- a/internal/rules/no_self_compare/no_self_compare_test.go
+++ b/internal/rules/no_self_compare/no_self_compare_test.go
@@ -1,0 +1,233 @@
+package no_self_compare
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoSelfCompareRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoSelfCompareRule,
+
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream ESLint suite ----
+			{Code: `if (x === y) { }`},
+			{Code: `if (1 === 2) { }`},
+			{Code: `y=x*x`},
+			{Code: `foo.bar.baz === foo.bar.qux`},
+			{Code: `class C { #field; foo() { this.#field === this['#field']; } }`},
+			{Code: `class C { #field; foo() { this['#field'] === this.#field; } }`},
+
+			// ---- Non-comparison binary operators: rule only triggers on the 8 comparison ops ----
+			{Code: `x + x`},
+			{Code: `x - x`},
+			{Code: `x * x`},
+			{Code: `x / x`},
+			{Code: `x % x`},
+			{Code: `x ** x`},
+			{Code: `x & x`},
+			{Code: `x | x`},
+			{Code: `x ^ x`},
+			{Code: `x << x`},
+			{Code: `x >> x`},
+			{Code: `x >>> x`},
+			{Code: `x && x`},
+			{Code: `x || x`},
+			{Code: `x ?? x`},
+			{Code: `x, x`},
+			{Code: `x = x`},
+
+			// ---- Structurally different operands ----
+			{Code: `foo() === bar()`},
+			{Code: `a.b === a.c`},
+			{Code: `a[0] === a[1]`},
+			{Code: `(a + b) === (a - b)`},
+			{Code: `foo.bar() === foo.bar`},
+			{Code: `a?.b === a.b`}, // optional chain preserved
+
+			// ---- Unary / update differences ----
+			{Code: `+x === x`},
+			{Code: `-x === x`},
+			{Code: `!x === x`},
+			{Code: `typeof x === x`},
+			{Code: `++x === x`},
+
+			// ---- Different literal kinds or values ----
+			{Code: `1 === 1n`},
+			{Code: `1 === 2`},
+			{Code: `'a' === 'b'`},
+			{Code: "`a` === `b`"},
+
+			// ---- Template with differing quasi ----
+			{Code: "`a${x}` === `b${x}`"},
+			{Code: "`${x}` === `${y}`"},
+
+			// ---- TypeScript syntax shouldn't confuse structural compare ----
+			{Code: `(x as number) === (y as number)`},
+			{Code: `(x!) === (y!)`},
+
+			// ---- Token-form-sensitive (matches ESLint: different source tokens) ----
+			// HasSameTokens compares raw source at each leaf, so these are
+			// distinguished just like ESLint's token-level getTokens() would.
+			{Code: `0x1 === 1`},
+			{Code: `1n === 0x1n`},
+			{Code: `'a' === "a"`},
+			{Code: `1e2 === 100`},
+			{Code: `1.0 === 1`},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream ESLint suite ----
+			{
+				Code: `if (x === x) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Message: "Comparing to itself is potentially pointless.", Line: 1, Column: 5, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: `if (x !== x) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 5, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: `if (x > x) { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 5, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: `if ('x' > 'x') { }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 5, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `do {} while (x === x)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 14, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `x === x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code: `x !== x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+				},
+			},
+			{
+				Code: `x == x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code: `x != x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code: `x > x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 6},
+				},
+			},
+			{
+				Code: `x < x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 6},
+				},
+			},
+			{
+				Code: `x >= x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code: `x <= x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 7},
+				},
+			},
+			{
+				Code: `foo.bar().baz.qux >= foo.bar ().baz .qux`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 41},
+				},
+			},
+			{
+				Code: `class C { #field; foo() { this.#field === this.#field; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 27, EndLine: 1, EndColumn: 54},
+				},
+			},
+
+			// ---- Extra: full operator coverage on compound / complex expressions ----
+			{
+				Code: `a.b.c === a.b.c`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: `a[0] === a[0]`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `foo() === foo()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			// tsgo strips parens structurally; self-compare still detected.
+			{
+				Code: `(x) === x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+			// ---- Multi-line position assertion ----
+			{
+				Code: "if (\n  x\n  ===\n  x\n) {}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 2, Column: 3, EndLine: 4, EndColumn: 4},
+				},
+			},
+			// ---- Multi-byte / CJK identifier ----
+			{
+				Code: `中 === 中`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 8},
+				},
+			},
+
+			// ---- Same literal value, same source form → flagged (aligns with ESLint) ----
+			{
+				Code: `0x1 === 0x1`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: `1n === 1n`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_self_compare/no_self_compare_test.go
+++ b/internal/rules/no_self_compare/no_self_compare_test.go
@@ -50,12 +50,21 @@ func TestNoSelfCompareRule(t *testing.T) {
 			{Code: `foo.bar() === foo.bar`},
 			{Code: `a?.b === a.b`}, // optional chain preserved
 
-			// ---- Unary / update differences ----
+			// ---- Unary / update differences (different Kind on one side) ----
 			{Code: `+x === x`},
 			{Code: `-x === x`},
 			{Code: `!x === x`},
 			{Code: `typeof x === x`},
 			{Code: `++x === x`},
+
+			// ---- Same Kind, different operator token ----
+			// Regression guard: PrefixUnary / PostfixUnary store their operator
+			// as a Kind enum that tsgo's ForEachChild does NOT visit, so these
+			// would collapse under a naive children-only compare.
+			{Code: `+x === -x`},
+			{Code: `++x === --x`},
+			{Code: `x++ === x--`},
+			{Code: `~x === !x`},
 
 			// ---- Different literal kinds or values ----
 			{Code: `1 === 1n`},
@@ -226,6 +235,30 @@ func TestNoSelfCompareRule(t *testing.T) {
 				Code: `1n === 1n`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// ---- Same-operator unary/update — regression guard that the operator
+			//      gate doesn't over-filter the valid self-compare cases. ----
+			{
+				Code: `+x === +x`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: `x++ === x++`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 12},
+				},
+			},
+
+			// ---- Multi-byte (UTF-16 surrogate pair, BMP-outside emoji in string) ----
+			// LSP ranges are UTF-16-based; an emoji is 2 code units, not 1 rune.
+			{
+				Code: `'🍎' === '🍎'`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "comparingToSelf", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
 				},
 			},
 		},

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -1,0 +1,144 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"gotest.tools/v3/assert"
+)
+
+// parseBinaryOperands parses code expected to contain a top-level BinaryExpression
+// statement and returns its source file plus (left, right) operand nodes.
+// Used to exercise HasSameTokens on both sides of a comparison.
+func parseBinaryOperands(t *testing.T, code string) (*ast.SourceFile, *ast.Node, *ast.Node) {
+	t.Helper()
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "file.ts")
+	fs := NewOverlayVFSForFile(filePath, code)
+	program, err := CreateProgram(true, fs, rootDir, "tsconfig.json", CreateCompilerHost(rootDir, fs))
+	assert.NilError(t, err, "couldn't create program for code: "+code)
+	sourceFile := program.GetSourceFile(filePath)
+
+	var bin *ast.Node
+	var find func(node *ast.Node) bool
+	find = func(node *ast.Node) bool {
+		if node == nil {
+			return false
+		}
+		if node.Kind == ast.KindBinaryExpression {
+			bin = node
+			return true
+		}
+		return node.ForEachChild(find)
+	}
+	for _, stmt := range sourceFile.Statements.Nodes {
+		if find(stmt) {
+			break
+		}
+	}
+	if bin == nil {
+		t.Fatalf("no BinaryExpression found in code: %s", code)
+	}
+	b := bin.AsBinaryExpression()
+	return sourceFile, b.Left, b.Right
+}
+
+func TestHasSameTokens(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+		want bool
+	}{
+		// ---- Basic equality / inequality ----
+		{"identifier equal", `x === x`, true},
+		{"identifier differ", `x === y`, false},
+		{"numeric equal", `1 === 1`, true},
+		{"numeric differ", `1 === 2`, false},
+		{"string equal", `'a' === 'a'`, true},
+		{"string differ", `'a' === 'b'`, false},
+
+		// ---- Whitespace / comments inside operand are skipped as trivia ----
+		{"whitespace in member chain", `foo.bar().baz.qux === foo.bar ().baz .qux`, true},
+		{"comment between tokens", `/* c */ a /* c */ === /* c */ a /* c */`, true},
+		{"newlines inside operand", "a\n.\nb\n===\na.b", true},
+
+		// ---- Member / call expressions ----
+		{"property chain equal", `a.b.c === a.b.c`, true},
+		{"property chain differ", `a.b.c === a.b.d`, false},
+		{"element access equal", `a[0] === a[0]`, true},
+		{"element access differ", `a[0] === a[1]`, false},
+		{"call equal", `foo() === foo()`, true},
+		{"call differ args", `foo(1) === foo(2)`, false},
+
+		// ---- Optional chain preserved in tokens (?. vs .) ----
+		{"optional vs non-optional", `a?.b === a.b`, false},
+		{"optional equal", `a?.b === a?.b`, true},
+
+		// ---- Private identifier vs bracket string access ----
+		{"private vs bracket string", `this.#f === this['#f']`, false},
+
+		// ---- ESLint-distinctive cases that AreNodesStructurallyEqual would collapse ----
+		// (These are the reason HasSameTokens exists alongside AreNodesStructurallyEqual.)
+		{"hex vs decimal literal", `0x1 === 1`, false},
+		{"bigint hex vs decimal", `0x1n === 1n`, false},
+		{"scientific vs decimal", `1e2 === 100`, false},
+		{"trailing-zero decimal", `1.0 === 1`, false},
+		{"single vs double quote", `'a' === "a"`, false},
+
+		// ---- Template literals ----
+		{"template equal", "`a${x}b` === `a${x}b`", true},
+		{"template head differ", "`a${x}b` === `c${x}d`", false},
+		{"template expr differ", "`a${x}b` === `a${y}b`", false},
+
+		// ---- Parentheses on the operand are transparent ----
+		// ESLint: ESTree doesn't model parens as nodes, so getTokens(node.left)
+		// on `(x)` returns tokens inside the Identifier `x`'s own range — just
+		// `[x]`. rslint: SkipParentheses in HasSameTokens drops the parens
+		// before comparison. Both flag `(x) === x`.
+		{"paren left, bare right", `(x) === x`, true},
+		{"paren both sides", `(x) === (x)`, true},
+		{"nested parens", `((x)) === x`, true},
+
+		// ---- Unary / type-only syntax ----
+		{"unary vs bare", `+x === x`, false},
+		{"typeof equal", `typeof x === typeof x`, true},
+		{"as-expression equal", `(x as number) === (x as number)`, true},
+		{"as-expression differ type", `(x as number) === (x as string)`, false},
+		{"non-null equal", `(x!) === (x!)`, true},
+
+		// ---- Regex ----
+		{"regex equal", `/a/ === /a/`, true},
+		{"regex differ", `/a/ === /b/`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			sf, left, right := parseBinaryOperands(t, tt.code)
+			got := HasSameTokens(sf, left, right)
+			if got != tt.want {
+				t.Errorf("HasSameTokens(%q) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasSameTokensNilHandling(t *testing.T) {
+	t.Parallel()
+
+	sf, left, _ := parseBinaryOperands(t, `x === x`)
+
+	if !HasSameTokens(sf, nil, nil) {
+		t.Error("HasSameTokens(nil, nil) = false, want true")
+	}
+	if HasSameTokens(sf, nil, left) {
+		t.Error("HasSameTokens(nil, left) = true, want false")
+	}
+	if HasSameTokens(sf, left, nil) {
+		t.Error("HasSameTokens(left, nil) = true, want false")
+	}
+}

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -94,14 +94,21 @@ func TestHasSameTokens(t *testing.T) {
 		{"template head differ", "`a${x}b` === `c${x}d`", false},
 		{"template expr differ", "`a${x}b` === `a${y}b`", false},
 
-		// ---- Parentheses on the operand are transparent ----
-		// ESLint: ESTree doesn't model parens as nodes, so getTokens(node.left)
-		// on `(x)` returns tokens inside the Identifier `x`'s own range — just
-		// `[x]`. rslint: SkipParentheses in HasSameTokens drops the parens
-		// before comparison. Both flag `(x) === x`.
-		{"paren left, bare right", `(x) === x`, true},
-		{"paren both sides", `(x) === (x)`, true},
-		{"nested parens", `((x)) === x`, true},
+		// ---- Parentheses ----
+		// OUTER parens (wrapping a top-level operand) are transparent: they
+		// match ESLint/ESTree where `(x)` as an operand has range == the
+		// Identifier's own range, so getTokens sees just `[x]`. HasSameTokens
+		// applies SkipParentheses once at entry to replicate this.
+		{"paren outer left", `(x) === x`, true},
+		{"paren outer both", `(x) === (x)`, true},
+		{"nested outer parens", `((x)) === x`, true},
+		// INNER parens (inside a compound expression) are VISIBLE tokens in
+		// ESLint's view — `(x).y` has range including `(` and `)`, so tokens
+		// `[(, x, ), ., y]` differ from `x.y`'s `[x, ., y]`. The recursion
+		// does NOT re-strip parens, so these correctly differ here too.
+		{"inner paren vs bare", `(x).y === x.y`, false},
+		{"inner paren both sides", `(x).y === (x).y`, true},
+		{"deep inner paren differ", `a((x)).b === a(x).b`, false},
 
 		// ---- Unary / type-only syntax ----
 		{"unary vs bare", `+x === x`, false},
@@ -128,9 +135,21 @@ func TestHasSameTokens(t *testing.T) {
 		{"prefix bitwise vs logical not", `~x === !x`, false},
 
 		// ---- MetaProperty (new.target / import.meta) ----
-		// KeywordToken is a Kind field, not a child — name already
-		// distinguishes them in practice, but the keyword check is principled.
+		// KeywordToken is a Kind field, not a child — the general gap scan
+		// catches the `new` / `import` keyword in the prefix gap.
 		{"new.target equal", `new.target === new.target`, true},
+
+		// ---- Trailing commas / optional empty-arg parens ----
+		// These all have identical AST children but differ in the trivia
+		// tokens that live in the gaps (commas, parens). The general gap
+		// scan catches them; a naive children-only compare would not.
+		{"new without vs with parens", `new foo === new foo()`, false},
+		{"new with vs without parens", `new foo() === new foo`, false},
+		{"trailing comma left", `foo(a,) === foo(a)`, false},
+		{"trailing comma right", `foo(a) === foo(a,)`, false},
+		{"trailing comma both", `foo(a,) === foo(a,)`, true},
+		{"array trailing comma", `[a,] === [a]`, false},
+		{"array trailing comma both", `[a,] === [a,]`, true},
 
 		// ---- Regex ----
 		{"regex equal", `/a/ === /a/`, true},

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -168,6 +168,88 @@ func TestHasSameTokens(t *testing.T) {
 	}
 }
 
+// TestHasSameTokensFullAudit is a systematic sweep of every class of
+// divergence I can think of between tsgo's AST structure and ESLint's
+// token-level view. Any regression here indicates either a newly-found
+// tsgo ForEachChild hole or a drift in the gap-scan logic.
+func TestHasSameTokensFullAudit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		code string
+		want bool
+		why  string
+	}{
+		// Operator-field holes
+		{`+x === -x`, false, "prefix unary operator"},
+		{`x++ === x--`, false, "postfix unary operator"},
+		{`++x === --x`, false, "prefix update operator"},
+		{`~x === !x`, false, "bitwise vs logical not"},
+
+		// Meta property keyword
+		{`new.target === new.target`, true, "same meta keyword"},
+
+		// Trivia that isn't an AST node
+		{`new foo === new foo()`, false, "empty parens"},
+		{`foo(a,) === foo(a)`, false, "trailing comma in args"},
+		{`[a,] === [a]`, false, "trailing comma in array"},
+
+		// Paren visibility
+		{`(x).y === x.y`, false, "inner parens visible"},
+		{`(x) === x`, true, "outer parens stripped once"},
+
+		// Optional chain flag via *Node child
+		{`a?.b === a.b`, false, "optional dot preserved"},
+		{`a?.() === a()`, false, "optional call preserved"},
+
+		// Type args
+		{`foo<T>() === foo()`, false, "type arg list differs"},
+		{`foo<T>() === foo<U>()`, false, "type arg differs"},
+		{`foo<T>() === foo<T>()`, true, "same type args"},
+
+		// Modifiers
+		{`(async () => x) === (() => x)`, false, "async modifier differs"},
+		{`(function* g() {}) === (function g() {})`, false, "generator star differs"},
+
+		// Sequence / spread
+		{`(a, b) === (b, a)`, false, "sequence order differs"},
+		{`foo(...a) === foo(a)`, false, "spread vs no spread"},
+
+		// Literal forms (tsgo normalization defeated by raw source)
+		{`0b1 === 1`, false, "binary vs decimal"},
+		{`0o7 === 7`, false, "octal vs decimal"},
+		{`1_000 === 1000`, false, "underscore separator visible"},
+		{`foo === \u0066oo`, false, "unicode escape vs plain"},
+
+		// Null / undefined
+		{`null === null`, true, "null keyword self"},
+		{`undefined === undefined`, true, "undefined identifier self"},
+		{`null === undefined`, false, "null vs undefined"},
+
+		// Regex
+		{`/a/ === /a/g`, false, "regex flags differ"},
+		{`/a/g === /a/i`, false, "regex flags differ 2"},
+
+		// String escapes
+		{`'\n' === '\n'`, true, "same escape"},
+		{"'\\n' === '\\\\n'", false, "escape differs"},
+
+		// Template
+		{"`a${x}b` === `a${y}b`", false, "template expr differs"},
+		{"`a${x}b` === `a${x}b`", true, "template equal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.why, func(t *testing.T) {
+			t.Parallel()
+			sf, l, r := parseBinaryOperands(t, tt.code)
+			if got := HasSameTokens(sf, l, r); got != tt.want {
+				t.Errorf("%q: got %v want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasSameTokensNilHandling(t *testing.T) {
 	t.Parallel()
 

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -110,6 +110,28 @@ func TestHasSameTokens(t *testing.T) {
 		{"as-expression differ type", `(x as number) === (x as string)`, false},
 		{"non-null equal", `(x!) === (x!)`, true},
 
+		// ---- Operator fields stored outside ForEachChild ----
+		// tsgo's PrefixUnaryExpression / PostfixUnaryExpression store their
+		// operator as a Kind enum, not as a *Node child, so a naive
+		// ForEachChild-based compare would incorrectly collapse different
+		// operators. Lock in operator-sensitivity here.
+		{"prefix unary same op", `+x === +x`, true},
+		{"prefix unary differ op", `+x === -x`, false},
+		{"prefix unary update same", `++x === ++x`, true},
+		{"prefix unary update differ", `++x === --x`, false},
+		{"prefix typeof vs plus", `typeof x === +x`, false}, // different Kind entirely
+		{"postfix unary same op", `x++ === x++`, true},
+		{"postfix unary differ op", `x++ === x--`, false},
+		{"prefix vs postfix update", `++x === x++`, false}, // different Kind entirely
+		{"prefix logical-not same", `!x === !x`, true},     // same op → equal
+		{"prefix bitwise-not same", `~x === ~x`, true},
+		{"prefix bitwise vs logical not", `~x === !x`, false},
+
+		// ---- MetaProperty (new.target / import.meta) ----
+		// KeywordToken is a Kind field, not a child — name already
+		// distinguishes them in practice, but the keyword check is principled.
+		{"new.target equal", `new.target === new.target`, true},
+
 		// ---- Regex ----
 		{"regex equal", `/a/ === /a/`, true},
 		{"regex differ", `/a/ === /b/`, false},
@@ -140,5 +162,79 @@ func TestHasSameTokensNilHandling(t *testing.T) {
 	}
 	if HasSameTokens(sf, left, nil) {
 		t.Error("HasSameTokens(left, nil) = true, want false")
+	}
+}
+
+// TestAreNodesStructurallyEqual exercises the structural equality helper.
+// Documents how AreNodesStructurallyEqual intentionally diverges from
+// HasSameTokens — it normalizes literal source form (so `0x1` == `1`) — and
+// locks in the operator-sensitivity fix for Prefix/Postfix unary expressions
+// where ForEachChild does not visit the Operator field.
+func TestAreNodesStructurallyEqual(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		code string
+		want bool
+	}{
+		// ---- Agreement with HasSameTokens on the common cases ----
+		{"identifier equal", `x === x`, true},
+		{"identifier differ", `x === y`, false},
+		{"property chain equal", `a.b.c === a.b.c`, true},
+		{"property chain differ", `a.b.c === a.b.d`, false},
+		{"call equal", `foo() === foo()`, true},
+		{"optional vs non-optional", `a?.b === a.b`, false},
+		{"private vs bracket string", `this.#f === this['#f']`, false},
+		{"parens transparent", `(x) === x`, true},
+
+		// ---- Normalization: intentionally collapses literal source forms ----
+		// (This is the defining difference from HasSameTokens.)
+		{"hex vs decimal collapse", `0x1 === 1`, true},
+		{"bigint hex vs decimal collapse", `0x1n === 1n`, true},
+		{"scientific vs decimal collapse", `1e2 === 100`, true},
+		{"trailing-zero decimal collapse", `1.0 === 1`, true},
+		{"single vs double quote collapse", `'a' === "a"`, true},
+		{"different strings still differ", `'a' === 'b'`, false},
+		{"different numbers still differ", `1 === 2`, false},
+
+		// ---- Operator-sensitivity fix (Prefix/Postfix unary) ----
+		{"prefix unary same op", `+x === +x`, true},
+		{"prefix unary differ op", `+x === -x`, false},
+		{"prefix update same", `++x === ++x`, true},
+		{"prefix update differ", `++x === --x`, false},
+		{"postfix unary same op", `x++ === x++`, true},
+		{"postfix unary differ op", `x++ === x--`, false},
+		{"bitwise vs logical not", `~x === !x`, false},
+
+		// ---- MetaProperty ----
+		{"new.target equal", `new.target === new.target`, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, left, right := parseBinaryOperands(t, tt.code)
+			got := AreNodesStructurallyEqual(left, right)
+			if got != tt.want {
+				t.Errorf("AreNodesStructurallyEqual(%q) = %v, want %v", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAreNodesStructurallyEqualNilHandling(t *testing.T) {
+	t.Parallel()
+
+	_, left, _ := parseBinaryOperands(t, `x === x`)
+
+	if !AreNodesStructurallyEqual(nil, nil) {
+		t.Error("AreNodesStructurallyEqual(nil, nil) = false, want true")
+	}
+	if AreNodesStructurallyEqual(nil, left) {
+		t.Error("AreNodesStructurallyEqual(nil, left) = true, want false")
+	}
+	if AreNodesStructurallyEqual(left, nil) {
+		t.Error("AreNodesStructurallyEqual(left, nil) = true, want false")
 	}
 }

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1362,6 +1362,74 @@ func AreNodesStructurallyEqual(a, b *ast.Node) bool {
 	return true
 }
 
+// HasSameTokens reports whether two nodes produce the same token stream when
+// viewed at the raw-source level — matching ESLint's
+// `sourceCode.getTokens(a)` vs `sourceCode.getTokens(b)` semantics, which
+// preserves the original source form of each literal. Unlike
+// [AreNodesStructurallyEqual], this helper distinguishes:
+//
+//   - `'a'` vs `"a"` (different quote style)
+//   - `0x1` vs `1` (different numeric source form)
+//   - `1n` vs `0x1n` (different bigint source form)
+//   - `1e2` vs `100` / `1.0` vs `1`
+//
+// Implementation: we recurse on the AST using [ast.SkipParentheses] and
+// [ast.Node.ForEachChild]. At leaf nodes (no children — identifiers,
+// literals, keyword tokens) we compare the raw source slice via
+// [scanner.GetSourceTextOfNodeFromSourceFile]. Whitespace and comments
+// between tokens live only in composite-node source ranges and are never
+// part of any leaf's text, so the comparison is whitespace-insensitive in
+// the same way ESLint's `getTokens` is.
+//
+// A raw-scanner implementation (walking [scanner.Scanner.Scan] over each
+// node's source span) would be closer to ESLint mechanically but cannot
+// re-scan template-literal middles/tails without parser context
+// (`ReScanTemplateToken` is not exposed in the shim). The AST-recursion
+// route sidesteps that limitation while preserving the key property: raw
+// source at every leaf.
+//
+// Use this helper when porting an ESLint rule whose oracle is token-level
+// equality (e.g. `no-self-compare`'s `hasSameTokens`); use
+// [AreNodesStructurallyEqual] when the rule's oracle is structural AST
+// equality and literal-form differences should NOT matter (e.g. duplicate
+// case detection).
+func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	a = ast.SkipParentheses(a)
+	b = ast.SkipParentheses(b)
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Kind != b.Kind {
+		return false
+	}
+	var aKids, bKids []*ast.Node
+	a.ForEachChild(func(c *ast.Node) bool {
+		aKids = append(aKids, c)
+		return false
+	})
+	b.ForEachChild(func(c *ast.Node) bool {
+		bKids = append(bKids, c)
+		return false
+	})
+	// Leaves: identifiers, literals, keyword tokens. Compare raw source.
+	if len(aKids) == 0 && len(bKids) == 0 {
+		return scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, a, false) ==
+			scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, b, false)
+	}
+	if len(aKids) != len(bKids) {
+		return false
+	}
+	for i := range aKids {
+		if !HasSameTokens(sourceFile, aKids[i], bKids[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // IsArgumentOfSpecificCall reports whether `node` sits at argument position
 // `index` of a call to `<objectName>.<methodName>(...)` — covering optional
 // chaining and parenthesized callee expressions, e.g. `(Object?.defineProperty)(...)`.

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1424,116 +1424,83 @@ func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	a = ast.SkipParentheses(a)
-	b = ast.SkipParentheses(b)
+	return hasSameTokens(sourceFile, ast.SkipParentheses(a), ast.SkipParentheses(b))
+}
+
+// hasSameTokens is the recursive core. It does NOT call SkipParentheses
+// on its inputs — parens nested inside a compound expression are visible
+// tokens in ESLint's per-node getTokens view (e.g. `(x).y` has tokens
+// `[(, x, ), ., y]`), so a recursive paren strip would collapse them.
+func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
-	return hasSameTokensInner(sourceFile, a, b)
-}
-
-// hasSameTokensInner is the recursive core of [HasSameTokens]. It does
-// NOT call SkipParentheses — parens nested inside a compound expression
-// are visible tokens in ESLint's per-node getTokens view (e.g. `(x).y`
-// has tokens `[(, x, ), ., y]`), so a recursive paren strip would
-// collapse them incorrectly.
-func hasSameTokensInner(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	if a.Kind != b.Kind {
 		return false
 	}
-	var aKids, bKids []*ast.Node
-	a.ForEachChild(func(c *ast.Node) bool {
-		aKids = append(aKids, c)
-		return false
-	})
-	b.ForEachChild(func(c *ast.Node) bool {
-		bKids = append(bKids, c)
-		return false
-	})
-	// Leaves: identifiers, literals, keyword tokens. Compare raw source.
+	aKids, bKids := collectKids(a), collectKids(b)
+	// Leaves (no children via ForEachChild): compare raw source text.
 	if len(aKids) == 0 && len(bKids) == 0 {
-		return scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, a, false) ==
-			scanner.GetSourceTextOfNodeFromSourceFile(sourceFile, b, false)
+		return scanner.GetSourceTextOfNodeFromSourceFile(sf, a, false) ==
+			scanner.GetSourceTextOfNodeFromSourceFile(sf, b, false)
 	}
 	if len(aKids) != len(bKids) {
 		return false
 	}
-	for i := range aKids {
-		if !hasSameTokensInner(sourceFile, aKids[i], bKids[i]) {
-			return false
-		}
-	}
-	return sameGapTokens(sourceFile, a, aKids, b, bKids)
-}
-
-// sameGapTokens compares the token streams lying BETWEEN the children
-// of two composite nodes (plus the prefix gap before the first child
-// and the suffix gap after the last child). Those gaps hold operators,
-// punctuation, and keywords that ForEachChild does not yield as nodes.
-// Callers must have already verified len(aKids) == len(bKids).
-func sameGapTokens(sourceFile *ast.SourceFile, a *ast.Node, aKids []*ast.Node, b *ast.Node, bKids []*ast.Node) bool {
+	// Composite: compare children pairwise AND compare the token sequences
+	// living in the gaps between children (and the prefix / suffix gaps).
+	// Gap tokens are the operators / punctuation / keywords that
+	// ForEachChild does not yield as nodes — `(` `)` `,` `.` between call
+	// arguments, `+` / `-` for PrefixUnaryExpression, `new` / `import` for
+	// MetaProperty, and so on.
 	prevA, prevB := a.Pos(), b.Pos()
 	for i := range aKids {
-		if !sameTokensInRange(sourceFile, prevA, aKids[i].Pos(), prevB, bKids[i].Pos()) {
+		if !sameTokensInRange(sf, prevA, aKids[i].Pos(), prevB, bKids[i].Pos()) {
+			return false
+		}
+		if !hasSameTokens(sf, aKids[i], bKids[i]) {
 			return false
 		}
 		prevA, prevB = aKids[i].End(), bKids[i].End()
 	}
-	return sameTokensInRange(sourceFile, prevA, a.End(), prevB, b.End())
+	return sameTokensInRange(sf, prevA, a.End(), prevB, b.End())
+}
+
+func collectKids(n *ast.Node) []*ast.Node {
+	var out []*ast.Node
+	n.ForEachChild(func(c *ast.Node) bool { out = append(out, c); return false })
+	return out
 }
 
 // sameTokensInRange reports whether scanning [aStart, aEnd) and
 // [bStart, bEnd) produces the same sequence of (kind, raw text) pairs.
 // Trivia (whitespace, comments) is skipped by the scanner, matching
 // ESLint's `getTokens` which excludes comments by default.
-func sameTokensInRange(sourceFile *ast.SourceFile, aStart, aEnd, bStart, bEnd int) bool {
-	sa := openRangeScanner(sourceFile, aStart, aEnd)
-	sb := openRangeScanner(sourceFile, bStart, bEnd)
+func sameTokensInRange(sf *ast.SourceFile, aStart, aEnd, bStart, bEnd int) bool {
+	var sa, sb *scanner.Scanner
+	if aStart < aEnd {
+		sa = scanner.GetScannerForSourceFile(sf, aStart)
+	}
+	if bStart < bEnd {
+		sb = scanner.GetScannerForSourceFile(sf, bStart)
+	}
+	liveA := func() bool {
+		return sa != nil && sa.Token() != ast.KindEndOfFile && sa.TokenStart() < aEnd && sa.TokenEnd() <= aEnd
+	}
+	liveB := func() bool {
+		return sb != nil && sb.Token() != ast.KindEndOfFile && sb.TokenStart() < bEnd && sb.TokenEnd() <= bEnd
+	}
 	for {
-		kindA, textA, okA := nextRangeToken(sa, aEnd)
-		kindB, textB, okB := nextRangeToken(sb, bEnd)
-		if !okA && !okB {
+		la, lb := liveA(), liveB()
+		if !la && !lb {
 			return true
 		}
-		if okA != okB || kindA != kindB || textA != textB {
+		if la != lb || sa.Token() != sb.Token() || sa.TokenText() != sb.TokenText() {
 			return false
 		}
+		sa.Scan()
+		sb.Scan()
 	}
-}
-
-// rangeScanner pairs a scanner with its range end so nextRangeToken can
-// stop at the right place and truncate defensively against over-read.
-type rangeScanner struct {
-	s   *scanner.Scanner
-	end int
-}
-
-func openRangeScanner(sourceFile *ast.SourceFile, pos, end int) *rangeScanner {
-	if pos >= end {
-		return nil
-	}
-	return &rangeScanner{s: scanner.GetScannerForSourceFile(sourceFile, pos), end: end}
-}
-
-func nextRangeToken(rs *rangeScanner, end int) (ast.Kind, string, bool) {
-	if rs == nil || rs.s.Token() == ast.KindEndOfFile {
-		return 0, "", false
-	}
-	if rs.s.TokenStart() >= end {
-		return 0, "", false
-	}
-	// Defensive: don't accept a token that would spill past the gap end
-	// (can happen when a stray backtick inside the gap region gets
-	// scanned as a NoSubstitutionTemplateLiteral extending to the next
-	// backtick — rare in practice since template gaps are empty, but
-	// harmless to guard).
-	if rs.s.TokenEnd() > end {
-		return 0, "", false
-	}
-	kind := rs.s.Token()
-	text := rs.s.TokenText()
-	rs.s.Scan()
-	return kind, text, true
 }
 
 // IsArgumentOfSpecificCall reports whether `node` sits at argument position

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1338,6 +1338,23 @@ func AreNodesStructurallyEqual(a, b *ast.Node) bool {
 	case ast.KindTemplateHead, ast.KindTemplateMiddle, ast.KindTemplateTail,
 		ast.KindRegularExpressionLiteral:
 		return a.Text() == b.Text()
+	case ast.KindPrefixUnaryExpression:
+		// tsgo stores the operator as a Kind field, not as a child node, so
+		// ForEachChild would otherwise collapse `+x` and `-x` (both have one
+		// child, the Operand). Compare the Operator field before recursing.
+		ap, bp := a.AsPrefixUnaryExpression(), b.AsPrefixUnaryExpression()
+		return ap.Operator == bp.Operator && AreNodesStructurallyEqual(ap.Operand, bp.Operand)
+	case ast.KindPostfixUnaryExpression:
+		// Same gotcha as PrefixUnaryExpression — ForEachChild omits Operator.
+		ap, bp := a.AsPostfixUnaryExpression(), b.AsPostfixUnaryExpression()
+		return ap.Operator == bp.Operator && AreNodesStructurallyEqual(ap.Operand, bp.Operand)
+	case ast.KindMetaProperty:
+		// `new.target` and `import.meta` both use MetaProperty; the meta
+		// keyword lives in KeywordToken (Kind), which ForEachChild doesn't
+		// visit. In practice `name` (target vs meta) already distinguishes
+		// them, but compare the keyword explicitly for principled alignment.
+		am, bm := a.AsMetaProperty(), b.AsMetaProperty()
+		return am.KeywordToken == bm.KeywordToken && AreNodesStructurallyEqual(am.Name(), bm.Name())
 	}
 	// Composite / pure-token kinds: compare children pairwise. Token kinds
 	// without children (operators, keywords) fall through the empty loop and
@@ -1404,6 +1421,21 @@ func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	}
 	if a.Kind != b.Kind {
 		return false
+	}
+	// tsgo's ForEachChild does not visit operator/keyword fields that are
+	// stored as Kind enums rather than *Node children. Left to the generic
+	// recursion below, `+x` and `-x` would collapse (both PrefixUnary, same
+	// single Operand child). Compare those fields explicitly here.
+	switch a.Kind {
+	case ast.KindPrefixUnaryExpression:
+		ap, bp := a.AsPrefixUnaryExpression(), b.AsPrefixUnaryExpression()
+		return ap.Operator == bp.Operator && HasSameTokens(sourceFile, ap.Operand, bp.Operand)
+	case ast.KindPostfixUnaryExpression:
+		ap, bp := a.AsPostfixUnaryExpression(), b.AsPostfixUnaryExpression()
+		return ap.Operator == bp.Operator && HasSameTokens(sourceFile, ap.Operand, bp.Operand)
+	case ast.KindMetaProperty:
+		am, bm := a.AsMetaProperty(), b.AsMetaProperty()
+		return am.KeywordToken == bm.KeywordToken && HasSameTokens(sourceFile, am.Name(), bm.Name())
 	}
 	var aKids, bKids []*ast.Node
 	a.ForEachChild(func(c *ast.Node) bool {

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1393,23 +1393,33 @@ func AreNodesStructurallyEqual(a, b *ast.Node) bool {
 // Implementation: we recurse on the AST using [ast.SkipParentheses] and
 // [ast.Node.ForEachChild]. At leaf nodes (no children — identifiers,
 // literals, keyword tokens) we compare the raw source slice via
-// [scanner.GetSourceTextOfNodeFromSourceFile]. Whitespace and comments
-// between tokens live only in composite-node source ranges and are never
-// part of any leaf's text, so the comparison is whitespace-insensitive in
-// the same way ESLint's `getTokens` is.
+// [scanner.GetSourceTextOfNodeFromSourceFile]. For composite nodes we
+// recurse on children pairwise AND scan the "gaps" between children
+// (and before/after the first/last child) with [scanner.Scanner] to pick
+// up punctuation, keyword tokens, and operators that tsgo's ForEachChild
+// does not visit — `(` `)` `,` `.` between children of a CallExpression,
+// the `+`/`-` operator of a PrefixUnaryExpression, the `new`/`import`
+// keyword of a MetaProperty, and so on. Whitespace and comments in a
+// gap are trivia (scanner skips them), so the comparison is
+// whitespace-insensitive exactly like ESLint's `getTokens`.
 //
-// A raw-scanner implementation (walking [scanner.Scanner.Scan] over each
-// node's source span) would be closer to ESLint mechanically but cannot
-// re-scan template-literal middles/tails without parser context
-// (`ReScanTemplateToken` is not exposed in the shim). The AST-recursion
-// route sidesteps that limitation while preserving the key property: raw
-// source at every leaf.
+// Parens: stripped once at the top level (matches ESLint / ESTree, where
+// outer parens wrapping an operand aren't nodes and their tokens fall
+// outside the operand's range). Parens INSIDE a compound expression —
+// e.g. `(x).y` — ARE visible tokens in ESLint's view, and preserved here
+// by the recursion not calling SkipParentheses again.
+//
+// Templates: TemplateExpression / TemplateSpan children already cover
+// the whole template source range contiguously, so the gap between any
+// two children inside a template is empty. This means gap scanning never
+// enters template-expression context and thus never needs the scanner's
+// `ReScanTemplateToken` (which isn't exposed through the shim).
 //
 // Use this helper when porting an ESLint rule whose oracle is token-level
 // equality (e.g. `no-self-compare`'s `hasSameTokens`); use
 // [AreNodesStructurallyEqual] when the rule's oracle is structural AST
-// equality and literal-form differences should NOT matter (e.g. duplicate
-// case detection).
+// equality and literal-form / trivia differences should NOT matter (e.g.
+// duplicate case detection).
 func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	if a == nil || b == nil {
 		return a == b
@@ -1419,23 +1429,17 @@ func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	if a == nil || b == nil {
 		return a == b
 	}
+	return hasSameTokensInner(sourceFile, a, b)
+}
+
+// hasSameTokensInner is the recursive core of [HasSameTokens]. It does
+// NOT call SkipParentheses — parens nested inside a compound expression
+// are visible tokens in ESLint's per-node getTokens view (e.g. `(x).y`
+// has tokens `[(, x, ), ., y]`), so a recursive paren strip would
+// collapse them incorrectly.
+func hasSameTokensInner(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 	if a.Kind != b.Kind {
 		return false
-	}
-	// tsgo's ForEachChild does not visit operator/keyword fields that are
-	// stored as Kind enums rather than *Node children. Left to the generic
-	// recursion below, `+x` and `-x` would collapse (both PrefixUnary, same
-	// single Operand child). Compare those fields explicitly here.
-	switch a.Kind {
-	case ast.KindPrefixUnaryExpression:
-		ap, bp := a.AsPrefixUnaryExpression(), b.AsPrefixUnaryExpression()
-		return ap.Operator == bp.Operator && HasSameTokens(sourceFile, ap.Operand, bp.Operand)
-	case ast.KindPostfixUnaryExpression:
-		ap, bp := a.AsPostfixUnaryExpression(), b.AsPostfixUnaryExpression()
-		return ap.Operator == bp.Operator && HasSameTokens(sourceFile, ap.Operand, bp.Operand)
-	case ast.KindMetaProperty:
-		am, bm := a.AsMetaProperty(), b.AsMetaProperty()
-		return am.KeywordToken == bm.KeywordToken && HasSameTokens(sourceFile, am.Name(), bm.Name())
 	}
 	var aKids, bKids []*ast.Node
 	a.ForEachChild(func(c *ast.Node) bool {
@@ -1455,11 +1459,81 @@ func HasSameTokens(sourceFile *ast.SourceFile, a, b *ast.Node) bool {
 		return false
 	}
 	for i := range aKids {
-		if !HasSameTokens(sourceFile, aKids[i], bKids[i]) {
+		if !hasSameTokensInner(sourceFile, aKids[i], bKids[i]) {
 			return false
 		}
 	}
-	return true
+	return sameGapTokens(sourceFile, a, aKids, b, bKids)
+}
+
+// sameGapTokens compares the token streams lying BETWEEN the children
+// of two composite nodes (plus the prefix gap before the first child
+// and the suffix gap after the last child). Those gaps hold operators,
+// punctuation, and keywords that ForEachChild does not yield as nodes.
+// Callers must have already verified len(aKids) == len(bKids).
+func sameGapTokens(sourceFile *ast.SourceFile, a *ast.Node, aKids []*ast.Node, b *ast.Node, bKids []*ast.Node) bool {
+	prevA, prevB := a.Pos(), b.Pos()
+	for i := range aKids {
+		if !sameTokensInRange(sourceFile, prevA, aKids[i].Pos(), prevB, bKids[i].Pos()) {
+			return false
+		}
+		prevA, prevB = aKids[i].End(), bKids[i].End()
+	}
+	return sameTokensInRange(sourceFile, prevA, a.End(), prevB, b.End())
+}
+
+// sameTokensInRange reports whether scanning [aStart, aEnd) and
+// [bStart, bEnd) produces the same sequence of (kind, raw text) pairs.
+// Trivia (whitespace, comments) is skipped by the scanner, matching
+// ESLint's `getTokens` which excludes comments by default.
+func sameTokensInRange(sourceFile *ast.SourceFile, aStart, aEnd, bStart, bEnd int) bool {
+	sa := openRangeScanner(sourceFile, aStart, aEnd)
+	sb := openRangeScanner(sourceFile, bStart, bEnd)
+	for {
+		kindA, textA, okA := nextRangeToken(sa, aEnd)
+		kindB, textB, okB := nextRangeToken(sb, bEnd)
+		if !okA && !okB {
+			return true
+		}
+		if okA != okB || kindA != kindB || textA != textB {
+			return false
+		}
+	}
+}
+
+// rangeScanner pairs a scanner with its range end so nextRangeToken can
+// stop at the right place and truncate defensively against over-read.
+type rangeScanner struct {
+	s   *scanner.Scanner
+	end int
+}
+
+func openRangeScanner(sourceFile *ast.SourceFile, pos, end int) *rangeScanner {
+	if pos >= end {
+		return nil
+	}
+	return &rangeScanner{s: scanner.GetScannerForSourceFile(sourceFile, pos), end: end}
+}
+
+func nextRangeToken(rs *rangeScanner, end int) (ast.Kind, string, bool) {
+	if rs == nil || rs.s.Token() == ast.KindEndOfFile {
+		return 0, "", false
+	}
+	if rs.s.TokenStart() >= end {
+		return 0, "", false
+	}
+	// Defensive: don't accept a token that would spill past the gap end
+	// (can happen when a stray backtick inside the gap region gets
+	// scanned as a NoSubstitutionTemplateLiteral extending to the next
+	// backtick — rare in practice since template gaps are empty, but
+	// harmless to guard).
+	if rs.s.TokenEnd() > end {
+		return 0, "", false
+	}
+	kind := rs.s.Token()
+	text := rs.s.TokenText()
+	rs.s.Scan()
+	return kind, text, true
 }
 
 // IsArgumentOfSpecificCall reports whether `node` sits at argument position

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -288,6 +288,7 @@ export default defineConfig({
     './tests/eslint/rules/no-with.test.ts',
     './tests/eslint/rules/no-proto.test.ts',
     './tests/eslint/rules/no-return-assign.test.ts',
+    './tests/eslint/rules/no-self-compare.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-self-compare.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-self-compare.test.ts.snap
@@ -523,3 +523,81 @@ exports[`no-self-compare > invalid 20`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`no-self-compare > invalid 21`] = `
+{
+  "code": "+x === +x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 22`] = `
+{
+  "code": "x++ === x++",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 23`] = `
+{
+  "code": "'🍎' === '🍎'",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-self-compare.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-self-compare.test.ts.snap
@@ -1,0 +1,525 @@
+// Rstest Snapshot v1
+
+exports[`no-self-compare > invalid 1`] = `
+{
+  "code": "if (x === x) { }",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 2`] = `
+{
+  "code": "if (x !== x) { }",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 3`] = `
+{
+  "code": "if (x > x) { }",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 4`] = `
+{
+  "code": "if ('x' > 'x') { }",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 5`] = `
+{
+  "code": "do {} while (x === x)",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 6`] = `
+{
+  "code": "x === x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 7`] = `
+{
+  "code": "x !== x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 8`] = `
+{
+  "code": "x == x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 9`] = `
+{
+  "code": "x != x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 10`] = `
+{
+  "code": "x > x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 11`] = `
+{
+  "code": "x < x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 12`] = `
+{
+  "code": "x >= x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 13`] = `
+{
+  "code": "x <= x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 14`] = `
+{
+  "code": "foo.bar().baz.qux >= foo.bar ().baz .qux",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 15`] = `
+{
+  "code": "class C { #field; foo() { this.#field === this.#field; } }",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 16`] = `
+{
+  "code": "a.b.c === a.b.c",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 17`] = `
+{
+  "code": "a[0] === a[0]",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 18`] = `
+{
+  "code": "foo() === foo()",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 19`] = `
+{
+  "code": "(x) === x",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-self-compare > invalid 20`] = `
+{
+  "code": "if (
+  x
+  ===
+  x
+) {}",
+  "diagnostics": [
+    {
+      "message": "Comparing to itself is potentially pointless.",
+      "messageId": "comparingToSelf",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-self-compare",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-self-compare.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-self-compare.test.ts
@@ -1,0 +1,121 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-self-compare', {
+  valid: [
+    // ---- Upstream ESLint suite ----
+    `if (x === y) { }`,
+    `if (1 === 2) { }`,
+    `y=x*x`,
+    `foo.bar.baz === foo.bar.qux`,
+    `class C { #field; foo() { this.#field === this['#field']; } }`,
+    `class C { #field; foo() { this['#field'] === this.#field; } }`,
+
+    // ---- Non-comparison binary operators ----
+    `x + x`,
+    `x - x`,
+    `x * x`,
+    `x && x`,
+    `x || x`,
+    `x ?? x`,
+    `x, x`,
+    `x = x`,
+
+    // ---- Structurally different operands ----
+    `foo() === bar()`,
+    `a.b === a.c`,
+    `a[0] === a[1]`,
+    `a?.b === a.b`,
+
+    // ---- Different literal kinds / values ----
+    `1 === 1n`,
+    `1 === 2`,
+    `'a' === 'b'`,
+  ],
+  invalid: [
+    // ---- Upstream ESLint suite ----
+    {
+      code: `if (x === x) { }`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 5 }],
+    },
+    {
+      code: `if (x !== x) { }`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 5 }],
+    },
+    {
+      code: `if (x > x) { }`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 5 }],
+    },
+    {
+      code: `if ('x' > 'x') { }`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 5 }],
+    },
+    {
+      code: `do {} while (x === x)`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 14 }],
+    },
+    {
+      code: `x === x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x !== x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x == x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x != x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x > x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x < x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x >= x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x <= x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `foo.bar().baz.qux >= foo.bar ().baz .qux`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `class C { #field; foo() { this.#field === this.#field; } }`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 27 }],
+    },
+
+    // ---- Extra coverage ----
+    {
+      code: `a.b.c === a.b.c`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `a[0] === a[0]`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `foo() === foo()`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `(x) === x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: 'if (\n  x\n  ===\n  x\n) {}',
+      errors: [{ messageId: 'comparingToSelf', line: 2, column: 3 }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/no-self-compare.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-self-compare.test.ts
@@ -32,6 +32,12 @@ ruleTester.run('no-self-compare', {
     `1 === 1n`,
     `1 === 2`,
     `'a' === 'b'`,
+
+    // ---- Operator-sensitivity regression guards ----
+    `+x === -x`,
+    `++x === --x`,
+    `x++ === x--`,
+    `~x === !x`,
   ],
   invalid: [
     // ---- Upstream ESLint suite ----
@@ -116,6 +122,20 @@ ruleTester.run('no-self-compare', {
     {
       code: 'if (\n  x\n  ===\n  x\n) {}',
       errors: [{ messageId: 'comparingToSelf', line: 2, column: 3 }],
+    },
+    // ---- Unary self-compare (positive cases for the operator gate) ----
+    {
+      code: `+x === +x`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    {
+      code: `x++ === x++`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
+    },
+    // ---- Emoji (UTF-16 surrogate pair) inside string literal ----
+    {
+      code: `'🍎' === '🍎'`,
+      errors: [{ messageId: 'comparingToSelf', line: 1, column: 1 }],
     },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `no-self-compare` rule from ESLint to rslint. Disallows comparing a value to itself using any of the 8 equality/relational operators (`===`, `==`, `!==`, `!=`, `>`, `<`, `>=`, `<=`) — such comparisons are always trivially true/false (or `NaN`-sensitive) and typically indicate a typo.

Also introduces `utils.HasSameTokens`, a new helper in `internal/utils/ts_eslint.go` that mirrors ESLint's `sourceCode.getTokens()` semantics. Unlike `utils.AreNodesStructurallyEqual`, it preserves each literal's raw source form, so `'a'` ≠ `"a"`, `0x1` ≠ `1`, `1n` ≠ `0x1n` — matching ESLint 1:1 on these language-natural divergences. The helper is implemented as a structural AST walk that compares raw source text at each leaf via `scanner.GetSourceTextOfNodeFromSourceFile`, avoiding the template-literal re-scan limitation of a direct scanner-based approach.

Dogfood run: both `rsbuild` (1197 files) and `rspack` (392 files) produce 0 diagnostics; regex sweeps of both repos confirm no real self-compares were missed — all candidate hits were `obj.name OP name`-style patterns where the two operands are structurally distinct.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-self-compare
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-self-compare.js
- Upstream tests: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-self-compare.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).