### PR TITLE
feat: port rule prefer-promise-reject-errors

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,8 +166,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_object"
-	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
-	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_wrappers"
 	"github.com/web-infra-dev/rslint/internal/rules/no_obj_calls"
@@ -198,9 +196,12 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
+	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
+	core_prefer_promise_reject_errors "github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
+	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
 	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
@@ -601,6 +602,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-undef", no_undef.NoUndefRule)
 	GlobalRuleRegistry.Register("no-undef-init", no_undef_init.NoUndefInitRule)
 	GlobalRuleRegistry.Register("prefer-const", prefer_const.PreferConstRule)
+	GlobalRuleRegistry.Register("prefer-promise-reject-errors", core_prefer_promise_reject_errors.PreferPromiseRejectErrorsRule)
 	GlobalRuleRegistry.Register("prefer-template", prefer_template.PreferTemplateRule)
 	GlobalRuleRegistry.Register("no-this-before-super", no_this_before_super.NoThisBeforeSuperRule)
 	GlobalRuleRegistry.Register("no-var", no_var.NoVarRule)

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -1,0 +1,213 @@
+package prefer_promise_reject_errors
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// skipTransparent unwraps parentheses, type assertions, non-null assertions,
+// and `satisfies` so that TypeScript-only syntax does not perturb the
+// AST-based shape checks ESLint performs at the source level.
+const skipTransparent = ast.OEKParentheses | ast.OEKAssertions
+
+func buildRejectAnErrorMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "rejectAnError",
+		Description: "Expected the Promise rejection reason to be an Error.",
+	}
+}
+
+type Options struct {
+	AllowEmptyReject bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{AllowEmptyReject: false}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["allowEmptyReject"].(bool); ok {
+			opts.AllowEmptyReject = v
+		}
+	}
+	return opts
+}
+
+// couldBeError mirrors ESLint's astUtils.couldBeError, adapted to the tsgo AST
+// where AssignmentExpression / LogicalExpression / SequenceExpression are all
+// flattened into BinaryExpression and ChainExpression has no analog.
+func couldBeError(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipOuterExpressions(node, skipTransparent)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier,
+		ast.KindCallExpression,
+		ast.KindNewExpression,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindTaggedTemplateExpression,
+		ast.KindYieldExpression,
+		ast.KindAwaitExpression:
+		return true
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin == nil || bin.OperatorToken == nil {
+			return false
+		}
+		switch bin.OperatorToken.Kind {
+		case ast.KindCommaToken:
+			return couldBeError(bin.Right)
+		case ast.KindEqualsToken, ast.KindAmpersandAmpersandEqualsToken:
+			return couldBeError(bin.Right)
+		case ast.KindBarBarEqualsToken, ast.KindQuestionQuestionEqualsToken:
+			return couldBeError(bin.Left) || couldBeError(bin.Right)
+		case ast.KindAmpersandAmpersandToken:
+			return couldBeError(bin.Right)
+		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+			return couldBeError(bin.Left) || couldBeError(bin.Right)
+		default:
+			return false
+		}
+	case ast.KindConditionalExpression:
+		ce := node.AsConditionalExpression()
+		if ce == nil {
+			return false
+		}
+		return couldBeError(ce.WhenTrue) || couldBeError(ce.WhenFalse)
+	default:
+		return false
+	}
+}
+
+func isUndefinedIdentifier(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, skipTransparent)
+	return node != nil && ast.IsIdentifier(node) && node.AsIdentifier().Text == "undefined"
+}
+
+func checkRejectCall(ctx rule.RuleContext, callExpression *ast.Node, allowEmptyReject bool) {
+	args := callExpression.Arguments()
+	if len(args) == 0 {
+		if allowEmptyReject {
+			return
+		}
+		ctx.ReportNode(callExpression, buildRejectAnErrorMessage())
+		return
+	}
+	first := args[0]
+	if !couldBeError(first) || isUndefinedIdentifier(first) {
+		ctx.ReportNode(callExpression, buildRejectAnErrorMessage())
+	}
+}
+
+var PreferPromiseRejectErrorsRule = rule.Rule{
+	Name: "prefer-promise-reject-errors",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				if utils.IsSpecificMemberAccess(node.AsCallExpression().Expression, "Promise", "reject") {
+					checkRejectCall(ctx, node, opts.AllowEmptyReject)
+				}
+			},
+			ast.KindNewExpression: func(node *ast.Node) {
+				// ESTree drops parentheses, so ESLint's `node.callee.type === "Identifier"`
+				// already succeeds for `new (Promise)(...)`. tsgo retains parens (and TS
+				// assertions), so unwrap them here to keep behavior aligned.
+				callee := ast.SkipOuterExpressions(node.AsNewExpression().Expression, skipTransparent)
+				if callee == nil || !ast.IsIdentifier(callee) || callee.AsIdentifier().Text != "Promise" {
+					return
+				}
+				args := node.Arguments()
+				if len(args) == 0 {
+					return
+				}
+				executor := ast.SkipOuterExpressions(args[0], skipTransparent)
+				if executor == nil || !ast.IsFunctionExpressionOrArrowFunction(executor) {
+					return
+				}
+				params := executor.Parameters()
+				if len(params) < 2 {
+					return
+				}
+				// ESLint requires the second parameter to be a plain Identifier:
+				// `params[1].type === "Identifier"` excludes destructuring
+				// (ObjectPattern / ArrayPattern), defaults (AssignmentPattern),
+				// and rest (RestElement). Mirror that here on the tsgo Parameter.
+				rejectParam := params[1].AsParameterDeclaration()
+				if rejectParam == nil || rejectParam.Initializer != nil || rejectParam.DotDotDotToken != nil {
+					return
+				}
+				rejectName := rejectParam.Name()
+				if rejectName == nil || !ast.IsIdentifier(rejectName) {
+					return
+				}
+				name := rejectName.AsIdentifier().Text
+
+				findRejectReferences(ctx, executor, name, func(call *ast.Node) {
+					checkRejectCall(ctx, call, opts.AllowEmptyReject)
+				})
+			},
+		}
+	},
+}
+
+// findRejectReferences walks the executor function's parameters and body and
+// invokes `visit` for every CallExpression whose callee identifier resolves to
+// a parameter declared on `executor` itself (i.e., not shadowed by an inner
+// scope). When the TypeChecker is available, symbol resolution drives the
+// decision — this transparently handles function-scope `var reject = …`
+// re-binding (which merges with the parameter symbol) and inner block-scoped
+// `let` / `const` / nested function shadowing. Otherwise, falls back to a
+// name-based scope walk.
+func findRejectReferences(ctx rule.RuleContext, executor *ast.Node, name string, visit func(call *ast.Node)) {
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if ast.IsCallExpression(n) {
+			callee := ast.SkipOuterExpressions(n.AsCallExpression().Expression, skipTransparent)
+			if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == name {
+				if isExecutorParameterReference(ctx, callee, executor, name) {
+					visit(n)
+				}
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	for _, param := range executor.Parameters() {
+		walk(param)
+	}
+	if body := executor.Body(); body != nil {
+		walk(body)
+	}
+}
+
+// isExecutorParameterReference reports whether `callee` resolves to a
+// parameter declared on `executor`. With type info we look at the callee's
+// symbol declarations; when the parser deduplicates the symbol (e.g.,
+// `function(reject, reject)` produces two distinct symbols, one per parameter),
+// any of them will still have `executor` as its parent, which is enough to
+// confirm the reference targets the executor's binding.
+func isExecutorParameterReference(ctx rule.RuleContext, callee *ast.Node, executor *ast.Node, name string) bool {
+	if ctx.TypeChecker != nil {
+		symbol := ctx.TypeChecker.GetSymbolAtLocation(callee)
+		if symbol != nil {
+			for _, decl := range symbol.Declarations {
+				if ast.IsParameter(decl) && decl.Parent == executor {
+					return true
+				}
+			}
+			return false
+		}
+	}
+	return !utils.IsNameShadowedBetween(callee, executor, name)
+}

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.md
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.md
@@ -1,0 +1,64 @@
+# prefer-promise-reject-errors
+
+## Rule Details
+
+This rule requires that Promises are rejected with `Error` objects only. Rejecting with non-`Error` values (such as strings or numbers) makes debugging harder because the rejection reason does not carry a stack trace.
+
+The rule flags two patterns:
+
+- `Promise.reject(value)` calls where `value` cannot be an `Error`.
+- `new Promise((resolve, reject) => { ... })` executors where the second parameter is invoked with a value that cannot be an `Error`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+Promise.reject("something bad happened");
+Promise.reject(5);
+Promise.reject();
+
+new Promise(function (resolve, reject) {
+  reject("something bad happened");
+});
+
+new Promise(function (resolve, reject) {
+  reject();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+Promise.reject(new Error("something bad happened"));
+Promise.reject(new TypeError("something bad happened"));
+
+new Promise(function (resolve, reject) {
+  reject(new Error("something bad happened"));
+});
+
+const foo = getUnknownValue();
+Promise.reject(foo);
+```
+
+## Options
+
+This rule accepts an options object with the following property:
+
+- `allowEmptyReject` (`boolean`, default `false`) — when `true`, allows calls to `Promise.reject()` and the executor's reject callback with no arguments.
+
+Examples of **correct** code for this rule with `{ "allowEmptyReject": true }`:
+
+```json
+{ "prefer-promise-reject-errors": ["error", { "allowEmptyReject": true }] }
+```
+
+```javascript
+Promise.reject();
+
+new Promise(function (resolve, reject) {
+  reject();
+});
+```
+
+## Original Documentation
+
+- [ESLint: prefer-promise-reject-errors](https://eslint.org/docs/latest/rules/prefer-promise-reject-errors)

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
@@ -1,0 +1,479 @@
+package prefer_promise_reject_errors
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferPromiseRejectErrorsRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferPromiseRejectErrorsRule,
+		// Valid cases
+		[]rule_tester.ValidTestCase{
+			{Code: `Promise.resolve(5)`},
+			{Code: `Foo.reject(5)`},
+			{Code: `Promise.reject(foo)`},
+			{Code: `Promise.reject(foo.bar)`},
+			{Code: `Promise.reject(foo.bar())`},
+			{Code: `Promise.reject(new Error())`},
+			{Code: `Promise.reject(new TypeError)`},
+			{Code: `Promise.reject(new Error('foo'))`},
+			{Code: `Promise.reject(foo || 5)`},
+			{Code: `Promise.reject(5 && foo)`},
+			{Code: `new Foo((resolve, reject) => reject(5))`},
+			{Code: `new Promise(function(resolve, reject) { return function(reject) { reject(5) } })`},
+			{Code: `new Promise(function(resolve, reject) { if (foo) { const reject = somethingElse; reject(5) } })`},
+			{Code: `new Promise(function(resolve, {apply}) { apply(5) })`},
+			{Code: `new Promise(function(resolve, reject) { resolve(5, reject) })`},
+			{Code: `async function foo() { Promise.reject(await foo); }`},
+			{
+				Code:    `Promise.reject()`,
+				Options: map[string]interface{}{"allowEmptyReject": true},
+			},
+			{
+				Code:    `new Promise(function(resolve, reject) { reject() })`,
+				Options: map[string]interface{}{"allowEmptyReject": true},
+			},
+
+			// ---- Optional chaining ----
+			{Code: `Promise.reject(obj?.foo)`},
+			{Code: `Promise.reject(obj?.foo())`},
+
+			// ---- Assignments ----
+			{Code: `Promise.reject(foo = new Error())`},
+			{Code: `Promise.reject(foo ||= 5)`},
+			{Code: `Promise.reject(foo.bar ??= 5)`},
+			{Code: `Promise.reject(foo[bar] ??= 5)`},
+
+			// ---- Private fields ----
+			{Code: `class C { #reject; foo() { Promise.#reject(5); } }`},
+			{Code: `class C { #error; foo() { Promise.reject(this.#error); } }`},
+
+			// ---- TypeScript-only syntax should be transparent to couldBeError ----
+			{Code: `Promise.reject(foo as Error)`},
+			{Code: `Promise.reject(<Error>foo)`},
+			{Code: `Promise.reject(foo!)`},
+			{Code: `Promise.reject(foo satisfies Error)`},
+
+			// ---- ESLint requires params[1].type === "Identifier"; non-plain
+			// second-parameter shapes are not analyzed.
+			{Code: `new Promise((resolve, reject = foo) => reject(5))`},
+			{Code: `new Promise((resolve, ...reject) => reject[0](5))`},
+			{Code: `new Promise(function(resolve, [reject]) { reject(5) })`},
+
+			// ---- Identifiers that resolve to globals such as NaN / Infinity
+			// are Identifier nodes, so couldBeError treats them as possibly Error.
+			{Code: `Promise.reject(NaN)`},
+			{Code: `Promise.reject(Infinity)`},
+
+			// ---- Calling Promise without `new` is not an executor pattern. ----
+			{Code: `Promise((resolve, reject) => reject(5))`},
+
+			// ---- TaggedTemplateExpression result could be an Error. ----
+			{Code: "Promise.reject(tag`msg`)"},
+
+			// ---- Reject as argument, not callee, does not invoke it. ----
+			{Code: `new Promise((resolve, reject) => arr.push(reject))`},
+
+			// ---- Reject method-like access (.call / .bind / .apply) is treated
+			// as a different operation by ESLint and is not flagged.
+			{Code: `new Promise((resolve, reject) => reject.call(null, new Error()))`},
+		},
+		// Invalid cases
+		[]rule_tester.InvalidTestCase{
+			{
+				Code: `Promise.reject(5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "Promise.reject(`foo`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(!foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(void foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "rejectAnError",
+						Message:   "Expected the Promise rejection reason to be an Error.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code: `Promise.reject(undefined)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject({ foo: 1 })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject([1, 2, 3])`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `Promise.reject()`,
+				Options: map[string]interface{}{"allowEmptyReject": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `new Promise(function(resolve, reject) { reject() })`,
+				Options: map[string]interface{}{"allowEmptyReject": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 41},
+				},
+			},
+			{
+				Code:    `Promise.reject(undefined)`,
+				Options: map[string]interface{}{"allowEmptyReject": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject('foo', somethingElse)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new Promise(function(resolve, reject) { reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 41},
+				},
+			},
+			{
+				Code: `new Promise((resolve, reject) => { reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `new Promise((resolve, reject) => reject(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 34},
+				},
+			},
+			{
+				Code: `new Promise((resolve, reject) => reject())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 34},
+				},
+			},
+			{
+				Code: `new Promise(function(yes, no) { no(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 33},
+				},
+			},
+			{
+				Code: `
+          new Promise((resolve, reject) => {
+            fs.readFile('foo.txt', (err, file) => {
+              if (err) reject('File not found')
+              else resolve(file)
+            })
+          })
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 4, Column: 24},
+				},
+			},
+			{
+				Code: `new Promise(({foo, bar, baz}, reject) => reject(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code: `new Promise(function(reject, reject) { reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `new Promise(function(foo, arguments) { arguments(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `new Promise((foo, arguments) => arguments(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 33},
+				},
+			},
+			{
+				Code: `new Promise(function({}, reject) { reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `new Promise(({}, reject) => reject(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `new Promise((resolve, reject, somethingElse = reject(5)) => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 47},
+				},
+			},
+
+			// ---- `var` re-declaration in a non-arrow function body merges with
+			// the parameter symbol (function-scope), so the call still reports.
+			{
+				Code: `new Promise(function(resolve, reject) { var reject = somethingElse; reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 69},
+				},
+			},
+
+			// ---- reject called from a nested callback inside the executor still
+			// resolves to the executor's parameter binding.
+			{
+				Code: `new Promise((resolve, reject) => setTimeout(() => reject(5), 0))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 51},
+				},
+			},
+			{
+				Code: `new Promise((resolve, reject) => arr.forEach(function () { reject('bad') }))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 60},
+				},
+			},
+
+			// ---- Spread cannot be statically classified as an Error candidate;
+			// ESLint's couldBeError lacks a SpreadElement case so it falls through
+			// to the default and reports.
+			{
+				Code: `Promise.reject(...args)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Plain literals that are not Errors ----
+			{
+				Code: `Promise.reject(null)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(true)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Computed bracket access with static string ----
+			{
+				Code: "Promise['reject'](5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "Promise[`reject`](5)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Named function expression as executor ----
+			{
+				Code: `new Promise(function fn(resolve, reject) { reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 44},
+				},
+			},
+
+			// ---- Async / generator executors are still functions, so reject
+			// calls inside them should be checked.
+			{
+				Code: `new Promise(async (resolve, reject) => reject(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `new Promise(function *(resolve, reject) { reject(5) })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 43},
+				},
+			},
+
+			// ---- Multiple reject calls in a single executor ----
+			{
+				Code: `new Promise((resolve, reject) => { reject(1); reject('x'); reject(); })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 36},
+					{MessageId: "rejectAnError", Line: 1, Column: 47},
+					{MessageId: "rejectAnError", Line: 1, Column: 60},
+				},
+			},
+
+			// ---- Parenthesized reject callee inside the executor body ----
+			{
+				Code: `new Promise((resolve, reject) => (reject)(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 34},
+				},
+			},
+
+			// ---- Optional chaining on the executor reject callback ----
+			{
+				Code: `new Promise((resolve, reject) => reject?.(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 34},
+				},
+			},
+
+			// ---- Parenthesized / TS-asserted Promise constructor must be
+			// transparent (ESTree strips parens, so ESLint already accepts
+			// `new (Promise)(executor)`).
+			{
+				Code: `new (Promise)((resolve, reject) => reject(5))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `new Promise(((resolve, reject) => reject(5)))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- Optional chaining ----
+			{
+				Code: `Promise.reject?.(5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise?.reject(5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise?.reject?.(5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(Promise?.reject)(5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(Promise?.reject)?.(5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Mathematical / bitwise assignments evaluate to primitives or throw ----
+			{
+				Code: `Promise.reject(foo += new Error())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo -= new Error())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo **= new Error())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo <<= new Error())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo |= new Error())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo &= new Error())`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- && short-circuit yields the falsy left or the right operand ----
+			{
+				Code: `Promise.reject(foo && 5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo &&= 5)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -293,6 +293,7 @@ export default defineConfig({
     './tests/eslint/rules/no-self-compare.test.ts',
     './tests/eslint/rules/no-unneeded-ternary.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
+    './tests/eslint/rules/prefer-promise-reject-errors.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
 
     // eslint-plugin-jest

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-promise-reject-errors.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-promise-reject-errors.test.ts.snap
@@ -1,0 +1,1494 @@
+// Rstest Snapshot v1
+
+exports[`prefer-promise-reject-errors > invalid 1`] = `
+{
+  "code": "Promise.reject(5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 2`] = `
+{
+  "code": "Promise.reject('foo')",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 3`] = `
+{
+  "code": "Promise.reject(\`foo\`)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 4`] = `
+{
+  "code": "Promise.reject(!foo)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 5`] = `
+{
+  "code": "Promise.reject(void foo)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 6`] = `
+{
+  "code": "Promise.reject()",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 7`] = `
+{
+  "code": "Promise.reject(undefined)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 8`] = `
+{
+  "code": "Promise.reject({ foo: 1 })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 9`] = `
+{
+  "code": "Promise.reject([1, 2, 3])",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 10`] = `
+{
+  "code": "Promise.reject()",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 11`] = `
+{
+  "code": "new Promise(function(resolve, reject) { reject() })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 12`] = `
+{
+  "code": "Promise.reject(undefined)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 13`] = `
+{
+  "code": "Promise.reject('foo', somethingElse)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 14`] = `
+{
+  "code": "new Promise(function(resolve, reject) { reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 15`] = `
+{
+  "code": "new Promise((resolve, reject) => { reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 16`] = `
+{
+  "code": "new Promise((resolve, reject) => reject(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 17`] = `
+{
+  "code": "new Promise((resolve, reject) => reject())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 18`] = `
+{
+  "code": "new Promise(function(yes, no) { no(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 19`] = `
+{
+  "code": "
+          new Promise((resolve, reject) => {
+            fs.readFile('foo.txt', (err, file) => {
+              if (err) reject('File not found')
+              else resolve(file)
+            })
+          })
+        ",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 4,
+        },
+        "start": {
+          "column": 24,
+          "line": 4,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 20`] = `
+{
+  "code": "new Promise(({foo, bar, baz}, reject) => reject(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 21`] = `
+{
+  "code": "new Promise(function(reject, reject) { reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 22`] = `
+{
+  "code": "new Promise(function(foo, arguments) { arguments(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 23`] = `
+{
+  "code": "new Promise((foo, arguments) => arguments(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 24`] = `
+{
+  "code": "new Promise(function({}, reject) { reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 25`] = `
+{
+  "code": "new Promise(({}, reject) => reject(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 26`] = `
+{
+  "code": "new Promise((resolve, reject, somethingElse = reject(5)) => {})",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 27`] = `
+{
+  "code": "new Promise(function(resolve, reject) { var reject = somethingElse; reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 28`] = `
+{
+  "code": "new Promise((resolve, reject) => setTimeout(() => reject(5), 0))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 29`] = `
+{
+  "code": "new Promise((resolve, reject) => arr.forEach(function () { reject('bad') }))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 30`] = `
+{
+  "code": "Promise.reject(...args)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 31`] = `
+{
+  "code": "Promise.reject(null)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 32`] = `
+{
+  "code": "Promise.reject(0)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 33`] = `
+{
+  "code": "Promise.reject(true)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 34`] = `
+{
+  "code": "Promise['reject'](5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 35`] = `
+{
+  "code": "Promise[\`reject\`](5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 36`] = `
+{
+  "code": "new Promise(function fn(resolve, reject) { reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 37`] = `
+{
+  "code": "new Promise(async (resolve, reject) => reject(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 38`] = `
+{
+  "code": "new Promise(function *(resolve, reject) { reject(5) })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 39`] = `
+{
+  "code": "new Promise((resolve, reject) => { reject(1); reject('x'); reject(); })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 60,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 40`] = `
+{
+  "code": "new Promise((resolve, reject) => (reject)(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 41`] = `
+{
+  "code": "new Promise((resolve, reject) => reject?.(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 42`] = `
+{
+  "code": "new (Promise)((resolve, reject) => reject(5))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 43`] = `
+{
+  "code": "new Promise(((resolve, reject) => reject(5)))",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 44`] = `
+{
+  "code": "Promise.reject?.(5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 45`] = `
+{
+  "code": "Promise?.reject(5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 46`] = `
+{
+  "code": "Promise?.reject?.(5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 47`] = `
+{
+  "code": "(Promise?.reject)(5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 48`] = `
+{
+  "code": "(Promise?.reject)?.(5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 49`] = `
+{
+  "code": "Promise.reject(foo += new Error())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 50`] = `
+{
+  "code": "Promise.reject(foo -= new Error())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 51`] = `
+{
+  "code": "Promise.reject(foo **= new Error())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 52`] = `
+{
+  "code": "Promise.reject(foo <<= new Error())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 53`] = `
+{
+  "code": "Promise.reject(foo |= new Error())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 54`] = `
+{
+  "code": "Promise.reject(foo &= new Error())",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 55`] = `
+{
+  "code": "Promise.reject(foo && 5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 56`] = `
+{
+  "code": "Promise.reject(foo &&= 5)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-promise-reject-errors.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-promise-reject-errors.test.ts
@@ -1,0 +1,345 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-promise-reject-errors', {
+  valid: [
+    'Promise.resolve(5)',
+    'Foo.reject(5)',
+    'Promise.reject(foo)',
+    'Promise.reject(foo.bar)',
+    'Promise.reject(foo.bar())',
+    'Promise.reject(new Error())',
+    'Promise.reject(new TypeError)',
+    "Promise.reject(new Error('foo'))",
+    'Promise.reject(foo || 5)',
+    'Promise.reject(5 && foo)',
+    'new Foo((resolve, reject) => reject(5))',
+    'new Promise(function(resolve, reject) { return function(reject) { reject(5) } })',
+    'new Promise(function(resolve, reject) { if (foo) { const reject = somethingElse; reject(5) } })',
+    'new Promise(function(resolve, {apply}) { apply(5) })',
+    'new Promise(function(resolve, reject) { resolve(5, reject) })',
+    'async function foo() { Promise.reject(await foo); }',
+    {
+      code: 'Promise.reject()',
+      options: { allowEmptyReject: true },
+    },
+    {
+      code: 'new Promise(function(resolve, reject) { reject() })',
+      options: { allowEmptyReject: true },
+    },
+
+    // ---- Optional chaining ----
+    'Promise.reject(obj?.foo)',
+    'Promise.reject(obj?.foo())',
+
+    // ---- Assignments ----
+    'Promise.reject(foo = new Error())',
+    'Promise.reject(foo ||= 5)',
+    'Promise.reject(foo.bar ??= 5)',
+    'Promise.reject(foo[bar] ??= 5)',
+
+    // ---- Private fields ----
+    'class C { #reject; foo() { Promise.#reject(5); } }',
+    'class C { #error; foo() { Promise.reject(this.#error); } }',
+
+    // ---- TypeScript-only syntax should be transparent to couldBeError ----
+    'Promise.reject(foo as Error)',
+    'Promise.reject(<Error>foo)',
+    'Promise.reject(foo!)',
+    'Promise.reject(foo satisfies Error)',
+
+    // ---- ESLint requires params[1].type === "Identifier"; non-plain
+    // second-parameter shapes are not analyzed.
+    'new Promise((resolve, reject = foo) => reject(5))',
+    'new Promise((resolve, ...reject) => reject[0](5))',
+    'new Promise(function(resolve, [reject]) { reject(5) })',
+
+    // ---- Identifiers that resolve to globals are still Identifier nodes ----
+    'Promise.reject(NaN)',
+    'Promise.reject(Infinity)',
+
+    // ---- Calling Promise without `new` is not an executor pattern. ----
+    'Promise((resolve, reject) => reject(5))',
+
+    // ---- TaggedTemplateExpression result could be an Error. ----
+    'Promise.reject(tag`msg`)',
+
+    // ---- Reject as argument, not callee, does not invoke it. ----
+    'new Promise((resolve, reject) => arr.push(reject))',
+
+    // ---- Reject method-like access (.call / .bind / .apply) is treated
+    // as a different operation by ESLint and is not flagged.
+    'new Promise((resolve, reject) => reject.call(null, new Error()))',
+  ],
+  invalid: [
+    {
+      code: 'Promise.reject(5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: "Promise.reject('foo')",
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(`foo`)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(!foo)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(void foo)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject()',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(undefined)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject({ foo: 1 })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject([1, 2, 3])',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject()',
+      options: { allowEmptyReject: false },
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'new Promise(function(resolve, reject) { reject() })',
+      options: { allowEmptyReject: false },
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 41 }],
+    },
+    {
+      code: 'Promise.reject(undefined)',
+      options: { allowEmptyReject: true },
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: "Promise.reject('foo', somethingElse)",
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'new Promise(function(resolve, reject) { reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 41 }],
+    },
+    {
+      code: 'new Promise((resolve, reject) => { reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 36 }],
+    },
+    {
+      code: 'new Promise((resolve, reject) => reject(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 34 }],
+    },
+    {
+      code: 'new Promise((resolve, reject) => reject())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 34 }],
+    },
+    {
+      code: 'new Promise(function(yes, no) { no(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 33 }],
+    },
+    {
+      code: `
+          new Promise((resolve, reject) => {
+            fs.readFile('foo.txt', (err, file) => {
+              if (err) reject('File not found')
+              else resolve(file)
+            })
+          })
+        `,
+      errors: [{ messageId: 'rejectAnError', line: 4, column: 24 }],
+    },
+    {
+      code: 'new Promise(({foo, bar, baz}, reject) => reject(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 42 }],
+    },
+    {
+      code: 'new Promise(function(reject, reject) { reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 40 }],
+    },
+    {
+      code: 'new Promise(function(foo, arguments) { arguments(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 40 }],
+    },
+    {
+      code: 'new Promise((foo, arguments) => arguments(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 33 }],
+    },
+    {
+      code: 'new Promise(function({}, reject) { reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 36 }],
+    },
+    {
+      code: 'new Promise(({}, reject) => reject(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 29 }],
+    },
+    {
+      code: 'new Promise((resolve, reject, somethingElse = reject(5)) => {})',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 47 }],
+    },
+    {
+      code: 'new Promise(function(resolve, reject) { var reject = somethingElse; reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 69 }],
+    },
+
+    // ---- reject called from a nested callback inside the executor still
+    // resolves to the executor's parameter binding.
+    {
+      code: 'new Promise((resolve, reject) => setTimeout(() => reject(5), 0))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 51 }],
+    },
+    {
+      code: "new Promise((resolve, reject) => arr.forEach(function () { reject('bad') }))",
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 60 }],
+    },
+
+    // ---- Spread cannot be statically classified as an Error candidate ----
+    {
+      code: 'Promise.reject(...args)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+
+    // ---- Plain literals that are not Errors ----
+    {
+      code: 'Promise.reject(null)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(0)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(true)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+
+    // ---- Computed bracket access with static string ----
+    {
+      code: "Promise['reject'](5)",
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise[`reject`](5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+
+    // ---- Named function expression as executor ----
+    {
+      code: 'new Promise(function fn(resolve, reject) { reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 44 }],
+    },
+
+    // ---- Async / generator executors are still functions, so reject calls
+    // inside them should be checked.
+    {
+      code: 'new Promise(async (resolve, reject) => reject(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 40 }],
+    },
+    {
+      code: 'new Promise(function *(resolve, reject) { reject(5) })',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 43 }],
+    },
+
+    // ---- Multiple reject calls in a single executor ----
+    {
+      code: "new Promise((resolve, reject) => { reject(1); reject('x'); reject(); })",
+      errors: [
+        { messageId: 'rejectAnError', line: 1, column: 36 },
+        { messageId: 'rejectAnError', line: 1, column: 47 },
+        { messageId: 'rejectAnError', line: 1, column: 60 },
+      ],
+    },
+
+    // ---- Parenthesized reject callee inside the executor body ----
+    {
+      code: 'new Promise((resolve, reject) => (reject)(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 34 }],
+    },
+
+    // ---- Optional chaining on the executor reject callback ----
+    {
+      code: 'new Promise((resolve, reject) => reject?.(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 34 }],
+    },
+
+    // ---- Parenthesized / TS-asserted Promise constructor must be
+    // transparent (ESTree strips parens, so ESLint already accepts
+    // `new (Promise)(executor)`).
+    {
+      code: 'new (Promise)((resolve, reject) => reject(5))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 36 }],
+    },
+    {
+      code: 'new Promise(((resolve, reject) => reject(5)))',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 35 }],
+    },
+
+    // ---- Optional chaining ----
+    {
+      code: 'Promise.reject?.(5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise?.reject(5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise?.reject?.(5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: '(Promise?.reject)(5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: '(Promise?.reject)?.(5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+
+    // ---- Mathematical / bitwise assignments evaluate to primitives or throw ----
+    {
+      code: 'Promise.reject(foo += new Error())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo -= new Error())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo **= new Error())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo <<= new Error())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo |= new Error())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo &= new Error())',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+
+    // ---- && short-circuit yields the falsy left or the right operand ----
+    {
+      code: 'Promise.reject(foo && 5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo &&= 5)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `prefer-promise-reject-errors` rule from ESLint to rslint.

The rule requires `Promise` rejections to use `Error` objects (or possibly-Error expressions). It flags two patterns:

- `Promise.reject(value)` calls where the argument cannot be an `Error` (purely AST-based detection via `utils.IsSpecificMemberAccess`, which transparently handles parens, optional chaining, and computed bracket access).
- `new Promise((resolve, reject) => …)` executors where the second parameter is invoked with a non-`Error` argument. Reference resolution uses tsgo's `TypeChecker.GetSymbolAtLocation` so that function-scope `var` re-declarations, duplicate-named parameters, and inner block-scoped shadowing all match ESLint's scope-manager behavior. Falls back to a name-based scope walk via `utils.IsNameShadowedBetween` when type info is unavailable.

The argument check (`couldBeError`) mirrors ESLint's `astUtils.couldBeError`, adapted to tsgo's flattened `BinaryExpression` for `||=`/`??=`/sequence/logical operators. TypeScript-only wrapping syntax (`as T`, `<T>x`, `x!`, `x satisfies T`) is transparently skipped via `ast.SkipOuterExpressions`.

Real-world validation: ran the binary against rsbuild (1197 files → 0 reports, all `reject(err)` / `reject(new Error(...))` patterns correctly passed) and rspack (392 files → 2 reports at `packages/rspack-test-tools/src/test/creator.ts:195` and `:201`, both empty `Promise.reject()` calls — true positives matching ESLint's default `allowEmptyReject: false`).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/prefer-promise-reject-errors
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/prefer-promise-reject-errors.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).