### PR TITLE
feat: port rule no-unneeded-ternary

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -189,6 +189,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef_init"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
+	"github.com/web-infra-dev/rslint/internal/rules/no_unneeded_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
@@ -596,6 +597,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)
 	GlobalRuleRegistry.Register("no-extra-boolean-cast", no_extra_boolean_cast.NoExtraBooleanCastRule)
+	GlobalRuleRegistry.Register("no-unneeded-ternary", no_unneeded_ternary.NoUnneededTernaryRule)
 	GlobalRuleRegistry.Register("no-undef", no_undef.NoUndefRule)
 	GlobalRuleRegistry.Register("no-undef-init", no_undef_init.NoUndefInitRule)
 	GlobalRuleRegistry.Register("prefer-const", prefer_const.PreferConstRule)

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary.go
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary.go
@@ -1,0 +1,311 @@
+package no_unneeded_ternary
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-unneeded-ternary
+
+type options struct {
+	defaultAssignment bool
+}
+
+func parseOptions(opts any) options {
+	result := options{defaultAssignment: true}
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap == nil {
+		return result
+	}
+	if v, ok := optsMap["defaultAssignment"].(bool); ok {
+		result.defaultAssignment = v
+	}
+	return result
+}
+
+// boolKind reports whether node (after peeling parens) is a `true`/`false`
+// keyword and returns its boolean value.
+func boolKind(node *ast.Node) (bool, bool) {
+	inner := ast.SkipParentheses(node)
+	switch inner.Kind {
+	case ast.KindTrueKeyword:
+		return true, true
+	case ast.KindFalseKeyword:
+		return false, true
+	}
+	return false, false
+}
+
+// isBooleanExpression mirrors ESLint's helper: a node is a guaranteed boolean
+// when it is a comparison BinaryExpression or `!expr`. tsgo uses
+// PrefixUnaryExpression for `!`.
+func isBooleanExpression(node *ast.Node) bool {
+	inner := ast.SkipParentheses(node)
+	switch inner.Kind {
+	case ast.KindBinaryExpression:
+		op := inner.AsBinaryExpression().OperatorToken
+		if op == nil {
+			return false
+		}
+		switch op.Kind {
+		case ast.KindEqualsEqualsToken, ast.KindEqualsEqualsEqualsToken,
+			ast.KindExclamationEqualsToken, ast.KindExclamationEqualsEqualsToken,
+			ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken,
+			ast.KindLessThanToken, ast.KindLessThanEqualsToken,
+			ast.KindInKeyword, ast.KindInstanceOfKeyword:
+			return true
+		}
+	case ast.KindPrefixUnaryExpression:
+		return inner.AsPrefixUnaryExpression().Operator == ast.KindExclamationToken
+	}
+	return false
+}
+
+// inverseOperatorString returns the swapped equality operator text and true
+// when the operator has an inverse, mirroring ESLint's OPERATOR_INVERSES map.
+// (Only ==/!= and ===/!== have safe inverses; relational operators like
+// `<`/`>=` do not, since both sides return false for NaN.)
+func inverseOperatorString(op ast.Kind) (string, bool) {
+	switch op {
+	case ast.KindEqualsEqualsToken:
+		return "!=", true
+	case ast.KindExclamationEqualsToken:
+		return "==", true
+	case ast.KindEqualsEqualsEqualsToken:
+		return "!==", true
+	case ast.KindExclamationEqualsEqualsToken:
+		return "===", true
+	}
+	return "", false
+}
+
+// eslintLikePrecedence returns a numeric precedence matching ESLint's
+// astUtils.getPrecedence so behavior parity holds for tsgo nodes that ESLint
+// classifies (e.g. ArrowFunction = 1, ConditionalExpression = 3). Returns -1
+// for TypeScript-only kinds (AsExpression, etc.) so the caller wraps them in
+// parentheses defensively, matching ESLint's behavior on unknown node types.
+func eslintLikePrecedence(node *ast.Node) int {
+	switch node.Kind {
+	case ast.KindArrowFunction:
+		return 1
+	case ast.KindYieldExpression:
+		return 1
+	case ast.KindConditionalExpression:
+		return 3
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin.OperatorToken == nil {
+			return -1
+		}
+		op := bin.OperatorToken.Kind
+		if op == ast.KindCommaToken {
+			return 0
+		}
+		if ast.IsAssignmentOperator(op) {
+			return 1
+		}
+		switch op {
+		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+			return 4
+		case ast.KindAmpersandAmpersandToken:
+			return 5
+		case ast.KindBarToken:
+			return 6
+		case ast.KindCaretToken:
+			return 7
+		case ast.KindAmpersandToken:
+			return 8
+		case ast.KindEqualsEqualsToken, ast.KindExclamationEqualsToken,
+			ast.KindEqualsEqualsEqualsToken, ast.KindExclamationEqualsEqualsToken:
+			return 9
+		case ast.KindLessThanToken, ast.KindLessThanEqualsToken,
+			ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken,
+			ast.KindInKeyword, ast.KindInstanceOfKeyword:
+			return 10
+		case ast.KindLessThanLessThanToken, ast.KindGreaterThanGreaterThanToken,
+			ast.KindGreaterThanGreaterThanGreaterThanToken:
+			return 11
+		case ast.KindPlusToken, ast.KindMinusToken:
+			return 12
+		case ast.KindAsteriskToken, ast.KindSlashToken, ast.KindPercentToken:
+			return 13
+		case ast.KindAsteriskAsteriskToken:
+			return 15
+		}
+		return 20
+	case ast.KindPrefixUnaryExpression:
+		op := node.AsPrefixUnaryExpression().Operator
+		if op == ast.KindPlusPlusToken || op == ast.KindMinusMinusToken {
+			return 17
+		}
+		return 16
+	case ast.KindPostfixUnaryExpression:
+		return 17
+	case ast.KindAwaitExpression, ast.KindDeleteExpression,
+		ast.KindVoidExpression, ast.KindTypeOfExpression:
+		return 16
+	case ast.KindCallExpression:
+		return 18
+	case ast.KindNewExpression:
+		return 19
+	case ast.KindIdentifier, ast.KindThisKeyword, ast.KindSuperKeyword,
+		ast.KindNullKeyword, ast.KindTrueKeyword, ast.KindFalseKeyword,
+		ast.KindNumericLiteral, ast.KindStringLiteral, ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral, ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTemplateExpression, ast.KindArrayLiteralExpression,
+		ast.KindObjectLiteralExpression, ast.KindFunctionExpression,
+		ast.KindClassExpression, ast.KindParenthesizedExpression,
+		ast.KindPropertyAccessExpression, ast.KindElementAccessExpression,
+		ast.KindTaggedTemplateExpression, ast.KindSpreadElement,
+		ast.KindMetaProperty:
+		return 20
+	}
+	// TypeScript-specific (AsExpression, SatisfiesExpression,
+	// TypeAssertionExpression, ...) and any other kind ESLint does not
+	// classify: ESLint returns -1 to force wrapping for safety.
+	return -1
+}
+
+// isCoalesceExpression reports whether node (after parens) is a `??`
+// BinaryExpression. Mirrors ESLint's astUtils.isCoalesceExpression.
+func isCoalesceExpression(node *ast.Node) bool {
+	if node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	op := node.AsBinaryExpression().OperatorToken
+	return op != nil && op.Kind == ast.KindQuestionQuestionToken
+}
+
+// invertExpression returns source text for the boolean inverse of testNode.
+// testNode is the raw `cond.Condition` (still wrapped in any parens). Mirrors
+// ESLint's invertExpression: swap ==/=== style operators in place when
+// possible, otherwise prefix with `!` and parenthesize when precedence
+// requires it.
+func invertExpression(sf *ast.SourceFile, testNode *ast.Node) string {
+	inner := ast.SkipParentheses(testNode)
+	if inner.Kind == ast.KindBinaryExpression {
+		bin := inner.AsBinaryExpression()
+		if bin.OperatorToken != nil {
+			if invOp, ok := inverseOperatorString(bin.OperatorToken.Kind); ok {
+				innerRange := utils.TrimNodeTextRange(sf, inner)
+				opRange := utils.TrimNodeTextRange(sf, bin.OperatorToken)
+				text := sf.Text()
+				return text[innerRange.Pos():opRange.Pos()] + invOp + text[opRange.End():innerRange.End()]
+			}
+		}
+	}
+	testText := utils.TrimmedNodeText(sf, testNode)
+	if eslintLikePrecedence(inner) < 16 {
+		return "!(" + testText + ")"
+	}
+	return "!" + testText
+}
+
+// matchesDefaultAssignment reports whether the conditional matches the
+// pattern `id ? id : expression` after peeling parens on test and consequent.
+func matchesDefaultAssignment(test, consequent *ast.Node) bool {
+	innerTest := ast.SkipParentheses(test)
+	innerCons := ast.SkipParentheses(consequent)
+	if innerTest.Kind != ast.KindIdentifier || innerCons.Kind != ast.KindIdentifier {
+		return false
+	}
+	return innerTest.AsIdentifier().Text == innerCons.AsIdentifier().Text
+}
+
+// buildBooleanLiteralFix returns the fix for the
+// `unnecessaryConditionalExpression` case. Returns nil when no safe fix
+// exists (e.g. both sides equal but test has side effects).
+func buildBooleanLiteralFix(sf *ast.SourceFile, cond *ast.ConditionalExpression, consVal, altVal bool) []rule.RuleFix {
+	condNode := cond.AsNode()
+	if consVal == altVal {
+		// `foo ? true : true` → `true`, but only when test is a bare
+		// identifier (no side effects).
+		if ast.SkipParentheses(cond.Condition).Kind != ast.KindIdentifier {
+			return nil
+		}
+		text := "false"
+		if consVal {
+			text = "true"
+		}
+		return []rule.RuleFix{rule.RuleFixReplace(sf, condNode, text)}
+	}
+	if altVal {
+		// `foo ? false : true` → `!foo` (or operator inversion).
+		return []rule.RuleFix{rule.RuleFixReplace(sf, condNode, invertExpression(sf, cond.Condition))}
+	}
+	// `foo ? true : false` → `foo` when test is already a boolean
+	// expression, else `!!foo`.
+	var replacement string
+	if isBooleanExpression(cond.Condition) {
+		replacement = utils.TrimmedNodeText(sf, cond.Condition)
+	} else {
+		replacement = "!" + invertExpression(sf, cond.Condition)
+	}
+	return []rule.RuleFix{rule.RuleFixReplace(sf, condNode, replacement)}
+}
+
+// buildDefaultAssignmentFix returns the fix for the
+// `unnecessaryConditionalAssignment` case (`a ? a : b` → `a || b`).
+// The alternate gets wrapped in parens when its precedence is below `||` or
+// it's a `??` expression — but only when not already parenthesized.
+func buildDefaultAssignmentFix(sf *ast.SourceFile, cond *ast.ConditionalExpression) []rule.RuleFix {
+	condNode := cond.AsNode()
+	innerAlt := ast.SkipParentheses(cond.WhenFalse)
+	alreadyParenthesised := cond.WhenFalse.Kind == ast.KindParenthesizedExpression
+
+	shouldWrap := (eslintLikePrecedence(innerAlt) < 4 || isCoalesceExpression(innerAlt)) && !alreadyParenthesised
+
+	var alternateText string
+	if shouldWrap {
+		alternateText = "(" + utils.TrimmedNodeText(sf, innerAlt) + ")"
+	} else {
+		alternateText = utils.TrimmedNodeText(sf, cond.WhenFalse)
+	}
+
+	testText := utils.TrimmedNodeText(sf, cond.Condition)
+	return []rule.RuleFix{rule.RuleFixReplace(sf, condNode, testText+" || "+alternateText)}
+}
+
+// NoUnneededTernaryRule disallows ternary operators when simpler alternatives
+// exist: `x ? true : false` → `x` / `!!x`, and (with `defaultAssignment:
+// false`) `a ? a : b` → `a || b`.
+var NoUnneededTernaryRule = rule.Rule{
+	Name: "no-unneeded-ternary",
+	Run: func(ctx rule.RuleContext, ruleOptions any) rule.RuleListeners {
+		opts := parseOptions(ruleOptions)
+
+		condExprMsg := rule.RuleMessage{
+			Id:          "unnecessaryConditionalExpression",
+			Description: "Unnecessary use of boolean literals in conditional expression.",
+		}
+		condAssignMsg := rule.RuleMessage{
+			Id:          "unnecessaryConditionalAssignment",
+			Description: "Unnecessary use of conditional expression for default assignment.",
+		}
+
+		return rule.RuleListeners{
+			ast.KindConditionalExpression: func(node *ast.Node) {
+				cond := node.AsConditionalExpression()
+				if cond == nil {
+					return
+				}
+
+				consVal, consOk := boolKind(cond.WhenTrue)
+				altVal, altOk := boolKind(cond.WhenFalse)
+				if consOk && altOk {
+					if fixes := buildBooleanLiteralFix(ctx.SourceFile, cond, consVal, altVal); fixes != nil {
+						ctx.ReportNodeWithFixes(node, condExprMsg, fixes...)
+					} else {
+						ctx.ReportNode(node, condExprMsg)
+					}
+					return
+				}
+
+				if !opts.defaultAssignment && matchesDefaultAssignment(cond.Condition, cond.WhenTrue) {
+					ctx.ReportNodeWithFixes(node, condAssignMsg, buildDefaultAssignmentFix(ctx.SourceFile, cond)...)
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary.md
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary.md
@@ -44,14 +44,6 @@ f(x ? x : 1);
 | ------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
 | `defaultAssignment` | boolean | `true`  | When `false`, also flag the `a ? a : b` default-assignment pattern (auto-fixed to `a \|\| b`). |
 
-## Differences from ESLint
-
-- TypeScript-specific expressions (`as`, `satisfies`, type assertions, etc.)
-  are unknown to ESLint's precedence table; ESLint treats them as the lowest
-  precedence and wraps them in parentheses defensively when emitting `||`
-  fixes. rslint mirrors that behavior so an alternate like `bar as any`
-  becomes `(bar as any)` after the fix, matching ESLint's output.
-
 ## Original Documentation
 
 [no-unneeded-ternary - ESLint](https://eslint.org/docs/latest/rules/no-unneeded-ternary)

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary.md
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary.md
@@ -1,0 +1,57 @@
+# no-unneeded-ternary
+
+## Rule Details
+
+Disallows ternary expressions when a simpler alternative exists. Two patterns
+are flagged:
+
+- **Boolean-literal selection** — `cond ? true : false` (or any combination of
+  boolean literals on both arms) collapses to `cond`, `!cond`, `!!cond`, or
+  the boolean literal itself. Always reported.
+- **Default assignment** — `a ? a : b` is equivalent to `a || b`. Reported
+  only when the `defaultAssignment` option is set to `false`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = x === 2 ? true : false;
+var b = x ? true : false;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = x === 2 ? "Yes" : "No";
+var b = x !== false;
+var c = x ? "Yes" : "No";
+var d = x ? y : x;
+```
+
+Examples of **incorrect** code for this rule with `{ "defaultAssignment": false }`:
+
+```json
+{ "no-unneeded-ternary": ["error", { "defaultAssignment": false }] }
+```
+
+```javascript
+var a = x ? x : 1;
+f(x ? x : 1);
+```
+
+## Options
+
+| Option              | Type    | Default | Description                                                                              |
+| ------------------- | ------- | ------- | ---------------------------------------------------------------------------------------- |
+| `defaultAssignment` | boolean | `true`  | When `false`, also flag the `a ? a : b` default-assignment pattern (auto-fixed to `a \|\| b`). |
+
+## Differences from ESLint
+
+- TypeScript-specific expressions (`as`, `satisfies`, type assertions, etc.)
+  are unknown to ESLint's precedence table; ESLint treats them as the lowest
+  precedence and wraps them in parentheses defensively when emitting `||`
+  fixes. rslint mirrors that behavior so an alternate like `bar as any`
+  becomes `(bar as any)` after the fix, matching ESLint's output.
+
+## Original Documentation
+
+[no-unneeded-ternary - ESLint](https://eslint.org/docs/latest/rules/no-unneeded-ternary)

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary_test.go
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary_test.go
@@ -1,0 +1,618 @@
+package no_unneeded_ternary
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnneededTernaryRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUnneededTernaryRule,
+
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream ESLint suite ----
+			{Code: `config.newIsCap = config.newIsCap !== false`},
+			{Code: `var a = x === 2 ? 'Yes' : 'No';`},
+			{Code: `var a = x === 2 ? true : 'No';`},
+			{Code: `var a = x === 2 ? 'Yes' : false;`},
+			{Code: `var a = x === 2 ? 'true' : 'false';`},
+			{Code: `var a = foo ? foo : bar;`},
+			{Code: `var value = 'a';var canSet = true;var result = value || (canSet ? 'unset' : 'can not set')`},
+			{Code: `var a = foo ? bar : foo;`},
+			{Code: `foo ? bar : foo;`},
+			{Code: `var a = f(x ? x : 1)`},
+			{Code: `f(x ? x : 1);`},
+			{Code: `foo ? foo : bar;`},
+			{Code: `var a = foo ? 'Yes' : foo;`},
+			{
+				Code:    `var a = foo ? 'Yes' : foo;`,
+				Options: map[string]interface{}{"defaultAssignment": false},
+			},
+			{
+				Code:    `var a = foo ? bar : foo;`,
+				Options: map[string]interface{}{"defaultAssignment": false},
+			},
+			{
+				Code:    `foo ? bar : foo;`,
+				Options: map[string]interface{}{"defaultAssignment": false},
+			},
+
+			// ---- Default-assignment pattern stays valid by default ----
+			{Code: `var a = foo ? foo : 'No';`},
+			{Code: `var a = foo ? foo : bar;`},
+
+			// ---- Mixed boolean + non-boolean: not both literals → no report ----
+			{Code: `var a = foo ? true : null;`},
+			{Code: `var a = foo ? null : false;`},
+			{Code: `var a = foo ? 1 : 0;`},
+
+			// ---- Conditional that isn't a default-assignment pattern (test ≠ consequent) ----
+			{
+				Code:    `var a = foo ? bar : 1;`,
+				Options: map[string]interface{}{"defaultAssignment": false},
+			},
+			// Property access doesn't match the simple-identifier pattern.
+			{
+				Code:    `var a = foo.bar ? foo.bar : baz;`,
+				Options: map[string]interface{}{"defaultAssignment": false},
+			},
+
+			// ---- Explicit `defaultAssignment: true` matches the no-options default ----
+			{
+				Code:    `var a = foo ? foo : bar;`,
+				Options: map[string]interface{}{"defaultAssignment": true},
+			},
+			// Empty options object: same as defaults.
+			{
+				Code:    `var a = foo ? foo : bar;`,
+				Options: map[string]interface{}{},
+			},
+			// Identifier vs different identifier: not a default-assignment pattern.
+			{
+				Code:    `var a = foo ? bar : baz;`,
+				Options: map[string]interface{}{"defaultAssignment": false},
+			},
+			// Test and consequent are SAME identifier text but different tokens
+			// (different `Identifier` node references); both are "foo" so the rule
+			// flags this — keep this in invalid.
+
+			// ---- Test that *contains* a boolean literal but isn't itself one ----
+			{Code: `var a = (x === true) ? "Y" : "N";`},
+			{Code: `var a = !!x ? "Y" : "N";`},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream ESLint suite — boolean-literal ternary ----
+			{
+				Code:   `var a = x === 2 ? true : false;`,
+				Output: []string{`var a = x === 2;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Message: "Unnecessary use of boolean literals in conditional expression.", Line: 1, Column: 9, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:   `var a = x >= 2 ? true : false;`,
+				Output: []string{`var a = x >= 2;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:   `var a = x ? true : false;`,
+				Output: []string{`var a = !!x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:   `var a = x === 1 ? false : true;`,
+				Output: []string{`var a = x !== 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code:   `var a = x != 1 ? false : true;`,
+				Output: []string{`var a = x == 1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:   `var a = foo() ? false : true;`,
+				Output: []string{`var a = !foo();`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 29},
+				},
+			},
+			{
+				Code:   `var a = !foo() ? false : true;`,
+				Output: []string{`var a = !!foo();`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:   `var a = foo + bar ? false : true;`,
+				Output: []string{`var a = !(foo + bar);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				Code:   `var a = x instanceof foo ? false : true;`,
+				Output: []string{`var a = !(x instanceof foo);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:   `var a = foo ? false : false;`,
+				Output: []string{`var a = false;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 28},
+				},
+			},
+			{
+				// Test has side effects → no autofix even though both
+				// arms collapse to the same literal.
+				Code: `var a = foo() ? false : false;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:   `var a = x instanceof foo ? true : false;`,
+				Output: []string{`var a = x instanceof foo;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 40},
+				},
+			},
+			{
+				Code:   `var a = !foo ? true : false;`,
+				Output: []string{`var a = !foo;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 28},
+				},
+			},
+
+			// ---- Upstream ESLint suite — defaultAssignment: false ----
+			{
+				Code: `
+                var value = 'a'
+                var canSet = true
+                var result = value ? value : canSet ? 'unset' : 'can not set'
+            `,
+				Output: []string{`
+                var value = 'a'
+                var canSet = true
+                var result = value || (canSet ? 'unset' : 'can not set')
+            `},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Message: "Unnecessary use of conditional expression for default assignment.", Line: 4, Column: 30, EndLine: 4, EndColumn: 78},
+				},
+			},
+			{
+				Code:    `foo ? foo : (bar ? baz : qux)`,
+				Output:  []string{`foo || (bar ? baz : qux)`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 30},
+				},
+			},
+			{
+				Code:    `function* fn() { foo ? foo : yield bar }`,
+				Output:  []string{`function* fn() { foo || (yield bar) }`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 18, EndLine: 1, EndColumn: 39},
+				},
+			},
+			{
+				Code:    `var a = foo ? foo : 'No';`,
+				Output:  []string{`var a = foo || 'No';`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    `var a = ((foo)) ? (((((foo))))) : ((((((((((((((bar))))))))))))));`,
+				Output:  []string{`var a = ((foo)) || ((((((((((((((bar))))))))))))));`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 66},
+				},
+			},
+			{
+				Code:    `var a = b ? b : c => c;`,
+				Output:  []string{`var a = b || (c => c);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    `var a = b ? b : c = 0;`,
+				Output:  []string{`var a = b || (c = 0);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code:    `var a = b ? b : (c => c);`,
+				Output:  []string{`var a = b || (c => c);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 25},
+				},
+			},
+			{
+				Code:    `var a = b ? b : (c = 0);`,
+				Output:  []string{`var a = b || (c = 0);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:    `var a = b ? b : (c) => (c);`,
+				Output:  []string{`var a = b || ((c) => (c));`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 27},
+				},
+			},
+			{
+				Code:    `var a = b ? b : c, d; // this is ((b ? b : c), (d))`,
+				Output:  []string{`var a = b || c, d; // this is ((b ? b : c), (d))`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 18},
+				},
+			},
+			{
+				Code:    `var a = b ? b : (c, d);`,
+				Output:  []string{`var a = b || (c, d);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code:    `f(x ? x : 1);`,
+				Output:  []string{`f(x || 1);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 3, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code:    `x ? x : 1;`,
+				Output:  []string{`x || 1;`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code:    `var a = foo ? foo : bar;`,
+				Output:  []string{`var a = foo || bar;`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 24},
+				},
+			},
+			{
+				Code:    `var a = foo ? foo : a ?? b;`,
+				Output:  []string{`var a = foo || (a ?? b);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 9, EndLine: 1, EndColumn: 27},
+				},
+			},
+
+			// ---- TypeScript-specific (replaces upstream's typescript-parser fixtures) ----
+			// TS-specific kinds (AsExpression, etc.) are unknown to ESLint's
+			// precedence table and get -1 → wrapped defensively. We mirror
+			// that behavior in eslintLikePrecedence so TS expressions get the
+			// same parens ESLint would emit.
+			{
+				Code:   `foo as any ? false : true`,
+				Output: []string{`!(foo as any)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 1, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code:    `foo ? foo : bar as any`,
+				Output:  []string{`foo || (bar as any)`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 23},
+				},
+			},
+
+			// ---- Extra: tsgo-specific paren-shape coverage ----
+			// Outer parens around the test still classified as Identifier
+			// after SkipParentheses → both-equal fix path runs.
+			{
+				Code:   `var a = (foo) ? true : true;`,
+				Output: []string{`var a = true;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 28},
+				},
+			},
+			// Parenthesized boolean literal in either arm — boolKind peels
+			// parens, so this still reports.
+			{
+				Code:   `var a = x ? (true) : (false);`,
+				Output: []string{`var a = !!x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// Multi-line position assertion: the conditional spans 3 lines.
+			{
+				Code:   "var a = x\n  ? true\n  : false;",
+				Output: []string{`var a = !!x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 3, EndColumn: 10},
+				},
+			},
+
+			// ---- Extra: unary-keyword tests (typeof / delete / void / await) ----
+			// `typeof x === 'string'` is already a boolean expression: unwraps cleanly.
+			{
+				Code:   `var a = typeof x === 'string' ? true : false;`,
+				Output: []string{`var a = typeof x === 'string';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 45},
+				},
+			},
+			// `typeof x` alone is not a boolean expression: needs `!!`. Token
+			// fusion is safe — the next token is the `typeof` keyword.
+			{
+				Code:   `var a = typeof x ? true : false;`,
+				Output: []string{`var a = !!typeof x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 32},
+				},
+			},
+			// Operator-inversion path with `===` after `typeof`.
+			{
+				Code:   `var a = typeof x === 'string' ? false : true;`,
+				Output: []string{`var a = typeof x !== 'string';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 45},
+				},
+			},
+			// `delete obj.x ? false : true` → `!delete obj.x`. Test has side
+			// effects but the rule still emits a fix (matches ESLint).
+			{
+				Code:   `var a = delete obj.x ? false : true;`,
+				Output: []string{`var a = !delete obj.x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 36},
+				},
+			},
+			// `void` expression as test.
+			{
+				Code:   `var a = void x ? true : false;`,
+				Output: []string{`var a = !!void x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 30},
+				},
+			},
+			// `await` expression as test (inside async function).
+			{
+				Code:   `async function f() { return await x ? true : false; }`,
+				Output: []string{`async function f() { return !!await x; }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 29, EndLine: 1, EndColumn: 51},
+				},
+			},
+
+			// ---- Update expressions (++ / --) as test ----
+			// Prefix update — token fusion concern: `!` + `++x` should NOT
+			// merge into anything bad. `!++x` parses as `!(++x)`.
+			{
+				Code:   `var a = ++x ? false : true;`,
+				Output: []string{`var a = !++x;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 27},
+				},
+			},
+			// Postfix update.
+			{
+				Code:   `var a = x++ ? true : false;`,
+				Output: []string{`var a = !!x++;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 27},
+				},
+			},
+
+			// ---- Paren-wrapped tests — verify TrimmedNodeText preserves them ----
+			// `(foo + bar)` test: precedence still triggers wrap, so the
+			// fixer emits `!((foo + bar))` (matches ESLint).
+			{
+				Code:   `var a = (foo + bar) ? false : true;`,
+				Output: []string{`var a = !((foo + bar));`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 35},
+				},
+			},
+			// `(typeof x === 'string')` test — paren-wrapped boolean
+			// expression: unwrap path keeps the parens.
+			{
+				Code:   `var a = (typeof x === 'string') ? true : false;`,
+				Output: []string{`var a = (typeof x === 'string');`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 47},
+				},
+			},
+
+			// ---- Compact-spacing operator inversion ----
+			// No spaces around `===` — inversion preserves the exact spacing.
+			{
+				Code:   `var a = x===1?false:true;`,
+				Output: []string{`var a = x!==1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// Wide spacing around `===` — same preservation rule.
+			{
+				Code:   `var a = x  ===   1 ? false : true;`,
+				Output: []string{`var a = x  !==   1;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- Multi-byte (CJK) identifier as test/consequent ----
+			{
+				Code:   `var a = 中 === 国 ? true : false;`,
+				Output: []string{`var a = 中 === 国;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 31},
+				},
+			},
+
+			// ---- TypeScript: SatisfiesExpression ----
+			// SatisfiesExpression is unknown to ESLint → -1 precedence → wrapped
+			// defensively, mirroring the AsExpression behavior.
+			{
+				Code:   `var a = x satisfies number ? false : true;`,
+				Output: []string{`var a = !(x satisfies number);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 42},
+				},
+			},
+			{
+				Code:    `foo ? foo : bar satisfies number`,
+				Output:  []string{`foo || (bar satisfies number)`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 33},
+				},
+			},
+
+			// ---- Nested default-assignment: rule reports both, fixer
+			// resolves overlap by re-running. Expect two iterations.
+			{
+				Code: `foo ? foo : (foo ? foo : c)`,
+				Output: []string{
+					`foo || (foo ? foo : c)`,
+					`foo || (foo || c)`,
+				},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 28},
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 14, EndLine: 1, EndColumn: 27},
+				},
+			},
+
+			// ---- defaultAssignment: true explicit + no report ----
+			// Already in valid suite. The default is true, so this is just a
+			// regression guard for the option-parsing code path.
+
+			// ---- Test that's a Boolean() call: NOT a boolean expression
+			// because we don't recognize Boolean() as one (matches ESLint). ----
+			{
+				Code:   `var a = Boolean(x) ? true : false;`,
+				Output: []string{`var a = !!Boolean(x);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- A test that is a comparison wrapped in parens, both arms
+			// equal (alternate fix path: emit literal text only when test is
+			// an Identifier — here it's NOT, so no fix). ----
+			{
+				Code: `var a = x === 1 ? true : true;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 30},
+				},
+			},
+
+			// ---- Right-associative conditional as alternate — `?:` is
+			// right-associative so `b ? b : c ? d : e` is `b ? b : (c?d:e)`.
+			// The inner is NOT parenthesised → wrap on output.
+			{
+				Code:    `b ? b : c ? d : e;`,
+				Output:  []string{`b || (c ? d : e);`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 18},
+				},
+			},
+
+			// ---- Function/class expressions as alternate ----
+			{
+				Code:    `b ? b : function() { return 1; };`,
+				Output:  []string{`b || function() { return 1; };`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				Code:    `b ? b : class { static foo() {} };`,
+				Output:  []string{`b || class { static foo() {} };`},
+				Options: map[string]interface{}{"defaultAssignment": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalAssignment", Line: 1, Column: 1, EndLine: 1, EndColumn: 34},
+				},
+			},
+
+			// ---- `new Foo()` and template literal tests ----
+			{
+				Code:   `var a = new Foo() ? true : false;`,
+				Output: []string{`var a = !!new Foo();`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 33},
+				},
+			},
+			{
+				Code:   "var a = `abc` ? true : false;",
+				Output: []string{"var a = !!`abc`;"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 29},
+				},
+			},
+			// Property access (computed and dotted) as test.
+			{
+				Code:   `var a = obj["foo"] ? true : false;`,
+				Output: []string{`var a = !!obj["foo"];`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 34},
+				},
+			},
+			{
+				Code:   `var a = obj.foo ? true : false;`,
+				Output: []string{`var a = !!obj.foo;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 31},
+				},
+			},
+
+			// ---- Optional chain as test ----
+			{
+				Code:   `var a = foo?.bar ? true : false;`,
+				Output: []string{`var a = !!foo?.bar;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryConditionalExpression", Line: 1, Column: 9, EndLine: 1, EndColumn: 32},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -291,6 +291,7 @@ export default defineConfig({
     './tests/eslint/rules/no-proto.test.ts',
     './tests/eslint/rules/no-return-assign.test.ts',
     './tests/eslint/rules/no-self-compare.test.ts',
+    './tests/eslint/rules/no-unneeded-ternary.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unneeded-ternary.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-unneeded-ternary.test.ts.snap
@@ -1,0 +1,1498 @@
+// Rstest Snapshot v1
+
+exports[`no-unneeded-ternary > invalid 1`] = `
+{
+  "code": "var a = x === 2 ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 2`] = `
+{
+  "code": "var a = x >= 2 ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 3`] = `
+{
+  "code": "var a = x ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 4`] = `
+{
+  "code": "var a = x === 1 ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 5`] = `
+{
+  "code": "var a = x != 1 ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 6`] = `
+{
+  "code": "var a = foo() ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 7`] = `
+{
+  "code": "var a = !foo() ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 8`] = `
+{
+  "code": "var a = foo + bar ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 9`] = `
+{
+  "code": "var a = x instanceof foo ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 10`] = `
+{
+  "code": "var a = foo ? false : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 11`] = `
+{
+  "code": "var a = foo() ? false : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 12`] = `
+{
+  "code": "var a = x instanceof foo ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 13`] = `
+{
+  "code": "var a = !foo ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 14`] = `
+{
+  "code": "var result = value ? value : canSet ? 'unset' : 'can not set'",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 15`] = `
+{
+  "code": "foo ? foo : (bar ? baz : qux)",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 16`] = `
+{
+  "code": "function* fn() { foo ? foo : yield bar }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 17`] = `
+{
+  "code": "var a = foo ? foo : 'No';",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 18`] = `
+{
+  "code": "var a = ((foo)) ? (((((foo))))) : ((((((((((((((bar))))))))))))));",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 19`] = `
+{
+  "code": "var a = b ? b : c => c;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 20`] = `
+{
+  "code": "var a = b ? b : c = 0;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 21`] = `
+{
+  "code": "var a = b ? b : (c => c);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 22`] = `
+{
+  "code": "var a = b ? b : (c = 0);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 23`] = `
+{
+  "code": "var a = b ? b : (c) => (c);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 24`] = `
+{
+  "code": "var a = b ? b : c, d;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 25`] = `
+{
+  "code": "var a = b ? b : (c, d);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 26`] = `
+{
+  "code": "f(x ? x : 1);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 27`] = `
+{
+  "code": "x ? x : 1;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 28`] = `
+{
+  "code": "var a = foo ? foo : bar;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 29`] = `
+{
+  "code": "var a = foo ? foo : a ?? b;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 30`] = `
+{
+  "code": "foo as any ? false : true",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 31`] = `
+{
+  "code": "foo ? foo : bar as any",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 32`] = `
+{
+  "code": "var a = typeof x === 'string' ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 33`] = `
+{
+  "code": "var a = typeof x ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 34`] = `
+{
+  "code": "var a = typeof x === 'string' ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 35`] = `
+{
+  "code": "var a = delete obj.x ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 36`] = `
+{
+  "code": "var a = void x ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 37`] = `
+{
+  "code": "async function f() { return await x ? true : false; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 38`] = `
+{
+  "code": "var a = ++x ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 39`] = `
+{
+  "code": "var a = x++ ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 40`] = `
+{
+  "code": "var a = (foo + bar) ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 41`] = `
+{
+  "code": "var a = (typeof x === 'string') ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 42`] = `
+{
+  "code": "var a = x===1?false:true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 43`] = `
+{
+  "code": "var a = x  ===   1 ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 44`] = `
+{
+  "code": "var a = 中 === 国 ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 45`] = `
+{
+  "code": "var a = x satisfies number ? false : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 46`] = `
+{
+  "code": "foo ? foo : bar satisfies number",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 47`] = `
+{
+  "code": "foo ? foo : (foo ? foo : c)",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 48`] = `
+{
+  "code": "var a = Boolean(x) ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 49`] = `
+{
+  "code": "var a = x === 1 ? true : true;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 50`] = `
+{
+  "code": "b ? b : c ? d : e;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 51`] = `
+{
+  "code": "b ? b : function() { return 1; };",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 52`] = `
+{
+  "code": "b ? b : class { static foo() {} };",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of conditional expression for default assignment.",
+      "messageId": "unnecessaryConditionalAssignment",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 53`] = `
+{
+  "code": "var a = new Foo() ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 54`] = `
+{
+  "code": "var a = \`abc\` ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 55`] = `
+{
+  "code": "var a = obj["foo"] ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 56`] = `
+{
+  "code": "var a = obj.foo ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unneeded-ternary > invalid 57`] = `
+{
+  "code": "var a = foo?.bar ? true : false;",
+  "diagnostics": [
+    {
+      "message": "Unnecessary use of boolean literals in conditional expression.",
+      "messageId": "unnecessaryConditionalExpression",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-unneeded-ternary",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unneeded-ternary.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unneeded-ternary.test.ts
@@ -35,221 +35,313 @@ ruleTester.run('no-unneeded-ternary', {
     // ---- Boolean-literal ternary ----
     {
       code: `var a = x === 2 ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x >= 2 ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x === 1 ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x != 1 ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = foo() ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = !foo() ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = foo + bar ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x instanceof foo ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = foo ? false : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = foo() ? false : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x instanceof foo ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = !foo ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- defaultAssignment: false ----
     {
       code: `var result = value ? value : canSet ? 'unset' : 'can not set'`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 14 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 14 },
+      ],
     },
     {
       code: `foo ? foo : (bar ? baz : qux)`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
     {
       code: `function* fn() { foo ? foo : yield bar }`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 18 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 18 },
+      ],
     },
     {
       code: `var a = foo ? foo : 'No';`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = ((foo)) ? (((((foo))))) : ((((((((((((((bar))))))))))))));`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : c => c;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : c = 0;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : (c => c);`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : (c = 0);`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : (c) => (c);`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : c, d;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = b ? b : (c, d);`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `f(x ? x : 1);`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 3 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 3 },
+      ],
     },
     {
       code: `x ? x : 1;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
     {
       code: `var a = foo ? foo : bar;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = foo ? foo : a ?? b;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 },
+      ],
     },
 
     // ---- TypeScript-specific (AsExpression) ----
     {
       code: `foo as any ? false : true`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 1 },
+      ],
     },
     {
       code: `foo ? foo : bar as any`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
 
     // ---- Unary-keyword tests (typeof / delete / void / await) ----
     {
       code: `var a = typeof x === 'string' ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = typeof x ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = typeof x === 'string' ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = delete obj.x ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = void x ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `async function f() { return await x ? true : false; }`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 29 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 29 },
+      ],
     },
 
     // ---- Update expressions ----
     {
       code: `var a = ++x ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x++ ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- Paren-wrapped tests ----
     {
       code: `var a = (foo + bar) ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = (typeof x === 'string') ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- Compact-spacing operator inversion ----
     {
       code: `var a = x===1?false:true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = x  ===   1 ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- Multi-byte CJK identifiers ----
     {
       code: `var a = 中 === 国 ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- TypeScript: SatisfiesExpression ----
     {
       code: `var a = x satisfies number ? false : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `foo ? foo : bar satisfies number`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
 
     // ---- Nested default-assignment: rule reports both inner and outer ----
@@ -266,56 +358,76 @@ ruleTester.run('no-unneeded-ternary', {
     // (matches ESLint), so falls through to `!!Boolean(x)`. ----
     {
       code: `var a = Boolean(x) ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- Both arms equal but test has side effects: report, no fix ----
     {
       code: `var a = x === 1 ? true : true;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- Right-associative conditional as alternate ----
     {
       code: `b ? b : c ? d : e;`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
 
     // ---- Function/class expressions as alternate ----
     {
       code: `b ? b : function() { return 1; };`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
     {
       code: `b ? b : class { static foo() {} };`,
       options: { defaultAssignment: false },
-      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+      ],
     },
 
     // ---- new / template literal / property access tests ----
     {
       code: `var a = new Foo() ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: 'var a = `abc` ? true : false;',
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = obj["foo"] ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
     {
       code: `var a = obj.foo ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
 
     // ---- Optional chain as test ----
     {
       code: `var a = foo?.bar ? true : false;`,
-      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+      errors: [
+        { messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 },
+      ],
     },
   ],
 });

--- a/packages/rslint-test-tools/tests/eslint/rules/no-unneeded-ternary.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-unneeded-ternary.test.ts
@@ -1,0 +1,321 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unneeded-ternary', {
+  valid: [
+    // ---- Upstream ESLint suite ----
+    `config.newIsCap = config.newIsCap !== false`,
+    `var a = x === 2 ? 'Yes' : 'No';`,
+    `var a = x === 2 ? true : 'No';`,
+    `var a = x === 2 ? 'Yes' : false;`,
+    `var a = x === 2 ? 'true' : 'false';`,
+    `var a = foo ? foo : bar;`,
+    `var value = 'a';var canSet = true;var result = value || (canSet ? 'unset' : 'can not set')`,
+    `var a = foo ? bar : foo;`,
+    `foo ? bar : foo;`,
+    `var a = f(x ? x : 1)`,
+    `f(x ? x : 1);`,
+    `foo ? foo : bar;`,
+    `var a = foo ? 'Yes' : foo;`,
+    {
+      code: `var a = foo ? 'Yes' : foo;`,
+      options: { defaultAssignment: false },
+    },
+    {
+      code: `var a = foo ? bar : foo;`,
+      options: { defaultAssignment: false },
+    },
+    {
+      code: `foo ? bar : foo;`,
+      options: { defaultAssignment: false },
+    },
+  ],
+  invalid: [
+    // ---- Boolean-literal ternary ----
+    {
+      code: `var a = x === 2 ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x >= 2 ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x === 1 ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x != 1 ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = foo() ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = !foo() ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = foo + bar ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x instanceof foo ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = foo ? false : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = foo() ? false : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x instanceof foo ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = !foo ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- defaultAssignment: false ----
+    {
+      code: `var result = value ? value : canSet ? 'unset' : 'can not set'`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 14 }],
+    },
+    {
+      code: `foo ? foo : (bar ? baz : qux)`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `function* fn() { foo ? foo : yield bar }`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 18 }],
+    },
+    {
+      code: `var a = foo ? foo : 'No';`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = ((foo)) ? (((((foo))))) : ((((((((((((((bar))))))))))))));`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : c => c;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : c = 0;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : (c => c);`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : (c = 0);`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : (c) => (c);`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : c, d;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = b ? b : (c, d);`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `f(x ? x : 1);`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 3 }],
+    },
+    {
+      code: `x ? x : 1;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `var a = foo ? foo : bar;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = foo ? foo : a ?? b;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 9 }],
+    },
+
+    // ---- TypeScript-specific (AsExpression) ----
+    {
+      code: `foo as any ? false : true`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 1 }],
+    },
+    {
+      code: `foo ? foo : bar as any`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+
+    // ---- Unary-keyword tests (typeof / delete / void / await) ----
+    {
+      code: `var a = typeof x === 'string' ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = typeof x ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = typeof x === 'string' ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = delete obj.x ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = void x ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `async function f() { return await x ? true : false; }`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 29 }],
+    },
+
+    // ---- Update expressions ----
+    {
+      code: `var a = ++x ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x++ ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- Paren-wrapped tests ----
+    {
+      code: `var a = (foo + bar) ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = (typeof x === 'string') ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- Compact-spacing operator inversion ----
+    {
+      code: `var a = x===1?false:true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = x  ===   1 ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- Multi-byte CJK identifiers ----
+    {
+      code: `var a = 中 === 国 ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- TypeScript: SatisfiesExpression ----
+    {
+      code: `var a = x satisfies number ? false : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `foo ? foo : bar satisfies number`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+
+    // ---- Nested default-assignment: rule reports both inner and outer ----
+    {
+      code: `foo ? foo : (foo ? foo : c)`,
+      options: { defaultAssignment: false },
+      errors: [
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 },
+        { messageId: 'unnecessaryConditionalAssignment', line: 1, column: 14 },
+      ],
+    },
+
+    // ---- Boolean() call as test: not a boolean expression in our rule
+    // (matches ESLint), so falls through to `!!Boolean(x)`. ----
+    {
+      code: `var a = Boolean(x) ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- Both arms equal but test has side effects: report, no fix ----
+    {
+      code: `var a = x === 1 ? true : true;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- Right-associative conditional as alternate ----
+    {
+      code: `b ? b : c ? d : e;`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+
+    // ---- Function/class expressions as alternate ----
+    {
+      code: `b ? b : function() { return 1; };`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+    {
+      code: `b ? b : class { static foo() {} };`,
+      options: { defaultAssignment: false },
+      errors: [{ messageId: 'unnecessaryConditionalAssignment', line: 1, column: 1 }],
+    },
+
+    // ---- new / template literal / property access tests ----
+    {
+      code: `var a = new Foo() ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: 'var a = `abc` ? true : false;',
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = obj["foo"] ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+    {
+      code: `var a = obj.foo ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+
+    // ---- Optional chain as test ----
+    {
+      code: `var a = foo?.bar ? true : false;`,
+      errors: [{ messageId: 'unnecessaryConditionalExpression', line: 1, column: 9 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-unneeded-ternary` rule from ESLint to rslint.

The rule disallows ternary operators when simpler alternatives exist:
- Boolean-literal selection — `cond ? true : false` collapses to `cond` / `!cond` / `!!cond` / the literal itself
- Default assignment (when `defaultAssignment: false`) — `a ? a : b` is reported and auto-fixed to `a || b`

Both `messageId`s, the `defaultAssignment` option, and the autofix output are aligned 1:1 with the original ESLint rule. Verified by:
- Migrating all upstream ESLint test cases (17 valid + 31 invalid) plus 40+ extra boundary tests covering paren-wrapped tests, TS \`as\`/\`satisfies\` expressions, nested default-assignment with multi-iteration fix, unary-keyword tests (\`typeof\`/\`delete\`/\`void\`/\`await\`), update expressions, multi-byte identifiers, and tight/wide operator spacing.
- Differential check on rsbuild and rspack: rslint reports match ESLint exactly at the same file:line:column.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-unneeded-ternary
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-unneeded-ternary.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).