### PR TITLE
docs(port-rule): clarify scope — rule semantics, not framework parity

### DIFF
--- a/agents/port-rule/references/PORT_RULE.md
+++ b/agents/port-rule/references/PORT_RULE.md
@@ -6,6 +6,24 @@ You are an expert Software Engineer tasked with porting ESLint rules to `rslint`
 
 ---
 
+## Scope: rule semantics, not framework parity
+
+Your job is porting the **rule's semantics** — given equivalent input, produce equivalent diagnostics. You are **not** responsible for re-implementing ESLint framework concepts that rslint deliberately does not expose. Examples:
+
+- `/*global ...*/` / `/*eslint ...*/` directive comments
+- `languageOptions.globals` / `parserOptions.sourceType` override / `parserOptions.ecmaFeatures.*`
+- `env: 'browser' | 'node' | ...`
+
+When an upstream test case depends on one of these:
+
+- **Don't** reimplement the concept inside your rule (e.g., parsing `/*global*/` comments yourself).
+- **Don't** list the gap under the rule's "Differences from ESLint" section — framework gaps apply to every rule, not yours.
+- **Do** mark the upstream case `skip: true` with an inline reason such as `// SKIP: rslint does not support ESLint's <concept>`.
+
+The rule doc's "Differences from ESLint" section is reserved for semantic differences of this specific rule — either intentional choices (Phase 1 Step 5.A) or tsgo/Go-semantic side effects (Phase 1 Step 5.B).
+
+---
+
 ## Related Documents
 
 | Document                                       | Description                                                         |


### PR DESCRIPTION
## Summary

Add a new \`## Scope\` section to \`agents/port-rule/references/PORT_RULE.md\`
right after \`## Role & Objective\`, to set the boundary before any phase
begins: rule porters are responsible for the **rule's semantics**, not
for re-implementing ESLint framework concepts rslint deliberately does
not expose.

This captures the lessons from iterating on the \`no-redeclare\` port —
framework gaps (e.g. \`/*global*/\` directive comments, \`languageOptions.globals\`,
\`env\`, \`parserOptions.sourceType\` / \`ecmaFeatures\`) kept accidentally
leaking into the rule's \"Differences from ESLint\" section, and tempted
private workarounds inside the rule. Codifying the boundary keeps future
ports focused.

Three explicit directives per framework concept:

- **Don't** reimplement the concept inside the rule.
- **Don't** list the gap under \"Differences from ESLint\" — framework
  gaps apply to every rule, not yours.
- **Do** mark dependent upstream cases \`skip: true\` with an inline
  reason.

Phase 1 Step 5's A/B divergence taxonomy is unchanged — the Scope
section excludes framework gaps from the taxonomy's input rather than
adding a new class.

## Related Links

- PR #713 (\`@typescript-eslint/no-redeclare\` port) — the one that
  surfaced the need for this clarification.

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).