### PR TITLE
feat: port rule require-yield

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -203,6 +203,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
+	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
 	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
@@ -631,6 +632,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
+	GlobalRuleRegistry.Register("require-yield", require_yield.RequireYieldRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/require_yield/require_yield.go
+++ b/internal/rules/require_yield/require_yield.go
@@ -1,0 +1,80 @@
+package require_yield
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildMissingYieldMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "missingYield",
+		Description: "This generator function does not have 'yield'.",
+	}
+}
+
+func isGenerator(node *ast.Node) bool {
+	return ast.GetFunctionFlags(node)&ast.FunctionFlagsGenerator != 0
+}
+
+func hasNonEmptyBody(node *ast.Node) bool {
+	body := node.Body()
+	if body == nil || body.Kind != ast.KindBlock {
+		return false
+	}
+	block := body.AsBlock()
+	if block == nil || block.Statements == nil {
+		return false
+	}
+	return len(block.Statements.Nodes) > 0
+}
+
+// https://eslint.org/docs/latest/rules/require-yield
+var RequireYieldRule = rule.Rule{
+	Name: "require-yield",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		stack := make([]int, 0, 8)
+
+		beginChecking := func(node *ast.Node) {
+			if isGenerator(node) {
+				stack = append(stack, 0)
+			}
+		}
+
+		endChecking := func(node *ast.Node) {
+			if !isGenerator(node) {
+				return
+			}
+			n := len(stack)
+			if n == 0 {
+				return
+			}
+			count := stack[n-1]
+			stack = stack[:n-1]
+
+			if count == 0 && hasNonEmptyBody(node) {
+				ctx.ReportRange(
+					utils.GetFunctionHeadLoc(ctx.SourceFile, node),
+					buildMissingYieldMessage(),
+				)
+			}
+		}
+
+		incYield := func(node *ast.Node) {
+			if n := len(stack); n > 0 {
+				stack[n-1]++
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration:                      beginChecking,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): endChecking,
+			ast.KindFunctionExpression:                       beginChecking,
+			rule.ListenerOnExit(ast.KindFunctionExpression):  endChecking,
+			ast.KindMethodDeclaration:                        beginChecking,
+			rule.ListenerOnExit(ast.KindMethodDeclaration):   endChecking,
+
+			ast.KindYieldExpression: incYield,
+		}
+	},
+}

--- a/internal/rules/require_yield/require_yield.go
+++ b/internal/rules/require_yield/require_yield.go
@@ -29,52 +29,107 @@ func hasNonEmptyBody(node *ast.Node) bool {
 	return len(block.Statements.Nodes) > 0
 }
 
+// bodyLikeRange returns the [pos, end) of the "execution body" of a scope-
+// bearing node. Yield expressions whose position falls inside this range
+// are attributed to this scope; yields outside it (e.g. in a computed
+// property key) pass through to an outer scope.
+//
+// Required because tsgo performs error-recovery parsing: an illegally
+// placed `yield` (e.g. inside a non-generator function body) still
+// produces a KindYieldExpression AST node. Without position-aware
+// attribution, such a yield would bubble up to the nearest enclosing
+// generator on the stack and cause a false negative.
+func bodyLikeRange(node *ast.Node) (int, int, bool) {
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindMethodDeclaration,
+		ast.KindArrowFunction,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindConstructor:
+		body := node.Body()
+		if body == nil {
+			return 0, 0, false
+		}
+		return body.Pos(), body.End(), true
+	case ast.KindPropertyDeclaration:
+		init := node.AsPropertyDeclaration().Initializer
+		if init == nil {
+			return 0, 0, false
+		}
+		return init.Pos(), init.End(), true
+	}
+	return 0, 0, false
+}
+
+type stackFrame struct {
+	node  *ast.Node
+	count int
+}
+
 // https://eslint.org/docs/latest/rules/require-yield
 var RequireYieldRule = rule.Rule{
 	Name: "require-yield",
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
-		stack := make([]int, 0, 8)
+		stack := make([]stackFrame, 0, 8)
 
-		beginChecking := func(node *ast.Node) {
-			if isGenerator(node) {
-				stack = append(stack, 0)
-			}
+		enter := func(node *ast.Node) {
+			stack = append(stack, stackFrame{node: node})
 		}
 
-		endChecking := func(node *ast.Node) {
-			if !isGenerator(node) {
-				return
-			}
+		exit := func(node *ast.Node) {
 			n := len(stack)
 			if n == 0 {
 				return
 			}
-			count := stack[n-1]
+			top := stack[n-1]
 			stack = stack[:n-1]
-
-			if count == 0 && hasNonEmptyBody(node) {
+			// PropertyDeclaration represents an implicit constructor scope
+			// for its initializer; it is never a generator itself.
+			if top.node.Kind == ast.KindPropertyDeclaration {
+				return
+			}
+			if isGenerator(top.node) && top.count == 0 && hasNonEmptyBody(top.node) {
 				ctx.ReportRange(
-					utils.GetFunctionHeadLoc(ctx.SourceFile, node),
+					utils.GetFunctionHeadLoc(ctx.SourceFile, top.node),
 					buildMissingYieldMessage(),
 				)
 			}
 		}
 
-		incYield := func(node *ast.Node) {
-			if n := len(stack); n > 0 {
-				stack[n-1]++
+		countYield := func(node *ast.Node) {
+			for i := len(stack) - 1; i >= 0; i-- {
+				bp, be, ok := bodyLikeRange(stack[i].node)
+				if !ok {
+					continue
+				}
+				if node.Pos() >= bp && node.End() <= be {
+					stack[i].count++
+					return
+				}
 			}
 		}
 
 		return rule.RuleListeners{
-			ast.KindFunctionDeclaration:                      beginChecking,
-			rule.ListenerOnExit(ast.KindFunctionDeclaration): endChecking,
-			ast.KindFunctionExpression:                       beginChecking,
-			rule.ListenerOnExit(ast.KindFunctionExpression):  endChecking,
-			ast.KindMethodDeclaration:                        beginChecking,
-			rule.ListenerOnExit(ast.KindMethodDeclaration):   endChecking,
+			ast.KindFunctionDeclaration:                      enter,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration): exit,
+			ast.KindFunctionExpression:                       enter,
+			rule.ListenerOnExit(ast.KindFunctionExpression):  exit,
+			ast.KindMethodDeclaration:                        enter,
+			rule.ListenerOnExit(ast.KindMethodDeclaration):   exit,
+			ast.KindArrowFunction:                            enter,
+			rule.ListenerOnExit(ast.KindArrowFunction):       exit,
+			ast.KindGetAccessor:                              enter,
+			rule.ListenerOnExit(ast.KindGetAccessor):         exit,
+			ast.KindSetAccessor:                              enter,
+			rule.ListenerOnExit(ast.KindSetAccessor):         exit,
+			ast.KindConstructor:                              enter,
+			rule.ListenerOnExit(ast.KindConstructor):         exit,
+			ast.KindPropertyDeclaration:                      enter,
+			rule.ListenerOnExit(ast.KindPropertyDeclaration): exit,
 
-			ast.KindYieldExpression: incYield,
+			ast.KindYieldExpression: countYield,
 		}
 	},
 }

--- a/internal/rules/require_yield/require_yield.go
+++ b/internal/rules/require_yield/require_yield.go
@@ -29,16 +29,22 @@ func hasNonEmptyBody(node *ast.Node) bool {
 	return len(block.Statements.Nodes) > 0
 }
 
-// bodyLikeRange returns the [pos, end) of the "execution body" of a scope-
-// bearing node. Yield expressions whose position falls inside this range
-// are attributed to this scope; yields outside it (e.g. in a computed
-// property key) pass through to an outer scope.
+// bodyLikeRange returns the [pos, end) of the "execution scope" of a
+// scope-bearing node. Yield expressions whose position falls inside this
+// range are attributed to this scope; yields outside it (e.g. in a
+// computed property key or a decorator expression) pass through to an
+// outer scope.
 //
 // Required because tsgo performs error-recovery parsing: an illegally
-// placed `yield` (e.g. inside a non-generator function body) still
-// produces a KindYieldExpression AST node. Without position-aware
-// attribution, such a yield would bubble up to the nearest enclosing
-// generator on the stack and cause a false negative.
+// placed `yield` (e.g. inside a non-generator function body or in a
+// parameter default value of a non-generator) still produces a
+// KindYieldExpression AST node. Without position-aware attribution, such
+// a yield would bubble up to the nearest enclosing generator on the
+// stack and cause a false negative.
+//
+// For function-like nodes the scope starts at the parameter list, so
+// that yield in parameter default values is attributed here rather than
+// leaking to an outer generator.
 func bodyLikeRange(node *ast.Node) (int, int, bool) {
 	switch node.Kind {
 	case ast.KindFunctionDeclaration,
@@ -52,13 +58,23 @@ func bodyLikeRange(node *ast.Node) (int, int, bool) {
 		if body == nil {
 			return 0, 0, false
 		}
-		return body.Pos(), body.End(), true
+		pos := body.Pos()
+		if params := node.ParameterList(); params != nil {
+			pos = params.Loc.Pos()
+		}
+		return pos, body.End(), true
 	case ast.KindPropertyDeclaration:
 		init := node.AsPropertyDeclaration().Initializer
 		if init == nil {
 			return 0, 0, false
 		}
 		return init.Pos(), init.End(), true
+	case ast.KindClassStaticBlockDeclaration:
+		body := node.AsClassStaticBlockDeclaration().Body
+		if body == nil {
+			return 0, 0, false
+		}
+		return body.Pos(), body.End(), true
 	}
 	return 0, 0, false
 }
@@ -85,9 +101,11 @@ var RequireYieldRule = rule.Rule{
 			}
 			top := stack[n-1]
 			stack = stack[:n-1]
-			// PropertyDeclaration represents an implicit constructor scope
-			// for its initializer; it is never a generator itself.
-			if top.node.Kind == ast.KindPropertyDeclaration {
+			// PropertyDeclaration initializer and ClassStaticBlockDeclaration
+			// both represent implicit-constructor-like scopes that are never
+			// themselves generators.
+			if top.node.Kind == ast.KindPropertyDeclaration ||
+				top.node.Kind == ast.KindClassStaticBlockDeclaration {
 				return
 			}
 			if isGenerator(top.node) && top.count == 0 && hasNonEmptyBody(top.node) {
@@ -112,22 +130,24 @@ var RequireYieldRule = rule.Rule{
 		}
 
 		return rule.RuleListeners{
-			ast.KindFunctionDeclaration:                      enter,
-			rule.ListenerOnExit(ast.KindFunctionDeclaration): exit,
-			ast.KindFunctionExpression:                       enter,
-			rule.ListenerOnExit(ast.KindFunctionExpression):  exit,
-			ast.KindMethodDeclaration:                        enter,
-			rule.ListenerOnExit(ast.KindMethodDeclaration):   exit,
-			ast.KindArrowFunction:                            enter,
-			rule.ListenerOnExit(ast.KindArrowFunction):       exit,
-			ast.KindGetAccessor:                              enter,
-			rule.ListenerOnExit(ast.KindGetAccessor):         exit,
-			ast.KindSetAccessor:                              enter,
-			rule.ListenerOnExit(ast.KindSetAccessor):         exit,
-			ast.KindConstructor:                              enter,
-			rule.ListenerOnExit(ast.KindConstructor):         exit,
-			ast.KindPropertyDeclaration:                      enter,
-			rule.ListenerOnExit(ast.KindPropertyDeclaration): exit,
+			ast.KindFunctionDeclaration:                              enter,
+			rule.ListenerOnExit(ast.KindFunctionDeclaration):         exit,
+			ast.KindFunctionExpression:                               enter,
+			rule.ListenerOnExit(ast.KindFunctionExpression):          exit,
+			ast.KindMethodDeclaration:                                enter,
+			rule.ListenerOnExit(ast.KindMethodDeclaration):           exit,
+			ast.KindArrowFunction:                                    enter,
+			rule.ListenerOnExit(ast.KindArrowFunction):               exit,
+			ast.KindGetAccessor:                                      enter,
+			rule.ListenerOnExit(ast.KindGetAccessor):                 exit,
+			ast.KindSetAccessor:                                      enter,
+			rule.ListenerOnExit(ast.KindSetAccessor):                 exit,
+			ast.KindConstructor:                                      enter,
+			rule.ListenerOnExit(ast.KindConstructor):                 exit,
+			ast.KindPropertyDeclaration:                              enter,
+			rule.ListenerOnExit(ast.KindPropertyDeclaration):         exit,
+			ast.KindClassStaticBlockDeclaration:                      enter,
+			rule.ListenerOnExit(ast.KindClassStaticBlockDeclaration): exit,
 
 			ast.KindYieldExpression: countYield,
 		}

--- a/internal/rules/require_yield/require_yield.md
+++ b/internal/rules/require_yield/require_yield.md
@@ -1,0 +1,37 @@
+# require-yield
+
+## Rule Details
+
+This rule generates warnings for generator functions that do not have the `yield` keyword.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function* foo() {
+  return 10;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function* foo() {
+  yield 5;
+  return 10;
+}
+
+function foo() {
+  return 10;
+}
+
+// This rule does not warn on empty generator functions.
+function* foo() {}
+```
+
+## When Not To Use It
+
+If you don't want to notify generator functions that have no `yield` expression, then it's safe to disable this rule.
+
+## Original Documentation
+
+- https://eslint.org/docs/latest/rules/require-yield

--- a/internal/rules/require_yield/require_yield_test.go
+++ b/internal/rules/require_yield/require_yield_test.go
@@ -1,0 +1,444 @@
+package require_yield
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireYieldRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RequireYieldRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Upstream ESLint suite ----
+			{Code: `function foo() { return 0; }`},
+			{Code: `function* foo() { yield 0; }`},
+			{Code: `function* foo() { }`},
+			{Code: `(function* foo() { yield 0; })();`},
+			{Code: `(function* foo() { })();`},
+			{Code: `var obj = { *foo() { yield 0; } };`},
+			{Code: `var obj = { *foo() { } };`},
+			{Code: `class A { *foo() { yield 0; } };`},
+			{Code: `class A { *foo() { } };`},
+
+			// ---- Yield variants ----
+			// Bare yield (no argument)
+			{Code: `function* foo() { yield; }`},
+			// yield* delegation
+			{Code: `function* foo() { yield* [1, 2, 3]; }`},
+
+			// ---- Async generators ----
+			{Code: `async function* foo() { yield 0; }`},
+			{Code: `async function* foo() { }`},
+
+			// ---- Yield inside control flow ----
+			{Code: `function* foo() { if (true) { yield 1; } }`},
+			{Code: `function* foo() { while (true) { yield 1; } }`},
+			{Code: `function* foo() { try { yield 1; } catch (e) {} }`},
+			{Code: `function* foo() { try { } catch (e) { yield 1; } }`},
+			{Code: `function* foo() { try { } finally { yield 1; } }`},
+
+			// ---- Export forms ----
+			{Code: `export function* foo() { yield 1; }`, Tsx: true},
+			{Code: `export default function*() { yield 1; }`, Tsx: true},
+
+			// ---- Class method forms ----
+			{Code: `class A { static *foo() { yield 0; } }`},
+			{Code: `class A { *#foo() { yield 0; } }`},
+
+			// ---- Computed / class expression / anonymous ----
+			{Code: `var obj = { *['foo']() { yield 0; } };`},
+			{Code: `const A = class { *foo() { yield 0; } };`},
+			{Code: `(function*() { yield 0; })();`},
+
+			// ---- Arrow inside generator (arrow can't be generator) ----
+			{Code: `function* foo() { const x = () => 1; yield x; }`},
+
+			// ---- Nested generators, both have yield ----
+			{Code: `function* outer() { function* inner() { yield 1; } yield 2; }`},
+
+			// ---- TS modifiers on class generator methods ----
+			{Code: `class A { async *foo() { yield 0; } }`},
+			{Code: `class A { public *foo() { yield 0; } }`},
+			{Code: `class A { private *foo() { yield 0; } }`},
+			{Code: `class A { protected *foo() { yield 0; } }`},
+			{Code: `class A { public static async *foo() { yield 0; } }`},
+
+			// ---- Function expression as object property value ----
+			{Code: `var obj = { foo: function*() { yield 0; } };`},
+
+			// ---- Control flow variants ----
+			{Code: `function* foo() { for (const x of [1]) yield x; }`},
+			{Code: `function* foo(x: number) { switch (x) { case 1: yield 1; break; default: yield 0; } }`},
+			{Code: `function* foo() { do { yield 1; } while (false); }`},
+
+			// ---- Generic generator ----
+			{Code: `function* foo<T>(x: T): Generator<T> { yield x; }`},
+
+			// ---- Nested FE inside arrow inside generator ----
+			{Code: `function* foo() { const f = () => function*() { yield 1; }; yield 2; }`},
+
+			// ---- Overload signatures (no body) + impl with yield ----
+			{Code: `function* foo(x: string): Generator<string>; function* foo(x: number): Generator<number>; function* foo(x: any): Generator<any> { yield x; }`},
+
+			// ---- Ambient declarations (no body) ----
+			{Code: `declare function* foo(): Generator<number>;`},
+
+			// ---- PropertyDefinition (class field) with generator FE ----
+			{Code: `class A { foo = function*() { yield 0; }; }`},
+
+			// ---- Multi-line function head ----
+			{Code: "function*\n  foo() {\n  yield 0;\n}"},
+
+			// ---- Decorator scenarios (with yield, so valid) ----
+			// Single method decorator
+			{Code: `function dec(t: any, k: any, d: any) {} class A { @dec *foo() { yield 0; } }`},
+			// Multiple method decorators
+			{Code: `function d1(t: any, k: any, d: any) {} function d2(t: any, k: any, d: any) {} class A { @d1 @d2 *foo() { yield 0; } }`},
+			// Decorator factory (with args)
+			{Code: `function dec() { return (t: any, k: any, d: any) => {}; } class A { @dec() *foo() { yield 0; } }`},
+			// Decorator + TS modifiers
+			{Code: `function dec(t: any, k: any, d: any) {} class A { @dec public static *foo() { yield 0; } }`},
+			// Decorator + async generator
+			{Code: `function dec(t: any, k: any, d: any) {} class A { @dec async *foo() { yield 0; } }`},
+			// Class-level decorator (shouldn't affect method position)
+			{Code: `function classDec(t: any) {} @classDec class A { *foo() { yield 0; } }`},
+			// Class field decorator + generator FE
+			{Code: `function dec(t: any, k: any) {} class A { @dec foo = function*() { yield 0; }; }`},
+			// Multi-line decorator
+			{Code: "function dec(t: any, k: any, d: any) {}\nclass A {\n  @dec\n  *foo() { yield 0; }\n}"},
+
+			// ---- JSDoc scenarios (with yield, so valid) ----
+			// JSDoc before function declaration
+			{Code: `/** doc */ function* foo() { yield 0; }`},
+			// Multi-line JSDoc
+			{Code: "/**\n * doc\n */\nfunction* foo() { yield 0; }"},
+			// JSDoc before class method
+			{Code: `class A { /** doc */ *foo() { yield 0; } }`},
+			// JSDoc before object method
+			{Code: `var o = { /** doc */ *foo() { yield 0; } };`},
+			// JSDoc + FunctionExpression as property value
+			{Code: `var o = { /** doc */ foo: function*() { yield 0; } };`},
+			// JSDoc before anonymous FE in IIFE
+			{Code: `(/** doc */ function*() { yield 0; })();`},
+			// Line comment before function
+			{Code: "// comment\nfunction* foo() { yield 0; }"},
+			// Block comment (non-JSDoc) before function
+			{Code: `/* comment */ function* foo() { yield 0; }`},
+			// JSDoc on class field with FE
+			{Code: `class A { /** doc */ foo = function*() { yield 0; }; }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Upstream ESLint suite ----
+			{
+				Code: `function* foo() { return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `(function* foo() { return 0; })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 2, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `var obj = { *foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 13, EndLine: 1, EndColumn: 17},
+				},
+			},
+			{
+				Code: `class A { *foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 11, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code: `function* foo() { function* bar() { yield 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { function* bar() { return 0; } yield 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 19, EndLine: 1, EndColumn: 32},
+				},
+			},
+
+			// ---- Async generator ----
+			{
+				Code: `async function* foo() { return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 20},
+				},
+			},
+
+			// ---- Export forms ----
+			{
+				Code: `export function* foo() { return 0; }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 8, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `export default function*() { return 0; }`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 16, EndLine: 1, EndColumn: 25},
+				},
+			},
+
+			// ---- Class method forms ----
+			{
+				Code: `class A { static *foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 11, EndLine: 1, EndColumn: 22},
+				},
+			},
+			{
+				Code: `class A { *#foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 11, EndLine: 1, EndColumn: 16},
+				},
+			},
+
+			// ---- Computed / class expression / anonymous FE ----
+			{
+				Code: `var obj = { *['foo']() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 13, EndLine: 1, EndColumn: 21},
+				},
+			},
+			{
+				Code: `const A = class { *foo() { return 0; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 19, EndLine: 1, EndColumn: 23},
+				},
+			},
+			{
+				Code: `(function*() { return 0; })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 2, EndLine: 1, EndColumn: 11},
+				},
+			},
+
+			// ---- Control flow without yield in any branch ----
+			{
+				Code: `function* foo() { if (true) { return 1; } else { return 2; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- Arrow inside generator (arrow not a generator, body has no yield) ----
+			{
+				Code: `function* foo() { const x = () => 1; return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- Multi-line ----
+			{
+				Code: "function* foo() {\n  return 0;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- Async class method generator ----
+			{
+				Code: `class A { async *foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 11, EndLine: 1, EndColumn: 21},
+				},
+			},
+
+			// ---- Public/static combined ----
+			{
+				Code: `class A { public static async *foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 11, EndLine: 1, EndColumn: 35},
+				},
+			},
+
+			// ---- Function expression as object property value ----
+			{
+				Code: `var obj = { foo: function*() { return 0; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 13, EndLine: 1, EndColumn: 27},
+				},
+			},
+
+			// ---- Generic generator ----
+			{
+				Code: `function* foo<T>(x: T): Generator<T> { return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 17},
+				},
+			},
+
+			// ---- Overload signatures + impl with no yield ----
+			{
+				Code: `function* foo(x: string): Generator<string>; function* foo(x: number): Generator<number>; function* foo(x: any): Generator<any> { return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 91, EndLine: 1, EndColumn: 104},
+				},
+			},
+
+			// ---- Nested FE inside arrow: outer has no yield ----
+			{
+				Code: `function* foo() { const f = () => function*() { yield 1; }; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+
+			// ---- Class field with generator FE ----
+			{
+				Code: `class A { foo = function*() { return 0; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 11, EndLine: 1, EndColumn: 26},
+				},
+			},
+
+			// ---- Multi-line function head ----
+			{
+				Code: "function*\n  foo() {\n  return 0;\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 2, EndColumn: 6},
+				},
+			},
+
+			// ---- Decorator scenarios ----
+			// Single method decorator (no args)
+			{
+				Code: "declare function dec(t: any, k: any, d: any): void;\nclass A { @dec *foo() { return 0; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 11, EndLine: 2, EndColumn: 20},
+				},
+			},
+			// Decorator factory (with args) — stress test for findOpenParenPos
+			{
+				Code: "declare function dec(): (t: any, k: any, d: any) => void;\nclass A { @dec() *foo() { return 0; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 11, EndLine: 2, EndColumn: 22},
+				},
+			},
+			// Multiple method decorators
+			{
+				Code: "declare function d1(t: any, k: any, d: any): void; declare function d2(t: any, k: any, d: any): void;\nclass A { @d1 @d2 *foo() { return 0; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 11, EndLine: 2, EndColumn: 23},
+				},
+			},
+			// Decorator + TS modifiers
+			{
+				Code: "declare function dec(t: any, k: any, d: any): void;\nclass A { @dec public static *foo() { return 0; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 11, EndLine: 2, EndColumn: 34},
+				},
+			},
+			// Decorator + async generator
+			{
+				Code: "declare function dec(t: any, k: any, d: any): void;\nclass A { @dec async *foo() { return 0; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 11, EndLine: 2, EndColumn: 26},
+				},
+			},
+			// Class-level decorator (shouldn't affect method position)
+			{
+				Code: "declare function classDec(t: any): void;\n@classDec\nclass A { *foo() { return 0; } }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 3, Column: 11, EndLine: 3, EndColumn: 15},
+				},
+			},
+			// Class field decorator + generator FE
+			{
+				Code: "declare function dec(t: any, k: any): void;\nclass A { @dec foo = function*() { return 0; }; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 11, EndLine: 2, EndColumn: 31},
+				},
+			},
+			// Multi-line decorator
+			{
+				Code: "declare function dec(t: any, k: any, d: any): void;\nclass A {\n  @dec\n  *foo() { return 0; }\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 3, Column: 3, EndLine: 4, EndColumn: 7},
+				},
+			},
+
+			// ---- JSDoc / comment scenarios ----
+			// JSDoc before function declaration
+			{
+				Code: `/** doc */ function* foo() { return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 12, EndLine: 1, EndColumn: 25},
+				},
+			},
+			// Multi-line JSDoc
+			{
+				Code: "/**\n * doc\n */\nfunction* foo() { return 0; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 4, Column: 1, EndLine: 4, EndColumn: 14},
+				},
+			},
+			// JSDoc before class method
+			{
+				Code: `class A { /** doc */ *foo() { return 0; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// JSDoc before object method
+			{
+				Code: `var o = { /** doc */ *foo() { return 0; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 22, EndLine: 1, EndColumn: 26},
+				},
+			},
+			// JSDoc + FunctionExpression as property value
+			{
+				Code: `var o = { /** doc */ foo: function*() { return 0; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 22, EndLine: 1, EndColumn: 36},
+				},
+			},
+			// JSDoc before anonymous FE in IIFE
+			{
+				Code: `(/** doc */ function*() { return 0; })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 13, EndLine: 1, EndColumn: 22},
+				},
+			},
+			// Line comment before function
+			{
+				Code: "// comment\nfunction* foo() { return 0; }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 2, Column: 1, EndLine: 2, EndColumn: 14},
+				},
+			},
+			// Block comment (non-JSDoc) before function
+			{
+				Code: `/* comment */ function* foo() { return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 15, EndLine: 1, EndColumn: 28},
+				},
+			},
+			// JSDoc on class field with FE
+			{
+				Code: `class A { /** doc */ foo = function*() { return 0; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 22, EndLine: 1, EndColumn: 37},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/require_yield/require_yield_test.go
+++ b/internal/rules/require_yield/require_yield_test.go
@@ -515,6 +515,53 @@ func TestRequireYieldRule(t *testing.T) {
 					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
 				},
 			},
+
+			// ---- Illegal yield in parameter default values (nested non-gen) ----
+			{
+				Code: `function* outer() { function bar(x = yield 1) { return x; } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: `function* outer() { const f = (x = yield 1) => x; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: `function* outer() { class C { m(x = yield 1) { return x; } } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: `function* outer() { const o = { set x(v = yield 1) {} }; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: `function* outer() { class C { constructor(x = yield 1) {} } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+
+			// ---- Class static block (illegal yield) ----
+			{
+				Code: `function* outer() { class C { static { yield 1; } } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
+			// Static block with both illegal and legal yields in sub-scopes.
+			{
+				Code: `function* outer() { class C { static { function* g() { yield 1; } yield 2; } } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 16},
+				},
+			},
 		},
 	)
 }

--- a/internal/rules/require_yield/require_yield_test.go
+++ b/internal/rules/require_yield/require_yield_test.go
@@ -131,6 +131,16 @@ func TestRequireYieldRule(t *testing.T) {
 			{Code: `/* comment */ function* foo() { yield 0; }`},
 			// JSDoc on class field with FE
 			{Code: `class A { /** doc */ foo = function*() { yield 0; }; }`},
+
+			// ---- Yield attribution boundary scenarios ----
+			// Yield in computed property key of object method (belongs to outer generator).
+			{Code: `function* foo() { const o = { [yield 1]() { return 0; } }; return 0; }`},
+			// Yield in computed property key of class method.
+			{Code: `function* foo() { class C { [yield 1]() { return 0; } } return 0; }`},
+			// Yield in class heritage expression.
+			{Code: `function* foo() { class C extends (yield 1) {} return 0; }`},
+			// Nested yield expression.
+			{Code: `function* foo() { yield yield 1; }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// ---- Upstream ESLint suite ----
@@ -437,6 +447,72 @@ func TestRequireYieldRule(t *testing.T) {
 				Code: `class A { /** doc */ foo = function*() { return 0; }; }`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "missingYield", Line: 1, Column: 22, EndLine: 1, EndColumn: 37},
+				},
+			},
+
+			// ---- Illegal yield in nested non-generator scope must NOT rescue outer generator ----
+			// tsgo performs error-recovery parsing and still emits a KindYieldExpression
+			// node for these illegal positions; attribution logic must isolate them.
+			{
+				Code: `function* foo() { function inner() { yield 1; } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { const f = function() { yield 1; }; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { const f = () => { yield 1; }; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { const f = () => yield 1; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { class C { m() { yield 1; } } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { const o = { get x() { yield 1; return 0; } }; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { const o = { set x(v) { yield 1; } }; return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { class C { constructor() { yield 1; } } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: `function* foo() { class C { x = yield 1; } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
+				},
+			},
+			// Two-level: outer gen -> non-generator method -> nested generator with yield.
+			// Outer gen has no yield; inner nested gen is a separate scope and does not count.
+			{
+				Code: `function* foo() { class C { m() { function* g() { yield 1; } } } return 0; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingYield", Line: 1, Column: 1, EndLine: 1, EndColumn: 14},
 				},
 			},
 		},

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -196,7 +196,13 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 	switch node.Kind {
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
 		start := TrimNodeTextRange(sourceFile, node)
-		if parenPos := findOpenParenPos(sourceFile, node); parenPos >= 0 {
+		// Start scanning for the parameters `(` after the method name to avoid
+		// matching the `(` of a decorator factory call like `@dec()`.
+		searchFrom := node.Pos()
+		if name := node.Name(); name != nil {
+			searchFrom = name.End()
+		}
+		if parenPos := findOpenParenPosFrom(sourceFile, searchFrom, node.End()); parenPos >= 0 {
 			return start.WithEnd(parenPos)
 		}
 		if node.Body() != nil {
@@ -257,8 +263,12 @@ func GetFunctionHeadLoc(sourceFile *ast.SourceFile, node *ast.Node) core.TextRan
 
 // findOpenParenPos finds the position of the first '(' token in a function node.
 func findOpenParenPos(sourceFile *ast.SourceFile, node *ast.Node) int {
-	s := scanner.GetScannerForSourceFile(sourceFile, node.Pos())
-	end := node.End()
+	return findOpenParenPosFrom(sourceFile, node.Pos(), node.End())
+}
+
+// findOpenParenPosFrom scans for the first '(' token within [start, end).
+func findOpenParenPosFrom(sourceFile *ast.SourceFile, start int, end int) int {
+	s := scanner.GetScannerForSourceFile(sourceFile, start)
 	for s.TokenStart() < end {
 		if s.Token() == ast.KindOpenParenToken {
 			return s.TokenStart()

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -296,6 +296,7 @@ export default defineConfig({
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/prefer-promise-reject-errors.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
+    './tests/eslint/rules/require-yield.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-yield.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-yield.test.ts.snap
@@ -1,0 +1,1114 @@
+// Rstest Snapshot v1
+
+exports[`require-yield > invalid 1`] = `
+{
+  "code": "function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 2`] = `
+{
+  "code": "(function* foo() { return 0; })();",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 3`] = `
+{
+  "code": "var obj = { *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 4`] = `
+{
+  "code": "class A { *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 5`] = `
+{
+  "code": "function* foo() { function* bar() { yield 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 6`] = `
+{
+  "code": "function* foo() { function* bar() { return 0; } yield 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 7`] = `
+{
+  "code": "async function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 8`] = `
+{
+  "code": "export function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 9`] = `
+{
+  "code": "export default function*() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 10`] = `
+{
+  "code": "class A { static *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 11`] = `
+{
+  "code": "class A { *#foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 12`] = `
+{
+  "code": "var obj = { *['foo']() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 13`] = `
+{
+  "code": "const A = class { *foo() { return 0; } };",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 14`] = `
+{
+  "code": "(function*() { return 0; })();",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 15`] = `
+{
+  "code": "function* foo() { if (true) { return 1; } else { return 2; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 16`] = `
+{
+  "code": "function* foo() { const x = () => 1; return x; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 17`] = `
+{
+  "code": "function* foo() {
+  return 0;
+}",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 18`] = `
+{
+  "code": "class A { async *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 19`] = `
+{
+  "code": "class A { public static async *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 20`] = `
+{
+  "code": "var obj = { foo: function*() { return 0; } };",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 21`] = `
+{
+  "code": "function* foo<T>(x: T): Generator<T> { return x; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 22`] = `
+{
+  "code": "function* foo(x: string): Generator<string>; function* foo(x: number): Generator<number>; function* foo(x: any): Generator<any> { return x; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 104,
+          "line": 1,
+        },
+        "start": {
+          "column": 91,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 23`] = `
+{
+  "code": "function* foo() { const f = () => function*() { yield 1; }; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 24`] = `
+{
+  "code": "class A { foo = function*() { return 0; }; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 25`] = `
+{
+  "code": "function*
+  foo() {
+  return 0;
+}",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 26`] = `
+{
+  "code": "declare function dec(t: any, k: any, d: any): void;
+class A { @dec *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 27`] = `
+{
+  "code": "declare function dec(): (t: any, k: any, d: any) => void;
+class A { @dec() *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 28`] = `
+{
+  "code": "declare function d1(t: any, k: any, d: any): void; declare function d2(t: any, k: any, d: any): void;
+class A { @d1 @d2 *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 29`] = `
+{
+  "code": "declare function dec(t: any, k: any, d: any): void;
+class A { @dec public static *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 30`] = `
+{
+  "code": "declare function dec(t: any, k: any, d: any): void;
+class A { @dec async *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 31`] = `
+{
+  "code": "declare function classDec(t: any): void;
+@classDec
+class A { *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 32`] = `
+{
+  "code": "declare function dec(t: any, k: any): void;
+class A { @dec foo = function*() { return 0; }; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 33`] = `
+{
+  "code": "declare function dec(t: any, k: any, d: any): void;
+class A {
+  @dec
+  *foo() { return 0; }
+}",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 34`] = `
+{
+  "code": "/** doc */ function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 35`] = `
+{
+  "code": "/**
+ * doc
+ */
+function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 4,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 36`] = `
+{
+  "code": "class A { /** doc */ *foo() { return 0; } }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 37`] = `
+{
+  "code": "var o = { /** doc */ *foo() { return 0; } };",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 38`] = `
+{
+  "code": "var o = { /** doc */ foo: function*() { return 0; } };",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 39`] = `
+{
+  "code": "(/** doc */ function*() { return 0; })();",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 40`] = `
+{
+  "code": "// comment
+function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 41`] = `
+{
+  "code": "/* comment */ function* foo() { return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 42`] = `
+{
+  "code": "class A { /** doc */ foo = function*() { return 0; }; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-yield.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-yield.test.ts.snap
@@ -1112,3 +1112,263 @@ exports[`require-yield > invalid 42`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`require-yield > invalid 43`] = `
+{
+  "code": "function* foo() { function inner() { yield 1; } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 44`] = `
+{
+  "code": "function* foo() { const f = function() { yield 1; }; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 45`] = `
+{
+  "code": "function* foo() { const f = () => { yield 1; }; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 46`] = `
+{
+  "code": "function* foo() { const f = () => yield 1; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 47`] = `
+{
+  "code": "function* foo() { class C { m() { yield 1; } } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 48`] = `
+{
+  "code": "function* foo() { const o = { get x() { yield 1; return 0; } }; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 49`] = `
+{
+  "code": "function* foo() { const o = { set x(v) { yield 1; } }; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 50`] = `
+{
+  "code": "function* foo() { class C { constructor() { yield 1; } } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 51`] = `
+{
+  "code": "function* foo() { class C { x = yield 1; } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 52`] = `
+{
+  "code": "function* foo() { class C { m() { function* g() { yield 1; } } } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-yield.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/require-yield.test.ts.snap
@@ -1372,3 +1372,185 @@ exports[`require-yield > invalid 52`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`require-yield > invalid 53`] = `
+{
+  "code": "function* outer() { function bar(x = yield 1) { return x; } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 54`] = `
+{
+  "code": "function* outer() { const f = (x = yield 1) => x; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 55`] = `
+{
+  "code": "function* outer() { class C { m(x = yield 1) { return x; } } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 56`] = `
+{
+  "code": "function* outer() { const o = { set x(v = yield 1) {} }; return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 57`] = `
+{
+  "code": "function* outer() { class C { constructor(x = yield 1) {} } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 58`] = `
+{
+  "code": "function* outer() { class C { static { yield 1; } } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`require-yield > invalid 59`] = `
+{
+  "code": "function* outer() { class C { static { function* g() { yield 1; } yield 2; } } return 0; }",
+  "diagnostics": [
+    {
+      "message": "This generator function does not have 'yield'.",
+      "messageId": "missingYield",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "require-yield",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/require-yield.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/require-yield.test.ts
@@ -1,0 +1,647 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-yield', {
+  valid: [
+    // ---- Upstream ESLint suite ----
+    `function foo() { return 0; }`,
+    `function* foo() { yield 0; }`,
+    `function* foo() { }`,
+    `(function* foo() { yield 0; })();`,
+    `(function* foo() { })();`,
+    `var obj = { *foo() { yield 0; } };`,
+    `var obj = { *foo() { } };`,
+    `class A { *foo() { yield 0; } };`,
+    `class A { *foo() { } };`,
+
+    // ---- Yield variants ----
+    `function* foo() { yield; }`,
+    `function* foo() { yield* [1, 2, 3]; }`,
+
+    // ---- Async generators ----
+    `async function* foo() { yield 0; }`,
+    `async function* foo() { }`,
+
+    // ---- Yield inside control flow ----
+    `function* foo() { if (true) { yield 1; } }`,
+    `function* foo() { while (true) { yield 1; } }`,
+    `function* foo() { try { yield 1; } catch (e) {} }`,
+    `function* foo() { try { } catch (e) { yield 1; } }`,
+    `function* foo() { try { } finally { yield 1; } }`,
+
+    // ---- Export forms ----
+    `export function* foo() { yield 1; }`,
+    `export default function*() { yield 1; }`,
+
+    // ---- Class method forms ----
+    `class A { static *foo() { yield 0; } }`,
+    `class A { *#foo() { yield 0; } }`,
+
+    // ---- Computed / class expression / anonymous ----
+    `var obj = { *['foo']() { yield 0; } };`,
+    `const A = class { *foo() { yield 0; } };`,
+    `(function*() { yield 0; })();`,
+
+    // ---- Arrow inside generator ----
+    `function* foo() { const x = () => 1; yield x; }`,
+
+    // ---- Nested generators, both have yield ----
+    `function* outer() { function* inner() { yield 1; } yield 2; }`,
+
+    // ---- TS modifiers on class generator methods ----
+    `class A { async *foo() { yield 0; } }`,
+    `class A { public *foo() { yield 0; } }`,
+    `class A { private *foo() { yield 0; } }`,
+    `class A { protected *foo() { yield 0; } }`,
+    `class A { public static async *foo() { yield 0; } }`,
+
+    // ---- FE as object property value ----
+    `var obj = { foo: function*() { yield 0; } };`,
+
+    // ---- Control flow variants ----
+    `function* foo() { for (const x of [1]) yield x; }`,
+    `function* foo(x: number) { switch (x) { case 1: yield 1; break; default: yield 0; } }`,
+    `function* foo() { do { yield 1; } while (false); }`,
+
+    // ---- Generic generator ----
+    `function* foo<T>(x: T): Generator<T> { yield x; }`,
+
+    // ---- Nested FE inside arrow inside generator ----
+    `function* foo() { const f = () => function*() { yield 1; }; yield 2; }`,
+
+    // ---- Overload signatures ----
+    `function* foo(x: string): Generator<string>; function* foo(x: number): Generator<number>; function* foo(x: any): Generator<any> { yield x; }`,
+
+    // ---- Ambient declarations (no body) ----
+    `declare function* foo(): Generator<number>;`,
+
+    // ---- Class field with generator FE ----
+    `class A { foo = function*() { yield 0; }; }`,
+
+    // ---- Multi-line function head ----
+    'function*\n  foo() {\n  yield 0;\n}',
+
+    // ---- Decorator scenarios (with yield) ----
+    `function dec(t: any, k: any, d: any) {} class A { @dec *foo() { yield 0; } }`,
+    `function d1(t: any, k: any, d: any) {} function d2(t: any, k: any, d: any) {} class A { @d1 @d2 *foo() { yield 0; } }`,
+    `function dec() { return (t: any, k: any, d: any) => {}; } class A { @dec() *foo() { yield 0; } }`,
+    `function dec(t: any, k: any, d: any) {} class A { @dec public static *foo() { yield 0; } }`,
+    `function dec(t: any, k: any, d: any) {} class A { @dec async *foo() { yield 0; } }`,
+    `function classDec(t: any) {} @classDec class A { *foo() { yield 0; } }`,
+    `function dec(t: any, k: any) {} class A { @dec foo = function*() { yield 0; }; }`,
+    'function dec(t: any, k: any, d: any) {}\nclass A {\n  @dec\n  *foo() { yield 0; }\n}',
+
+    // ---- JSDoc / comment scenarios (with yield) ----
+    `/** doc */ function* foo() { yield 0; }`,
+    '/**\n * doc\n */\nfunction* foo() { yield 0; }',
+    `class A { /** doc */ *foo() { yield 0; } }`,
+    `var o = { /** doc */ *foo() { yield 0; } };`,
+    `var o = { /** doc */ foo: function*() { yield 0; } };`,
+    `(/** doc */ function*() { yield 0; })();`,
+    '// comment\nfunction* foo() { yield 0; }',
+    `/* comment */ function* foo() { yield 0; }`,
+    `class A { /** doc */ foo = function*() { yield 0; }; }`,
+  ],
+  invalid: [
+    // ---- Upstream ESLint suite ----
+    {
+      code: `function* foo() { return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `(function* foo() { return 0; })();`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: `var obj = { *foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+    {
+      code: `class A { *foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { function* bar() { yield 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { function* bar() { return 0; } yield 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 19,
+          endLine: 1,
+          endColumn: 32,
+        },
+      ],
+    },
+
+    // ---- Async generator ----
+    {
+      code: `async function* foo() { return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 20,
+        },
+      ],
+    },
+
+    // ---- Export forms ----
+    {
+      code: `export function* foo() { return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 8,
+          endLine: 1,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: `export default function*() { return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 16,
+          endLine: 1,
+          endColumn: 25,
+        },
+      ],
+    },
+
+    // ---- Class method forms ----
+    {
+      code: `class A { static *foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: `class A { *#foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+
+    // ---- Computed / class expression / anonymous FE ----
+    {
+      code: `var obj = { *['foo']() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 21,
+        },
+      ],
+    },
+    {
+      code: `const A = class { *foo() { return 0; } };`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 19,
+          endLine: 1,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: `(function*() { return 0; })();`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 2,
+          endLine: 1,
+          endColumn: 11,
+        },
+      ],
+    },
+
+    // ---- Control flow without yield in any branch ----
+    {
+      code: `function* foo() { if (true) { return 1; } else { return 2; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+
+    // ---- Arrow inside generator ----
+    {
+      code: `function* foo() { const x = () => 1; return x; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+
+    // ---- Multi-line ----
+    {
+      code: 'function* foo() {\n  return 0;\n}',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+
+    // ---- Async class method generator ----
+    {
+      code: `class A { async *foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 21,
+        },
+      ],
+    },
+
+    // ---- Public/static combined ----
+    {
+      code: `class A { public static async *foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 35,
+        },
+      ],
+    },
+
+    // ---- FE as object property value ----
+    {
+      code: `var obj = { foo: function*() { return 0; } };`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 27,
+        },
+      ],
+    },
+
+    // ---- Generic generator ----
+    {
+      code: `function* foo<T>(x: T): Generator<T> { return x; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 17,
+        },
+      ],
+    },
+
+    // ---- Overload signatures + impl with no yield ----
+    {
+      code: `function* foo(x: string): Generator<string>; function* foo(x: number): Generator<number>; function* foo(x: any): Generator<any> { return x; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 91,
+          endLine: 1,
+          endColumn: 104,
+        },
+      ],
+    },
+
+    // ---- Nested FE inside arrow: outer has no yield ----
+    {
+      code: `function* foo() { const f = () => function*() { yield 1; }; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+
+    // ---- Class field with generator FE ----
+    {
+      code: `class A { foo = function*() { return 0; }; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 11,
+          endLine: 1,
+          endColumn: 26,
+        },
+      ],
+    },
+
+    // ---- Multi-line function head ----
+    {
+      code: 'function*\n  foo() {\n  return 0;\n}',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 2,
+          endColumn: 6,
+        },
+      ],
+    },
+
+    // ---- Decorator scenarios ----
+    {
+      code: 'declare function dec(t: any, k: any, d: any): void;\nclass A { @dec *foo() { return 0; } }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 20,
+        },
+      ],
+    },
+    {
+      code: 'declare function dec(): (t: any, k: any, d: any) => void;\nclass A { @dec() *foo() { return 0; } }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: 'declare function d1(t: any, k: any, d: any): void; declare function d2(t: any, k: any, d: any): void;\nclass A { @d1 @d2 *foo() { return 0; } }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 23,
+        },
+      ],
+    },
+    {
+      code: 'declare function dec(t: any, k: any, d: any): void;\nclass A { @dec public static *foo() { return 0; } }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 34,
+        },
+      ],
+    },
+    {
+      code: 'declare function dec(t: any, k: any, d: any): void;\nclass A { @dec async *foo() { return 0; } }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 26,
+        },
+      ],
+    },
+    {
+      code: 'declare function classDec(t: any): void;\n@classDec\nclass A { *foo() { return 0; } }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 15,
+        },
+      ],
+    },
+    {
+      code: 'declare function dec(t: any, k: any): void;\nclass A { @dec foo = function*() { return 0; }; }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 11,
+          endLine: 2,
+          endColumn: 31,
+        },
+      ],
+    },
+    {
+      code: 'declare function dec(t: any, k: any, d: any): void;\nclass A {\n  @dec\n  *foo() { return 0; }\n}',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 3,
+          column: 3,
+          endLine: 4,
+          endColumn: 7,
+        },
+      ],
+    },
+
+    // ---- JSDoc / comment scenarios ----
+    {
+      code: `/** doc */ function* foo() { return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 12,
+          endLine: 1,
+          endColumn: 25,
+        },
+      ],
+    },
+    {
+      code: '/**\n * doc\n */\nfunction* foo() { return 0; }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 4,
+          column: 1,
+          endLine: 4,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `class A { /** doc */ *foo() { return 0; } }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 26,
+        },
+      ],
+    },
+    {
+      code: `var o = { /** doc */ *foo() { return 0; } };`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 26,
+        },
+      ],
+    },
+    {
+      code: `var o = { /** doc */ foo: function*() { return 0; } };`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 36,
+        },
+      ],
+    },
+    {
+      code: `(/** doc */ function*() { return 0; })();`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 13,
+          endLine: 1,
+          endColumn: 22,
+        },
+      ],
+    },
+    {
+      code: '// comment\nfunction* foo() { return 0; }',
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 2,
+          column: 1,
+          endLine: 2,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `/* comment */ function* foo() { return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 15,
+          endLine: 1,
+          endColumn: 28,
+        },
+      ],
+    },
+    {
+      code: `class A { /** doc */ foo = function*() { return 0; }; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 22,
+          endLine: 1,
+          endColumn: 37,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/require-yield.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/require-yield.test.ts
@@ -102,6 +102,12 @@ ruleTester.run('require-yield', {
     '// comment\nfunction* foo() { yield 0; }',
     `/* comment */ function* foo() { yield 0; }`,
     `class A { /** doc */ foo = function*() { yield 0; }; }`,
+
+    // ---- Yield attribution boundary scenarios ----
+    `function* foo() { const o = { [yield 1]() { return 0; } }; return 0; }`,
+    `function* foo() { class C { [yield 1]() { return 0; } } return 0; }`,
+    `function* foo() { class C extends (yield 1) {} return 0; }`,
+    `function* foo() { yield yield 1; }`,
   ],
   invalid: [
     // ---- Upstream ESLint suite ----
@@ -640,6 +646,128 @@ ruleTester.run('require-yield', {
           column: 22,
           endLine: 1,
           endColumn: 37,
+        },
+      ],
+    },
+
+    // ---- Illegal yield in nested non-generator scope must NOT rescue outer generator ----
+    {
+      code: `function* foo() { function inner() { yield 1; } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { const f = function() { yield 1; }; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { const f = () => { yield 1; }; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { const f = () => yield 1; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { class C { m() { yield 1; } } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { const o = { get x() { yield 1; return 0; } }; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { const o = { set x(v) { yield 1; } }; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { class C { constructor() { yield 1; } } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { class C { x = yield 1; } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
+        },
+      ],
+    },
+    {
+      code: `function* foo() { class C { m() { function* g() { yield 1; } } } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 14,
         },
       ],
     },

--- a/packages/rslint-test-tools/tests/eslint/rules/require-yield.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/require-yield.test.ts
@@ -771,5 +771,93 @@ ruleTester.run('require-yield', {
         },
       ],
     },
+
+    // ---- Illegal yield in parameter default values (nested non-gen) ----
+    {
+      code: `function* outer() { function bar(x = yield 1) { return x; } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `function* outer() { const f = (x = yield 1) => x; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `function* outer() { class C { m(x = yield 1) { return x; } } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `function* outer() { const o = { set x(v = yield 1) {} }; return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `function* outer() { class C { constructor(x = yield 1) {} } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+
+    // ---- Class static block (illegal yield) ----
+    {
+      code: `function* outer() { class C { static { yield 1; } } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
+    {
+      code: `function* outer() { class C { static { function* g() { yield 1; } yield 2; } } return 0; }`,
+      errors: [
+        {
+          messageId: 'missingYield',
+          line: 1,
+          column: 1,
+          endLine: 1,
+          endColumn: 16,
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `require-yield` rule from ESLint to rslint.

This rule generates warnings for generator functions that have a non-empty body but no `yield` expression.

The port covers the full upstream ESLint suite plus TS-specific shapes (async generators, class modifiers, private identifiers, computed keys, class fields with generator FEs, JSDoc/comment prefixes, and decorators — including decorator factories like `@dec()`).

### Notes on the `@dec()` fix

During test-driven verification, a pre-existing defect was found in `utils.GetFunctionHeadLoc`: when a method was preceded by a decorator factory (e.g. `@dec()`), the internal `findOpenParenPos` helper matched the decorator's `(` instead of the method's parameters `(`, producing an incorrect report range.

The fix scans for the parameters `(` starting from after the method name, which skips decorators and modifiers. All other rules that use `GetFunctionHeadLoc` (`accessor-pairs`, `no-misused-promises`, `explicit-function-return-type`, `require-await`, `promise-function-async`) continue to pass.

### End-to-end verification

Ran the built binary against real projects:

- **rsbuild** (1197 files): 0 reports — project contains no generators (confirmed via grep).
- **rspack** (392 files): 0 reports — all 4 existing generators contain `yield` (verified manually).
- **Smoke file** with 15 known invalid cases: all 15 reported with byte-exact line/column positions.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/require-yield
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/require-yield.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).