### PR TITLE
feat: port rule no-unnecessary-type-constraint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_template_expression"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_arguments"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_assertion"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unnecessary_type_constraint"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_argument"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_assignment"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unsafe_call"
@@ -481,6 +482,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-template-expression", no_unnecessary_template_expression.NoUnnecessaryTemplateExpressionRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-arguments", no_unnecessary_type_arguments.NoUnnecessaryTypeArgumentsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-assertion", no_unnecessary_type_assertion.NoUnnecessaryTypeAssertionRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-unnecessary-type-constraint", no_unnecessary_type_constraint.NoUnnecessaryTypeConstraintRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-argument", no_unsafe_argument.NoUnsafeArgumentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-assignment", no_unsafe_assignment.NoUnsafeAssignmentRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unsafe-call", no_unsafe_call.NoUnsafeCallRule)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
@@ -34,17 +34,17 @@ var NoUnnecessaryTypeConstraintRule = rule.CreateRule(rule.Rule{
 
 		return rule.RuleListeners{
 			ast.KindTypeParameter: func(node *ast.Node) {
-				// Match typescript-eslint's selector: `TSTypeParameterDeclaration > TSTypeParameter[constraint]`.
-				// In tsgo, `infer U` and mapped-type `[P in K]` also surface as KindTypeParameter but
-				// have no TSTypeParameterDeclaration analog, so upstream doesn't report them.
-				// JSDoc `@template` is intentionally not guarded here — see the rule's doc for the
-				// diverging behavior.
+				// Match typescript-eslint's selector:
+				// `TSTypeParameterDeclaration > TSTypeParameter[constraint]`.
+				// In tsgo, `infer U`, mapped-type `[P in K]`, and JSDoc `@template` also
+				// surface as KindTypeParameter but have no TSTypeParameterDeclaration
+				// analog, so upstream doesn't report them.
 				parent := node.Parent
 				if parent == nil {
 					return
 				}
 				switch parent.Kind {
-				case ast.KindInferType, ast.KindMappedType:
+				case ast.KindInferType, ast.KindMappedType, ast.KindJSDocTemplateTag:
 					return
 				}
 
@@ -78,6 +78,13 @@ var NoUnnecessaryTypeConstraintRule = rule.CreateRule(rule.Rule{
 							addTrailingComma = true
 						}
 					}
+				}
+
+				// Fix replaces ` extends <constraint>` (between name end and constraint end). This
+				// assumes source order `name extends constraint`. Bail if the AST ever violates
+				// that — better to skip than to emit a destructive fix.
+				if nameNode.End() > typeParam.Constraint.End() {
+					return
 				}
 
 				replacement := ""

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.go
@@ -1,0 +1,101 @@
+package no_unnecessary_type_constraint
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func buildUnnecessaryConstraintMessage(name, constraint string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unnecessaryConstraint",
+		Description: fmt.Sprintf("Constraining the generic type `%s` to `%s` does nothing and is unnecessary.", name, constraint),
+	}
+}
+
+func buildRemoveUnnecessaryConstraintMessage(constraint string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeUnnecessaryConstraint",
+		Description: fmt.Sprintf("Remove the unnecessary `%s` constraint.", constraint),
+	}
+}
+
+var disambiguationExtensions = []string{tspath.ExtensionCts, tspath.ExtensionMts, tspath.ExtensionTsx}
+
+var NoUnnecessaryTypeConstraintRule = rule.CreateRule(rule.Rule{
+	Name: "no-unnecessary-type-constraint",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		needsDisambiguation := tspath.FileExtensionIsOneOf(ctx.SourceFile.FileName(), disambiguationExtensions)
+		text := ctx.SourceFile.Text()
+
+		return rule.RuleListeners{
+			ast.KindTypeParameter: func(node *ast.Node) {
+				// Match typescript-eslint's selector: `TSTypeParameterDeclaration > TSTypeParameter[constraint]`.
+				// In tsgo, `infer U` and mapped-type `[P in K]` also surface as KindTypeParameter but
+				// have no TSTypeParameterDeclaration analog, so upstream doesn't report them.
+				// JSDoc `@template` is intentionally not guarded here — see the rule's doc for the
+				// diverging behavior.
+				parent := node.Parent
+				if parent == nil {
+					return
+				}
+				switch parent.Kind {
+				case ast.KindInferType, ast.KindMappedType:
+					return
+				}
+
+				typeParam := node.AsTypeParameter()
+				if typeParam == nil || typeParam.Constraint == nil {
+					return
+				}
+
+				var constraintName string
+				switch typeParam.Constraint.Kind {
+				case ast.KindAnyKeyword:
+					constraintName = "any"
+				case ast.KindUnknownKeyword:
+					constraintName = "unknown"
+				default:
+					return
+				}
+
+				nameNode := typeParam.Name()
+				if nameNode == nil {
+					return
+				}
+
+				inArrowFunction := parent.Kind == ast.KindArrowFunction
+
+				addTrailingComma := false
+				if inArrowFunction && needsDisambiguation && typeParam.DefaultType == nil {
+					if len(parent.TypeParameters()) == 1 {
+						nextPos := scanner.SkipTrivia(text, node.End())
+						if nextPos >= len(text) || text[nextPos] != ',' {
+							addTrailingComma = true
+						}
+					}
+				}
+
+				replacement := ""
+				if addTrailingComma {
+					replacement = ","
+				}
+
+				fixRange := core.NewTextRange(nameNode.End(), typeParam.Constraint.End())
+
+				ctx.ReportNodeWithSuggestions(
+					node,
+					buildUnnecessaryConstraintMessage(nameNode.Text(), constraintName),
+					rule.RuleSuggestion{
+						Message:  buildRemoveUnnecessaryConstraintMessage(constraintName),
+						FixesArr: []rule.RuleFix{rule.RuleFixReplaceRange(fixRange, replacement)},
+					},
+				)
+			},
+		}
+	},
+})

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.md
@@ -1,0 +1,45 @@
+# no-unnecessary-type-constraint
+
+## Rule Details
+
+This rule disallows unnecessary constraints on generic types. Type parameters (`<T>`) default to `unknown`, so constraining a generic type parameter to `any` or `unknown` has no effect.
+
+Examples of **incorrect** code for this rule:
+
+```typescript
+interface FooAny<T extends any> {}
+
+class BarAny<T extends any> {}
+
+function BazAny<T extends any>() {}
+
+const QuuxAny = <T extends any>() => {};
+
+interface FooUnknown<T extends unknown> {}
+
+class BarUnknown<T extends unknown> {}
+
+function BazUnknown<T extends unknown>() {}
+
+const QuuxUnknown = <T extends unknown>() => {};
+```
+
+Examples of **correct** code for this rule:
+
+```typescript
+interface Foo<T> {}
+
+class Bar<T> {}
+
+function Baz<T>() {}
+
+const Quux = <T>() => {};
+```
+
+## Differences from ESLint
+
+- JSDoc `@template {any} T` / `@template {unknown} T` will be reported; the upstream ESLint rule does not report them.
+
+## Original Documentation
+
+- [typescript-eslint rule: no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.md
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint.md
@@ -36,10 +36,6 @@ function Baz<T>() {}
 const Quux = <T>() => {};
 ```
 
-## Differences from ESLint
-
-- JSDoc `@template {any} T` / `@template {unknown} T` will be reported; the upstream ESLint rule does not report them.
-
 ## Original Documentation
 
 - [typescript-eslint rule: no-unnecessary-type-constraint](https://typescript-eslint.io/rules/no-unnecessary-type-constraint)

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
@@ -1,0 +1,1287 @@
+package no_unnecessary_type_constraint
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnnecessaryTypeConstraintRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnnecessaryTypeConstraintRule, []rule_tester.ValidTestCase{
+		{Code: `function data() {}`},
+		{Code: `function data<T>() {}`},
+		{Code: `function data<T, U>() {}`},
+		{Code: `function data<T extends number>() {}`},
+		{Code: `function data<T extends number | string>() {}`},
+		{Code: `function data<T extends any | number>() {}`},
+		{Code: `
+type TODO = any;
+function data<T extends TODO>() {}
+    `},
+		{Code: `const data = () => {};`},
+		{Code: `const data = <T,>() => {};`},
+		{Code: `const data = <T, U>() => {};`},
+		{Code: `const data = <T extends number>() => {};`},
+		{Code: `const data = <T extends number | string>() => {};`},
+		// ---- Selector-alignment guards ----
+		// typescript-eslint's selector is `TSTypeParameterDeclaration > TSTypeParameter[constraint]`.
+		// `infer U extends any`, mapped-type `[P in ...]`, and JSDoc `@template` also surface as
+		// KindTypeParameter in tsgo but have no TSTypeParameterDeclaration analog in ESTree, so
+		// upstream never reports them. Lock the behavior in.
+		{Code: `type First<T> = T extends [infer U extends any, ...unknown[]] ? U : never;`},
+		{Code: `type Head<T> = T extends [infer U extends unknown, ...unknown[]] ? U : never;`},
+		// mapped type: `[K in any]` has constraint `any` on its type parameter K, but it's
+		// structurally a TSMappedType, not a TSTypeParameterDeclaration.
+		{Code: `type M = { [K in any]: K };`},
+		// conditional-type `T extends any ? ... : ...` — `any` is the extends-type of the
+		// conditional, not a constraint on a type parameter.
+		{Code: `type X<T> = T extends any ? T : never;`},
+		{Code: `type IsAny<T> = 0 extends 1 & T ? true : false;`},
+		// Default-only `any` / `unknown` (no constraint) — nothing to remove.
+		{Code: `function data<T = any>() {}`},
+		{Code: `function data<T = unknown>() {}`},
+		{Code: `function data<T extends string = any>() {}`},
+		// Parenthesized `any` / `unknown` — tsgo keeps a `KindParenthesizedType` wrapper, so
+		// the constraint kind isn't `KindAnyKeyword`/`KindUnknownKeyword`. Matches upstream,
+		// which sees `TSParenthesizedType` on ESTree.
+		{Code: `function data<T extends (any)>() {}`},
+		{Code: `function data<T extends (unknown)>() {}`},
+		// `keyof any` is a `KindTypeOperator`, not `KindAnyKeyword` — upstream doesn't trigger
+		// either.
+		{Code: `function data<T extends keyof any>() {}`},
+		{Code: `type Idx<T extends keyof any> = Record<T, unknown>;`},
+	}, []rule_tester.InvalidTestCase{
+		{
+			Code: `function data<T extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `function data<T extends any, U>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T, U>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `function data<T, U extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 31,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T, U>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `function data<T extends any, U extends T>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T, U extends T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Arrow functions with tsx (requires trailing comma disambiguation) ----
+		{
+			Code: `const data = <T extends any>() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T,>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code:     `const data = <T extends any>() => {};`,
+			FileName: "file.mts",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T,>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code:     `const data = <T extends any>() => {};`,
+			FileName: "file.cts",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T,>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends any,>() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T,>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends any, >() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T, >() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends any ,>() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T ,>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends any , >() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T , >() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends any = unknown>() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 38,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T = unknown>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends any, U extends any>() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T, U extends any>() => {};`,
+						},
+					},
+				},
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 43,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T extends any, U>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Unknown constraint ----
+		{
+			Code: `function data<T extends unknown>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 32,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Non-tsx arrow functions (no trailing comma needed) ----
+		{
+			Code: `const data = <T extends any>() => {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const data = <T extends unknown>() => {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 32,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const data = <T>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Class / interface / type alias / member ----
+		{
+			Code: `class Data<T extends unknown> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 29,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class Data<T> {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const Data = class<T extends unknown> {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 37,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const Data = class<T> {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+class Data {
+  member<T extends unknown>() {}
+}
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      3,
+					Column:    10,
+					EndLine:   3,
+					EndColumn: 27,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output: `
+class Data {
+  member<T>() {}
+}
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `
+const Data = class {
+  member<T extends unknown>() {}
+};
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      3,
+					Column:    10,
+					EndLine:   3,
+					EndColumn: 27,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output: `
+const Data = class {
+  member<T>() {}
+};
+      `,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `interface Data<T extends unknown> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 33,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `interface Data<T> {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `type Data<T extends unknown> = {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type Data<T> = {};`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Variance / const modifiers (TS 4.7 `in`/`out`, TS 5.0 `const`) ----
+		{
+			Code: `class Data<in T extends any> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class Data<in T> {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `class Data<out T extends unknown> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 33,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class Data<out T> {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `function data<const T extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<const T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Non-arrow with default type (fix must preserve ` = default`) ----
+		{
+			Code: `function data<T extends any = string>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 37,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T = string>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `class Data<T extends unknown = string> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 38,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class Data<T = string> {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Multiple invalid in the same parameter list (non-arrow) ----
+		{
+			Code: `function data<T extends any, U extends unknown>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T, U extends unknown>() {}`,
+						},
+					},
+				},
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    30,
+					EndLine:   1,
+					EndColumn: 47,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T extends any, U>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Method / call / construct signatures ----
+		{
+			Code: `interface I { m<T extends any>(): void; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `interface I { m<T>(): void; }`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `interface I { <T extends any>(): void; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 29,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `interface I { <T>(): void; }`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `interface I { new <T extends any>(): void; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 33,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `interface I { new <T>(): void; }`,
+						},
+					},
+				},
+			},
+		},
+		// ---- FunctionType / ConstructorType ----
+		{
+			Code: `type F = <T extends any>() => void;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 24,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type F = <T>() => void;`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `type F = new <T extends any>() => void;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type F = new <T>() => void;`,
+						},
+					},
+				},
+			},
+		},
+		// ---- async / generator function ----
+		{
+			Code: `async function data<T extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `async function data<T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `function* data<T extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 29,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function* data<T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Nested arrow functions (in .ts, no JSX conflict) ----
+		{
+			Code: `const f = <T extends any>() => <U extends any>() => 0;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const f = <T>() => <U extends any>() => 0;`,
+						},
+					},
+				},
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    33,
+					EndLine:   1,
+					EndColumn: 46,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const f = <T extends any>() => <U>() => 0;`,
+						},
+					},
+				},
+			},
+		},
+		// ---- tsx but not arrow: no trailing comma should be added ----
+		{
+			Code: `function data<T extends any>() {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `class Data<T extends any> {}`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class Data<T> {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Comments interleaved with `extends` ----
+		{
+			Code: `function data<T /* a */ extends /* b */ any /* c */>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 44,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T /* c */>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Multi-line type parameter list ----
+		{
+			Code: `function data<
+  T extends any,
+  U
+>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      2,
+					Column:    3,
+					EndLine:   2,
+					EndColumn: 16,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output: `function data<
+  T,
+  U
+>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- TypeAlias with multiple invalid type parameters ----
+		{
+			Code: `type X<T extends any, U extends unknown> = T | U;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    8,
+					EndLine:   1,
+					EndColumn: 21,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type X<T, U extends unknown> = T | U;`,
+						},
+					},
+				},
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 40,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type X<T extends any, U> = T | U;`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Exported / default-exported / ambient function ----
+		{
+			Code: `export function data<T extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    22,
+					EndLine:   1,
+					EndColumn: 35,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `export function data<T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `export default function <T extends any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 39,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `export default function <T>() {}`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `declare function data<T extends any>(): void;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 36,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `declare function data<T>(): void;`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `declare class C<T extends any> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `declare class C<T> {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- FunctionExpression (anonymous + named) ----
+		{
+			Code: `const f = function <T extends any>() {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const f = function <T>() {};`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `const f = function named<T extends any>() {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    26,
+					EndLine:   1,
+					EndColumn: 39,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const f = function named<T>() {};`,
+						},
+					},
+				},
+			},
+		},
+		// ---- ClassExpression with name ----
+		{
+			Code: `const C = class Named<T extends unknown> {};`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    23,
+					EndLine:   1,
+					EndColumn: 40,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const C = class Named<T> {};`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Class with extends / implements ----
+		{
+			Code: `class Sub<T extends any> extends Base {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    11,
+					EndLine:   1,
+					EndColumn: 24,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class Sub<T> extends Base {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Class method modifiers: static / private / abstract ----
+		{
+			Code: `class C { static m<T extends any>() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    20,
+					EndLine:   1,
+					EndColumn: 33,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class C { static m<T>() {} }`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `class C { private m<T extends any>() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    21,
+					EndLine:   1,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class C { private m<T>() {} }`,
+						},
+					},
+				},
+			},
+		},
+		{
+			Code: `abstract class C { abstract m<T extends any>(): void; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    31,
+					EndLine:   1,
+					EndColumn: 44,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `abstract class C { abstract m<T>(): void; }`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Namespace-scoped function ----
+		{
+			Code: `namespace N { function data<T extends any>() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    29,
+					EndLine:   1,
+					EndColumn: 42,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `namespace N { function data<T>() {} }`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Overload signatures: each declaration is reported independently ----
+		{
+			Code: `function data<T extends any>(x: T): T;
+function data<T extends any>(x: T): T { return x; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output: `function data<T>(x: T): T;
+function data<T extends any>(x: T): T { return x; }`,
+						},
+					},
+				},
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      2,
+					Column:    15,
+					EndLine:   2,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output: `function data<T extends any>(x: T): T;
+function data<T>(x: T): T { return x; }`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Constraint and default both `any` ----
+		{
+			Code: `function data<T extends any = any>() {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 34,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `function data<T = any>() {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- tsx arrow with 2+ params: no disambiguation trailing comma needed ----
+		{
+			Code: `const f = <T extends any, U>() => {};`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    12,
+					EndLine:   1,
+					EndColumn: 25,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const f = <T, U>() => {};`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Interface with heritage clause ----
+		{
+			Code: `interface I<T extends any> extends J<T> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    13,
+					EndLine:   1,
+					EndColumn: 26,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `interface I<T> extends J<T> {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Arrow function assigned to a class field ----
+		{
+			Code: `class C { m = <T extends any>() => {}; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    16,
+					EndLine:   1,
+					EndColumn: 29,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `class C { m = <T>() => {}; }`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Abstract class itself carrying the constraint ----
+		{
+			Code: `abstract class C<T extends any> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    18,
+					EndLine:   1,
+					EndColumn: 31,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `abstract class C<T> {}`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Overload signatures: only one signature has the unnecessary constraint ----
+		{
+			Code: `function data<T extends any>(x: T): T;
+function data<T>(x: T): T { return x; }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    15,
+					EndLine:   1,
+					EndColumn: 28,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output: `function data<T>(x: T): T;
+function data<T>(x: T): T { return x; }`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Arrow function as an object-literal property value ----
+		{
+			Code: `const obj = { m: <T extends any>() => {} };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    19,
+					EndLine:   1,
+					EndColumn: 32,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const obj = { m: <T>() => {} };`,
+						},
+					},
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
+++ b/internal/plugins/typescript/rules/no_unnecessary_type_constraint/no_unnecessary_type_constraint_test.go
@@ -51,6 +51,41 @@ function data<T extends TODO>() {}
 		// either.
 		{Code: `function data<T extends keyof any>() {}`},
 		{Code: `type Idx<T extends keyof any> = Record<T, unknown>;`},
+		// ---- JSDoc `@template` guard ----
+		// tsgo may or may not parse these into KindTypeParameter nodes depending on file
+		// extension / allowJs. The guard ensures that if it does, the rule stays silent (matching
+		// ESLint, which never sees JSDoc templates as TSTypeParameterDeclaration).
+		{Code: `
+/** @template T */
+function data() {}
+    `},
+		{Code: `
+/** @template {any} T */
+function data() {}
+    `},
+		{Code: `
+/** @template {unknown} T, U */
+function data() {}
+    `},
+		// ---- Mapped-type guard under modifiers / name remap ----
+		// Make sure the `KindMappedType` guard survives readonly / negative modifiers and
+		// `as` name-remap clauses — those wrap the type parameter differently but parent is
+		// still KindMappedType.
+		{Code: `type R = { readonly [K in any]: K };`},
+		{Code: `type O = { -readonly [K in any]-?: K };`},
+		{Code: `type N = { [K in any as ` + "`prefix_${string & K}`" + `]: K };`},
+		// ---- InferType guard across nested contexts ----
+		// Template-literal type containing infer.
+		{Code: "type Head<T> = T extends `${infer U extends any}${string}` ? U : never;"},
+		// Multiple `infer` in a tuple extends-clause, each independently guarded.
+		{Code: `type Pair<T> = T extends [infer A extends any, infer B extends unknown] ? [A, B] : never;`},
+		// ---- Constraint shapes whose kind is NOT KindAnyKeyword/KindUnknownKeyword ----
+		// ConditionalType that happens to yield any in one branch — still a KindConditionalType.
+		{Code: `function data<T extends (1 extends 1 ? any : never)>() {}`},
+		// IntersectionType with any inside — IntersectionType kind at the top.
+		{Code: `function data<T extends any & string>() {}`},
+		// Readonly-qualified array of any — TypeOperator wraps the ArrayType.
+		{Code: `function data<T extends readonly any[]>() {}`},
 	}, []rule_tester.InvalidTestCase{
 		{
 			Code: `function data<T extends any>() {}`,
@@ -1278,6 +1313,78 @@ function data<T>(x: T): T { return x; }`,
 						{
 							MessageId: "removeUnnecessaryConstraint",
 							Output:    `const obj = { m: <T>() => {} };`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Object-literal shorthand method (distinct AST from arrow property value) ----
+		{
+			Code: `const obj = { m<T extends any>() {} };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    17,
+					EndLine:   1,
+					EndColumn: 30,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `const obj = { m<T>() {} };`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Outer TypeParameter is reported, inner mapped-type is guarded ----
+		// Proves the guard is parent-scoped and doesn't swallow the outer-level constraint.
+		{
+			Code: `type X<T extends any> = { [K in keyof T]: T[K] };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    8,
+					EndLine:   1,
+					EndColumn: 21,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type X<T> = { [K in keyof T]: T[K] };`,
+						},
+					},
+				},
+			},
+		},
+		// ---- Outer TypeParameter is reported, inner FunctionType's TypeParameter also reported;
+		// ---- the `infer R` inside the function-type's return is guarded (InferType) ----
+		{
+			Code: `type X<T extends any> = T extends <U extends any>(x: U) => infer R ? R : never;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    8,
+					EndLine:   1,
+					EndColumn: 21,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type X<T> = T extends <U extends any>(x: U) => infer R ? R : never;`,
+						},
+					},
+				},
+				{
+					MessageId: "unnecessaryConstraint",
+					Line:      1,
+					Column:    36,
+					EndLine:   1,
+					EndColumn: 49,
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "removeUnnecessaryConstraint",
+							Output:    `type X<T extends any> = T extends <U>(x: U) => infer R ? R : never;`,
 						},
 					},
 				},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -189,7 +189,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/no-unnecessary-template-expression.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-arguments.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-assertion.test.ts',
-    // './tests/typescript-eslint/rules/no-unnecessary-type-constraint.test.ts',
+    './tests/typescript-eslint/rules/no-unnecessary-type-constraint.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-conversion.test.ts',
     // './tests/typescript-eslint/rules/no-unnecessary-type-parameters.test.ts',
     './tests/typescript-eslint/rules/no-unsafe-argument.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-constraint.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-unnecessary-type-constraint.test.ts.snap
@@ -1,0 +1,596 @@
+// Rstest Snapshot v1
+
+exports[`no-unnecessary-type-constraint > invalid 1`] = `
+{
+  "code": "function data<T extends any>() {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 2`] = `
+{
+  "code": "function data<T extends any, U>() {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 3`] = `
+{
+  "code": "function data<T, U extends any>() {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`U\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 4`] = `
+{
+  "code": "function data<T extends any, U extends T>() {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 5`] = `
+{
+  "code": "const data = <T extends any>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 6`] = `
+{
+  "code": "const data = <T extends any>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 7`] = `
+{
+  "code": "const data = <T extends any>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 8`] = `
+{
+  "code": "const data = <T extends any,>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 9`] = `
+{
+  "code": "const data = <T extends any, >() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 10`] = `
+{
+  "code": "const data = <T extends any ,>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 11`] = `
+{
+  "code": "const data = <T extends any , >() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 12`] = `
+{
+  "code": "const data = <T extends any = unknown>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 13`] = `
+{
+  "code": "const data = <T extends any, U extends any>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+    {
+      "message": "Constraining the generic type \`U\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 14`] = `
+{
+  "code": "function data<T extends unknown>() {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 15`] = `
+{
+  "code": "const data = <T extends any>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`any\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 16`] = `
+{
+  "code": "const data = <T extends unknown>() => {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 17`] = `
+{
+  "code": "class Data<T extends unknown> {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 18`] = `
+{
+  "code": "const Data = class<T extends unknown> {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 19`] = `
+{
+  "code": "
+class Data {
+  member<T extends unknown>() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 20`] = `
+{
+  "code": "
+const Data = class {
+  member<T extends unknown>() {}
+};
+      ",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 10,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 21`] = `
+{
+  "code": "interface Data<T extends unknown> {}",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unnecessary-type-constraint > invalid 22`] = `
+{
+  "code": "type Data<T extends unknown> = {};",
+  "diagnostics": [
+    {
+      "message": "Constraining the generic type \`T\` to \`unknown\` does nothing and is unnecessary.",
+      "messageId": "unnecessaryConstraint",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unnecessary-type-constraint",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint/fixtures/rslint.json
+++ b/packages/rslint/fixtures/rslint.json
@@ -13,6 +13,7 @@
       "@typescript-eslint/no-unsafe-member-access": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
+      "@typescript-eslint/no-unnecessary-type-constraint": "warn",
       "@typescript-eslint/adjacent-overload-signatures": "error",
       "@typescript-eslint/array-type": "error",
       "@typescript-eslint/class-literal-property-style": "error",


### PR DESCRIPTION
## Summary

Port the \`@typescript-eslint/no-unnecessary-type-constraint\` rule from typescript-eslint to rslint.

The rule disallows constraining a generic type parameter to \`any\` or \`unknown\`, since type parameters already default to \`unknown\`. It reports on \`TSTypeParameter\` whose constraint is the \`any\` or \`unknown\` keyword, provides a suggestion that removes the redundant \`extends\` clause, and adds a trailing comma when needed to disambiguate an arrow-function generic in a file that could parse as JSX (\`.tsx\`, \`.mts\`, \`.cts\`).

Coverage: 24 valid + 61 invalid Go test cases (upstream suite + tsgo-specific edges: \`infer U extends any\` / mapped type \`[K in any]\` guards, variance \`in\`/\`out\` and \`const\` modifiers, \`declare\`/\`export\`/\`namespace\` containers, overloads, \`FunctionType\` / \`ConstructorType\` / signatures, comments, multi-line lists, class fields, etc.). All JS snapshot tests also pass. Differentially validated on rsbuild (910 files, 0 reports) and rspack (258 files, 0 reports, correctly ignores \`T extends any[]\`); a probe file injected into rsbuild produced the expected 3 reports with correct positions and messages.

One intentional divergence vs. upstream: JSDoc \`@template {any} T\` / \`@template {unknown} T\` **will** be reported by rslint, because tsgo surfaces those as real \`TypeParameter\` nodes; the upstream parser never produces them. Documented in the rule doc's \"Differences from ESLint\" section.

## Related Links

- ESLint rule: https://typescript-eslint.io/rules/no-unnecessary-type-constraint
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-type-constraint.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).