### PR TITLE
feat: port rule strict

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -205,6 +205,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
+	"github.com/web-infra-dev/rslint/internal/rules/strict"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
 	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
@@ -599,6 +600,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-self-compare", no_self_compare.NoSelfCompareRule)
 	GlobalRuleRegistry.Register("no-sequences", no_sequences.NoSequencesRule)
 	GlobalRuleRegistry.Register("no-shadow-restricted-names", no_shadow_restricted_names.NoShadowRestrictedNamesRule)
+	GlobalRuleRegistry.Register("strict", strict.StrictRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
 	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)

--- a/internal/rules/strict/strict.go
+++ b/internal/rules/strict/strict.go
@@ -1,0 +1,453 @@
+package strict
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/strict
+//
+// NOTE: Unlike ESLint, rslint does not expose languageOptions.parserOptions
+// (ecmaFeatures.impliedStrict / ecmaFeatures.globalReturn) or
+// sourceType === "commonjs". rslint detects ES modules via
+// ast.IsExternalModule (presence of import/export) and treats every other
+// file as a script. Consequences:
+//   - "safe" resolves to "function" on script files and "module" on ES modules
+//     (ESLint's commonjs-aware "global" fallback has no rslint analogue).
+//   - "implied" and "globalReturn" code paths are unreachable.
+// See strict.md "Differences from ESLint" for the user-visible contract.
+
+type strictMode int
+
+const (
+	modeNever strictMode = iota
+	modeGlobal
+	modeFunction
+	modeModule
+)
+
+func (m strictMode) messageId() string {
+	switch m {
+	case modeNever:
+		return "never"
+	case modeGlobal:
+		return "global"
+	case modeFunction:
+		return "function"
+	case modeModule:
+		return "module"
+	}
+	return ""
+}
+
+// shouldFix mirrors ESLint's shouldFix — true when the reported diagnostic
+// corresponds to a redundant directive that should simply be removed.
+func shouldFix(errorType string) bool {
+	switch errorType {
+	case "multiple", "unnecessary", "module", "unnecessaryInClasses":
+		return true
+	}
+	return false
+}
+
+// messageDescriptionFor returns the static description text for a given
+// messageId (matches ESLint's meta.messages entries verbatim so Go tests can
+// assert on Message if desired).
+func messageDescriptionFor(msgId string) string {
+	switch msgId {
+	case "function":
+		return "Use the function form of 'use strict'."
+	case "global":
+		return "Use the global form of 'use strict'."
+	case "multiple":
+		return "Multiple 'use strict' directives."
+	case "never":
+		return "Strict mode is not permitted."
+	case "unnecessary":
+		return "Unnecessary 'use strict' directive."
+	case "module":
+		return "'use strict' is unnecessary inside of modules."
+	case "unnecessaryInClasses":
+		return "'use strict' is unnecessary inside of classes."
+	case "nonSimpleParameterList":
+		return "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."
+	}
+	return ""
+}
+
+// getUseStrictDirectives collects all "use strict" directives at the start of
+// a statement list, stopping at the first non-matching statement. This
+// mirrors ESLint's helper of the same name exactly — any leading non-matching
+// ExpressionStatement terminates the scan, even if it is itself a string
+// literal prologue directive (e.g. "use asm").
+func getUseStrictDirectives(statements []*ast.Node) []*ast.Node {
+	var directives []*ast.Node
+	for _, stmt := range statements {
+		if !ast.IsPrologueDirective(stmt) {
+			break
+		}
+		expr := stmt.Expression()
+		if expr == nil || expr.Text() != "use strict" {
+			break
+		}
+		directives = append(directives, stmt)
+	}
+	return directives
+}
+
+// isSimpleParameter is true when the parameter is a plain identifier with no
+// default value, no rest, no destructuring, and no type annotation-only
+// binding patterns. Matches ESLint's `node.type === "Identifier"` check on
+// ESTree parameters.
+func isSimpleParameter(param *ast.Node) bool {
+	if param == nil || param.Kind != ast.KindParameter {
+		return false
+	}
+	p := param.AsParameterDeclaration()
+	if p == nil {
+		return false
+	}
+	if p.DotDotDotToken != nil || p.Initializer != nil {
+		return false
+	}
+	name := p.Name()
+	return name != nil && name.Kind == ast.KindIdentifier
+}
+
+func isSimpleParameterList(params []*ast.Node) bool {
+	for _, p := range params {
+		if !isSimpleParameter(p) {
+			return false
+		}
+	}
+	return true
+}
+
+// getFunctionBodyStatements returns the statements of a function's block
+// body, or nil for arrow functions with expression bodies (no directive
+// prologue is possible).
+func getFunctionBodyStatements(node *ast.Node) []*ast.Node {
+	body := node.Body()
+	if body == nil || body.Kind != ast.KindBlock {
+		return nil
+	}
+	block := body.AsBlock()
+	if block == nil || block.Statements == nil {
+		return nil
+	}
+	return block.Statements.Nodes
+}
+
+// functionDescription mirrors ESLint's astUtils.getFunctionNameWithKind. It
+// produces the `{{name}}` placeholder of the `wrap` message — e.g.
+// `"async generator function 'foo'"`, `"static private method '#bar'"`,
+// `"arrow function"`. Modifier order matches ESLint: static, private, async,
+// generator.
+func functionDescription(node *ast.Node) string {
+	if node.Kind == ast.KindConstructor {
+		return "constructor"
+	}
+
+	flags := ast.GetFunctionFlags(node)
+	isAsync := flags&ast.FunctionFlagsAsync != 0
+	isGenerator := flags&ast.FunctionFlagsGenerator != 0
+
+	isStatic, isPrivate := false, false
+	parent := node.Parent
+	inClassBody := parent != nil && (parent.Kind == ast.KindClassDeclaration || parent.Kind == ast.KindClassExpression)
+	if inClassBody {
+		switch node.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			isStatic = ast.HasSyntacticModifier(node, ast.ModifierFlagsStatic)
+			if n := node.Name(); n != nil && n.Kind == ast.KindPrivateIdentifier {
+				isPrivate = true
+			}
+		}
+	}
+
+	var tokens []string
+	if isStatic {
+		tokens = append(tokens, "static")
+	}
+	if isPrivate {
+		tokens = append(tokens, "private")
+	}
+	if isAsync {
+		tokens = append(tokens, "async")
+	}
+	if isGenerator {
+		tokens = append(tokens, "generator")
+	}
+
+	switch node.Kind {
+	case ast.KindGetAccessor:
+		tokens = append(tokens, "getter")
+	case ast.KindSetAccessor:
+		tokens = append(tokens, "setter")
+	case ast.KindMethodDeclaration:
+		tokens = append(tokens, "method")
+	case ast.KindArrowFunction:
+		tokens = append(tokens, "arrow", "function")
+	default:
+		tokens = append(tokens, "function")
+	}
+
+	if name := node.Name(); name != nil {
+		if name.Kind == ast.KindPrivateIdentifier {
+			// PrivateIdentifier.Text already includes the leading '#'.
+			tokens = append(tokens, fmt.Sprintf("'%s'", name.AsPrivateIdentifier().Text))
+		} else if nameStr, ok := utils.GetStaticPropertyName(name); ok {
+			tokens = append(tokens, fmt.Sprintf("'%s'", nameStr))
+		}
+	}
+
+	return strings.Join(tokens, " ")
+}
+
+func reportDirectives(ctx rule.RuleContext, directives []*ast.Node, msgId string, fix bool) {
+	desc := messageDescriptionFor(msgId)
+	for _, d := range directives {
+		msg := rule.RuleMessage{Id: msgId, Description: desc}
+		if fix {
+			ctx.ReportNodeWithFixes(d, msg, rule.RuleFixRemove(ctx.SourceFile, d))
+		} else {
+			ctx.ReportNode(d, msg)
+		}
+	}
+}
+
+// handleProgram processes the source-file level prologue once at rule setup.
+// The linter does not fire a KindSourceFile listener, so this runs eagerly.
+func handleProgram(ctx rule.RuleContext, m strictMode) {
+	if ctx.SourceFile.Statements == nil {
+		return
+	}
+	body := ctx.SourceFile.Statements.Nodes
+	directives := getUseStrictDirectives(body)
+
+	if m == modeGlobal {
+		if len(body) > 0 && len(directives) == 0 {
+			// ESLint v9 reports the range from the first body statement to
+			// the last body statement.
+			startRange := utils.TrimNodeTextRange(ctx.SourceFile, body[0])
+			endRange := utils.TrimNodeTextRange(ctx.SourceFile, body[len(body)-1])
+			rng := core.NewTextRange(startRange.Pos(), endRange.End())
+			ctx.ReportRange(rng, rule.RuleMessage{
+				Id:          "global",
+				Description: messageDescriptionFor("global"),
+			})
+		}
+		if len(directives) > 1 {
+			reportDirectives(ctx, directives[1:], "multiple", true)
+		}
+		return
+	}
+
+	// never / function / module: report every directive with the mode's
+	// messageId. "function" at global scope is unfixable (shouldFix=false).
+	msgId := m.messageId()
+	reportDirectives(ctx, directives, msgId, shouldFix(msgId))
+}
+
+// buildSimpleListeners is the listener set for every mode except "function".
+// Each function body's directive prologue is reported as a whole; no scope
+// tracking is needed because the mode is fixed across the file.
+func buildSimpleListeners(ctx rule.RuleContext, m strictMode) rule.RuleListeners {
+	handle := func(node *ast.Node) {
+		directives := getUseStrictDirectives(getFunctionBodyStatements(node))
+		if len(directives) == 0 {
+			return
+		}
+		if isSimpleParameterList(node.Parameters()) {
+			msgId := m.messageId()
+			reportDirectives(ctx, directives, msgId, shouldFix(msgId))
+			return
+		}
+		ctx.ReportNode(directives[0], rule.RuleMessage{
+			Id:          "nonSimpleParameterList",
+			Description: messageDescriptionFor("nonSimpleParameterList"),
+		})
+		if len(directives) > 1 {
+			reportDirectives(ctx, directives[1:], "multiple", true)
+		}
+	}
+	return rule.RuleListeners{
+		ast.KindFunctionDeclaration: handle,
+		ast.KindFunctionExpression:  handle,
+		ast.KindArrowFunction:       handle,
+		ast.KindMethodDeclaration:   handle,
+		ast.KindConstructor:         handle,
+		ast.KindGetAccessor:         handle,
+		ast.KindSetAccessor:         handle,
+	}
+}
+
+// isClassBodyMember returns true when the given node sits in a class body
+// member slot (method / accessor / constructor / field / static block). Used
+// to distinguish class-body descendants from decorators, heritage clauses,
+// type parameters, and other ClassDeclaration children that are visited
+// outside the `{ … }` body in ESLint's ClassBody scope.
+func isClassBodyMember(node *ast.Node) bool {
+	switch node.Kind {
+	case ast.KindPropertyDeclaration,
+		ast.KindMethodDeclaration,
+		ast.KindConstructor,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor,
+		ast.KindClassStaticBlockDeclaration,
+		ast.KindSemicolonClassElement:
+		return true
+	}
+	return false
+}
+
+// isInClassBody matches ESLint's `classScopes.length > 0` check. It is true
+// when `node` is a descendant of some enclosing class body member. Functions
+// that appear in a class's decorators, heritage clause, or modifiers are
+// NOT considered in a class body (ESLint only pushes classScopes on
+// ClassBody, not ClassDeclaration).
+func isInClassBody(node *ast.Node) bool {
+	child, parent := node, node.Parent
+	for parent != nil {
+		if parent.Kind == ast.KindClassDeclaration || parent.Kind == ast.KindClassExpression {
+			if isClassBodyMember(child) {
+				return true
+			}
+			// Reached this class via a non-body slot (decorator / heritage /
+			// etc.) — keep walking; an outer class may still contain us.
+		}
+		child, parent = parent, parent.Parent
+	}
+	return false
+}
+
+// buildFunctionModeListeners implements ESLint's "function" mode bookkeeping.
+// `scopes` tracks whether each enclosing function body is in strict mode
+// (self-declared or inherited from a strict parent). Class-body membership is
+// resolved per-visit via ancestor walking so that functions appearing in a
+// class's heritage / decorators are correctly treated as outside the class.
+func buildFunctionModeListeners(ctx rule.RuleContext) rule.RuleListeners {
+	var scopes []bool
+
+	enterFunction := func(node *ast.Node) {
+		// Skip ambient / bodyless declarations (TypeScript `declare function`,
+		// abstract methods, overload signatures) — no runtime body where a
+		// directive prologue applies.
+		if node.Body() == nil {
+			return
+		}
+		directives := getUseStrictDirectives(getFunctionBodyStatements(node))
+		isInClass := isInClassBody(node)
+		isParentGlobal := len(scopes) == 0 && !isInClass
+		isParentStrict := len(scopes) > 0 && scopes[len(scopes)-1]
+		isStrict := len(directives) > 0
+		simpleParams := isSimpleParameterList(node.Parameters())
+
+		if isStrict {
+			first := directives[0]
+			switch {
+			case !simpleParams:
+				ctx.ReportNode(first, rule.RuleMessage{
+					Id:          "nonSimpleParameterList",
+					Description: messageDescriptionFor("nonSimpleParameterList"),
+				})
+			case isParentStrict:
+				ctx.ReportNodeWithFixes(first, rule.RuleMessage{
+					Id:          "unnecessary",
+					Description: messageDescriptionFor("unnecessary"),
+				}, rule.RuleFixRemove(ctx.SourceFile, first))
+			case isInClass:
+				ctx.ReportNodeWithFixes(first, rule.RuleMessage{
+					Id:          "unnecessaryInClasses",
+					Description: messageDescriptionFor("unnecessaryInClasses"),
+				}, rule.RuleFixRemove(ctx.SourceFile, first))
+			}
+			if len(directives) > 1 {
+				reportDirectives(ctx, directives[1:], "multiple", true)
+			}
+		} else if isParentGlobal {
+			if simpleParams {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "function",
+					Description: messageDescriptionFor("function"),
+				})
+			} else {
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "wrap",
+					Description: fmt.Sprintf("Wrap %s in a function with 'use strict' directive.", functionDescription(node)),
+				})
+			}
+		}
+
+		scopes = append(scopes, isParentStrict || isStrict)
+	}
+
+	exitFunction := func(node *ast.Node) {
+		if node.Body() == nil {
+			return
+		}
+		if len(scopes) > 0 {
+			scopes = scopes[:len(scopes)-1]
+		}
+	}
+
+	return rule.RuleListeners{
+		ast.KindFunctionDeclaration:                      enterFunction,
+		ast.KindFunctionExpression:                       enterFunction,
+		ast.KindArrowFunction:                            enterFunction,
+		ast.KindMethodDeclaration:                        enterFunction,
+		ast.KindConstructor:                              enterFunction,
+		ast.KindGetAccessor:                              enterFunction,
+		ast.KindSetAccessor:                              enterFunction,
+		rule.ListenerOnExit(ast.KindFunctionDeclaration): exitFunction,
+		rule.ListenerOnExit(ast.KindFunctionExpression):  exitFunction,
+		rule.ListenerOnExit(ast.KindArrowFunction):       exitFunction,
+		rule.ListenerOnExit(ast.KindMethodDeclaration):   exitFunction,
+		rule.ListenerOnExit(ast.KindConstructor):         exitFunction,
+		rule.ListenerOnExit(ast.KindGetAccessor):         exitFunction,
+		rule.ListenerOnExit(ast.KindSetAccessor):         exitFunction,
+	}
+}
+
+var StrictRule = rule.Rule{
+	Name: "strict",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		optStr := utils.GetOptionsString(options)
+		if optStr == "" {
+			optStr = "safe"
+		}
+
+		var m strictMode
+		switch optStr {
+		case "never":
+			m = modeNever
+		case "global":
+			m = modeGlobal
+		case "function":
+			m = modeFunction
+		case "safe":
+			// rslint cannot detect commonjs / globalReturn; "safe" on a
+			// script file therefore always maps to "function" (matching
+			// ESLint's non-commonjs, non-globalReturn behavior).
+			m = modeFunction
+		default:
+			m = modeFunction
+		}
+
+		if ast.IsExternalModule(ctx.SourceFile) {
+			m = modeModule
+		}
+
+		handleProgram(ctx, m)
+
+		if m == modeFunction {
+			return buildFunctionModeListeners(ctx)
+		}
+		return buildSimpleListeners(ctx, m)
+	},
+}

--- a/internal/rules/strict/strict.md
+++ b/internal/rules/strict/strict.md
@@ -1,0 +1,118 @@
+# strict
+
+## Rule Details
+
+Require or disallow strict mode directives (`"use strict"`).
+
+The rule supports four options:
+
+- `"safe"` (default) — equivalent to `"function"` for script files; module files always use `"module"` semantics.
+- `"never"` — disallows all strict mode directives.
+- `"global"` — requires exactly one strict directive in global scope and disallows all other directives.
+- `"function"` — requires one strict directive in each top-level function and disallows directives in the global scope or in nested functions / class bodies.
+
+When the file is an ES module (detected via top-level `import` / `export`), the rule always uses module semantics: every `"use strict"` directive is reported as unnecessary and removed by autofix.
+
+## Examples
+
+### `"never"`
+
+```json
+{ "strict": ["error", "never"] }
+```
+
+Examples of **incorrect** code:
+
+```javascript
+"use strict";
+function foo() {}
+```
+
+```javascript
+function foo() {
+    "use strict";
+}
+```
+
+Examples of **correct** code:
+
+```javascript
+function foo() {}
+```
+
+### `"global"`
+
+```json
+{ "strict": ["error", "global"] }
+```
+
+Examples of **incorrect** code:
+
+```javascript
+function foo() {}
+```
+
+```javascript
+function foo() {
+    "use strict";
+}
+```
+
+```javascript
+"use strict";
+function foo() {
+    "use strict";
+}
+```
+
+Examples of **correct** code:
+
+```javascript
+"use strict";
+function foo() {}
+```
+
+### `"function"`
+
+```json
+{ "strict": ["error", "function"] }
+```
+
+Examples of **incorrect** code:
+
+```javascript
+"use strict";
+function foo() {}
+```
+
+```javascript
+function foo() {}
+(function() {
+    function bar() {
+        "use strict";
+    }
+}());
+```
+
+Examples of **correct** code:
+
+```javascript
+function foo() {
+    "use strict";
+}
+
+(function() {
+    "use strict";
+    function bar() {}
+    function baz(a = 1) {}
+}());
+
+const foo2 = (function() {
+    "use strict";
+    return function foo(a = 1) {};
+}());
+```
+
+## Original Documentation
+
+- https://eslint.org/docs/latest/rules/strict

--- a/internal/rules/strict/strict_test.go
+++ b/internal/rules/strict/strict_test.go
@@ -1,0 +1,780 @@
+package strict
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Ported from ESLint's tests/lib/rules/strict.js.
+//
+// Cases that rely on ESLint-only language options (parserOptions.ecmaFeatures
+// .{impliedStrict,globalReturn} and sourceType === "commonjs") are preserved
+// with Skip: true so the mapping to the upstream suite stays explicit.
+// rslint detects ES modules structurally via ast.IsExternalModule, so any
+// test that needed sourceType: "module" is adapted to include an
+// `export {};` or equivalent trigger.
+func TestStrictRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&StrictRule,
+		[]rule_tester.ValidTestCase{
+			// ---- "never" mode ----
+			{Code: `foo();`, Options: "never"},
+			{Code: `function foo() { return; }`, Options: "never"},
+			{Code: `var foo = function() { return; };`, Options: "never"},
+			{Code: `foo(); 'use strict';`, Options: "never"},
+			{Code: `function foo() { bar(); 'use strict'; return; }`, Options: "never"},
+			{Code: `var foo = function() { { 'use strict'; } return; };`, Options: "never"},
+			{Code: `(function() { bar('use strict'); return; }());`, Options: "never"},
+			{Code: `var fn = x => 1;`, Options: "never"},
+			{Code: `var fn = x => { return; };`, Options: "never"},
+			// ESLint uses `sourceType: "module"` here; rslint triggers module mode
+			// via an import/export, and in module mode "use strict" is reported
+			// (not valid) — so the equivalent valid case is plain script code.
+			// The module variant is exercised in the invalid suite below.
+			{Code: `foo(); export {};`, Options: "never"},
+			// SKIP: parserOptions.ecmaFeatures.impliedStrict is not exposed by rslint.
+			{Code: `function foo() { return; }`, Options: "never", Skip: true},
+
+			// ---- "global" mode ----
+			{Code: `// Intentionally empty`, Options: "global"},
+			{Code: `"use strict"; foo();`, Options: "global"},
+			{Code: `/* license */
+/* eslint-disable rule-to-test/strict */
+foo();`, Options: "global", Skip: true}, // SKIP: relies on ESLint disable semantics we don't emulate here.
+			// Module files always ignore "global" in favor of "module" mode — the
+			// ESLint variant uses sourceType: "module"; rslint adapts by adding
+			// `export {};` which likewise triggers module detection.
+			{Code: `foo(); export {};`, Options: "global", Skip: true}, // covered in invalid suite (module reports any "use strict")
+			// SKIP: parserOptions.ecmaFeatures.impliedStrict not exposed.
+			{Code: `function foo() { return; }`, Options: "global", Skip: true},
+			{Code: `'use strict'; function foo() { return; }`, Options: "global"},
+			{Code: `'use strict'; var foo = function() { return; };`, Options: "global"},
+			{Code: `'use strict'; function foo() { bar(); 'use strict'; return; }`, Options: "global"},
+			{Code: `'use strict'; var foo = function() { bar(); 'use strict'; return; };`, Options: "global"},
+			{Code: `'use strict'; function foo() { return function() { bar(); 'use strict'; return; }; }`, Options: "global"},
+			{Code: `'use strict'; var foo = () => { return () => { bar(); 'use strict'; return; }; }`, Options: "global"},
+
+			// ---- "function" mode ----
+			{Code: `function foo() { 'use strict'; return; }`, Options: "function"},
+			// SKIP: ESLint uses sourceType: "module"; in rslint, module mode
+			// reports all "use strict" — the behavior is covered by the module
+			// test cases that add `export {};`.
+			{Code: `function foo() { return; } export {};`, Options: "function", Skip: true},
+			// SKIP: parserOptions.ecmaFeatures.impliedStrict not exposed.
+			{Code: `function foo() { return; }`, Options: "function", Skip: true},
+			{Code: `var foo = function() { return; } export {};`, Options: "function", Skip: true},
+			{Code: `var foo = function() { 'use strict'; return; }`, Options: "function"},
+			{Code: `function foo() { 'use strict'; return; } var bar = function() { 'use strict'; bar(); };`, Options: "function"},
+			{Code: `var foo = function() { 'use strict'; function bar() { return; } bar(); };`, Options: "function"},
+			{Code: `var foo = () => { 'use strict'; var bar = () => 1; bar(); };`, Options: "function"},
+			// SKIP: sourceType: "module" — nested arrow valid case, module variant covered by module tests.
+			{Code: `var foo = () => { var bar = () => 1; bar(); }; export {};`, Options: "function", Skip: true},
+			{Code: `class A { constructor() { } }`, Options: "function"},
+			{Code: `class A { foo() { } }`, Options: "function"},
+			{Code: `class A { foo() { function bar() { } } }`, Options: "function"},
+			{Code: `(function() { 'use strict'; function foo(a = 0) { } }())`, Options: "function"},
+
+			// ---- "safe" mode ----
+			{Code: `function foo() { 'use strict'; return; }`, Options: "safe"},
+			// SKIP: parserOptions.ecmaFeatures.globalReturn not exposed.
+			{Code: `'use strict'; function foo() { return; }`, Options: "safe", Skip: true},
+			// SKIP: sourceType: "module" valid case — behavior covered in invalid suite via `export {};`.
+			{Code: `function foo() { return; } export {};`, Options: "safe", Skip: true},
+			// SKIP: impliedStrict not exposed.
+			{Code: `function foo() { return; }`, Options: "safe", Skip: true},
+
+			// ---- default to "safe" (= "function" in rslint) ----
+			{Code: `function foo() { 'use strict'; return; }`},
+			// SKIP: globalReturn not exposed.
+			{Code: `'use strict'; function foo() { return; }`, Skip: true},
+			// SKIP: module-sourced valid case covered elsewhere.
+			{Code: `function foo() { return; } export {};`, Skip: true},
+			// SKIP: impliedStrict not exposed.
+			{Code: `function foo() { return; }`, Skip: true},
+
+			// ---- Class static blocks (no directive prologue inside) ----
+			{Code: `'use strict'; class C { static { foo; } }`, Options: "global"},
+			{Code: `'use strict'; class C { static { 'use strict'; } }`, Options: "global"},
+			{Code: `'use strict'; class C { static { 'use strict'; 'use strict'; } }`, Options: "global"},
+			{Code: `class C { static { foo; } }`, Options: "function"},
+			{Code: `class C { static { 'use strict'; } }`, Options: "function"},
+			{Code: `class C { static { 'use strict'; 'use strict'; } }`, Options: "function"},
+			{Code: `class C { static { foo; } }`, Options: "never"},
+			{Code: `class C { static { 'use strict'; } }`, Options: "never"},
+			{Code: `class C { static { 'use strict'; 'use strict'; } }`, Options: "never"},
+			// SKIP: sourceType: "module" — module path exercised in invalid suite.
+			{Code: `class C { static { 'use strict'; } } export {};`, Options: "safe", Skip: true},
+			// SKIP: impliedStrict not exposed.
+			{Code: `class C { static { 'use strict'; } }`, Options: "safe", Skip: true},
+			// SKIP: sourceType: "commonjs" — rslint cannot distinguish CommonJS scripts.
+			{Code: `'use strict'; module.exports = function identity (value) { return value; }`, Skip: true},
+			{Code: `'use strict'; module.exports = function identity (value) { return value; }`, Options: "safe", Skip: true},
+
+			// ---- Class heritage (not class body) ----
+			// A function in an `extends` clause is NOT inside the class body, so
+			// a `"use strict"` directive there is neither `unnecessary` nor
+			// `unnecessaryInClasses` — it is the top-level directive of that
+			// function (valid under "function" mode).
+			{
+				Code:    `class Foo extends (function() { 'use strict'; return class {}; }()) {}`,
+				Options: "function",
+			},
+
+			// ---- Ambient / bodyless declarations (TypeScript) ----
+			// `declare function`, abstract methods, and overload signatures have
+			// no runtime body; the rule must not demand per-function "use strict"
+			// on them. (Program-level "global" enforcement still applies — a file
+			// whose only statement is a declare function with no top-level
+			// directive is still flagged by "global" mode, matching ESLint.)
+			{Code: `declare function foo(): void;`, Options: "function"},
+			{Code: `declare function foo(): void;`, Options: "never"},
+			{Code: `'use strict'; declare function foo(): void;`, Options: "global"},
+			{Code: `abstract class A { abstract foo(): void; }`, Options: "function"},
+			{
+				Code:    `function foo(): void; function foo(a: number): void; function foo(a?: number) { 'use strict'; }`,
+				Options: "function",
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- "never" mode ----
+			{
+				Code:    `"use strict"; foo();`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `function foo() { 'use strict'; return; }`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:    `var foo = function() { 'use strict'; return; };`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:    `function foo() { return function() { 'use strict'; return; }; }`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code:    `'use strict'; function foo() { "use strict"; return; }`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 1, Column: 1},
+					{MessageId: "never", Line: 1, Column: 32},
+				},
+			},
+			// Module detection (rslint analogue of sourceType: "module").
+			{
+				Code:    `"use strict"; foo(); export {};`,
+				Output:  []string{` foo(); export {};`},
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "module", Line: 1, Column: 1},
+				},
+			},
+			// SKIP: ESLint uses impliedStrict; rslint has no equivalent.
+			{
+				Code:    `'use strict'; function foo() { 'use strict'; return; }`,
+				Options: "never",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "implied"}, {MessageId: "implied"}},
+			},
+			// SKIP: module + impliedStrict combination; module-only covered above.
+			{
+				Code:    `'use strict'; function foo() { 'use strict'; return; }`,
+				Options: "never",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "module"}, {MessageId: "module"}},
+			},
+
+			// ---- "global" mode ----
+			{
+				Code:    `foo();`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `/* license */
+function foo() {}
+function bar() {}
+/* end */`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 2, Column: 1, EndLine: 3, EndColumn: 18},
+				},
+			},
+			{
+				Code:    `function foo() { 'use strict'; return; }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 1},
+					{MessageId: "global", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:    `var foo = function() { 'use strict'; return; }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 1},
+					{MessageId: "global", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code:    `var foo = () => { 'use strict'; return () => 1; }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 1},
+					{MessageId: "global", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    `'use strict'; function foo() { 'use strict'; return; }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code:    `'use strict'; var foo = function() { 'use strict'; return; };`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code:    `'use strict'; 'use strict'; foo();`,
+				Output:  []string{`'use strict';  foo();`},
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multiple", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code:    `'use strict'; foo(); export {};`,
+				Output:  []string{` foo(); export {};`},
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "module", Line: 1, Column: 1},
+				},
+			},
+			// SKIP: impliedStrict not exposed.
+			{
+				Code:    `'use strict'; function foo() { 'use strict'; return; }`,
+				Options: "global",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "implied"}, {MessageId: "implied"}},
+			},
+
+			// ---- "function" mode ----
+			{
+				Code:    `'use strict'; foo();`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `'use strict'; (function() { 'use strict'; return true; }());`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `(function() { 'use strict'; function f() { 'use strict'; return } return true; }());`,
+				Output:  []string{`(function() { 'use strict'; function f() {  return } return true; }());`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessary", Line: 1, Column: 44},
+				},
+			},
+			{
+				Code:    `(function() { return true; }());`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code:    `(() => { return true; })();`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code:    `(() => true)();`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 2},
+				},
+			},
+			{
+				Code:    `var foo = function() { foo(); 'use strict'; return; }; function bar() { foo(); 'use strict'; }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 11},
+					{MessageId: "function", Line: 1, Column: 56},
+				},
+			},
+			{
+				Code:    `function foo() { 'use strict'; 'use strict'; return; }`,
+				Output:  []string{`function foo() { 'use strict';  return; }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multiple", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code:    `var foo = function() { 'use strict'; 'use strict'; return; }`,
+				Output:  []string{`var foo = function() { 'use strict';  return; }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "multiple", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code:    `var foo = function() {  'use strict'; return; }; export {};`,
+				Output:  []string{`var foo = function() {   return; }; export {};`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "module", Line: 1, Column: 25},
+				},
+			},
+			// SKIP: impliedStrict not exposed.
+			{
+				Code:    `'use strict'; function foo() { 'use strict'; return; }`,
+				Options: "function",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "implied"}, {MessageId: "implied"}},
+			},
+			{
+				Code:    `function foo() { return function() { 'use strict'; return; }; }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `var foo = function() { function bar() { 'use strict'; return; } return; }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 11},
+				},
+			},
+			{
+				Code:    `function foo() { 'use strict'; return; } var bar = function() { return; };`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 52},
+				},
+			},
+			{
+				Code:    `var foo = function() { 'use strict'; return; }; function bar() { return; };`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 49},
+				},
+			},
+			{
+				Code:    `function foo() { 'use strict'; return function() { 'use strict'; 'use strict'; return; }; }`,
+				Output:  []string{`function foo() { 'use strict'; return function() {   return; }; }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessary", Line: 1, Column: 52},
+					{MessageId: "multiple", Line: 1, Column: 66},
+				},
+			},
+			{
+				Code:    `var foo = function() { 'use strict'; function bar() { 'use strict'; 'use strict'; return; } }`,
+				Output:  []string{`var foo = function() { 'use strict'; function bar() {   return; } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessary", Line: 1, Column: 55},
+					{MessageId: "multiple", Line: 1, Column: 69},
+				},
+			},
+			{
+				Code:    `var foo = () => { return; };`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- Classes ----
+			{
+				Code:    `class A { constructor() { "use strict"; } }`,
+				Output:  []string{`class A { constructor() {  } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:    `class A { foo() { "use strict"; } }`,
+				Output:  []string{`class A { foo() {  } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code:    `class A { foo() { function bar() { "use strict"; } } }`,
+				Output:  []string{`class A { foo() { function bar() {  } } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code:    `class A { field = () => { "use strict"; } }`,
+				Output:  []string{`class A { field = () => {  } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code:    `class A { field = function() { "use strict"; } }`,
+				Output:  []string{`class A { field = function() {  } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 1, Column: 32},
+				},
+			},
+
+			// ---- "safe" mode (= "function" in rslint script files) ----
+			{
+				Code:    `'use strict'; function foo() { return; }`,
+				Options: "safe",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 1},
+					{MessageId: "function", Line: 1, Column: 15},
+				},
+			},
+			// SKIP: globalReturn not exposed.
+			{
+				Code:    `function foo() { 'use strict'; return; }`,
+				Options: "safe",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "global"}, {MessageId: "global"}},
+			},
+			// SKIP: impliedStrict not exposed.
+			{
+				Code:    `'use strict'; function foo() { 'use strict'; return; }`,
+				Options: "safe",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "implied"}, {MessageId: "implied"}},
+			},
+
+			// ---- Default "safe" (= "function" in rslint script files) ----
+			{
+				Code: `'use strict'; function foo() { return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 1},
+					{MessageId: "function", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `function foo() { return; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 1},
+				},
+			},
+			// SKIP: globalReturn not exposed.
+			{
+				Code:   `function foo() { 'use strict'; return; }`,
+				Skip:   true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "global"}, {MessageId: "global"}},
+			},
+
+			// ---- Non-simple parameter list: https://github.com/eslint/eslint/issues/6405 ----
+			{
+				Code:    `function foo(a = 0) { 'use strict' }`,
+				Options: []interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `(function() { 'use strict'; function foo(a = 0) { 'use strict' } }())`,
+				Options: []interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 51},
+				},
+			},
+			// SKIP: globalReturn not exposed.
+			{
+				Code:    `function foo(a = 0) { 'use strict' }`,
+				Options: []interface{}{},
+				Skip:    true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{Message: "Use the global form of 'use strict'."},
+					{MessageId: "nonSimpleParameterList"},
+				},
+			},
+			// SKIP: globalReturn not exposed.
+			{
+				Code:    `'use strict'; function foo(a = 0) { 'use strict' }`,
+				Options: []interface{}{},
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "nonSimpleParameterList"}},
+			},
+			{
+				Code:    `function foo(a = 0) { 'use strict' }`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `function foo(a = 0) { 'use strict' }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 1, Column: 1},
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `'use strict'; function foo(a = 0) { 'use strict' }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code:    `function foo(a = 0) { 'use strict' }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `(function() { 'use strict'; function foo(a = 0) { 'use strict' } }())`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "nonSimpleParameterList", Line: 1, Column: 51},
+				},
+			},
+			{
+				Code:    `function foo(a = 0) { }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap function 'foo' in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `(function() { function foo(a = 0) { } }())`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Message: "Use the function form of 'use strict'.", Line: 1, Column: 2},
+				},
+			},
+
+			// ---- wrap message: full modifier / kind coverage (rslint addition) ----
+			// Each case sits at program scope with a non-simple parameter list and
+			// no directive, which is the only path that reaches `wrap`. Covers the
+			// modifier prefixes produced by ESLint's getFunctionNameWithKind.
+			{
+				Code:    `async function foo(a = 0) { }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap async function 'foo' in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `function* gen(a = 0) { }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap generator function 'gen' in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `async function* gen(a = 0) { }`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap async generator function 'gen' in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				Code:    `(function(a = 0) { })();`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap function in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    2,
+					},
+				},
+			},
+			{
+				Code:    `(function named(a = 0) { })();`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap function 'named' in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    2,
+					},
+				},
+			},
+			{
+				Code:    `var foo = (a = 0) => { };`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap arrow function in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+			{
+				Code:    `var foo = async (a = 0) => { };`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "wrap",
+						Message:   "Wrap async arrow function in a function with 'use strict' directive.",
+						Line:      1,
+						Column:    11,
+					},
+				},
+			},
+
+			// ---- Functions inside class static blocks ----
+			{
+				Code: `'use strict'; class C { static { function foo() {
+'use strict'; } } }`,
+				Options: "global",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "global", Line: 2},
+				},
+			},
+			{
+				Code: `class C { static { function foo() {
+'use strict'; } } }`,
+				Options: "never",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "never", Line: 2},
+				},
+			},
+			{
+				Code: `class C { static { function foo() {
+'use strict'; } } } export {};`,
+				Output: []string{`class C { static { function foo() {
+ } } } export {};`},
+				Options: "safe",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "module", Line: 2},
+				},
+			},
+			// SKIP: impliedStrict not exposed.
+			{
+				Code: `class C { static { function foo() {
+'use strict'; } } }`,
+				Options: "safe",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "implied", Line: 2}},
+			},
+			{
+				Code: `function foo() {'use strict'; class C { static { function foo() {
+'use strict'; } } } }`,
+				Output: []string{`function foo() {'use strict'; class C { static { function foo() {
+ } } } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessary", Line: 2},
+				},
+			},
+			{
+				Code: `class C { static { function foo() {
+'use strict'; } } }`,
+				Output: []string{`class C { static { function foo() {
+ } } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 2},
+				},
+			},
+			{
+				Code: `class C { static { function foo() {
+'use strict';
+'use strict'; } } }`,
+				Output: []string{`class C { static { function foo() {
+
+ } } }`},
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryInClasses", Line: 2},
+					{MessageId: "multiple", Line: 3},
+				},
+			},
+			// SKIP: sourceType: "commonjs" — rslint cannot distinguish CommonJS scripts.
+			{
+				Code:    `module.exports = function identity (value) { return value; }`,
+				Options: "safe",
+				Skip:    true,
+				Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "global", Line: 1}},
+			},
+			{
+				Code:   `module.exports = function identity (value) { return value; }`,
+				Skip:   true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "global", Line: 1}},
+			},
+
+			// ---- Class heritage: functions in extends are NOT in class body ----
+			// A function expression in an `extends` clause sits outside the class
+			// body in ESLint's scope model, so it should be treated as a top-level
+			// function — "function" mode requires a `"use strict"` there.
+			{
+				Code:    `class Foo extends (function() { return class {}; }()) {}`,
+				Options: "function",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "function", Line: 1, Column: 20},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -292,6 +292,7 @@ export default defineConfig({
     './tests/eslint/rules/no-return-assign.test.ts',
     './tests/eslint/rules/no-self-compare.test.ts',
     './tests/eslint/rules/no-sequences.test.ts',
+    './tests/eslint/rules/strict.test.ts',
     './tests/eslint/rules/no-unneeded-ternary.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/prefer-promise-reject-errors.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/strict.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/strict.test.ts.snap
@@ -1,0 +1,1294 @@
+// Rstest Snapshot v1
+
+exports[`strict > invalid 1`] = `
+{
+  "code": ""use strict"; foo();",
+  "diagnostics": [
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 2`] = `
+{
+  "code": "function foo() { 'use strict'; return; }",
+  "diagnostics": [
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 3`] = `
+{
+  "code": "var foo = function() { 'use strict'; return; };",
+  "diagnostics": [
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 4`] = `
+{
+  "code": "function foo() { return function() { 'use strict'; return; }; }",
+  "diagnostics": [
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 5`] = `
+{
+  "code": "'use strict'; function foo() { "use strict"; return; }",
+  "diagnostics": [
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 6`] = `
+{
+  "code": ""use strict"; foo(); export {};",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of modules.",
+      "messageId": "module",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 7`] = `
+{
+  "code": "foo();",
+  "diagnostics": [
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 8`] = `
+{
+  "code": "function foo() { 'use strict'; return; }",
+  "diagnostics": [
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 9`] = `
+{
+  "code": "var foo = function() { 'use strict'; return; }",
+  "diagnostics": [
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 10`] = `
+{
+  "code": "var foo = () => { 'use strict'; return () => 1; }",
+  "diagnostics": [
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 11`] = `
+{
+  "code": "'use strict'; function foo() { 'use strict'; return; }",
+  "diagnostics": [
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 12`] = `
+{
+  "code": "'use strict'; 'use strict'; foo();",
+  "diagnostics": [
+    {
+      "message": "Multiple 'use strict' directives.",
+      "messageId": "multiple",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 13`] = `
+{
+  "code": "'use strict'; foo(); export {};",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of modules.",
+      "messageId": "module",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 14`] = `
+{
+  "code": "'use strict'; foo();",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 15`] = `
+{
+  "code": "'use strict'; (function() { 'use strict'; return true; }());",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 16`] = `
+{
+  "code": "(function() { 'use strict'; function f() { 'use strict'; return } return true; }());",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'use strict' directive.",
+      "messageId": "unnecessary",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 17`] = `
+{
+  "code": "(function() { return true; }());",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 18`] = `
+{
+  "code": "(() => { return true; })();",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 19`] = `
+{
+  "code": "function foo() { 'use strict'; 'use strict'; return; }",
+  "diagnostics": [
+    {
+      "message": "Multiple 'use strict' directives.",
+      "messageId": "multiple",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 20`] = `
+{
+  "code": "function foo() { return function() { 'use strict'; return; }; }",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 21`] = `
+{
+  "code": "function foo() { 'use strict'; return function() { 'use strict'; 'use strict'; return; }; }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'use strict' directive.",
+      "messageId": "unnecessary",
+      "range": {
+        "end": {
+          "column": 65,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Multiple 'use strict' directives.",
+      "messageId": "multiple",
+      "range": {
+        "end": {
+          "column": 79,
+          "line": 1,
+        },
+        "start": {
+          "column": 66,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 22`] = `
+{
+  "code": "var foo = () => { return; };",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 23`] = `
+{
+  "code": "class A { constructor() { "use strict"; } }",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of classes.",
+      "messageId": "unnecessaryInClasses",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 24`] = `
+{
+  "code": "class A { foo() { "use strict"; } }",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of classes.",
+      "messageId": "unnecessaryInClasses",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 25`] = `
+{
+  "code": "class A { foo() { function bar() { "use strict"; } } }",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of classes.",
+      "messageId": "unnecessaryInClasses",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 26`] = `
+{
+  "code": "class A { field = () => { "use strict"; } }",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of classes.",
+      "messageId": "unnecessaryInClasses",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 27`] = `
+{
+  "code": "class A { field = function() { "use strict"; } }",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of classes.",
+      "messageId": "unnecessaryInClasses",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 28`] = `
+{
+  "code": "'use strict'; function foo() { return; }",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 29`] = `
+{
+  "code": "'use strict'; function foo() { return; }",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 30`] = `
+{
+  "code": "function foo() { return; }",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 31`] = `
+{
+  "code": "function foo(a = 0) { 'use strict' }",
+  "diagnostics": [
+    {
+      "message": "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016.",
+      "messageId": "nonSimpleParameterList",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 32`] = `
+{
+  "code": "function foo(a = 0) { 'use strict' }",
+  "diagnostics": [
+    {
+      "message": "Use the global form of 'use strict'.",
+      "messageId": "global",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+    {
+      "message": "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016.",
+      "messageId": "nonSimpleParameterList",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 33`] = `
+{
+  "code": "function foo(a = 0) { 'use strict' }",
+  "diagnostics": [
+    {
+      "message": "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016.",
+      "messageId": "nonSimpleParameterList",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 34`] = `
+{
+  "code": "function foo(a = 0) { }",
+  "diagnostics": [
+    {
+      "message": "Wrap function 'foo' in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 35`] = `
+{
+  "code": "async function foo(a = 0) { }",
+  "diagnostics": [
+    {
+      "message": "Wrap async function 'foo' in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 36`] = `
+{
+  "code": "function* gen(a = 0) { }",
+  "diagnostics": [
+    {
+      "message": "Wrap generator function 'gen' in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 37`] = `
+{
+  "code": "async function* gen(a = 0) { }",
+  "diagnostics": [
+    {
+      "message": "Wrap async generator function 'gen' in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 38`] = `
+{
+  "code": "(function(a = 0) { })();",
+  "diagnostics": [
+    {
+      "message": "Wrap function in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 39`] = `
+{
+  "code": "(function named(a = 0) { })();",
+  "diagnostics": [
+    {
+      "message": "Wrap function 'named' in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 2,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 40`] = `
+{
+  "code": "var foo = (a = 0) => { };",
+  "diagnostics": [
+    {
+      "message": "Wrap arrow function in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 41`] = `
+{
+  "code": "var foo = async (a = 0) => { };",
+  "diagnostics": [
+    {
+      "message": "Wrap async arrow function in a function with 'use strict' directive.",
+      "messageId": "wrap",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 42`] = `
+{
+  "code": "class C { static { function foo() { 
+'use strict'; } } }",
+  "diagnostics": [
+    {
+      "message": "Strict mode is not permitted.",
+      "messageId": "never",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 43`] = `
+{
+  "code": "function foo() {'use strict'; class C { static { function foo() { 
+'use strict'; } } } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary 'use strict' directive.",
+      "messageId": "unnecessary",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 44`] = `
+{
+  "code": "class C { static { function foo() { 
+'use strict'; } } }",
+  "diagnostics": [
+    {
+      "message": "'use strict' is unnecessary inside of classes.",
+      "messageId": "unnecessaryInClasses",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`strict > invalid 45`] = `
+{
+  "code": "class Foo extends (function() { return class {}; }()) {}",
+  "diagnostics": [
+    {
+      "message": "Use the function form of 'use strict'.",
+      "messageId": "function",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "strict",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/strict.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/strict.test.ts
@@ -1,0 +1,388 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('strict', {
+  valid: [
+    // "never" mode
+    { code: 'foo();', options: ['never'] as any },
+    { code: 'function foo() { return; }', options: ['never'] as any },
+    {
+      code: 'var foo = function() { return; };',
+      options: ['never'] as any,
+    },
+    { code: "foo(); 'use strict';", options: ['never'] as any },
+    {
+      code: "function foo() { bar(); 'use strict'; return; }",
+      options: ['never'] as any,
+    },
+    {
+      code: "var foo = function() { { 'use strict'; } return; };",
+      options: ['never'] as any,
+    },
+    {
+      code: "(function() { bar('use strict'); return; }());",
+      options: ['never'] as any,
+    },
+    { code: 'var fn = x => 1;', options: ['never'] as any },
+    { code: 'var fn = x => { return; };', options: ['never'] as any },
+
+    // "global" mode
+    { code: '// Intentionally empty', options: ['global'] as any },
+    { code: "'use strict'; foo();", options: ['global'] as any },
+    {
+      code: "'use strict'; function foo() { return; }",
+      options: ['global'] as any,
+    },
+    {
+      code: "'use strict'; var foo = function() { return; };",
+      options: ['global'] as any,
+    },
+    {
+      code: "'use strict'; function foo() { bar(); 'use strict'; return; }",
+      options: ['global'] as any,
+    },
+    {
+      code: "'use strict'; function foo() { return function() { bar(); 'use strict'; return; }; }",
+      options: ['global'] as any,
+    },
+    {
+      code: "'use strict'; var foo = () => { return () => { bar(); 'use strict'; return; }; }",
+      options: ['global'] as any,
+    },
+
+    // "function" mode
+    {
+      code: "function foo() { 'use strict'; return; }",
+      options: ['function'] as any,
+    },
+    {
+      code: "var foo = function() { 'use strict'; return; }",
+      options: ['function'] as any,
+    },
+    {
+      code: "function foo() { 'use strict'; return; } var bar = function() { 'use strict'; bar(); };",
+      options: ['function'] as any,
+    },
+    {
+      code: "var foo = function() { 'use strict'; function bar() { return; } bar(); };",
+      options: ['function'] as any,
+    },
+    {
+      code: "var foo = () => { 'use strict'; var bar = () => 1; bar(); };",
+      options: ['function'] as any,
+    },
+    { code: 'class A { constructor() { } }', options: ['function'] as any },
+    { code: 'class A { foo() { } }', options: ['function'] as any },
+    {
+      code: 'class A { foo() { function bar() { } } }',
+      options: ['function'] as any,
+    },
+    {
+      code: "(function() { 'use strict'; function foo(a = 0) { } }())",
+      options: ['function'] as any,
+    },
+
+    // "safe" / default
+    {
+      code: "function foo() { 'use strict'; return; }",
+      options: ['safe'] as any,
+    },
+    "function foo() { 'use strict'; return; }",
+
+    // class static blocks have no directive prologue
+    {
+      code: "'use strict'; class C { static { foo; } }",
+      options: ['global'] as any,
+    },
+    {
+      code: "'use strict'; class C { static { 'use strict'; } }",
+      options: ['global'] as any,
+    },
+    {
+      code: "'use strict'; class C { static { 'use strict'; 'use strict'; } }",
+      options: ['global'] as any,
+    },
+    { code: 'class C { static { foo; } }', options: ['function'] as any },
+    {
+      code: "class C { static { 'use strict'; } }",
+      options: ['function'] as any,
+    },
+    {
+      code: "class C { static { 'use strict'; 'use strict'; } }",
+      options: ['function'] as any,
+    },
+    { code: 'class C { static { foo; } }', options: ['never'] as any },
+    {
+      code: "class C { static { 'use strict'; } }",
+      options: ['never'] as any,
+    },
+    {
+      code: "class C { static { 'use strict'; 'use strict'; } }",
+      options: ['never'] as any,
+    },
+
+    // class heritage: function inside `extends` is NOT in the class body
+    {
+      code: "class Foo extends (function() { 'use strict'; return class {}; }()) {}",
+      options: ['function'] as any,
+    },
+
+    // ambient / bodyless declarations (TypeScript)
+    { code: 'declare function foo(): void;', options: ['function'] as any },
+    { code: 'declare function foo(): void;', options: ['never'] as any },
+    {
+      code: 'abstract class A { abstract foo(): void; }',
+      options: ['function'] as any,
+    },
+    {
+      code: "function foo(): void; function foo(a: number): void; function foo(a?: number) { 'use strict'; }",
+      options: ['function'] as any,
+    },
+  ],
+  invalid: [
+    // "never" mode
+    {
+      code: '"use strict"; foo();',
+      options: ['never'] as any,
+      errors: [{ messageId: 'never' }],
+    },
+    {
+      code: "function foo() { 'use strict'; return; }",
+      options: ['never'] as any,
+      errors: [{ messageId: 'never' }],
+    },
+    {
+      code: "var foo = function() { 'use strict'; return; };",
+      options: ['never'] as any,
+      errors: [{ messageId: 'never' }],
+    },
+    {
+      code: "function foo() { return function() { 'use strict'; return; }; }",
+      options: ['never'] as any,
+      errors: [{ messageId: 'never' }],
+    },
+    {
+      code: '\'use strict\'; function foo() { "use strict"; return; }',
+      options: ['never'] as any,
+      errors: [{ messageId: 'never' }, { messageId: 'never' }],
+    },
+    {
+      code: '"use strict"; foo(); export {};',
+      options: ['never'] as any,
+      errors: [{ messageId: 'module' }],
+    },
+
+    // "global" mode
+    {
+      code: 'foo();',
+      options: ['global'] as any,
+      errors: [{ messageId: 'global' }],
+    },
+    {
+      code: "function foo() { 'use strict'; return; }",
+      options: ['global'] as any,
+      errors: [{ messageId: 'global' }, { messageId: 'global' }],
+    },
+    {
+      code: "var foo = function() { 'use strict'; return; }",
+      options: ['global'] as any,
+      errors: [{ messageId: 'global' }, { messageId: 'global' }],
+    },
+    {
+      code: "var foo = () => { 'use strict'; return () => 1; }",
+      options: ['global'] as any,
+      errors: [{ messageId: 'global' }, { messageId: 'global' }],
+    },
+    {
+      code: "'use strict'; function foo() { 'use strict'; return; }",
+      options: ['global'] as any,
+      errors: [{ messageId: 'global' }],
+    },
+    {
+      code: "'use strict'; 'use strict'; foo();",
+      options: ['global'] as any,
+      errors: [{ messageId: 'multiple' }],
+    },
+    {
+      code: "'use strict'; foo(); export {};",
+      options: ['global'] as any,
+      errors: [{ messageId: 'module' }],
+    },
+
+    // "function" mode
+    {
+      code: "'use strict'; foo();",
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: "'use strict'; (function() { 'use strict'; return true; }());",
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: "(function() { 'use strict'; function f() { 'use strict'; return } return true; }());",
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessary' }],
+    },
+    {
+      code: '(function() { return true; }());',
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: '(() => { return true; })();',
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: "function foo() { 'use strict'; 'use strict'; return; }",
+      options: ['function'] as any,
+      errors: [{ messageId: 'multiple' }],
+    },
+    {
+      code: "function foo() { return function() { 'use strict'; return; }; }",
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+    {
+      code: "function foo() { 'use strict'; return function() { 'use strict'; 'use strict'; return; }; }",
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessary' }, { messageId: 'multiple' }],
+    },
+    {
+      code: 'var foo = () => { return; };',
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+
+    // classes
+    {
+      code: 'class A { constructor() { "use strict"; } }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessaryInClasses' }],
+    },
+    {
+      code: 'class A { foo() { "use strict"; } }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessaryInClasses' }],
+    },
+    {
+      code: 'class A { foo() { function bar() { "use strict"; } } }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessaryInClasses' }],
+    },
+    {
+      code: 'class A { field = () => { "use strict"; } }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessaryInClasses' }],
+    },
+    {
+      code: 'class A { field = function() { "use strict"; } }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessaryInClasses' }],
+    },
+
+    // safe / default (= function in rslint script files)
+    {
+      code: "'use strict'; function foo() { return; }",
+      options: ['safe'] as any,
+      errors: [{ messageId: 'function' }, { messageId: 'function' }],
+    },
+    {
+      code: "'use strict'; function foo() { return; }",
+      errors: [{ messageId: 'function' }, { messageId: 'function' }],
+    },
+    {
+      code: 'function foo() { return; }',
+      errors: [{ messageId: 'function' }],
+    },
+
+    // non-simple parameter list
+    {
+      code: "function foo(a = 0) { 'use strict' }",
+      options: ['never'] as any,
+      errors: [{ messageId: 'nonSimpleParameterList' }],
+    },
+    {
+      code: "function foo(a = 0) { 'use strict' }",
+      options: ['global'] as any,
+      errors: [
+        { messageId: 'global' },
+        { messageId: 'nonSimpleParameterList' },
+      ],
+    },
+    {
+      code: "function foo(a = 0) { 'use strict' }",
+      options: ['function'] as any,
+      errors: [{ messageId: 'nonSimpleParameterList' }],
+    },
+    {
+      code: 'function foo(a = 0) { }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    // wrap message: modifier / kind coverage
+    {
+      code: 'async function foo(a = 0) { }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'function* gen(a = 0) { }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'async function* gen(a = 0) { }',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: '(function(a = 0) { })();',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: '(function named(a = 0) { })();',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'var foo = (a = 0) => { };',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+    {
+      code: 'var foo = async (a = 0) => { };',
+      options: ['function'] as any,
+      errors: [{ messageId: 'wrap' }],
+    },
+
+    // functions inside class static blocks
+    {
+      code: "class C { static { function foo() { \n'use strict'; } } }",
+      options: ['never'] as any,
+      errors: [{ messageId: 'never' }],
+    },
+    {
+      code: "function foo() {'use strict'; class C { static { function foo() { \n'use strict'; } } } }",
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessary' }],
+    },
+    {
+      code: "class C { static { function foo() { \n'use strict'; } } }",
+      options: ['function'] as any,
+      errors: [{ messageId: 'unnecessaryInClasses' }],
+    },
+
+    // class heritage: function in extends without "use strict" still needs one
+    // under "function" mode (it's effectively top-level, not in class body).
+    {
+      code: 'class Foo extends (function() { return class {}; }()) {}',
+      options: ['function'] as any,
+      errors: [{ messageId: 'function' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `strict` rule from ESLint to rslint.

Requires or disallows strict mode directives (`"use strict"`). Supports four options — `"safe"` (default), `"never"`, `"global"`, `"function"` — plus automatic module detection: files with top-level `import`/`export` are treated as ES modules and any `"use strict"` there is reported as unnecessary (auto-fixed).

Includes full coverage of the nine applicable ESLint messageIds (`never` / `global` / `function` / `module` / `multiple` / `unnecessary` / `unnecessaryInClasses` / `nonSimpleParameterList` / `wrap`) with their exact message text, including `wrap`'s full modifier prefixes (static / private / async / generator) produced by ESLint's `getFunctionNameWithKind`. Class body membership is resolved via ancestor walking so functions appearing in a class's heritage clause or decorators are correctly treated as outside the class body.

Validated on rsbuild and rspack: every reported diagnostic matches ESLint's `strict` rule output under the default `"safe"` option.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/strict
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/strict.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).