### PR TITLE
feat: port rule promise/param-names

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/typescript-go/shim/tspath"
 	importPlugin "github.com/web-infra-dev/rslint/internal/plugins/import"
 	jestPlugin "github.com/web-infra-dev/rslint/internal/plugins/jest"
+	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/adjacent_overload_signatures"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/array_type"
@@ -339,6 +340,11 @@ var KnownPlugins = []PluginInfo{
 		getAllRules: func() []rule.Rule { return jestPlugin.GetAllRules() },
 	},
 	{
+		RulePrefix:  "promise",
+		DeclNames:   []string{"eslint-plugin-promise", "promise"},
+		getAllRules: func() []rule.Rule { return promisePlugin.GetAllRules() },
+	},
+	{
 		RulePrefix:  "react",
 		DeclNames:   []string{"react"},
 		getAllRules: func() []rule.Rule { return reactPlugin.GetAllRules() },
@@ -411,6 +417,7 @@ func RegisterAllRules() {
 		registerAllEslintImportPluginRules()
 		registerAllReactPluginRules()
 		registerAllJestPluginRules()
+		registerAllPromisePluginRules()
 		registerAllCoreEslintRules()
 	})
 }
@@ -423,6 +430,12 @@ func registerAllReactPluginRules() {
 
 func registerAllJestPluginRules() {
 	for _, rule := range jestPlugin.GetAllRules() {
+		GlobalRuleRegistry.Register(rule.Name, rule)
+	}
+}
+
+func registerAllPromisePluginRules() {
+	for _, rule := range promisePlugin.GetAllRules() {
 		GlobalRuleRegistry.Register(rule.Name, rule)
 	}
 }

--- a/internal/config/config_plugin_test.go
+++ b/internal/config/config_plugin_test.go
@@ -84,14 +84,13 @@ func TestGetCoreRules(t *testing.T) {
 func TestGetPluginRules_Disjoint(t *testing.T) {
 	RegisterAllRules()
 
-	tsRules := GetPluginRules("@typescript-eslint")
-	coreRules := GetCoreRules()
-	importRules := GetPluginRules("import")
-	jestRules := GetPluginRules("jest")
-	reactRules := GetPluginRules("react")
+	// Sum across core + every known plugin, so this test does not need to be
+	// edited each time a new plugin is added.
+	total := len(GetCoreRules())
+	for _, plugin := range KnownPlugins {
+		total += len(GetPluginRules(plugin.RulePrefix))
+	}
 
-	// Together they should cover all registered rules
-	total := len(tsRules) + len(coreRules) + len(importRules) + len(jestRules) + len(reactRules)
 	allRules := GlobalRuleRegistry.GetAllRules()
 	if total != len(allRules) {
 		t.Errorf("Expected total %d to equal all rules %d", total, len(allRules))

--- a/internal/plugins/promise/all.go
+++ b/internal/plugins/promise/all.go
@@ -1,0 +1,12 @@
+package promise_plugin
+
+import (
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func GetAllRules() []rule.Rule {
+	return []rule.Rule{
+		param_names.ParamNamesRule,
+	}
+}

--- a/internal/plugins/promise/fixtures/fixtures.go
+++ b/internal/plugins/promise/fixtures/fixtures.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"path"
+	"runtime"
+)
+
+func GetRootDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return path.Dir(filename)
+}

--- a/internal/plugins/promise/fixtures/tsconfig.json
+++ b/internal/plugins/promise/fixtures/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "experimentalDecorators": true
+  }
+}

--- a/internal/plugins/promise/plugin.go
+++ b/internal/plugins/promise/plugin.go
@@ -1,0 +1,3 @@
+package promise_plugin
+
+const PLUGIN_NAME = "eslint-plugin-promise"

--- a/internal/plugins/promise/rules/param_names/param_names.go
+++ b/internal/plugins/promise/rules/param_names/param_names.go
@@ -1,0 +1,146 @@
+package param_names
+
+import (
+	"fmt"
+
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// skipTransparent only unwraps parens — ESLint's ESTree parser drops
+// parentheses, so `new (Promise)(...)` and `new Promise((fn))` already have
+// the identifier / function visible at the ESLint level. TS-only wrappers
+// (type assertions, non-null, satisfies) are intentionally NOT unwrapped:
+// the original rule treats `new (Promise as any)(...)` as not-a-Promise-
+// constructor (callee.type !== 'Identifier') and skips silently, and we
+// mirror that — a user writing `as` is often deliberately signalling "this
+// isn't the standard Promise constructor, don't lint me".
+const skipTransparent = ast.OEKParentheses
+
+const (
+	defaultResolvePattern = "^_?resolve$"
+	defaultRejectPattern  = "^_?reject$"
+)
+
+type Options struct {
+	ResolvePattern string
+	RejectPattern  string
+}
+
+func parseOptions(options any) Options {
+	opts := Options{
+		ResolvePattern: defaultResolvePattern,
+		RejectPattern:  defaultRejectPattern,
+	}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["resolvePattern"].(string); ok && v != "" {
+			opts.ResolvePattern = v
+		}
+		if v, ok := optsMap["rejectPattern"].(string); ok && v != "" {
+			opts.RejectPattern = v
+		}
+	}
+	return opts
+}
+
+func buildResolveParamNamesMessage(pattern string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "resolveParamNames",
+		Description: fmt.Sprintf(`Promise constructor parameters must be named to match "%s"`, pattern),
+	}
+}
+
+func buildRejectParamNamesMessage(pattern string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "rejectParamNames",
+		Description: fmt.Sprintf(`Promise constructor parameters must be named to match "%s"`, pattern),
+	}
+}
+
+// paramName returns the plain identifier name of a parameter, or "" if the
+// parameter is a destructuring pattern, has a default value (AssignmentPattern
+// in ESTree), or is a rest element — matching ESLint's `params[i].name`, which
+// is only defined on Identifier-shaped parameters.
+func paramName(param *ast.Node) string {
+	if param == nil || !ast.IsParameter(param) {
+		return ""
+	}
+	decl := param.AsParameterDeclaration()
+	if decl == nil {
+		return ""
+	}
+	if decl.Initializer != nil || decl.DotDotDotToken != nil {
+		return ""
+	}
+	name := decl.Name()
+	if name == nil || !ast.IsIdentifier(name) {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+// regexMatch wraps regexp2.MatchString, discarding the timeout error.
+func regexMatch(re *regexp2.Regexp, s string) bool {
+	matched, _ := re.MatchString(s)
+	return matched
+}
+
+var ParamNamesRule = rule.Rule{
+	Name: "promise/param-names",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		// ECMAScript + Unicode flags mirror ESLint's `new RegExp(pattern, 'u')`
+		// so user patterns using lookaround, backreferences, or `\p{...}` work
+		// identically to the original rule (Go's standard `regexp` / RE2 does not).
+		const reOpts = regexp2.ECMAScript | regexp2.Unicode
+		resolveRe, err := regexp2.Compile(opts.ResolvePattern, reOpts)
+		if err != nil {
+			return rule.RuleListeners{}
+		}
+		rejectRe, err := regexp2.Compile(opts.RejectPattern, reOpts)
+		if err != nil {
+			return rule.RuleListeners{}
+		}
+
+		return rule.RuleListeners{
+			ast.KindNewExpression: func(node *ast.Node) {
+				callee := ast.SkipOuterExpressions(node.AsNewExpression().Expression, skipTransparent)
+				if callee == nil || !ast.IsIdentifier(callee) || callee.AsIdentifier().Text != "Promise" {
+					return
+				}
+				args := node.Arguments()
+				if len(args) != 1 {
+					return
+				}
+				executor := ast.SkipOuterExpressions(args[0], skipTransparent)
+				if executor == nil || !ast.IsFunctionExpressionOrArrowFunction(executor) {
+					return
+				}
+				// Filter out the TS `this` parameter — it's a tsgo-specific
+				// ParameterDeclaration that @typescript-eslint/parser strips
+				// from `.params` before the ESLint rule sees it.
+				params := make([]*ast.Node, 0, len(executor.Parameters()))
+				for _, p := range executor.Parameters() {
+					if !ast.IsThisParameter(p) {
+						params = append(params, p)
+					}
+				}
+				if len(params) == 0 {
+					return
+				}
+
+				if resolveName := paramName(params[0]); resolveName != "" && !regexMatch(resolveRe, resolveName) {
+					ctx.ReportNode(params[0], buildResolveParamNamesMessage(opts.ResolvePattern))
+				}
+				if len(params) >= 2 {
+					if rejectName := paramName(params[1]); rejectName != "" && !regexMatch(rejectRe, rejectName) {
+						ctx.ReportNode(params[1], buildRejectParamNamesMessage(opts.RejectPattern))
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/promise/rules/param_names/param_names.md
+++ b/internal/plugins/promise/rules/param_names/param_names.md
@@ -1,0 +1,60 @@
+# param-names
+
+Enforce consistent param names and ordering when creating new promises.
+
+## Rule Details
+
+Ensures that `new Promise()` is instantiated with the parameter names
+`resolve, reject` to avoid confusion with order such as `reject, resolve`.
+The Promise constructor uses the
+[RevealingConstructor pattern](https://blog.domenic.me/the-revealing-constructor-pattern/).
+Using the same parameter names as the language specification makes code more
+uniform and easier to understand.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+new Promise(function (reject, resolve) {}); // incorrect order
+new Promise(function (ok, fail) {}); // non-standard parameter names
+new Promise(function (_, reject) {}); // a simple underscore is not allowed
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+new Promise(function (resolve) {});
+new Promise(function (resolve, reject) {});
+new Promise(function (_resolve, _reject) {}); // unused-marker underscore prefix is allowed
+```
+
+## Options
+
+### `resolvePattern`
+
+Pass `{ resolvePattern: "^_?resolve$" }` to customize the first argument name
+pattern. Default is `"^_?resolve$"`.
+
+```json
+{ "promise/param-names": ["error", { "resolvePattern": "^yes$" }] }
+```
+
+```javascript
+new Promise(function (yes, reject) {});
+```
+
+### `rejectPattern`
+
+Pass `{ rejectPattern: "^_?reject$" }` to customize the second argument name
+pattern. Default is `"^_?reject$"`.
+
+```json
+{ "promise/param-names": ["error", { "rejectPattern": "^no$" }] }
+```
+
+```javascript
+new Promise(function (resolve, no) {});
+```
+
+## Original Documentation
+
+- [eslint-plugin-promise: param-names](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/param-names.md)

--- a/internal/plugins/promise/rules/param_names/param_names_test.go
+++ b/internal/plugins/promise/rules/param_names/param_names_test.go
@@ -1,0 +1,515 @@
+package param_names_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/promise/rules/param_names"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+const msgForResolve = `Promise constructor parameters must be named to match "^_?resolve$"`
+const msgForReject = `Promise constructor parameters must be named to match "^_?reject$"`
+
+func TestParamNames(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&param_names.ParamNamesRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: `new Promise(function(resolve, reject) {})`},
+			{Code: `new Promise(function(resolve, _reject) {})`},
+			{Code: `new Promise(function(_resolve, reject) {})`},
+			{Code: `new Promise(function(_resolve, _reject) {})`},
+			{Code: `new Promise(function(resolve) {})`},
+			{Code: `new Promise(function(_resolve) {})`},
+			{Code: `new Promise(resolve => {})`},
+			{Code: `new Promise((resolve, reject) => {})`},
+			{Code: `new Promise(() => {})`},
+			{Code: `new NonPromise()`},
+			{
+				Code:    `new Promise((yes, no) => {})`,
+				Options: map[string]interface{}{"resolvePattern": "^yes$", "rejectPattern": "^no$"},
+			},
+
+			// ---- Patterns/defaults/rest skip (mirrors ESLint `.name===undefined`) ----
+			{Code: `new Promise(function({ resolve, reject }) {})`},
+			{Code: `new Promise(function([resolve, reject]) {})`},
+			{Code: `new Promise(function(resolve = () => {}, reject = () => {}) {})`},
+			{Code: `new Promise(function(...args) {})`},
+			{Code: `new Promise(function({ a }, { b }) {})`},
+			// Mixed: first is identifier (checked), second is destructuring (skipped)
+			{Code: `new Promise(function(resolve, { foo }) {})`},
+			// Mixed: first is destructuring (skipped), second is identifier (checked)
+			{Code: `new Promise(function({ foo }, reject) {})`},
+
+			// ---- Not a Promise constructor invocation ----
+			{Code: `new Promise(handler)`},
+			{Code: `new Promise(function(reject, resolve) {}, extraArg)`},
+			{Code: `Promise(function(reject, resolve) {})`},
+			{Code: `new Foo.Promise(function(reject, resolve) {})`},
+			{Code: `new globalThis.Promise(function(reject, resolve) {})`},
+			{Code: `new Promise()`},
+			{Code: `new Promise(123)`},
+			{Code: `new Promise("abc")`},
+
+			// ---- Async executor (FunctionExpression / ArrowFunction) ----
+			{Code: `new Promise(async function(resolve, reject) {})`},
+			{Code: `new Promise(async (resolve, reject) => {})`},
+
+			// ---- TS type assertion on callee / executor: rule silently skips,
+			//      mirroring ESLint's `callee.type !== 'Identifier'` short-circuit.
+			//      Bad names here are NOT reported (aligns with eslint-plugin-promise
+			//      under @typescript-eslint/parser).
+			{Code: `new (Promise as any)(function(resolve, reject) {})`},
+			{Code: `new (Promise as any)(function(ok, fail) {})`},
+			{Code: `new (<any>Promise)(function(ok, fail) {})`},
+			{Code: `new Promise((function(ok, fail) {}) as any)`},
+
+			// ---- Partial options: other field falls back to default ----
+			{
+				Code:    `new Promise((yes, reject) => {})`,
+				Options: map[string]interface{}{"resolvePattern": "^yes$"},
+			},
+			{
+				Code:    `new Promise((resolve, no) => {})`,
+				Options: map[string]interface{}{"rejectPattern": "^no$"},
+			},
+
+			// ---- regexp2 / ECMAScript features (RE2 can't handle these) ----
+			// Lookbehind
+			{
+				Code:    `new Promise((resolve) => {})`,
+				Options: map[string]interface{}{"resolvePattern": "(?<!_)resolve"},
+			},
+			// Unicode property escape
+			{
+				Code:    `new Promise((resolve) => {})`,
+				Options: map[string]interface{}{"resolvePattern": `^\p{Ll}+$`},
+			},
+
+			// ---- Invalid pattern: rule silently no-ops (can't match) ----
+			{
+				Code:    `new Promise((reject, resolve) => {})`,
+				Options: map[string]interface{}{"resolvePattern": "[unclosed"},
+			},
+
+			// ---- TS generic type argument on Promise ----
+			{Code: `new Promise<number>((resolve, reject) => {})`},
+			{Code: `new Promise<void>(function(resolve, reject) {})`},
+
+			// ---- 3+ executor params: ESLint only checks first two ----
+			{Code: `new Promise((resolve, reject, extra) => {})`},
+			{Code: `new Promise((resolve, reject, a, b, c) => {})`},
+
+			// ---- Named function expression ----
+			{Code: `new Promise(function named(resolve, reject) {})`},
+
+			// ---- Empty params on FunctionExpression (not just arrow) ----
+			{Code: `new Promise(function() {})`},
+
+			// ---- Spread executor argument is not a FunctionExpression ----
+			{Code: `new Promise(...args)`},
+
+			// ---- TS `this` parameter is stripped before resolve/reject indexing ----
+			{Code: `new Promise<void>(function(this: any, resolve, reject) {})`},
+			{Code: `new Promise<void>(function(this: unknown, _resolve) {})`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ESLint upstream invalid cases ----
+			{
+				Code: `new Promise(function(reject, resolve) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 28,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    30,
+						EndLine:   1,
+						EndColumn: 37,
+					},
+				},
+			},
+			{
+				Code: `new Promise(function(resolve, rej) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    31,
+						EndLine:   1,
+						EndColumn: 34,
+					},
+				},
+			},
+			{
+				Code: `new Promise(yes => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    13,
+						EndLine:   1,
+						EndColumn: 16,
+					},
+				},
+			},
+			{
+				Code: `new Promise((yes, no) => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 17,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    19,
+						EndLine:   1,
+						EndColumn: 21,
+					},
+				},
+			},
+			{
+				Code:    `new Promise(function(resolve, reject) {})`,
+				Options: map[string]interface{}{"resolvePattern": "^yes$", "rejectPattern": "^no$"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   `Promise constructor parameters must be named to match "^yes$"`,
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 29,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   `Promise constructor parameters must be named to match "^no$"`,
+						Line:      1,
+						Column:    31,
+						EndLine:   1,
+						EndColumn: 37,
+					},
+				},
+			},
+
+			// ---- Single underscore is NOT acceptable under default pattern ----
+			{
+				Code: `new Promise(function(_, reject) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 23,
+					},
+				},
+			},
+
+			// ---- Parenthesized Promise identifier is still recognized ----
+			{
+				Code: `new (Promise)(function(ok, fail) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    24,
+						EndLine:   1,
+						EndColumn: 26,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    28,
+						EndLine:   1,
+						EndColumn: 32,
+					},
+				},
+			},
+
+			// ---- Async function executor ----
+			{
+				Code: `new Promise(async function(ok, fail) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    28,
+						EndLine:   1,
+						EndColumn: 30,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    32,
+						EndLine:   1,
+						EndColumn: 36,
+					},
+				},
+			},
+			{
+				Code: `new Promise(async (ok, fail) => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    20,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    24,
+						EndLine:   1,
+						EndColumn: 28,
+					},
+				},
+			},
+
+			// ---- Partial options: only resolvePattern changed ----
+			{
+				Code:    `new Promise((no, rejectX) => {})`,
+				Options: map[string]interface{}{"resolvePattern": "^yes$"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   `Promise constructor parameters must be named to match "^yes$"`,
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 16,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    18,
+						EndLine:   1,
+						EndColumn: 25,
+					},
+				},
+			},
+
+			// ---- Partial options: only rejectPattern changed ----
+			{
+				Code:    `new Promise((resolveX, yes) => {})`,
+				Options: map[string]interface{}{"rejectPattern": "^no$"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   `Promise constructor parameters must be named to match "^no$"`,
+						Line:      1,
+						Column:    24,
+						EndLine:   1,
+						EndColumn: 27,
+					},
+				},
+			},
+
+			// ---- Pattern with backslashes: message must preserve the raw source
+			//      (ESLint uses `regex.source`; our formatter must NOT re-escape `\`).
+			{
+				Code:    `new Promise((bad) => {})`,
+				Options: map[string]interface{}{"resolvePattern": `^\w+resolve$`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   `Promise constructor parameters must be named to match "^\w+resolve$"`,
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 17,
+					},
+				},
+			},
+
+			// ---- ECMAScript-only lookbehind pattern compiles under regexp2 ----
+			{
+				Code:    `new Promise((_resolve) => {})`,
+				Options: map[string]interface{}{"resolvePattern": "(?<!_)resolve"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   `Promise constructor parameters must be named to match "(?<!_)resolve"`,
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
+
+			// ---- Two-line executor body: column still 1-based on correct line ----
+			{
+				Code: "new Promise(function(ok, fail) {\n  return 0;\n})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 24,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    26,
+						EndLine:   1,
+						EndColumn: 30,
+					},
+				},
+			},
+
+			// ---- TS generic type argument: still reports bad names ----
+			{
+				Code: `new Promise<number>((ok, fail) => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    22,
+						EndLine:   1,
+						EndColumn: 24,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    26,
+						EndLine:   1,
+						EndColumn: 30,
+					},
+				},
+			},
+
+			// ---- 3+ params: only first two are checked, third/fourth ignored ----
+			{
+				Code: `new Promise((ok, fail, also_wrong) => {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    14,
+						EndLine:   1,
+						EndColumn: 16,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    18,
+						EndLine:   1,
+						EndColumn: 22,
+					},
+				},
+			},
+
+			// ---- TS `this` parameter is stripped; bad names in real params still reported ----
+			{
+				Code: `new Promise<void>(function(this: any, ok, fail) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    39,
+						EndLine:   1,
+						EndColumn: 41,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    43,
+						EndLine:   1,
+						EndColumn: 47,
+					},
+				},
+			},
+
+			// ---- Named function expression ----
+			{
+				Code: `new Promise(function named(ok, fail) {})`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      1,
+						Column:    28,
+						EndLine:   1,
+						EndColumn: 30,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      1,
+						Column:    32,
+						EndLine:   1,
+						EndColumn: 36,
+					},
+				},
+			},
+
+			// ---- Params split across lines (multi-line position) ----
+			{
+				Code: "new Promise(function(\n  ok,\n  fail\n) {})",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "resolveParamNames",
+						Message:   msgForResolve,
+						Line:      2,
+						Column:    3,
+						EndLine:   2,
+						EndColumn: 5,
+					},
+					{
+						MessageId: "rejectParamNames",
+						Message:   msgForReject,
+						Line:      3,
+						Column:    3,
+						EndLine:   3,
+						EndColumn: 7,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -310,6 +310,9 @@ export default defineConfig({
     './tests/eslint-plugin-jest/rules/prefer-todo.test.ts',
     './tests/eslint-plugin-jest/rules/valid-describe-callback.test.ts',
 
+    // eslint-plugin-promise
+    './tests/eslint-plugin-promise/rules/param-names.test.ts',
+
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',
   ],
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rslint.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rslint.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.files.json", "./tsconfig.virtual.json"]
+      }
+    },
+    "rules": {},
+    "plugins": ["promise"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rule-tester.ts
@@ -1,0 +1,215 @@
+import path from 'node:path';
+import util from 'node:util';
+
+import { lint } from '@rslint/core';
+
+interface SuggestionOutput {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, unknown> | undefined;
+  output: string;
+}
+
+interface TestCaseError {
+  message?: string | RegExp;
+  messageId?: string;
+  /**
+   * @deprecated `type` is deprecated and will be removed in the next major version.
+   */
+  type?: string | undefined;
+  data?: any;
+  line?: number | undefined;
+  column?: number | undefined;
+  endLine?: number | undefined;
+  endColumn?: number | undefined;
+  suggestions?: SuggestionOutput[] | undefined;
+}
+
+// Port from 'eslint'
+export interface ValidTestCase {
+  name?: string;
+  code: string;
+  options?: any;
+  filename?: string | undefined;
+  only?: boolean;
+  settings?: Record<string, any> | undefined;
+}
+
+export interface InvalidTestCase extends ValidTestCase {
+  errors: number | (TestCaseError | string)[];
+  output?: string | null | undefined;
+}
+
+export class RuleTester {
+  run(
+    ruleName: string,
+    rule: never,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    ruleName = 'promise/' + ruleName;
+    describe(ruleName, () => {
+      const cwd = process.cwd();
+      const config = path.resolve(import.meta.dirname, './rslint.json');
+
+      // test whether case has only
+      let hasOnly =
+        cases.valid.some((x) => {
+          if (typeof x === 'object' && x.only) {
+            return true;
+          } else {
+            return false;
+          }
+        }) || cases.invalid.some((x) => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (hasOnly) {
+            if (typeof validCase === 'string') {
+              continue;
+            }
+            if (!validCase.only) {
+              continue;
+            }
+          }
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+
+          const options =
+            typeof validCase === 'string' ? [] : validCase.options || [];
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof validCase === 'string'
+              ? defaultFilename
+              : (validCase.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+
+          const diags = await lint({
+            config,
+            workingDirectory: cwd,
+            fileContents: {
+              [absoluteFilename]: code,
+            },
+            ruleOptions: {
+              [ruleName]: options,
+            },
+          });
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case, but got: ${JSON.stringify(diags)}\nCode: ${code}`,
+          );
+        }
+      });
+      test('invalid', async (t) => {
+        for (const item of cases.invalid) {
+          assert.ok(
+            item.errors || item.errors === 0,
+            `Did not specify errors for an invalid test of ${ruleName}`,
+          );
+          if (Array.isArray(item.errors) && item.errors.length === 0) {
+            assert.fail('Invalid cases must have at least one error');
+          }
+
+          const { code, only = false, options = [] } = item;
+          if (hasOnly && !only) {
+            continue;
+          }
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof item === 'string'
+              ? defaultFilename
+              : (item.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+          const diags = await lint({
+            config,
+            workingDirectory: cwd,
+            fileContents: {
+              [absoluteFilename]: code,
+            },
+            ruleOptions: {
+              [ruleName]: options,
+            },
+          });
+
+          if (typeof item.errors === 'number') {
+            if (item.errors === 0) {
+              assert.fail(
+                "Invalid cases must have 'error' value greater than 0",
+              );
+            }
+
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors,
+                item.errors === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+          } else {
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors.length,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors.length,
+                item.errors.length === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+
+            const hasMessageOfThisRule = diags.diagnostics.some(
+              (d) => d.ruleName === ruleName,
+            );
+
+            for (let i = 0, l = item.errors.length; i < l; i++) {
+              const error = item.errors[i];
+              const message = diags.diagnostics[i];
+
+              assert(
+                hasMessageOfThisRule,
+                'Error rule name should be the same as the name of the rule being tested',
+              );
+              if (typeof error === 'string' || error instanceof RegExp) {
+                // Just an error message.
+                assertMessageMatches(message.message, error);
+                assert.ok(
+                  message.suggestions === void 0,
+                  `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
+                );
+              } else if (typeof error === 'object' && error !== null) {
+                if (typeof error.message === 'string') {
+                  assertMessageMatches(message.message, error.message);
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+}
+
+/**
+ * Asserts that the message matches its expected value. If the expected
+ * value is a regular expression, it is checked against the actual
+ * value.
+ */
+function assertMessageMatches(actual: string, expected: string | RegExp): void {
+  if (expected instanceof RegExp) {
+    // assert.js doesn't have a built-in RegExp match function
+    assert.ok(
+      expected.test(actual),
+      `Expected '${actual}' to match ${expected}`,
+    );
+  } else {
+    assert.strictEqual(actual, expected);
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/param-names.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/rules/param-names.test.ts
@@ -1,0 +1,226 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+const messageForResolve =
+  'Promise constructor parameters must be named to match "^_?resolve$"';
+const messageForReject =
+  'Promise constructor parameters must be named to match "^_?reject$"';
+
+ruleTester.run('param-names', {} as never, {
+  valid: [
+    // ESLint upstream
+    { code: 'new Promise(function(resolve, reject) {})' },
+    { code: 'new Promise(function(resolve, _reject) {})' },
+    { code: 'new Promise(function(_resolve, reject) {})' },
+    { code: 'new Promise(function(_resolve, _reject) {})' },
+    { code: 'new Promise(function(resolve) {})' },
+    { code: 'new Promise(function(_resolve) {})' },
+    { code: 'new Promise(resolve => {})' },
+    { code: 'new Promise((resolve, reject) => {})' },
+    { code: 'new Promise(() => {})' },
+    { code: 'new NonPromise()' },
+    {
+      code: 'new Promise((yes, no) => {})',
+      options: [{ resolvePattern: '^yes$', rejectPattern: '^no$' }],
+    },
+
+    // Patterns/defaults/rest skip (mirrors ESLint `.name===undefined`)
+    { code: 'new Promise(function({ resolve, reject }) {})' },
+    { code: 'new Promise(function([resolve, reject]) {})' },
+    { code: 'new Promise(function(resolve = () => {}, reject = () => {}) {})' },
+    { code: 'new Promise(function(...args) {})' },
+    { code: 'new Promise(function(resolve, { foo }) {})' },
+    { code: 'new Promise(function({ foo }, reject) {})' },
+
+    // Not a Promise constructor invocation
+    { code: 'new Promise(handler)' },
+    { code: 'new Promise(function(reject, resolve) {}, extraArg)' },
+    { code: 'Promise(function(reject, resolve) {})' },
+    { code: 'new Foo.Promise(function(reject, resolve) {})' },
+    { code: 'new globalThis.Promise(function(reject, resolve) {})' },
+    { code: 'new Promise()' },
+
+    // Async executor
+    { code: 'new Promise(async function(resolve, reject) {})' },
+    { code: 'new Promise(async (resolve, reject) => {})' },
+
+    // TS type assertion on callee / executor: rule silently skips,
+    // mirroring ESLint's `callee.type !== 'Identifier'` short-circuit.
+    { code: 'new (Promise as any)(function(resolve, reject) {})' },
+    { code: 'new (Promise as any)(function(ok, fail) {})' },
+    { code: 'new Promise((function(ok, fail) {}) as any)' },
+
+    // Partial options
+    {
+      code: 'new Promise((yes, reject) => {})',
+      options: [{ resolvePattern: '^yes$' }],
+    },
+    {
+      code: 'new Promise((resolve, no) => {})',
+      options: [{ rejectPattern: '^no$' }],
+    },
+
+    // regexp2 / ECMAScript features (lookbehind, \p{...})
+    {
+      code: 'new Promise((resolve) => {})',
+      options: [{ resolvePattern: '(?<!_)resolve' }],
+    },
+    {
+      code: 'new Promise((resolve) => {})',
+      options: [{ resolvePattern: '^\\p{Ll}+$' }],
+    },
+
+    // Invalid pattern: rule silently no-ops
+    {
+      code: 'new Promise((reject, resolve) => {})',
+      options: [{ resolvePattern: '[unclosed' }],
+    },
+
+    // TS generic type argument
+    { code: 'new Promise<number>((resolve, reject) => {})' },
+    { code: 'new Promise<void>(function(resolve, reject) {})' },
+
+    // 3+ executor params: only first two checked
+    { code: 'new Promise((resolve, reject, extra) => {})' },
+    { code: 'new Promise((resolve, reject, a, b, c) => {})' },
+
+    // Named function expression
+    { code: 'new Promise(function named(resolve, reject) {})' },
+
+    // Empty params on FunctionExpression
+    { code: 'new Promise(function() {})' },
+
+    // TS `this` parameter is stripped before resolve/reject indexing
+    { code: 'new Promise<void>(function(this: any, resolve, reject) {})' },
+    { code: 'new Promise<void>(function(this: unknown, _resolve) {})' },
+  ],
+
+  invalid: [
+    // ESLint upstream
+    {
+      code: 'new Promise(function(reject, resolve) {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+    {
+      code: 'new Promise(function(resolve, rej) {})',
+      errors: [{ message: messageForReject }],
+    },
+    {
+      code: 'new Promise(yes => {})',
+      errors: [{ message: messageForResolve }],
+    },
+    {
+      code: 'new Promise((yes, no) => {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+    {
+      code: 'new Promise(function(resolve, reject) {})',
+      options: [{ resolvePattern: '^yes$', rejectPattern: '^no$' }],
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named to match "^yes$"',
+        },
+        {
+          message:
+            'Promise constructor parameters must be named to match "^no$"',
+        },
+      ],
+    },
+
+    // Single underscore is NOT acceptable under default pattern
+    {
+      code: 'new Promise(function(_, reject) {})',
+      errors: [{ message: messageForResolve }],
+    },
+
+    // Parenthesized Promise identifier
+    {
+      code: 'new (Promise)(function(ok, fail) {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+
+    // Async executor
+    {
+      code: 'new Promise(async function(ok, fail) {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+    {
+      code: 'new Promise(async (ok, fail) => {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+
+    // Partial options
+    {
+      code: 'new Promise((no, rejectX) => {})',
+      options: [{ resolvePattern: '^yes$' }],
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named to match "^yes$"',
+        },
+        { message: messageForReject },
+      ],
+    },
+    {
+      code: 'new Promise((resolveX, yes) => {})',
+      options: [{ rejectPattern: '^no$' }],
+      errors: [
+        { message: messageForResolve },
+        {
+          message:
+            'Promise constructor parameters must be named to match "^no$"',
+        },
+      ],
+    },
+
+    // Pattern with backslashes: message must preserve the raw source
+    {
+      code: 'new Promise((bad) => {})',
+      options: [{ resolvePattern: '^\\w+resolve$' }],
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named to match "^\\w+resolve$"',
+        },
+      ],
+    },
+
+    // ECMAScript-only lookbehind compiles under regexp2
+    {
+      code: 'new Promise((_resolve) => {})',
+      options: [{ resolvePattern: '(?<!_)resolve' }],
+      errors: [
+        {
+          message:
+            'Promise constructor parameters must be named to match "(?<!_)resolve"',
+        },
+      ],
+    },
+
+    // TS generic type argument: still reports bad names
+    {
+      code: 'new Promise<number>((ok, fail) => {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+
+    // 3+ params: only first two checked
+    {
+      code: 'new Promise((ok, fail, also_wrong) => {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+
+    // Named function expression
+    {
+      code: 'new Promise(function named(ok, fail) {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+
+    // TS `this` parameter is stripped; bad names in real params still reported
+    {
+      code: 'new Promise<void>(function(this: any, ok, fail) {})',
+      errors: [{ message: messageForResolve }, { message: messageForReject }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/tsconfig.files.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/tsconfig.files.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "allowJs": true
+  },
+  "include": ["files/**/*"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-promise/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-promise/tsconfig.virtual.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"]
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}


### PR DESCRIPTION
## Summary

Port the `promise/param-names` rule from `eslint-plugin-promise` to rslint.

The rule enforces that `new Promise()` is instantiated with parameter names matching `resolve, reject` (or custom patterns via `resolvePattern` / `rejectPattern`), preventing confusion like `new Promise((reject, resolve) => {})`.

This PR also introduces the `eslint-plugin-promise` plugin skeleton (`internal/plugins/promise/`) so future promise-family rules can be added alongside.

Notes on semantic alignment with the original rule:
- Uses `github.com/dlclark/regexp2` with `ECMAScript | Unicode` flags to mirror ESLint's `new RegExp(pattern, 'u')` — user patterns with lookaround, backreferences, or `\p{...}` behave identically.
- TS `this` parameter (`function(this: any, resolve, reject)`) is stripped before indexing, mirroring `@typescript-eslint/parser`'s `.params` filtering.
- TS type assertions on callee/executor (`new (Promise as any)(...)`) are NOT unwrapped — rule silently skips, matching the original's `callee.type !== 'Identifier'` short-circuit.
- Differential validation against real ESLint on rspack's `ExternalsPlugin.ts:107` produced byte-identical output (same line, column, and message text).

## Related Links

- Rule docs: https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/param-names.md
- Source: https://github.com/eslint-community/eslint-plugin-promise/blob/main/rules/param-names.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).