### PR TITLE
feat: port rule no-regex-spaces

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,6 +176,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_param_reassign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_proto"
 	"github.com/web-infra-dev/rslint/internal/rules/no_prototype_builtins"
+	"github.com/web-infra-dev/rslint/internal/rules/no_regex_spaces"
 	"github.com/web-infra-dev/rslint/internal/rules/no_restricted_imports"
 	"github.com/web-infra-dev/rslint/internal/rules/no_return_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
@@ -585,6 +586,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)
 	GlobalRuleRegistry.Register("no-param-reassign", no_param_reassign.NoParamReassignRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)
+	GlobalRuleRegistry.Register("no-regex-spaces", no_regex_spaces.NoRegexSpacesRule)
 	GlobalRuleRegistry.Register("no-return-assign", no_return_assign.NoReturnAssignRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)

--- a/internal/rules/no_regex_spaces/no_regex_spaces.go
+++ b/internal/rules/no_regex_spaces/no_regex_spaces.go
@@ -1,0 +1,287 @@
+package no_regex_spaces
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var (
+	doubleSpaceRe   = regexp.MustCompile(` {2}`)
+	spacesPatternRe = regexp.MustCompile(`( {2,})(?: [+*{?]|[^+*{?]|$)`)
+)
+
+// https://eslint.org/docs/latest/rules/no-regex-spaces
+var NoRegexSpacesRule = rule.Rule{
+	Name: "no-regex-spaces",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		sf := ctx.SourceFile
+
+		reportAndMaybeFix := func(reportNode *ast.Node, pattern, rawPattern string, rawPatternStart int, flags utils.RegexFlags) {
+			// Fast path: skip if raw source has no consecutive spaces. This mirrors
+			// ESLint's early-out — avoids false positives like RegExp(' \ ') where
+			// the parsed pattern has two adjacent spaces but the source doesn't.
+			if !doubleSpaceRe.MatchString(rawPattern) {
+				return
+			}
+
+			// Match ESLint's `try { regExpParser.parsePattern(...) } catch { return }`:
+			// skip any pattern that fails to parse under its flags.
+			if !isValidRegexPattern(pattern, flags) {
+				return
+			}
+
+			classRanges := collectClassRanges(pattern, flags)
+
+			matches := spacesPatternRe.FindAllStringSubmatchIndex(pattern, -1)
+			for _, m := range matches {
+				index := m[2]
+				length := m[3] - m[2]
+
+				if indexInAnyRange(index, classRanges) {
+					continue
+				}
+
+				msg := rule.RuleMessage{
+					Id:          "multipleSpaces",
+					Description: fmt.Sprintf("Spaces are hard to count. Use {%d}.", length),
+				}
+				if pattern == rawPattern {
+					fix := rule.RuleFixReplaceRange(
+						core.NewTextRange(rawPatternStart+index, rawPatternStart+index+length),
+						fmt.Sprintf(" {%d}", length),
+					)
+					ctx.ReportNodeWithFixes(reportNode, msg, fix)
+				} else {
+					ctx.ReportNode(reportNode, msg)
+				}
+				// Report only the first occurrence of consecutive spaces.
+				return
+			}
+		}
+
+		checkRegExpConstructor := func(callee *ast.Node, args *ast.NodeList, reportNode *ast.Node) {
+			callee = ast.SkipParentheses(callee)
+			if callee == nil || callee.Kind != ast.KindIdentifier || callee.AsIdentifier().Text != "RegExp" {
+				return
+			}
+			if utils.IsShadowed(callee, "RegExp") {
+				return
+			}
+			if args == nil || len(args.Nodes) == 0 {
+				return
+			}
+
+			patternNode := args.Nodes[0]
+			if patternNode.Kind != ast.KindStringLiteral {
+				return
+			}
+			pattern := patternNode.AsStringLiteral().Text
+
+			patternRange := utils.TrimNodeTextRange(sf, patternNode)
+			rawFull := sf.Text()[patternRange.Pos():patternRange.End()]
+			if len(rawFull) < 2 {
+				return
+			}
+			rawPattern := rawFull[1 : len(rawFull)-1]
+			rawPatternStart := patternRange.Pos() + 1
+
+			flagsStr := ""
+			if len(args.Nodes) >= 2 {
+				flagsNode := args.Nodes[1]
+				if flagsNode.Kind != ast.KindStringLiteral {
+					// Flags cannot be determined — ESLint skips in this case.
+					return
+				}
+				flagsStr = flagsNode.AsStringLiteral().Text
+			}
+
+			reportAndMaybeFix(reportNode, pattern, rawPattern, rawPatternStart, utils.ParseRegexFlags(flagsStr))
+		}
+
+		return rule.RuleListeners{
+			ast.KindRegularExpressionLiteral: func(node *ast.Node) {
+				text := node.Text()
+				pattern, flagsStr := utils.ExtractRegexPatternAndFlags(text)
+				if pattern == "" {
+					return
+				}
+				nodeRange := utils.TrimNodeTextRange(sf, node)
+				rawPatternStart := nodeRange.Pos() + 1
+				reportAndMaybeFix(node, pattern, pattern, rawPatternStart, utils.ParseRegexFlags(flagsStr))
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				checkRegExpConstructor(call.Expression, call.Arguments, node)
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				newExpr := node.AsNewExpression()
+				checkRegExpConstructor(newExpr.Expression, newExpr.Arguments, node)
+			},
+		}
+	},
+}
+
+// collectClassRanges returns byte ranges [start, end) for every character class
+// in the pattern (including v-flag nested classes). Ranges are sorted by start
+// and may overlap (outer wraps inner).
+func collectClassRanges(pattern string, flags utils.RegexFlags) []classRange {
+	var ranges []classRange
+	utils.IterateRegexCharacterClasses(pattern, flags, func(start, end int) {
+		ranges = append(ranges, classRange{start: start, end: end})
+	})
+	// IterateRegexCharacterClasses under v-flag visits nested classes first,
+	// so sort ascending to let binary search short-circuit.
+	sort.Slice(ranges, func(i, j int) bool { return ranges[i].start < ranges[j].start })
+	return ranges
+}
+
+type classRange struct {
+	start int
+	end   int
+}
+
+func indexInAnyRange(idx int, ranges []classRange) bool {
+	for _, cr := range ranges {
+		if idx < cr.start {
+			return false
+		}
+		if idx < cr.end {
+			return true
+		}
+	}
+	return false
+}
+
+// isValidRegexPattern reports whether the pattern parses cleanly under its
+// flags, mirroring ESLint's `regexpp.parsePattern` try/catch. We combine two
+// checks:
+//
+//   - regexp2 compile catches structural errors (unclosed `[`, unmatched
+//     quantifier under Unicode mode, bad hex escapes, etc.).
+//   - A narrow u-flag identity-escape check for the handful of escapes
+//     regexp2 accepts but ES-u-mode rejects (`\a`, `\9`, …). ESLint rejects
+//     these under u/v, and silently skipping them keeps us aligned.
+//
+// If ANY check fails the pattern is treated as unparsable and the rule
+// skips reporting — matching ESLint.
+func isValidRegexPattern(pattern string, flags utils.RegexFlags) bool {
+	var opt regexp2.RegexOptions = regexp2.ECMAScript
+	if flags.UV() {
+		opt |= regexp2.Unicode
+	}
+	if _, err := regexp2.Compile(pattern, opt); err != nil {
+		return false
+	}
+	if flags.UV() {
+		if hasInvalidIdentityEscapeForUFlag(pattern) {
+			return false
+		}
+		if hasUnmatchedBraceForUFlag(pattern) {
+			return false
+		}
+	}
+	return true
+}
+
+// hasUnmatchedBraceForUFlag reports whether the pattern contains a literal `{`
+// that is not part of a valid `{n}` / `{n,}` / `{n,m}` quantifier or a
+// recognized `\u{...}` / `\p{...}` / `\q{...}` escape. Under the u/v flag this
+// is a SyntaxError per ECMAScript, but regexp2 accepts it (its .NET lineage
+// treats a bare `{` as literal). The scan is outside character classes only —
+// inside a class, `{` is always literal.
+func hasUnmatchedBraceForUFlag(pattern string) bool {
+	inClass := false
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		if c == '\\' {
+			if i+1 >= len(pattern) {
+				return false
+			}
+			i += 2
+			continue
+		}
+		if c == '[' && !inClass {
+			inClass = true
+			i++
+			continue
+		}
+		if c == ']' && inClass {
+			inClass = false
+			i++
+			continue
+		}
+		if inClass {
+			i++
+			continue
+		}
+		if c == '{' && !looksLikeQuantifier(pattern, i) {
+			return true
+		}
+		i++
+	}
+	return false
+}
+
+// looksLikeQuantifier reports whether pattern[start] opens a valid
+// `{n}` / `{n,}` / `{n,m}` quantifier.
+func looksLikeQuantifier(pattern string, start int) bool {
+	i := start + 1
+	digits := 0
+	for i < len(pattern) && pattern[i] >= '0' && pattern[i] <= '9' {
+		i++
+		digits++
+	}
+	if digits == 0 {
+		return false
+	}
+	if i < len(pattern) && pattern[i] == ',' {
+		i++
+		for i < len(pattern) && pattern[i] >= '0' && pattern[i] <= '9' {
+			i++
+		}
+	}
+	return i < len(pattern) && pattern[i] == '}'
+}
+
+// hasInvalidIdentityEscapeForUFlag scans for escapes that ECMAScript u/v mode
+// rejects but regexp2 accepts. Conservative: on malformed input it returns
+// false (i.e. defers to regexp2's verdict) rather than inventing an error.
+func hasInvalidIdentityEscapeForUFlag(pattern string) bool {
+	i := 0
+	for i < len(pattern) {
+		c := pattern[i]
+		if c != '\\' || i+1 >= len(pattern) {
+			i++
+			continue
+		}
+		next := pattern[i+1]
+		switch next {
+		// Recognized single-letter escapes.
+		case 'd', 'D', 'w', 'W', 's', 'S', 'b', 'B', 'n', 't', 'r', 'v', 'f', '0',
+			'x', 'u', 'c', 'p', 'P', 'k', 'q',
+			// SyntaxCharacter / `/` — legal identity escapes under u.
+			'^', '$', '.', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|', '\\', '/':
+			i += 2
+			continue
+		}
+		// Decimal backreference (\1..\9) is legal.
+		if next >= '1' && next <= '9' {
+			i += 2
+			continue
+		}
+		// Any letter/digit identity escape not recognized above is illegal under u.
+		if (next >= 'a' && next <= 'z') || (next >= 'A' && next <= 'Z') {
+			return true
+		}
+		i += 2
+	}
+	return false
+}

--- a/internal/rules/no_regex_spaces/no_regex_spaces.md
+++ b/internal/rules/no_regex_spaces/no_regex_spaces.md
@@ -34,19 +34,6 @@ contains escape sequences that differ from the raw source (e.g.
 `new RegExp('\\d  ')`), the rule reports but does not autofix — the index into
 the parsed pattern would not map cleanly back to source positions.
 
-## Implementation Notes
-
-Character-class boundaries are walked via `utils.IterateRegexCharacterClasses`
-(shared with `no-misleading-character-class`), so regular classes, v-flag
-nested classes, and `\q{...}` string disjunction are all handled uniformly.
-
-Pattern syntax is validated with `regexp2` (ECMAScript mode, plus Unicode when
-`u` or `v` is set), supplemented by narrow checks for two classes of construct
-that ECMAScript u/v-mode rejects but regexp2's .NET lineage accepts: identity
-escapes on letters/digits (`\a`, `\9`) and a bare `{` that doesn't open a valid
-quantifier. Patterns that fail validation are skipped, matching ESLint's
-`regexpp.parsePattern` try/catch behavior.
-
 ## Original Documentation
 
 - ESLint rule: <https://eslint.org/docs/latest/rules/no-regex-spaces>

--- a/internal/rules/no_regex_spaces/no_regex_spaces.md
+++ b/internal/rules/no_regex_spaces/no_regex_spaces.md
@@ -1,0 +1,53 @@
+# no-regex-spaces
+
+## Rule Details
+
+Disallow multiple spaces in regular expressions. Two or more consecutive space
+characters are hard to count by eye; an explicit `{n}` quantifier expresses the
+same pattern unambiguously. The rule applies to both regex literals and the
+`RegExp` / `new RegExp` constructors (skipped when `RegExp` is shadowed in the
+enclosing scope or when the flags argument cannot be statically determined).
+Consecutive spaces inside character classes (`[...]`) are intentionally allowed
+and not reported.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var re = /foo   bar/;
+var re = new RegExp('foo   bar');
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var re = /foo {3}bar/;
+var re = new RegExp('foo {3}bar');
+var re = /[  ]/;
+```
+
+## Autofix
+
+When the parsed pattern and the raw source text agree (typically any regex
+literal, and `RegExp` / `new RegExp` calls whose pattern string contains no
+escape sequences), the rule rewrites `  ` into ` {n}`. When the pattern
+contains escape sequences that differ from the raw source (e.g.
+`new RegExp('\\d  ')`), the rule reports but does not autofix — the index into
+the parsed pattern would not map cleanly back to source positions.
+
+## Implementation Notes
+
+Character-class boundaries are walked via `utils.IterateRegexCharacterClasses`
+(shared with `no-misleading-character-class`), so regular classes, v-flag
+nested classes, and `\q{...}` string disjunction are all handled uniformly.
+
+Pattern syntax is validated with `regexp2` (ECMAScript mode, plus Unicode when
+`u` or `v` is set), supplemented by narrow checks for two classes of construct
+that ECMAScript u/v-mode rejects but regexp2's .NET lineage accepts: identity
+escapes on letters/digits (`\a`, `\9`) and a bare `{` that doesn't open a valid
+quantifier. Patterns that fail validation are skipped, matching ESLint's
+`regexpp.parsePattern` try/catch behavior.
+
+## Original Documentation
+
+- ESLint rule: <https://eslint.org/docs/latest/rules/no-regex-spaces>
+- Source code: <https://github.com/eslint/eslint/blob/main/lib/rules/no-regex-spaces.js>

--- a/internal/rules/no_regex_spaces/no_regex_spaces_test.go
+++ b/internal/rules/no_regex_spaces/no_regex_spaces_test.go
@@ -1,0 +1,312 @@
+package no_regex_spaces
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRegexSpacesRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoRegexSpacesRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Baseline: no consecutive spaces ----
+			{Code: `var foo = /foo/;`},
+			{Code: `var foo = RegExp('foo')`},
+			{Code: `var foo = / /;`},
+			{Code: `var foo = RegExp(' ')`},
+			{Code: `var foo = / a b c d /;`},
+
+			// ---- Single space followed by explicit quantifier ----
+			{Code: `var foo = /bar {3}baz/g;`},
+			{Code: `var foo = RegExp('bar {3}baz', 'g')`},
+			{Code: `var foo = new RegExp('bar {3}baz')`},
+			{Code: `var foo = /  +/;`},
+			{Code: `var foo = /  ?/;`},
+			{Code: `var foo = /  */;`},
+			{Code: `var foo = /  {2}/;`},
+
+			// ---- Tabs / non-space whitespace don't count ----
+			{Code: "var foo = /bar\t\t\tbaz/;"},
+			{Code: "var foo = RegExp('bar\t\t\tbaz');"},
+			{Code: "var foo = new RegExp('bar\t\t\tbaz');"},
+
+			// ---- RegExp is shadowed in the enclosing scope ----
+			{Code: `var RegExp = function() {}; var foo = new RegExp('bar   baz');`},
+			{Code: `var RegExp = function() {}; var foo = RegExp('bar   baz');`},
+
+			// ---- No consecutive spaces in the source code ----
+			{Code: `var foo = /bar \ baz/;`},
+			{Code: `var foo = /bar\ \ baz/;`},
+			{Code: `var foo = /bar \u0020 baz/;`},
+			{Code: `var foo = /bar\u0020\u0020baz/;`},
+			{Code: `var foo = new RegExp('bar \ baz')`},
+			{Code: `var foo = new RegExp('bar\ \ baz')`},
+			{Code: `var foo = new RegExp('bar \\ baz')`},
+			{Code: `var foo = new RegExp('bar \u0020 baz')`},
+			{Code: `var foo = new RegExp('bar\u0020\u0020baz')`},
+			{Code: `var foo = new RegExp('bar \\u0020 baz')`},
+
+			// ---- Spaces inside character classes ----
+			{Code: `var foo = /[  ]/;`},
+			{Code: `var foo = /[   ]/;`},
+			{Code: `var foo = / [  ] /;`},
+			{Code: `var foo = / [  ] [  ] /;`},
+			{Code: `var foo = new RegExp('[  ]');`},
+			{Code: `var foo = new RegExp('[   ]');`},
+			{Code: `var foo = new RegExp(' [  ] ');`},
+			{Code: `var foo = RegExp(' [  ] [  ] ');`},
+			{Code: `var foo = new RegExp(' \[   ');`},
+			{Code: `var foo = new RegExp(' \[   \] ');`},
+
+			// ---- ES2024 (v flag) ----
+			{Code: `var foo = /  {2}/v;`},
+			{Code: `var foo = /[\q{    }]/v;`},
+
+			// ---- Syntactically invalid patterns — ESLint skips via parse error ----
+			{Code: `var foo = new RegExp('[  ');`},
+			{Code: `var foo = new RegExp('{  ', 'u');`},
+			{Code: `var foo = new RegExp('{  ', 'v');`},
+
+			// ---- Flags cannot be determined ----
+			{Code: `new RegExp('  ', flags)`},
+			{Code: `new RegExp('[[abc]  ]', flags + 'v')`},
+			{Code: `new RegExp('[[abc]\q{  }]', flags + 'v')`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Regex literals ----
+			{
+				Code:   `var foo = /bar  baz/;`,
+				Output: []string{`var foo = /bar {2}baz/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = /bar    baz/;`,
+				Output: []string{`var foo = /bar {4}baz/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = / a b  c d /;`,
+				Output: []string{`var foo = / a b {2}c d /;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- RegExp constructor ----
+			{
+				Code:   `var foo = RegExp(' a b c d  ');`,
+				Output: []string{`var foo = RegExp(' a b c d {2}');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = RegExp('bar    baz');`,
+				Output: []string{`var foo = RegExp('bar {4}baz');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = new RegExp('bar    baz');`,
+				Output: []string{`var foo = new RegExp('bar {4}baz');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- RegExp not shadowed where it's called ----
+			{
+				Code:   `{ let RegExp = function() {}; } var foo = RegExp('bar    baz');`,
+				Output: []string{`{ let RegExp = function() {}; } var foo = RegExp('bar {4}baz');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 43},
+				},
+			},
+
+			// ---- Space runs followed by a quantifier — trailing space is quantified ----
+			{
+				Code:   `var foo = /bar   {3}baz/;`,
+				Output: []string{`var foo = /bar {2} {3}baz/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = /bar    ?baz/;`,
+				Output: []string{`var foo = /bar {3} ?baz/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = new RegExp('bar   *baz')`,
+				Output: []string{`var foo = new RegExp('bar {2} *baz')`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = RegExp('bar   +baz')`,
+				Output: []string{`var foo = RegExp('bar {2} +baz')`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = new RegExp('bar    ');`,
+				Output: []string{`var foo = new RegExp('bar {4}');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Escaped backslash + spaces in regex literal ----
+			{
+				Code:   `var foo = /bar\  baz/;`,
+				Output: []string{`var foo = /bar\ {2}baz/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Spaces outside character classes ----
+			{
+				Code:   `var foo = /[   ]  /;`,
+				Output: []string{`var foo = /[   ] {2}/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = /  [   ] /;`,
+				Output: []string{`var foo = / {2}[   ] /;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = new RegExp('[   ]  ');`,
+				Output: []string{`var foo = new RegExp('[   ] {2}');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = RegExp('  [ ]');`,
+				Output: []string{`var foo = RegExp(' {2}[ ]');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Escaped brackets don't open character classes ----
+			{
+				Code:   `var foo = /\[  /;`,
+				Output: []string{`var foo = /\[ {2}/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = /\[  \]/;`,
+				Output: []string{`var foo = /\[ {2}\]/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Non-capturing groups and assertions ----
+			{
+				Code:   `var foo = /(?:  )/;`,
+				Output: []string{`var foo = /(?: {2})/;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = RegExp('^foo(?=   )');`,
+				Output: []string{`var foo = RegExp('^foo(?= {3})');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Escape of the space character ----
+			{
+				Code:   `var foo = /\  /`,
+				Output: []string{`var foo = /\ {2}/`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = / \  /`,
+				Output: []string{`var foo = / \ {2}/`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Report only the first occurrence per pass; the rule tester
+			// re-runs the fix until stable, so a second pass catches the later
+			// run that the first pass left intact. Errors asserts against the
+			// FIRST-pass diagnostics only.
+			{
+				Code: `var foo = /  foo   /;`,
+				Output: []string{
+					`var foo = / {2}foo   /;`,
+					`var foo = / {2}foo {3}/;`,
+				},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Strings containing escape sequences — report but no fix ----
+			{
+				Code: `var foo = new RegExp('\\d  ')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: `var foo = RegExp('\u0041   ')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code: `var foo = new RegExp('\\[  \\]');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- ES2024 v-flag: nested character classes ----
+			{
+				Code:   `var foo = /[[    ]    ]    /v;`,
+				Output: []string{`var foo = /[[    ]    ] {4}/v;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:   `var foo = new RegExp('[[    ]    ]    ', 'v');`,
+				Output: []string{`var foo = new RegExp('[[    ]    ] {4}', 'v');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multipleSpaces", Line: 1, Column: 11},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -260,6 +260,7 @@ export default defineConfig({
     './tests/eslint/rules/no-fallthrough.test.ts',
     './tests/eslint/rules/no-invalid-regexp.test.ts',
     './tests/eslint/rules/no-misleading-character-class.test.ts',
+    './tests/eslint/rules/no-regex-spaces.test.ts',
     './tests/eslint/rules/no-new-symbol.test.ts',
     './tests/eslint/rules/no-restricted-imports.test.ts',
     './tests/eslint/rules/no-obj-calls.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-regex-spaces.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-regex-spaces.test.ts.snap
@@ -1,0 +1,755 @@
+// Rstest Snapshot v1
+
+exports[`no-regex-spaces > invalid 1`] = `
+{
+  "code": "var foo = /bar  baz/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 2`] = `
+{
+  "code": "var foo = /bar    baz/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 3`] = `
+{
+  "code": "var foo = / a b  c d /;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 4`] = `
+{
+  "code": "var foo = RegExp(' a b c d  ');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 5`] = `
+{
+  "code": "var foo = RegExp('bar    baz');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 6`] = `
+{
+  "code": "var foo = new RegExp('bar    baz');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 7`] = `
+{
+  "code": "{ let RegExp = function() {}; } var foo = RegExp('bar    baz');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 8`] = `
+{
+  "code": "var foo = /bar   {3}baz/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 9`] = `
+{
+  "code": "var foo = /bar    ?baz/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {3}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 10`] = `
+{
+  "code": "var foo = new RegExp('bar   *baz')",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 11`] = `
+{
+  "code": "var foo = RegExp('bar   +baz')",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 12`] = `
+{
+  "code": "var foo = new RegExp('bar    ');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 13`] = `
+{
+  "code": "var foo = /bar\\  baz/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 14`] = `
+{
+  "code": "var foo = /[   ]  /;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 15`] = `
+{
+  "code": "var foo = /  [   ] /;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 16`] = `
+{
+  "code": "var foo = new RegExp('[   ]  ');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 17`] = `
+{
+  "code": "var foo = RegExp('  [ ]');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 18`] = `
+{
+  "code": "var foo = /\\[  /;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 19`] = `
+{
+  "code": "var foo = /\\[  \\]/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 20`] = `
+{
+  "code": "var foo = /(?:  )/;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 21`] = `
+{
+  "code": "var foo = RegExp('^foo(?=   )');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {3}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 22`] = `
+{
+  "code": "var foo = /\\  /",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 23`] = `
+{
+  "code": "var foo = / \\  /",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 24`] = `
+{
+  "code": "var foo = /  foo   /;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 25`] = `
+{
+  "code": "var foo = new RegExp('\\d  ')",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 26`] = `
+{
+  "code": "var foo = RegExp('\\u0041   ')",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {3}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 27`] = `
+{
+  "code": "var foo = new RegExp('\\\\[  \\\\]');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {2}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 28`] = `
+{
+  "code": "var foo = /[[    ]    ]    /v;",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-regex-spaces > invalid 29`] = `
+{
+  "code": "var foo = new RegExp('[[    ]    ]    ', 'v');",
+  "diagnostics": [
+    {
+      "message": "Spaces are hard to count. Use {4}.",
+      "messageId": "multipleSpaces",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-regex-spaces",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-regex-spaces.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-regex-spaces.test.ts
@@ -1,0 +1,203 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-regex-spaces', {
+  valid: [
+    // Baseline: no consecutive spaces
+    'var foo = /foo/;',
+    "var foo = RegExp('foo')",
+    'var foo = / /;',
+    "var foo = RegExp(' ')",
+    'var foo = / a b c d /;',
+
+    // Single space followed by explicit quantifier
+    'var foo = /bar {3}baz/g;',
+    "var foo = RegExp('bar {3}baz', 'g')",
+    "var foo = new RegExp('bar {3}baz')",
+    'var foo = /  +/;',
+    'var foo = /  ?/;',
+    'var foo = /  */;',
+    'var foo = /  {2}/;',
+
+    // Tabs / non-space whitespace don't count
+    'var foo = /bar\t\t\tbaz/;',
+    "var foo = RegExp('bar\t\t\tbaz');",
+    "var foo = new RegExp('bar\t\t\tbaz');",
+
+    // RegExp shadowed in the enclosing scope
+    "var RegExp = function() {}; var foo = new RegExp('bar   baz');",
+    "var RegExp = function() {}; var foo = RegExp('bar   baz');",
+
+    // No consecutive spaces in the source
+    String.raw`var foo = /bar \ baz/;`,
+    String.raw`var foo = /bar\ \ baz/;`,
+    String.raw`var foo = /bar \u0020 baz/;`,
+    String.raw`var foo = /bar\u0020\u0020baz/;`,
+    String.raw`var foo = new RegExp('bar \ baz')`,
+    String.raw`var foo = new RegExp('bar\ \ baz')`,
+    String.raw`var foo = new RegExp('bar \\ baz')`,
+    String.raw`var foo = new RegExp('bar \u0020 baz')`,
+    String.raw`var foo = new RegExp('bar\u0020\u0020baz')`,
+    String.raw`var foo = new RegExp('bar \\u0020 baz')`,
+
+    // Spaces inside character classes
+    'var foo = /[  ]/;',
+    'var foo = /[   ]/;',
+    'var foo = / [  ] /;',
+    'var foo = / [  ] [  ] /;',
+    "var foo = new RegExp('[  ]');",
+    "var foo = new RegExp('[   ]');",
+    "var foo = new RegExp(' [  ] ');",
+    "var foo = RegExp(' [  ] [  ] ');",
+    String.raw`var foo = new RegExp(' \[   ');`,
+    String.raw`var foo = new RegExp(' \[   \] ');`,
+
+    // ES2024 v flag
+    'var foo = /  {2}/v;',
+    String.raw`var foo = /[\q{    }]/v;`,
+
+    // Invalid regex — skipped to match ESLint's parsePattern try/catch
+    "var foo = new RegExp('[  ');",
+    "var foo = new RegExp('{  ', 'u');",
+    "var foo = new RegExp('{  ', 'v');",
+
+    // Flags cannot be determined
+    "new RegExp('  ', flags)",
+    "new RegExp('[[abc]  ]', flags + 'v')",
+    String.raw`new RegExp('[[abc]\q{  }]', flags + 'v')`,
+  ],
+  invalid: [
+    {
+      code: 'var foo = /bar  baz/;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: 'var foo = /bar    baz/;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: 'var foo = / a b  c d /;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    {
+      code: "var foo = RegExp(' a b c d  ');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = RegExp('bar    baz');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = new RegExp('bar    baz');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // RegExp not shadowed where it's called
+    {
+      code: "{ let RegExp = function() {}; } var foo = RegExp('bar    baz');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Space runs followed by a quantifier
+    {
+      code: 'var foo = /bar   {3}baz/;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: 'var foo = /bar    ?baz/;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = new RegExp('bar   *baz')",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = RegExp('bar   +baz')",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = new RegExp('bar    ');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Escaped backslash + spaces in regex literal
+    {
+      code: String.raw`var foo = /bar\  baz/;`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Spaces outside character classes
+    { code: 'var foo = /[   ]  /;', errors: [{ messageId: 'multipleSpaces' }] },
+    {
+      code: 'var foo = /  [   ] /;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = new RegExp('[   ]  ');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = RegExp('  [ ]');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Escaped brackets don't open a class
+    {
+      code: String.raw`var foo = /\[  /;`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: String.raw`var foo = /\[  \]/;`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Non-capturing groups / assertions
+    { code: 'var foo = /(?:  )/;', errors: [{ messageId: 'multipleSpaces' }] },
+    {
+      code: "var foo = RegExp('^foo(?=   )');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Escape of the space character
+    {
+      code: String.raw`var foo = /\  /`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: String.raw`var foo = / \  /`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Report only the first occurrence of consecutive spaces
+    {
+      code: 'var foo = /  foo   /;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // Strings containing escape sequences — report but no fix
+    {
+      code: String.raw`var foo = new RegExp('\d  ')`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: String.raw`var foo = RegExp('\u0041   ')`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: String.raw`var foo = new RegExp('\\[  \\]');`,
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+
+    // ES2024 v-flag: nested character classes
+    {
+      code: 'var foo = /[[    ]    ]    /v;',
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+    {
+      code: "var foo = new RegExp('[[    ]    ]    ', 'v');",
+      errors: [{ messageId: 'multipleSpaces' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-regex-spaces` rule from ESLint to rslint.

Flags 2+ consecutive spaces in regex literals and `RegExp` / `new RegExp` constructor calls, and autofixes them to ` {n}` when the raw source and parsed pattern agree. Character-class scanning uses `utils.IterateRegexCharacterClasses` (shared with `no-misleading-character-class`), so regular classes, ES2024 v-flag nested classes, and `\q{...}` string disjunction are all handled uniformly. Pattern syntax is validated with `regexp2` in ECMAScript mode (plus `Unicode` under `u` / `v`), supplemented by narrow checks for u/v-mode constructs regexp2 accepts but ECMAScript rejects (identity escapes on letters/digits, bare `{` that doesn't open a valid quantifier), so patterns ESLint's `regexpp.parsePattern` would throw on are skipped.

Every ESLint upstream test case is covered 1:1 in both Go and JS tests — no `Skip: true`. Cross-validated against ESLint on a curated 40-case matrix (29 invalid + 11 valid): `(line, column, message)` triples byte-identical across both tools. Also ran the built binary over rsbuild (1197 files, 2.4s) and rspack (392 files, 7.2s); both produce 0 reports, matching ESLint.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-regex-spaces
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-regex-spaces.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).