### PR TITLE
feat: port rule react/no-danger

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -12,6 +12,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
@@ -33,6 +34,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
+		no_danger.NoDangerRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		self_closing_comp.SelfClosingCompRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -1,8 +1,6 @@
 package reactutil
 
 import (
-	"strings"
-
 	"github.com/microsoft/typescript-go/shim/ast"
 )
 
@@ -84,11 +82,15 @@ func GetJsxTagName(element *ast.Node) *ast.Node {
 
 // IsDOMComponent reports whether a JSX opening/self-closing element refers to
 // an intrinsic (DOM) element like <div> or <svg:path>, rather than a user
-// component like <Foo> or <foo.Bar>.
+// component like <Foo> or <Foo.Bar>.
 //
 // Mirrors ESLint-plugin-react's `jsxUtil.isDOMComponent`: a tag name is
-// intrinsic iff its string form starts with a lowercase letter and contains
-// no ".". Property-access tag names (<foo.bar>) are user components.
+// intrinsic iff `elementType(node)` starts with a lowercase letter (regex
+// `/^[a-z]/`). For member-expression tags (`<foo.bar>`, `<this.Foo>`) this
+// means the classification is decided by the leftmost base identifier's
+// first character — so `<foo.bar>` is DOM (matches ESLint, even though the
+// runtime React behavior is "always user component"), while `<Foo.Bar>` is
+// a user component.
 func IsDOMComponent(element *ast.Node) bool {
 	tagName := GetJsxTagName(element)
 	if tagName == nil {
@@ -104,10 +106,27 @@ func IsDOMComponent(element *ast.Node) bool {
 			return false
 		}
 		text = ns.Namespace.AsIdentifier().Text + ":" + ns.Name().AsIdentifier().Text
+	case ast.KindPropertyAccessExpression:
+		// Walk to the leftmost base — its first character decides the
+		// classification, matching `/^[a-z]/.test(elementType(node))`.
+		base := tagName
+		for base.Kind == ast.KindPropertyAccessExpression {
+			base = base.AsPropertyAccessExpression().Expression
+		}
+		switch base.Kind {
+		case ast.KindIdentifier:
+			text = base.AsIdentifier().Text
+		case ast.KindThisKeyword:
+			// `<this.Foo>` — jsx-ast-utils' elementType returns "this.Foo",
+			// first char is lowercase → DOM per ESLint's regex.
+			text = "this"
+		default:
+			return false
+		}
 	default:
 		return false
 	}
-	if text == "" || strings.Contains(text, ".") {
+	if text == "" {
 		return false
 	}
 	first := text[0]

--- a/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind_test.go
+++ b/internal/plugins/react/rules/jsx_no_bind/jsx_no_bind_test.go
@@ -47,6 +47,10 @@ func TestJsxNoBindRule(t *testing.T) {
 		{Code: `var x = <div onClick={function () { alert("1337"); }}></div>`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
 		// Namespaced DOM element is also intrinsic
 		{Code: `var x = <svg:path onClick={() => 1} />`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
+		// Property-access tag with a lowercase base — ESLint's isDOMComponent
+		// tests the first character of elementType only, so `<foo.Bar>` is
+		// classified as DOM and skipped under `ignoreDOMComponents: true`.
+		{Code: `var x = <foo.Bar onClick={() => 1} />`, Tsx: true, Options: map[string]interface{}{"ignoreDOMComponents": true}},
 
 		// ---------- 5. Bind-not-used-for-JSX-prop ----------
 		{
@@ -386,8 +390,9 @@ function C() {
 			},
 		},
 		{
-			// Property-access tag name is NOT a DOM component
-			Code:    `var x = <foo.Bar onClick={() => 1} />`,
+			// Property-access tag name with UPPERCASE base is a user component,
+			// so `ignoreDOMComponents: true` still reports it.
+			Code:    `var x = <Foo.Bar onClick={() => 1} />`,
 			Tsx:     true,
 			Options: map[string]interface{}{"ignoreDOMComponents": true},
 			Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/plugins/react/rules/no_danger/no_danger.go
+++ b/internal/plugins/react/rules/no_danger/no_danger.go
@@ -1,0 +1,89 @@
+package no_danger
+
+import (
+	"path"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var dangerousProps = map[string]bool{
+	"dangerouslySetInnerHTML": true,
+}
+
+var NoDangerRule = rule.Rule{
+	Name: "react/no-danger",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		var customComponentNames []string
+		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+			if arr, ok := optsMap["customComponentNames"].([]interface{}); ok {
+				for _, item := range arr {
+					if name, ok := item.(string); ok {
+						customComponentNames = append(customComponentNames, name)
+					}
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				attrName := reactutil.GetJsxPropName(node)
+				if !dangerousProps[attrName] {
+					return
+				}
+
+				parent := reactutil.GetJsxParentElement(node)
+				if parent == nil {
+					return
+				}
+
+				matched := reactutil.IsDOMComponent(parent)
+				if !matched && len(customComponentNames) > 0 {
+					functionName := getTagNameText(ctx.SourceFile, reactutil.GetJsxTagName(parent))
+					for _, pattern := range customComponentNames {
+						// path.Match mirrors minimatch for the simple patterns this rule
+						// accepts in practice (`*`, `Foo*`, `*Foo`, exact names). Component
+						// names never contain `/`, so the separator restriction is moot.
+						if ok, err := path.Match(pattern, functionName); ok && err == nil {
+							matched = true
+							break
+						}
+					}
+				}
+				if !matched {
+					return
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "dangerousProp",
+					Description: "Dangerous property '" + attrName + "' found",
+				})
+			},
+		}
+	},
+}
+
+// getTagNameText returns the full, structurally-correct tag-name string to
+// match against `customComponentNames`.
+//
+// NOTE: Unlike eslint-plugin-react/no-danger, which only flattens one level
+// of member access (`${nodeName.object.name}.${nodeName.property.name}` —
+// producing `"undefined.C"` for `<A.B.C>`) and passes an Identifier AST node
+// (not a string) into minimatch for `<ns:name>` — which throws `f.split is
+// not a function` at runtime — rslint reads the raw source text. This gives
+// the intuitive names (`"A.B.C"`, `"ns:name"`) so patterns like `["A.B.C"]`,
+// `["A.*"]`, or `["svg:path"]` behave as users would expect. Divergence
+// documented in no_danger.md.
+func getTagNameText(sourceFile *ast.SourceFile, tagName *ast.Node) string {
+	if tagName == nil {
+		return ""
+	}
+	if tagName.Kind == ast.KindIdentifier {
+		return tagName.AsIdentifier().Text
+	}
+	trimmed := utils.TrimNodeTextRange(sourceFile, tagName)
+	return strings.TrimSpace(sourceFile.Text()[trimmed.Pos():trimmed.End()])
+}

--- a/internal/plugins/react/rules/no_danger/no_danger.md
+++ b/internal/plugins/react/rules/no_danger/no_danger.md
@@ -1,0 +1,70 @@
+# no-danger
+
+Disallow usage of dangerous JSX properties.
+
+## Rule Details
+
+Dangerous properties in React are those whose behavior is known to be a common
+source of application vulnerabilities. The names of these properties make their
+dangerous nature explicit. Currently only `dangerouslySetInnerHTML` is checked.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var React = require('react');
+
+var Hello = <div dangerouslySetInnerHTML={{ __html: 'Hello World' }}></div>;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var React = require('react');
+
+var Hello = <div>Hello World</div>;
+```
+
+## Rule Options
+
+```json
+{ "react/no-danger": ["error", { "customComponentNames": ["*Panel", "Widget"] }] }
+```
+
+### `customComponentNames`
+
+An array of component name patterns. Defaults to `[]` (off for custom
+components). Patterns use `*` as a wildcard (minimatch-style). Set to
+`["*"]` to check every custom component, or list specific names such as
+`["MyComponent", "Sub*"]` to opt in by name.
+
+Examples of **incorrect** code with `{ "customComponentNames": ["*"] }`:
+
+```json
+{ "react/no-danger": ["error", { "customComponentNames": ["*"] }] }
+```
+
+```javascript
+<App dangerouslySetInnerHTML={{ __html: '<span>hello</span>' }} />;
+```
+
+## When Not To Use It
+
+Disable this rule if you know the content passed to `dangerouslySetInnerHTML`
+has already been sanitized.
+
+## Differences from ESLint
+
+- **Deep member tag names.** For `<A.B.C dangerouslySetInnerHTML={...} />`,
+  `eslint-plugin-react` flattens only one level of member access, producing
+  the string `"undefined.C"` when matching against `customComponentNames`.
+  rslint uses the full source-text name (`"A.B.C"`), so patterns such as
+  `["A.B.C"]` or `["A.*"]` match deep member tags as intended.
+- **JSX namespaced tag names.** For `<ns:name dangerouslySetInnerHTML={...} />`,
+  `eslint-plugin-react` passes an Identifier AST node (not a string) into
+  `minimatch`, which throws `f.split is not a function` at runtime — the
+  `customComponentNames` branch crashes on namespaced tags in ESLint. rslint
+  uses the string `"ns:name"`, so patterns match as expected.
+
+## Original Documentation
+
+- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md

--- a/internal/plugins/react/rules/no_danger/no_danger_test.go
+++ b/internal/plugins/react/rules/no_danger/no_danger_test.go
@@ -1,0 +1,459 @@
+package no_danger
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDangerRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDangerRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<App />;`, Tsx: true},
+		{Code: `<App dangerouslySetInnerHTML={{ __html: "" }} />;`, Tsx: true},
+		{Code: `<div className="bar"></div>;`, Tsx: true},
+		{
+			Code: `<div className="bar"></div>;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"*"},
+			},
+		},
+		{
+			Code: `
+				function App() {
+					return <Title dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Home"},
+			},
+		},
+		{
+			Code: `
+				function App() {
+					return <TextMUI dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"MUI*"},
+			},
+		},
+
+		// ---- Additional edge cases ----
+		// Case-sensitive: only the exact `dangerouslySetInnerHTML` spelling is dangerous.
+		{Code: `<div dangerouslySetInnerHtml={{ __html: "" }} />;`, Tsx: true},
+		// Similar-looking but distinct attribute name.
+		{Code: `<div innerHTML="<span />" />;`, Tsx: true},
+		// Multiple patterns, none matching the user component.
+		{
+			Code: `<Widget dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Foo*", "Bar*"},
+			},
+		},
+		// Empty `customComponentNames` means custom components are not checked.
+		{
+			Code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{},
+			},
+		},
+		// Options passed as a bare object (no array wrapper) — still works.
+		{
+			Code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Other"},
+			},
+		},
+		// Non-DOM React.Fragment-style tag is not checked by default.
+		{Code: `<React.Fragment></React.Fragment>;`, Tsx: true},
+		// Spread attribute alone on a DOM element is fine.
+		{Code: `<div {...props} />;`, Tsx: true},
+		// Single-character wildcard `?` — `MUI` pattern matches exactly 3 trailing chars,
+		// so a 4-char suffix like `MUIx` must not match.
+		{
+			Code: `<TextMUIx dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Text???"},
+			},
+		},
+		// Literal `.` in the pattern — exact-dot match only (no wildcard).
+		{
+			Code: `<Foo.Bar dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Foo.Baz"},
+			},
+		},
+		// Member tag with UPPERCASE base is a user component — no pattern,
+		// no report.
+		{
+			Code: `
+				const Foo: any = {};
+				Foo.Bar = () => null;
+				function App() {
+					return <Foo.Bar dangerouslySetInnerHTML={{ __html: "" }} />;
+				}
+			`,
+			Tsx: true,
+		},
+		// Defensive: non-array `customComponentNames` is ignored silently.
+		{
+			Code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": "MyComponent",
+			},
+		},
+		// Defensive: non-string entries in the array are skipped.
+		{
+			Code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{42, nil, false},
+			},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `<div dangerouslySetInnerHTML={{ __html: "" }}></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Message:   "Dangerous property 'dangerouslySetInnerHTML' found",
+					Line:      1,
+					Column:    6,
+				},
+			},
+		},
+		{
+			Code: `<App dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"*"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Line:      1,
+					Column:    6,
+				},
+			},
+		},
+		{
+			Code: `
+				function App() {
+					return <Title dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Title"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Line:      3,
+					Column:    20,
+				},
+			},
+		},
+		{
+			Code: `
+				function App() {
+					return <TextFoo dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"*Foo"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Line:      3,
+					Column:    22,
+				},
+			},
+		},
+		{
+			Code: `
+				function App() {
+					return <FooText dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Foo*"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Line:      3,
+					Column:    22,
+				},
+			},
+		},
+		{
+			Code: `
+				function App() {
+					return <TextMUI dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"*MUI"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Line:      3,
+					Column:    22,
+				},
+			},
+		},
+		{
+			Code: `
+				import type { ComponentProps } from "react";
+
+				const Comp = "div";
+				const Component = () => <></>;
+
+				const NestedComponent = (_props: ComponentProps<"div">) => <></>;
+
+				Component.NestedComponent = NestedComponent;
+
+				function App() {
+					return (
+						<>
+							<div dangerouslySetInnerHTML={{ __html: "<div>aaa</div>" }} />
+							<Comp dangerouslySetInnerHTML={{ __html: "<div>aaa</div>" }} />
+
+							<Component.NestedComponent
+								dangerouslySetInnerHTML={{ __html: '<div>aaa</div>' }} />
+						</>
+					);
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"*"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 14},
+				{MessageId: "dangerousProp", Line: 15},
+				{MessageId: "dangerousProp", Line: 18},
+			},
+		},
+
+		// ---- Additional edge cases ----
+
+		// Boolean-shorthand attribute (no value) on a DOM element — still dangerous by name.
+		{
+			Code: `<div dangerouslySetInnerHTML />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 6},
+			},
+		},
+		// Attribute on its own line — reported at the attribute position, not the tag's.
+		{
+			Code: "<div\n\tdangerouslySetInnerHTML={{ __html: '' }}\n/>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 2, Column: 2},
+			},
+		},
+		// Deeply-nested member tag (<A.B.C />) matched via `*` — the rule
+		// uses raw source text for the tag name, so this works without a
+		// hand-rolled member-expression flattener.
+		{
+			Code: `
+				const A: any = {};
+				A.B = { C: () => null };
+				function App() {
+					return <A.B.C dangerouslySetInnerHTML={{ __html: "" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"*"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 5},
+			},
+		},
+		// Any matching pattern in a multi-pattern list is enough.
+		{
+			Code: `<Widget dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Foo*", "Widget", "Bar*"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 9},
+			},
+		},
+		// Spread attribute co-located with the dangerous prop — rule still fires
+		// on the dangerous prop and leaves the spread alone.
+		{
+			Code: `<div {...props} dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 17},
+			},
+		},
+		// `?` glob wildcard — matches exactly one character per `?`.
+		{
+			Code: `<TextMUI dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Text???"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 10},
+			},
+		},
+		// Literal `.` in the pattern — exact-dot match on a member tag.
+		{
+			Code: `<Foo.Bar dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Foo.Bar"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 10},
+			},
+		},
+		// Generic component `<Foo<T> ...>` — type arguments must not confuse
+		// tag-name extraction.
+		{
+			Code: `
+				function Foo<T>(_: { x: T; dangerouslySetInnerHTML?: unknown }) { return null; }
+				function App() {
+					return <Foo<string> dangerouslySetInnerHTML={{ __html: "" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"Foo"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 4},
+			},
+		},
+		// Full range assertion — EndLine/EndColumn cover the entire attribute node.
+		{
+			Code: `<div dangerouslySetInnerHTML={{ __html: "x" }} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerousProp",
+					Line:      1,
+					Column:    6,
+					EndLine:   1,
+					EndColumn: 47,
+				},
+			},
+		},
+		// JSX namespaced element `<svg:path>` — intrinsic (lowercase start), so DOM.
+		{
+			Code: `<svg:path dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 11},
+			},
+		},
+		// Member tag with LOWERCASE base — `isDOMComponent` tests the first
+		// character of `elementType(node)` only, so `<foo.bar>` classifies as
+		// DOM and the rule fires without any customComponentNames entry.
+		{
+			Code: `
+				const foo: any = {};
+				foo.bar = () => null;
+				function App() {
+					return <foo.bar dangerouslySetInnerHTML={{ __html: "" }} />;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 5},
+			},
+		},
+		// `<this.Foo>` — `elementType` returns `"this.Foo"`, first char is
+		// lowercase → DOM-classified by ESLint's regex. rslint matches.
+		{
+			Code: `
+				class C {
+					render() {
+						return <this._Widget dangerouslySetInnerHTML={{ __html: "" }} />;
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 4},
+			},
+		},
+		// Locks "Differences from ESLint" #1: deep-member tag matched by its
+		// full dotted name. eslint-plugin-react would compute `"undefined.C"`
+		// here and NOT match either of these patterns; we use the source text
+		// (`"A.B.C"`) so both `["A.B.C"]` and `["A.*"]` fire.
+		{
+			Code: `
+				const A: any = {};
+				A.B = { C: () => null };
+				function App() {
+					return <A.B.C dangerouslySetInnerHTML={{ __html: "" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"A.B.C"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 5},
+			},
+		},
+		{
+			Code: `
+				const A: any = {};
+				A.B = { C: () => null };
+				function App() {
+					return <A.B.C dangerouslySetInnerHTML={{ __html: "" }} />;
+				}
+			`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"A.*"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 5},
+			},
+		},
+		// Locks "Differences from ESLint" #2: namespaced tag matched by an
+		// explicit `"ns:name"` pattern. The element is already DOM (lowercase
+		// first char) so it would be reported regardless — the point of this
+		// case is that the custom-pattern branch can also match a namespaced
+		// name, which eslint-plugin-react effectively cannot.
+		{
+			Code: `<svg:path dangerouslySetInnerHTML={{ __html: "" }} />;`,
+			Tsx:  true,
+			Options: map[string]interface{}{
+				"customComponentNames": []interface{}{"svg:path"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerousProp", Line: 1, Column: 11},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -88,6 +88,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
+    './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-danger.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-danger.test.ts
@@ -1,0 +1,317 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-danger', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    { code: `<App />;` },
+    { code: `<App dangerouslySetInnerHTML={{ __html: "" }} />;` },
+    { code: `<div className="bar"></div>;` },
+    {
+      code: `<div className="bar"></div>;`,
+      options: [{ customComponentNames: ['*'] }],
+    },
+    {
+      code: `
+        function App() {
+          return <Title dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['Home'] }],
+    },
+    {
+      code: `
+        function App() {
+          return <TextMUI dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['MUI*'] }],
+    },
+
+    // ---- Additional edge cases ----
+    // Case-sensitive: lowercase 'h' in 'Html' is not the dangerous attribute.
+    { code: `<div dangerouslySetInnerHtml={{ __html: "" }} />;` },
+    // Similar-looking but distinct attribute name.
+    { code: `<div innerHTML="<span />" />;` },
+    // Multiple patterns, none matching the user component.
+    {
+      code: `<Widget dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['Foo*', 'Bar*'] }],
+    },
+    // Empty customComponentNames disables checks on user components.
+    {
+      code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: [] }],
+    },
+    // No options at all is the same as empty customComponentNames.
+    { code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;` },
+    // Fragment has no attributes — nothing to flag.
+    { code: `<React.Fragment></React.Fragment>;` },
+    // Spread without the dangerous prop is fine.
+    { code: `const props: any = {}; <div {...props} />;` },
+    // `?` matches exactly one character — 4-char suffix doesn't match `???`.
+    {
+      code: `<TextMUIx dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['Text???'] }],
+    },
+    // Literal `.` — non-matching dotted name.
+    {
+      code: `<Foo.Bar dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['Foo.Baz'] }],
+    },
+    // UPPERCASE-base member tag is a user component — no pattern, no report.
+    {
+      code: `
+        const Foo: any = {};
+        Foo.Bar = () => null;
+        function App() {
+          return <Foo.Bar dangerouslySetInnerHTML={{ __html: "" }} />;
+        }
+      `,
+    },
+    // Defensive: non-array customComponentNames is ignored silently.
+    {
+      code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: 'MyComponent' }],
+    },
+    // Defensive: non-string entries in the array are skipped.
+    {
+      code: `<MyComponent dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: [42, null, false] }],
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `<div dangerouslySetInnerHTML={{ __html: "" }}></div>;`,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `<App dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;`,
+      options: [{ customComponentNames: ['*'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `
+        function App() {
+          return <Title dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['Title'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `
+        function App() {
+          return <TextFoo dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['*Foo'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `
+        function App() {
+          return <FooText dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['Foo*'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `
+        function App() {
+          return <TextMUI dangerouslySetInnerHTML={{ __html: "<span>hello</span>" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['*MUI'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `
+        const Comp = "div";
+        const Component = () => null;
+        function App() {
+          return (
+            <>
+              <div dangerouslySetInnerHTML={{ __html: "<div>aaa</div>" }} />
+              <Comp dangerouslySetInnerHTML={{ __html: "<div>aaa</div>" }} />
+
+              <Component.NestedComponent
+                dangerouslySetInnerHTML={{ __html: '<div>aaa</div>' }}
+              />
+            </>
+          );
+        }
+      `,
+      options: [{ customComponentNames: ['*'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+
+    // ---- Additional edge cases ----
+
+    // Boolean-shorthand dangerous prop still reports.
+    {
+      code: `<div dangerouslySetInnerHTML />;`,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Attribute on its own line.
+    {
+      code: `<div\n\tdangerouslySetInnerHTML={{ __html: '' }}\n/>;`,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Deeply-nested member tag matched via '*'.
+    {
+      code: `
+        const A: any = {};
+        A.B = { C: () => null };
+        function App() {
+          return <A.B.C dangerouslySetInnerHTML={{ __html: "" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['*'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // One matching pattern is enough in a multi-pattern list.
+    {
+      code: `<Widget dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['Foo*', 'Widget', 'Bar*'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Spread attribute co-located with the dangerous prop — still detects.
+    {
+      code: `const props: any = {}; const x = <div {...props} dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // `?` glob wildcard.
+    {
+      code: `<TextMUI dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['Text???'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Literal `.` — exact-dot match on a member tag.
+    {
+      code: `<Foo.Bar dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['Foo.Bar'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Generic component `<Foo<T> ...>`.
+    {
+      code: `
+        function Foo<T>(_: { x: T; dangerouslySetInnerHTML?: unknown }) { return null; }
+        function App() {
+          return <Foo<string> dangerouslySetInnerHTML={{ __html: "" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['Foo'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // JSX namespaced element `<svg:path>` — intrinsic DOM.
+    {
+      code: `<svg:path dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // LOWERCASE-base member tag `<foo.bar>` — `isDOMComponent` matches on
+    // the first character of elementType, so it's DOM-classified and fires
+    // without customComponentNames.
+    {
+      code: `
+        const foo: any = {};
+        foo.bar = () => null;
+        function App() {
+          return <foo.bar dangerouslySetInnerHTML={{ __html: "" }} />;
+        }
+      `,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // `<this.Foo>` — elementType returns "this.Foo", first char lowercase →
+    // DOM-classified.
+    {
+      code: `
+        class C {
+          render() {
+            return <this._Widget dangerouslySetInnerHTML={{ __html: "" }} />;
+          }
+        }
+      `,
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Locks "Differences from ESLint" #1: deep-member tag matched by its
+    // full dotted name. eslint-plugin-react would compute "undefined.C" and
+    // NOT match here; rslint uses source text so both patterns below fire.
+    {
+      code: `
+        const A: any = {};
+        A.B = { C: () => null };
+        function App() {
+          return <A.B.C dangerouslySetInnerHTML={{ __html: "" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['A.B.C'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    {
+      code: `
+        const A: any = {};
+        A.B = { C: () => null };
+        function App() {
+          return <A.B.C dangerouslySetInnerHTML={{ __html: "" }} />;
+        }
+      `,
+      options: [{ customComponentNames: ['A.*'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+    // Locks "Differences from ESLint" #2: namespaced tag matched by a
+    // literal `"ns:name"` pattern via the customComponentNames branch.
+    {
+      code: `<svg:path dangerouslySetInnerHTML={{ __html: "" }} />;`,
+      options: [{ customComponentNames: ['svg:path'] }],
+      errors: [
+        { message: "Dangerous property 'dangerouslySetInnerHTML' found" },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -94,6 +94,7 @@ lsproto
 marginx
 marginy
 Metas
+minimatch
 morestack
 multilines
 myfunc


### PR DESCRIPTION
## Summary

Port the `react/no-danger` rule from `eslint-plugin-react` to rslint.

The rule flags dangerous JSX properties (currently just `dangerouslySetInnerHTML`) on DOM elements and — when opted in via `customComponentNames` — on user components matching glob patterns.

### Implementation notes

- Reuses existing helpers: `utils.GetOptionsMap`, `utils.TrimNodeTextRange`, `reactutil.GetJsxPropName` / `GetJsxParentElement` / `GetJsxTagName` / `IsDOMComponent`.
- Uses `path.Match` from the Go stdlib as a minimatch-equivalent for the simple glob patterns this rule's `customComponentNames` option accepts in practice.

### `reactutil.IsDOMComponent` alignment fix

The shared helper previously treated all member-expression tags (`<foo.bar>`, `<Foo.Bar>`, `<this.Foo>`) as user components by short-circuiting on `strings.Contains(text, ".")`. This diverged from ESLint's `jsxUtil.isDOMComponent`, which tests `/^[a-z]/` against the full `elementType(node)` string. Updated to walk member expressions down to the leftmost base identifier and classify by its first character. Verified by actually running `eslint@^8` + `eslint-plugin-react` against:

- `<foo.bar dangerouslySetInnerHTML={...} />` → ESLint fires → now matches
- `<Foo.Bar dangerouslySetInnerHTML={...} />` → ESLint silent → still matches
- `<this._Widget dangerouslySetInnerHTML={...} />` → ESLint fires → now matches
- `<foo.Bar onClick={() => 1} />` with `jsx-no-bind { ignoreDOMComponents: true }` → ESLint silent → now matches

The one `jsx_no_bind` test that locked in the old divergence was flipped to a valid case (comment updated).

### Intentional divergences from upstream

Two edge cases where rslint is strictly more correct than `eslint-plugin-react`. Verified by running real ESLint; both documented in `no_danger.md` and locked by dedicated tests.

1. **Deep member tag names** — `<A.B.C dangerouslySetInnerHTML={...} />` with `customComponentNames: ['A.B.C']` or `['A.*']`. ESLint's ` `${nodeName.object.name}.${nodeName.property.name}` ` only flattens one level, producing `"undefined.C"` and silently failing to match. rslint uses the raw source text (`"A.B.C"`) so patterns match as users expect.
2. **JSX namespaced tag names in `customComponentNames`** — `<svg:path>` with `customComponentNames: ['svg:path']`. ESLint passes an Identifier AST node into `minimatch` and throws `f.split is not a function` at runtime. rslint uses the string `"ns:name"`.

### Real-world verification

Built the package and ran the resulting binary against two sibling repos:

- `web-infra-dev/rsbuild` (29 website files): 0 diagnostics — matches grep ground truth (no `dangerouslySetInnerHTML` in source).
- `web-infra-dev/rspack` (29 website files + 1 fixture): 2 diagnostics, both hand-verified line-and-column:
  - `website/components/Mermaid.tsx:55:16` — `<div dangerouslySetInnerHTML={{ __html: svg }} />` (DOM)
  - `tests/rspack-test/configCases/parsing/jsx-enabled/index.jsx:97:11` — `<text-block dangerouslySetInnerHTML={...} />` (custom element, lowercase-start → DOM per ESLint regex; confirmed with real ESLint)

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-danger.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).