### PR TITLE
feat: port rule no-sequences

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -182,6 +182,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_script_url"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_compare"
+	"github.com/web-infra-dev/rslint/internal/rules/no_sequences"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
@@ -593,6 +594,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
 	GlobalRuleRegistry.Register("no-self-compare", no_self_compare.NoSelfCompareRule)
+	GlobalRuleRegistry.Register("no-sequences", no_sequences.NoSequencesRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
 	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)

--- a/internal/rules/no_sequences/no_sequences.go
+++ b/internal/rules/no_sequences/no_sequences.go
@@ -1,0 +1,156 @@
+package no_sequences
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type options struct {
+	allowInParentheses bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{allowInParentheses: true}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowInParentheses"].(bool); ok {
+		opts.allowInParentheses = v
+	}
+	return opts
+}
+
+// isCommaBinary reports whether node is a BinaryExpression whose operator is
+// the comma token — tsgo's collapsed form of ESLint's SequenceExpression.
+func isCommaBinary(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := node.AsBinaryExpression()
+	return bin != nil && bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken
+}
+
+// walkUpSkippingParens returns the first ancestor of node that is not a
+// ParenthesizedExpression, along with the count of ParenthesizedExpression
+// wrappers traversed. The returned child is the direct descendant of that
+// ancestor (i.e. the node whose Parent is the returned ancestor).
+func walkUpSkippingParens(node *ast.Node) (parent *ast.Node, child *ast.Node, parenDepth int) {
+	child = node
+	parent = node.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parenDepth++
+		child = parent
+		parent = parent.Parent
+	}
+	return
+}
+
+// isForInitOrUpdate reports whether the outermost paren-skipped wrapper of
+// `node` sits in the init or update slot of a `for` statement. ESLint always
+// allows sequences in those positions regardless of `allowInParentheses`.
+func isForInitOrUpdate(node *ast.Node) bool {
+	parent, child, _ := walkUpSkippingParens(node)
+	if parent == nil || parent.Kind != ast.KindForStatement {
+		return false
+	}
+	forStmt := parent.AsForStatement()
+	if forStmt == nil {
+		return false
+	}
+	return child == forStmt.Initializer || child == forStmt.Incrementor
+}
+
+// isGrammarParenArrowBody reports whether the outermost wrapper of `node`
+// occupies the body slot of an arrow function. In tsgo the disambiguating
+// parens in `a => (x, y)` materialize as a ParenthesizedExpression wrapper,
+// so arrow bodies — unlike do-while / while / if / switch / with grammar
+// parens, which are consumed by the statement — need *two* wrappers before a
+// sequence expression counts as explicitly parenthesised.
+func isGrammarParenArrowBody(node *ast.Node) bool {
+	parent, child, _ := walkUpSkippingParens(node)
+	if parent == nil || !ast.IsArrowFunction(parent) {
+		return false
+	}
+	arrow := parent.AsArrowFunction()
+	return arrow != nil && arrow.Body == child
+}
+
+// isNestedInCommaBinary reports whether node is itself the operand of another
+// comma BinaryExpression (possibly through ParenthesizedExpression wrappers).
+// We only fire on the outermost comma so that a chain like `a, b, c` (parsed
+// left-associatively as `(a, b), c` in tsgo) produces a single diagnostic.
+func isNestedInCommaBinary(node *ast.Node) bool {
+	parent, _, _ := walkUpSkippingParens(node)
+	return isCommaBinary(parent)
+}
+
+// firstCommaToken walks down the left spine of a comma BinaryExpression chain
+// to find the token at the first comma — matching ESLint's
+// `sourceCode.getTokenAfter(node.expressions[0], isCommaToken)`. Parenthesized
+// wrappers are skipped so `(a, b), c` still reports at the inner `,`.
+func firstCommaToken(node *ast.Node) *ast.Node {
+	current := node
+	for {
+		bin := current.AsBinaryExpression()
+		left := ast.SkipParentheses(bin.Left)
+		if !isCommaBinary(left) {
+			return bin.OperatorToken
+		}
+		current = left
+	}
+}
+
+// https://eslint.org/docs/latest/rules/no-sequences
+var NoSequencesRule = rule.Rule{
+	Name: "no-sequences",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				if !isCommaBinary(node) {
+					return
+				}
+				// Only report once per comma chain — skip inner nodes of
+				// `(a, b), c` / `a, b, c`.
+				if isNestedInCommaBinary(node) {
+					return
+				}
+				// `for (init; cond; update)` — ESLint unconditionally allows
+				// sequences in init/update, even when allowInParentheses is
+				// false.
+				if isForInitOrUpdate(node) {
+					return
+				}
+
+				if opts.allowInParentheses {
+					_, _, parenDepth := walkUpSkippingParens(node)
+					required := 1
+					if isGrammarParenArrowBody(node) {
+						// Arrow body parens are materialized as a
+						// ParenthesizedExpression wrapper in tsgo, so an
+						// "extra" pair of parens bumps the wrapper count to 2.
+						required = 2
+					}
+					if parenDepth >= required {
+						return
+					}
+				}
+
+				commaToken := firstCommaToken(node)
+				if commaToken == nil {
+					return
+				}
+				ctx.ReportRange(
+					utils.TrimNodeTextRange(ctx.SourceFile, commaToken),
+					rule.RuleMessage{
+						Id:          "unexpectedCommaExpression",
+						Description: "Unexpected use of comma operator.",
+					},
+				)
+			},
+		}
+	},
+}

--- a/internal/rules/no_sequences/no_sequences.go
+++ b/internal/rules/no_sequences/no_sequences.go
@@ -47,11 +47,11 @@ func walkUpSkippingParens(node *ast.Node) (parent *ast.Node, child *ast.Node, pa
 	return
 }
 
-// isForInitOrUpdate reports whether the outermost paren-skipped wrapper of
-// `node` sits in the init or update slot of a `for` statement. ESLint always
-// allows sequences in those positions regardless of `allowInParentheses`.
-func isForInitOrUpdate(node *ast.Node) bool {
-	parent, child, _ := walkUpSkippingParens(node)
+// isForInitOrUpdate reports whether `child` sits in the init or update slot
+// of the `for` statement `parent`. Callers pass the paren-skipped ancestor
+// pair from walkUpSkippingParens. ESLint always allows sequences in those
+// positions regardless of `allowInParentheses`.
+func isForInitOrUpdate(parent, child *ast.Node) bool {
 	if parent == nil || parent.Kind != ast.KindForStatement {
 		return false
 	}
@@ -62,28 +62,19 @@ func isForInitOrUpdate(node *ast.Node) bool {
 	return child == forStmt.Initializer || child == forStmt.Incrementor
 }
 
-// isGrammarParenArrowBody reports whether the outermost wrapper of `node`
-// occupies the body slot of an arrow function. In tsgo the disambiguating
-// parens in `a => (x, y)` materialize as a ParenthesizedExpression wrapper,
-// so arrow bodies — unlike do-while / while / if / switch / with grammar
-// parens, which are consumed by the statement — need *two* wrappers before a
+// isGrammarParenArrowBody reports whether `child` occupies the body slot of
+// the arrow function `parent`. Callers pass the paren-skipped ancestor pair
+// from walkUpSkippingParens. In tsgo the disambiguating parens in
+// `a => (x, y)` materialize as a ParenthesizedExpression wrapper, so arrow
+// bodies — unlike do-while / while / if / switch / with grammar parens,
+// which are consumed by the statement — need *two* wrappers before a
 // sequence expression counts as explicitly parenthesised.
-func isGrammarParenArrowBody(node *ast.Node) bool {
-	parent, child, _ := walkUpSkippingParens(node)
+func isGrammarParenArrowBody(parent, child *ast.Node) bool {
 	if parent == nil || !ast.IsArrowFunction(parent) {
 		return false
 	}
 	arrow := parent.AsArrowFunction()
 	return arrow != nil && arrow.Body == child
-}
-
-// isNestedInCommaBinary reports whether node is itself the operand of another
-// comma BinaryExpression (possibly through ParenthesizedExpression wrappers).
-// We only fire on the outermost comma so that a chain like `a, b, c` (parsed
-// left-associatively as `(a, b), c` in tsgo) produces a single diagnostic.
-func isNestedInCommaBinary(node *ast.Node) bool {
-	parent, _, _ := walkUpSkippingParens(node)
-	return isCommaBinary(parent)
 }
 
 // firstCommaToken walks down the left spine of a comma BinaryExpression chain
@@ -113,22 +104,24 @@ var NoSequencesRule = rule.Rule{
 				if !isCommaBinary(node) {
 					return
 				}
+				// Single walk-up; all downstream checks read from these.
+				parent, child, parenDepth := walkUpSkippingParens(node)
+
 				// Only report once per comma chain — skip inner nodes of
 				// `(a, b), c` / `a, b, c`.
-				if isNestedInCommaBinary(node) {
+				if isCommaBinary(parent) {
 					return
 				}
 				// `for (init; cond; update)` — ESLint unconditionally allows
 				// sequences in init/update, even when allowInParentheses is
 				// false.
-				if isForInitOrUpdate(node) {
+				if isForInitOrUpdate(parent, child) {
 					return
 				}
 
 				if opts.allowInParentheses {
-					_, _, parenDepth := walkUpSkippingParens(node)
 					required := 1
-					if isGrammarParenArrowBody(node) {
+					if isGrammarParenArrowBody(parent, child) {
 						// Arrow body parens are materialized as a
 						// ParenthesizedExpression wrapper in tsgo, so an
 						// "extra" pair of parens bumps the wrapper count to 2.

--- a/internal/rules/no_sequences/no_sequences.md
+++ b/internal/rules/no_sequences/no_sequences.md
@@ -71,14 +71,6 @@ var foo = (1, 2);
 foo(a, (b, c), d);
 ```
 
-## Differences from ESLint
-
-- **Report position on 3+-element chains.** tsgo parses `a, b, c` as the
-  left-associative BinaryExpression `(a, b), c` rather than a flat
-  `SequenceExpression`. rslint walks down the left spine to report at the
-  first (leftmost) comma — matching ESLint's
-  `sourceCode.getTokenAfter(node.expressions[0], isCommaToken)`.
-
 ## Original Documentation
 
 - [ESLint rule: no-sequences](https://eslint.org/docs/latest/rules/no-sequences)

--- a/internal/rules/no_sequences/no_sequences.md
+++ b/internal/rules/no_sequences/no_sequences.md
@@ -1,0 +1,84 @@
+# no-sequences
+
+## Rule Details
+
+This rule forbids the use of the comma operator, with the following exceptions:
+
+- In the initialization or update portions of a `for` statement.
+- By default, if the expression sequence is explicitly wrapped in parentheses. This exception can be removed with the `"allowInParentheses": false` option.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+foo = doSomething(), val;
+
+0, eval("doSomething();");
+
+do {} while (doSomething(), !!test);
+
+for (; doSomething(), !!test; );
+
+if (doSomething(), !!test);
+
+switch (val = foo(), val) {}
+
+while (val = foo(), val < 42);
+
+with (doSomething(), val) {}
+
+const foo = (val) => (console.log('bar'), val);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+foo = (doSomething(), val);
+
+(0, eval)("doSomething();");
+
+do {} while ((doSomething(), !!test));
+
+for (i = 0, j = 10; i < j; i++, j--);
+
+if ((doSomething(), !!test));
+
+switch ((val = foo(), val)) {}
+
+while ((val = foo(), val < 42));
+
+with ((doSomething(), val)) {}
+
+const foo = (val) => ((console.log('bar'), val));
+```
+
+## Options
+
+This rule takes one optional object argument:
+
+- `allowInParentheses` — when set to `false`, disallows expression sequences even when explicitly wrapped in parentheses. Default `true`.
+
+Examples of **incorrect** code for this rule with `{ "allowInParentheses": false }`:
+
+```json
+{ "no-sequences": ["error", { "allowInParentheses": false }] }
+```
+
+```javascript
+var foo = (1, 2);
+
+(0, eval)("doSomething();");
+
+foo(a, (b, c), d);
+```
+
+## Differences from ESLint
+
+- **Report position on 3+-element chains.** tsgo parses `a, b, c` as the
+  left-associative BinaryExpression `(a, b), c` rather than a flat
+  `SequenceExpression`. rslint walks down the left spine to report at the
+  first (leftmost) comma — matching ESLint's
+  `sourceCode.getTokenAfter(node.expressions[0], isCommaToken)`.
+
+## Original Documentation
+
+- [ESLint rule: no-sequences](https://eslint.org/docs/latest/rules/no-sequences)

--- a/internal/rules/no_sequences/no_sequences_test.go
+++ b/internal/rules/no_sequences/no_sequences_test.go
@@ -1,0 +1,419 @@
+package no_sequences
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoSequencesRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoSequencesRule,
+
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream ESLint suite ----
+			{Code: `var arr = [1, 2];`},
+			{Code: `var obj = {a: 1, b: 2};`},
+			{Code: `var a = 1, b = 2;`},
+			{Code: `var foo = (1, 2);`},
+			{Code: `(0,eval)("foo()");`},
+			{Code: `for (i = 1, j = 2;; i++, j++);`},
+			{Code: `foo(a, (b, c), d);`},
+			{Code: `do {} while ((doSomething(), !!test));`},
+			{Code: `for ((doSomething(), somethingElse()); (doSomething(), !!test); );`},
+			{Code: `if ((doSomething(), !!test));`},
+			{Code: `switch ((doSomething(), val)) {}`},
+			{Code: `while ((doSomething(), !!test));`},
+			{Code: `with ((doSomething(), val)) {}`},
+			{Code: `a => ((doSomething(), a))`},
+
+			// Options object without the "allowInParentheses" property
+			{Code: `var foo = (1, 2);`, Options: map[string]interface{}{}},
+
+			// Explicitly set option "allowInParentheses" to default value
+			{Code: `var foo = (1, 2);`, Options: map[string]interface{}{"allowInParentheses": true}},
+
+			// allowInParentheses: false — for-init / for-update are always allowed
+			{Code: `for ((i = 0, j = 0); test; );`, Options: map[string]interface{}{"allowInParentheses": false}},
+			{Code: `for (; test; (i++, j++));`, Options: map[string]interface{}{"allowInParentheses": false}},
+
+			// https://github.com/eslint/eslint/issues/14572 — return of a parenthesised sequence
+			{Code: `const foo = () => { return ((bar = 123), 10) }`},
+			{Code: `const foo = () => (((bar = 123), 10));`},
+
+			// ---- Extra: chain element that is itself a (parenthesised) sequence
+			// stays valid — only the outer chain is considered, and it's parenthesised.
+			{Code: `var foo = ((1, 2), 3);`},
+
+			// ---- Extra containers: none appear in the grammar-paren list, so a
+			// single pair of parens around the sequence is enough to exempt.
+			// for-in RHS (Expression allows comma), for-of RHS (AssignmentExpression
+			// — here the paren wrap makes the sequence a PrimaryExpression).
+			{Code: `for (x in (a, b)) {}`},
+			{Code: `for (x of (a, b)) {}`},
+
+			// throw / return with parenthesised sequence
+			{Code: `function f() { throw (a, b); }`},
+			{Code: `function f() { return (a, b); }`},
+
+			// TypeScript: `as` / `satisfies` bind tighter than `,`, so the
+			// sequence must be wrapped for the AssignmentExpression position.
+			{Code: `const x = (a, b) as number;`},
+			{Code: `const x = (a, b) satisfies number;`},
+			{Code: `const x = ((a, b)) as number;`},
+
+			// Template literal / tagged template substitution
+			{Code: "const x = `${(a, b)}`;"},
+			{Code: "const x = tag`${(a, b)}`;"},
+
+			// Function / arrow parameter default value
+			{Code: `function f(x = (a, b)) {}`},
+			{Code: `const f = (x = (a, b)) => x;`},
+
+			// Optional-chain / element access — parenthesised sequence is fine
+			{Code: `foo?.((a, b));`},
+			{Code: `foo?.[(a, b)];`},
+			{Code: `foo[(a, b)];`},
+
+			// Class field initializer
+			{Code: `class C { x = (a, b); }`},
+			{Code: `class C { static x = (a, b); }`},
+
+			// Object computed key
+			{Code: `const obj = { [(a, b)]: 1 };`},
+
+			// Conditional expression slots — each slot is AssignmentExpression,
+			// so a bare sequence there requires parens to parse anyway.
+			{Code: `const x = (a, b) ? c : d;`},
+			{Code: `const x = a ? (b, c) : d;`},
+			{Code: `const x = a ? b : (c, d);`},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream ESLint suite ----
+			{
+				Code: `1, 2;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Message: "Unexpected use of comma operator.", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			{
+				Code: `a = 1, 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `do {} while (doSomething(), !!test);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `for (; doSomething(), !!test; );`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `if (doSomething(), !!test);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `switch (doSomething(), val) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `while (doSomething(), !!test);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `with (doSomething(), val) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `a => (doSomething(), a)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `(1), 2`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code: `((1)) , (2)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code: `while((1) , 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- allowInParentheses: false — sequences are flagged even inside parens
+			{
+				Code:    `var foo = (1, 2);`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    `(0,eval)("foo()");`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:    `foo(a, (b, c), d);`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:    `do {} while ((doSomething(), !!test));`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code:    `for (; (doSomething(), !!test); );`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code:    `if ((doSomething(), !!test));`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    `switch ((doSomething(), val)) {}`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `while ((doSomething(), !!test));`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code:    `with ((doSomething(), val)) {}`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:    `a => ((doSomething(), a))`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 21},
+				},
+			},
+
+			// ---- Extra edge cases ----
+
+			// Multi-line — `Line` / `EndLine` / `Column` / `EndColumn` assertion on the comma token
+			{
+				Code: "foo(\n  a,\n  b\n),\n2;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 4, Column: 2, EndLine: 4, EndColumn: 3},
+				},
+			},
+
+			// Chain of 3: should report once, at the FIRST comma (leftmost).
+			{
+				Code: `a, b, c;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+
+			// ---- for-in / for-of RHS — Expression / AssignmentExpression slot
+			// respectively. Neither is in ESLint's grammar-paren list; a bare
+			// sequence there must be flagged (for-of RHS even requires parens
+			// to parse, so the bare form is only reachable via for-in).
+			{
+				Code: `for (x in a, b) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			// allowInParentheses:false still reports when wrapped
+			{
+				Code:    `for (x in (a, b)) {}`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    `for (x of (a, b)) {}`,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 13},
+				},
+			},
+
+			// ---- throw / return — ThrowStatement / ReturnStatement are not
+			// in ESLint's grammar-paren list.
+			{
+				Code: `function f() { throw a, b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `function f() { return a, b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `() => { throw a, b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- TypeScript: `as` / `satisfies` bind tighter than comma, so
+			// `a, b as T` is `a, (b as T)` — outer sequence at bare
+			// ExpressionStatement scope, must be flagged.
+			{
+				Code: `a, b as number;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code: `a, b satisfies number;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 2},
+				},
+			},
+
+			// ---- Template literal / tagged template substitution
+			{
+				Code: "`${a, b}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 5},
+				},
+			},
+			{
+				Code: "tag`${a, b}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 8},
+				},
+			},
+
+			// ---- Element access with bracket-separated sequence
+			// Brackets (`[...]`) are NOT parens, so a bare sequence inside
+			// computed-access brackets must be flagged.
+			{
+				Code: `foo[a, b];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `foo?.[a, b];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 8},
+				},
+			},
+
+			// ---- JSX: JsxExpression slot — not in grammar-paren list.
+			{
+				Code:   `const x = <div>{a, b}</div>;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCommaExpression", Line: 1, Column: 18}},
+			},
+			{
+				Code:   `const x = <div id={a, b}/>;`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCommaExpression", Line: 1, Column: 21}},
+			},
+			// allowInParentheses:false — even parenthesised JSX expression
+			// slot should be flagged.
+			{
+				Code:    `const x = <div id={(a, b)}/>;`,
+				Tsx:     true,
+				Options: map[string]interface{}{"allowInParentheses": false},
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "unexpectedCommaExpression", Line: 1, Column: 22}},
+			},
+
+			// ---- Conditional expression slots: bare sequence where a slot
+			// expects an AssignmentExpression is a parse error, but a comma
+			// at the ConditionalExpression's outer boundary is still flagged.
+			// Example: `a ? b : c, d` parses as `(a ? b : c), d`.
+			{
+				Code: `a ? b : c, d;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 10},
+				},
+			},
+
+			// ---- Multi-byte position assertions (UTF-16 code units).
+			// Surrogate pair in a string literal — each emoji counts as 2
+			// UTF-16 units. Catches byte-offset / code-point counting bugs.
+			{
+				Code: `'🍎', 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 5, EndLine: 1, EndColumn: 6},
+				},
+			},
+			// BMP CJK identifiers — each is 1 UTF-16 unit but 3 UTF-8 bytes.
+			{
+				Code: `中, 文;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+			// Multi-line with emoji on a prior column
+			{
+				Code: "function f() {\n  return \"🍎\", 1;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 2, Column: 14, EndLine: 2, EndColumn: 15},
+				},
+			},
+
+			// ---- Longer chain (4 elements) — still reports once, at the
+			// leftmost comma.
+			{
+				Code: `a, b, c, d;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpectedCommaExpression", Line: 1, Column: 2, EndLine: 1, EndColumn: 3},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -291,6 +291,7 @@ export default defineConfig({
     './tests/eslint/rules/no-proto.test.ts',
     './tests/eslint/rules/no-return-assign.test.ts',
     './tests/eslint/rules/no-self-compare.test.ts',
+    './tests/eslint/rules/no-sequences.test.ts',
     './tests/eslint/rules/no-unneeded-ternary.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-sequences.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-sequences.test.ts.snap
@@ -1,0 +1,1017 @@
+// Rstest Snapshot v1
+
+exports[`no-sequences > invalid 1`] = `
+{
+  "code": "1, 2;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 2`] = `
+{
+  "code": "a = 1, 2",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 3`] = `
+{
+  "code": "do {} while (doSomething(), !!test);",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 4`] = `
+{
+  "code": "for (; doSomething(), !!test; );",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 5`] = `
+{
+  "code": "if (doSomething(), !!test);",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 6`] = `
+{
+  "code": "switch (doSomething(), val) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 7`] = `
+{
+  "code": "while (doSomething(), !!test);",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 8`] = `
+{
+  "code": "with (doSomething(), val) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 9`] = `
+{
+  "code": "a => (doSomething(), a)",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 10`] = `
+{
+  "code": "(1), 2",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 11`] = `
+{
+  "code": "((1)) , (2)",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 12`] = `
+{
+  "code": "while((1) , 2);",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 13`] = `
+{
+  "code": "var foo = (1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 14`] = `
+{
+  "code": "(0,eval)("foo()");",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 15`] = `
+{
+  "code": "foo(a, (b, c), d);",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 16`] = `
+{
+  "code": "do {} while ((doSomething(), !!test));",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 17`] = `
+{
+  "code": "for (; (doSomething(), !!test); );",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 18`] = `
+{
+  "code": "if ((doSomething(), !!test));",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 19`] = `
+{
+  "code": "switch ((doSomething(), val)) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 20`] = `
+{
+  "code": "while ((doSomething(), !!test));",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 21`] = `
+{
+  "code": "with ((doSomething(), val)) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 22`] = `
+{
+  "code": "a => ((doSomething(), a))",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 23`] = `
+{
+  "code": "for (x in a, b) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 24`] = `
+{
+  "code": "for (x in (a, b)) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 25`] = `
+{
+  "code": "for (x of (a, b)) {}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 26`] = `
+{
+  "code": "function f() { throw a, b; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 27`] = `
+{
+  "code": "function f() { return a, b; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 28`] = `
+{
+  "code": "() => { throw a, b; }",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 29`] = `
+{
+  "code": "a, b as number;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 30`] = `
+{
+  "code": "a, b satisfies number;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 31`] = `
+{
+  "code": "\`\${a, b}\`;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 32`] = `
+{
+  "code": "tag\`\${a, b}\`;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 33`] = `
+{
+  "code": "foo[a, b];",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 34`] = `
+{
+  "code": "foo?.[a, b];",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 35`] = `
+{
+  "code": "a ? b : c, d;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 36`] = `
+{
+  "code": "'🍎', 1;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 37`] = `
+{
+  "code": "中, 文;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 38`] = `
+{
+  "code": "function f() {
+  return "🍎", 1;
+}",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 14,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-sequences > invalid 39`] = `
+{
+  "code": "a, b, c, d;",
+  "diagnostics": [
+    {
+      "message": "Unexpected use of comma operator.",
+      "messageId": "unexpectedCommaExpression",
+      "range": {
+        "end": {
+          "column": 3,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-sequences",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-sequences.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-sequences.test.ts
@@ -1,0 +1,274 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-sequences', {
+  valid: [
+    // ---- Upstream ESLint suite ----
+    `var arr = [1, 2];`,
+    `var obj = {a: 1, b: 2};`,
+    `var a = 1, b = 2;`,
+    `var foo = (1, 2);`,
+    `(0,eval)("foo()");`,
+    `for (i = 1, j = 2;; i++, j++);`,
+    `foo(a, (b, c), d);`,
+    `do {} while ((doSomething(), !!test));`,
+    `for ((doSomething(), somethingElse()); (doSomething(), !!test); );`,
+    `if ((doSomething(), !!test));`,
+    `switch ((doSomething(), val)) {}`,
+    `while ((doSomething(), !!test));`,
+    `with ((doSomething(), val)) {}`,
+    `a => ((doSomething(), a))`,
+
+    // Options object without the "allowInParentheses" property
+    { code: `var foo = (1, 2);`, options: [{}] as any },
+
+    // Explicitly set option "allowInParentheses" to default value
+    {
+      code: `var foo = (1, 2);`,
+      options: [{ allowInParentheses: true }] as any,
+    },
+
+    // allowInParentheses: false — for-init / for-update are always allowed
+    {
+      code: `for ((i = 0, j = 0); test; );`,
+      options: [{ allowInParentheses: false }] as any,
+    },
+    {
+      code: `for (; test; (i++, j++));`,
+      options: [{ allowInParentheses: false }] as any,
+    },
+
+    // https://github.com/eslint/eslint/issues/14572 — return of a parenthesised sequence
+    `const foo = () => { return ((bar = 123), 10) }`,
+    `const foo = () => (((bar = 123), 10));`,
+
+    // ---- Extra containers: single pair of parens is enough to exempt.
+    `for (x in (a, b)) {}`,
+    `for (x of (a, b)) {}`,
+    `function f() { throw (a, b); }`,
+    `function f() { return (a, b); }`,
+
+    // TypeScript: `as` / `satisfies` bind tighter than comma, so sequence
+    // must be wrapped for the AssignmentExpression position.
+    `const x = (a, b) as number;`,
+    `const x = (a, b) satisfies number;`,
+    `const x = ((a, b)) as number;`,
+
+    // Template literal / tagged template substitution
+    'const x = `${(a, b)}`;',
+    'const x = tag`${(a, b)}`;',
+
+    // Function / arrow parameter default value
+    `function f(x = (a, b)) {}`,
+    `const f = (x = (a, b)) => x;`,
+
+    // Optional-chain / element access — parenthesised sequence is fine
+    `foo?.((a, b));`,
+    `foo?.[(a, b)];`,
+    `foo[(a, b)];`,
+
+    // Class field initializer
+    `class C { x = (a, b); }`,
+    `class C { static x = (a, b); }`,
+
+    // Object computed key
+    `const obj = { [(a, b)]: 1 };`,
+
+    // Conditional-expression slots
+    `const x = (a, b) ? c : d;`,
+    `const x = a ? (b, c) : d;`,
+    `const x = a ? b : (c, d);`,
+  ],
+  invalid: [
+    // ---- Upstream ESLint suite ----
+    {
+      code: `1, 2;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 2 }],
+    },
+    {
+      code: `a = 1, 2`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 6 }],
+    },
+    {
+      code: `do {} while (doSomething(), !!test);`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 27 }],
+    },
+    {
+      code: `for (; doSomething(), !!test; );`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 21 }],
+    },
+    {
+      code: `if (doSomething(), !!test);`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 18 }],
+    },
+    {
+      code: `switch (doSomething(), val) {}`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 22 }],
+    },
+    {
+      code: `while (doSomething(), !!test);`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 21 }],
+    },
+    {
+      code: `with (doSomething(), val) {}`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 20 }],
+    },
+    {
+      code: `a => (doSomething(), a)`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 20 }],
+    },
+    {
+      code: `(1), 2`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 4 }],
+    },
+    {
+      code: `((1)) , (2)`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 7 }],
+    },
+    {
+      code: `while((1) , 2);`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 11 }],
+    },
+
+    // ---- allowInParentheses: false — sequences flagged even inside parens ----
+    {
+      code: `var foo = (1, 2);`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 13 }],
+    },
+    {
+      code: `(0,eval)("foo()");`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 3 }],
+    },
+    {
+      code: `foo(a, (b, c), d);`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 10 }],
+    },
+    {
+      code: `do {} while ((doSomething(), !!test));`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 28 }],
+    },
+    {
+      code: `for (; (doSomething(), !!test); );`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 22 }],
+    },
+    {
+      code: `if ((doSomething(), !!test));`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 19 }],
+    },
+    {
+      code: `switch ((doSomething(), val)) {}`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 23 }],
+    },
+    {
+      code: `while ((doSomething(), !!test));`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 22 }],
+    },
+    {
+      code: `with ((doSomething(), val)) {}`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 21 }],
+    },
+    {
+      code: `a => ((doSomething(), a))`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 21 }],
+    },
+
+    // ---- for-in / for-of RHS ----
+    {
+      code: `for (x in a, b) {}`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 12 }],
+    },
+    {
+      code: `for (x in (a, b)) {}`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 13 }],
+    },
+    {
+      code: `for (x of (a, b)) {}`,
+      options: [{ allowInParentheses: false }] as any,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 13 }],
+    },
+
+    // ---- throw / return ----
+    {
+      code: `function f() { throw a, b; }`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 23 }],
+    },
+    {
+      code: `function f() { return a, b; }`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 24 }],
+    },
+    {
+      code: `() => { throw a, b; }`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 16 }],
+    },
+
+    // ---- TypeScript `as` / `satisfies` bind tighter than comma ----
+    {
+      code: `a, b as number;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 2 }],
+    },
+    {
+      code: `a, b satisfies number;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 2 }],
+    },
+
+    // ---- Template literal / tagged template substitution ----
+    {
+      code: '`${a, b}`;',
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 5 }],
+    },
+    {
+      code: 'tag`${a, b}`;',
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 8 }],
+    },
+
+    // ---- Element access with comma inside brackets ----
+    {
+      code: `foo[a, b];`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 6 }],
+    },
+    {
+      code: `foo?.[a, b];`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 8 }],
+    },
+
+    // ---- Conditional-expression boundary (`a ? b : c, d`) ----
+    {
+      code: `a ? b : c, d;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 10 }],
+    },
+
+    // ---- Multi-byte position assertions (UTF-16 code units) ----
+    // Surrogate pair in a string literal — emoji counts as 2 UTF-16 units
+    {
+      code: `'🍎', 1;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 5 }],
+    },
+    // BMP CJK identifier — each is 1 UTF-16 unit but 3 UTF-8 bytes
+    {
+      code: `中, 文;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 2 }],
+    },
+    {
+      code: 'function f() {\n  return "🍎", 1;\n}',
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 2, column: 14 }],
+    },
+
+    // ---- Longer chain (4 elements) — still reports once, leftmost comma
+    {
+      code: `a, b, c, d;`,
+      errors: [{ messageId: 'unexpectedCommaExpression', line: 1, column: 2 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the \`no-sequences\` rule from ESLint to rslint.

The rule forbids the use of the comma operator, with two exceptions:

- In the init / update slots of a \`for\` statement.
- When the expression sequence is explicitly wrapped in parentheses (configurable via \`allowInParentheses\`, default \`true\`).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-sequences
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-sequences.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).