### PR TITLE
feat: port rule react/button-has-type

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -1,6 +1,7 @@
 package react_plugin
 
 import (
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/button_has_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_boolean_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_closing_tag_location"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_equals_spacing"
@@ -22,6 +23,7 @@ import (
 
 func GetAllRules() []rule.Rule {
 	return []rule.Rule{
+		button_has_type.ButtonHasTypeRule,
 		jsx_boolean_value.JsxBooleanValueRule,
 		jsx_closing_tag_location.JsxClosingTagLocationRule,
 		jsx_equals_spacing.JsxEqualsSpacingRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -6,11 +6,42 @@ import (
 	"github.com/microsoft/typescript-go/shim/ast"
 )
 
-// IsCreateElementCall checks if the callee is React.createElement.
-func IsCreateElementCall(callee *ast.Node) bool {
+// DefaultReactPragma is the fallback object name for createElement calls
+// when `settings.react.pragma` is not configured, matching eslint-plugin-react.
+const DefaultReactPragma = "React"
+
+// GetReactPragma reads `settings.react.pragma` from the config settings map.
+// Returns DefaultReactPragma when the setting is absent, not a string, or empty.
+func GetReactPragma(settings map[string]interface{}) string {
+	if settings == nil {
+		return DefaultReactPragma
+	}
+	reactSettings, ok := settings["react"].(map[string]interface{})
+	if !ok {
+		return DefaultReactPragma
+	}
+	pragma, ok := reactSettings["pragma"].(string)
+	if !ok || pragma == "" {
+		return DefaultReactPragma
+	}
+	return pragma
+}
+
+// IsCreateElementCall reports whether the callee is `<pragma>.createElement`.
+// Pass an empty pragma to default to "React"; pass GetReactPragma(ctx.Settings)
+// to honor the user's `settings.react.pragma` configuration.
+//
+// Parentheses are transparently skipped on both the callee itself and the
+// pragma identifier (e.g. `(React).createElement` / `(React.createElement)()`),
+// matching ESTree's flattened shape.
+func IsCreateElementCall(callee *ast.Node, pragma string) bool {
 	if callee == nil {
 		return false
 	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	callee = ast.SkipParentheses(callee)
 	if callee.Kind != ast.KindPropertyAccessExpression {
 		return false
 	}
@@ -19,7 +50,8 @@ func IsCreateElementCall(callee *ast.Node) bool {
 	if nameNode.Kind != ast.KindIdentifier || nameNode.AsIdentifier().Text != "createElement" {
 		return false
 	}
-	if prop.Expression.Kind != ast.KindIdentifier || prop.Expression.AsIdentifier().Text != "React" {
+	pragmaExpr := ast.SkipParentheses(prop.Expression)
+	if pragmaExpr.Kind != ast.KindIdentifier || pragmaExpr.AsIdentifier().Text != pragma {
 		return false
 	}
 	return true

--- a/internal/plugins/react/rules/button_has_type/button_has_type.go
+++ b/internal/plugins/react/rules/button_has_type/button_has_type.go
@@ -1,0 +1,217 @@
+package button_has_type
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type buttonHasTypeOptions struct {
+	button bool
+	submit bool
+	reset  bool
+}
+
+func parseOptions(opts any) buttonHasTypeOptions {
+	cfg := buttonHasTypeOptions{button: true, submit: true, reset: true}
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap == nil {
+		return cfg
+	}
+	if v, ok := optsMap["button"]; ok {
+		if b, ok := v.(bool); ok {
+			cfg.button = b
+		}
+	}
+	if v, ok := optsMap["submit"]; ok {
+		if b, ok := v.(bool); ok {
+			cfg.submit = b
+		}
+	}
+	if v, ok := optsMap["reset"]; ok {
+		if b, ok := v.(bool); ok {
+			cfg.reset = b
+		}
+	}
+	return cfg
+}
+
+var ButtonHasTypeRule = rule.Rule{
+	Name: "react/button-has-type",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		cfg := parseOptions(options)
+
+		reportMissing := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "missingType",
+				Description: "Missing an explicit type attribute for button",
+			})
+		}
+		reportComplex := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "complexType",
+				Description: "The button type attribute must be specified by a static string or a trivial ternary expression",
+			})
+		}
+		checkValue := func(reportOn *ast.Node, value string) {
+			allowed, known := false, false
+			switch value {
+			case "button":
+				allowed, known = cfg.button, true
+			case "submit":
+				allowed, known = cfg.submit, true
+			case "reset":
+				allowed, known = cfg.reset, true
+			}
+			if !known {
+				ctx.ReportNode(reportOn, rule.RuleMessage{
+					Id:          "invalidValue",
+					Description: `"` + value + `" is an invalid value for button type attribute`,
+				})
+			} else if !allowed {
+				ctx.ReportNode(reportOn, rule.RuleMessage{
+					Id:          "forbiddenValue",
+					Description: `"` + value + `" is an invalid value for button type attribute`,
+				})
+			}
+		}
+
+		var checkExpression func(reportOn *ast.Node, expr *ast.Node)
+		checkExpression = func(reportOn *ast.Node, expr *ast.Node) {
+			if expr == nil {
+				reportComplex(reportOn)
+				return
+			}
+			inner := ast.SkipParentheses(expr)
+			if val, ok := utils.GetStaticExpressionValue(inner); ok {
+				checkValue(reportOn, val)
+				return
+			}
+			switch inner.Kind {
+			case ast.KindTrueKeyword:
+				checkValue(reportOn, "true")
+			case ast.KindFalseKeyword:
+				checkValue(reportOn, "false")
+			case ast.KindNullKeyword:
+				checkValue(reportOn, "null")
+			case ast.KindBigIntLiteral:
+				checkValue(reportOn, utils.NormalizeBigIntLiteral(inner.AsBigIntLiteral().Text))
+			case ast.KindConditionalExpression:
+				cond := inner.AsConditionalExpression()
+				checkExpression(reportOn, cond.WhenTrue)
+				checkExpression(reportOn, cond.WhenFalse)
+			default:
+				reportComplex(inner)
+			}
+		}
+
+		checkJsxButton := func(reportOn *ast.Node, tagName *ast.Node, attributes *ast.Node) {
+			if tagName == nil || tagName.Kind != ast.KindIdentifier || tagName.AsIdentifier().Text != "button" {
+				return
+			}
+			typeAttr := findJsxTypeAttribute(attributes)
+			if typeAttr == nil {
+				reportMissing(reportOn)
+				return
+			}
+			initializer := typeAttr.AsJsxAttribute().Initializer
+			if initializer == nil {
+				checkValue(reportOn, "true")
+				return
+			}
+			if initializer.Kind == ast.KindJsxExpression {
+				expr := initializer.AsJsxExpression().Expression
+				checkExpression(reportOn, expr)
+				return
+			}
+			if initializer.Kind == ast.KindStringLiteral {
+				checkValue(reportOn, initializer.AsStringLiteral().Text)
+				return
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement: func(node *ast.Node) {
+				parent := node.Parent
+				if parent == nil || parent.Kind != ast.KindJsxElement {
+					return
+				}
+				opening := node.AsJsxOpeningElement()
+				checkJsxButton(parent, opening.TagName, opening.Attributes)
+			},
+			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
+				self := node.AsJsxSelfClosingElement()
+				checkJsxButton(node, self.TagName, self.Attributes)
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !reactutil.IsCreateElementCall(call.Expression, reactutil.GetReactPragma(ctx.Settings)) {
+					return
+				}
+				if call.Arguments == nil || len(call.Arguments.Nodes) < 1 {
+					return
+				}
+				firstArg := ast.SkipParentheses(call.Arguments.Nodes[0])
+				if firstArg.Kind != ast.KindStringLiteral || firstArg.AsStringLiteral().Text != "button" {
+					return
+				}
+				if len(call.Arguments.Nodes) < 2 {
+					reportMissing(node)
+					return
+				}
+				secondArg := ast.SkipParentheses(call.Arguments.Nodes[1])
+				if secondArg.Kind != ast.KindObjectLiteralExpression {
+					reportMissing(node)
+					return
+				}
+				obj := secondArg.AsObjectLiteralExpression()
+				typeProp, typeValue := findObjectTypeProperty(obj)
+				if typeProp == nil {
+					reportMissing(node)
+					return
+				}
+				checkExpression(node, typeValue)
+			},
+		}
+	},
+}
+
+func findJsxTypeAttribute(attributes *ast.Node) *ast.Node {
+	if attributes == nil {
+		return nil
+	}
+	attrs := attributes.AsJsxAttributes()
+	if attrs.Properties == nil {
+		return nil
+	}
+	for _, prop := range attrs.Properties.Nodes {
+		if prop.Kind == ast.KindJsxAttribute && reactutil.GetJsxPropName(prop) == "type" {
+			return prop
+		}
+	}
+	return nil
+}
+
+func findObjectTypeProperty(obj *ast.ObjectLiteralExpression) (*ast.Node, *ast.Node) {
+	if obj == nil || obj.Properties == nil {
+		return nil, nil
+	}
+	for _, prop := range obj.Properties.Nodes {
+		switch prop.Kind {
+		case ast.KindPropertyAssignment:
+			pa := prop.AsPropertyAssignment()
+			name := pa.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "type" {
+				return prop, pa.Initializer
+			}
+		case ast.KindShorthandPropertyAssignment:
+			sa := prop.AsShorthandPropertyAssignment()
+			name := sa.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "type" {
+				return prop, name
+			}
+		}
+	}
+	return nil, nil
+}

--- a/internal/plugins/react/rules/button_has_type/button_has_type.md
+++ b/internal/plugins/react/rules/button_has_type/button_has_type.md
@@ -1,0 +1,74 @@
+# react/button-has-type
+
+## Rule Details
+
+Forbid `<button>` elements (and `React.createElement('button', ...)` calls) without an explicit `type` attribute. The default DOM `type` for a `button` is `"submit"`, which — when used inside a `<form>` — unexpectedly submits the form. Always specify one of `"button"`, `"submit"`, or `"reset"`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<button />
+<button type="foo" />
+<button type={foo} />
+<button type={`button${foo}`} />
+<button type={condition ? foo : "button"} />
+
+React.createElement("button")
+React.createElement("button", { type: foo })
+React.createElement("button", { type: "foo" })
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<button type="button" />
+<button type="submit" />
+<button type="reset" />
+<button type={"button"} />
+<button type={`button`} />
+<button type={condition ? "button" : "submit"} />
+
+React.createElement("button", { type: "button" })
+React.createElement("button", { type: "submit" })
+React.createElement("button", { type: "reset" })
+```
+
+## Options
+
+The rule takes one optional argument — an object that lets you forbid specific button types. Defaults:
+
+```json
+{
+  "button": true,
+  "submit": true,
+  "reset": true
+}
+```
+
+Setting one of these flags to `false` makes that type value forbidden. For example, with `{ "reset": false }`:
+
+```json
+{ "react/button-has-type": ["error", { "reset": false }] }
+```
+
+Examples of **incorrect** code with this configuration:
+
+```jsx
+<button type="reset" />
+<button type={condition ? "reset" : "button"} />
+```
+
+Examples of **correct** code with this configuration:
+
+```jsx
+<button type="button" />
+<button type="submit" />
+```
+
+## Limitations
+
+- Detects `<pragma>.createElement(...)` where `<pragma>` defaults to `React` and can be overridden via `settings.react.pragma` (e.g. `"Foo"` → `Foo.createElement(...)`). Destructured `createElement` (e.g. `import { createElement } from 'react'`) and `@jsx` comment pragmas are not supported.
+
+## Original Documentation
+
+- [react/button-has-type](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md)

--- a/internal/plugins/react/rules/button_has_type/button_has_type_test.go
+++ b/internal/plugins/react/rules/button_has_type/button_has_type_test.go
@@ -1,0 +1,649 @@
+package button_has_type
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestButtonHasTypeRule(t *testing.T) {
+	resetFalse := map[string]interface{}{"reset": false}
+	pragmaFoo := map[string]interface{}{
+		"react": map[string]interface{}{"pragma": "Foo"},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &ButtonHasTypeRule, []rule_tester.ValidTestCase{
+		// ---- JSX ----
+		{Code: `var x = <span/>`, Tsx: true},
+		{Code: `var x = <span type="foo"/>`, Tsx: true},
+		{Code: `var x = <button type="button"/>`, Tsx: true},
+		{Code: `var x = <button type="submit"/>`, Tsx: true},
+		{Code: `var x = <button type="reset"/>`, Tsx: true},
+		{Code: `var x = <button type={"button"}/>`, Tsx: true},
+		{Code: `var x = <button type={'button'}/>`, Tsx: true},
+		{Code: "var x = <button type={`button`}/>", Tsx: true},
+		{Code: `var x = <button type={condition ? "button" : "submit"}/>`, Tsx: true},
+		{Code: `var x = <button type={condition ? 'button' : 'submit'}/>`, Tsx: true},
+		{Code: "var x = <button type={condition ? `button` : `submit`}/>", Tsx: true},
+		{
+			Code:    `var x = <button type="button"/>`,
+			Options: resetFalse,
+			Tsx:     true,
+		},
+		// Paren-wrapped expressions (rslint edge case)
+		{Code: `var x = <button type={("button")}/>`, Tsx: true},
+		{Code: `var x = <button type={(condition ? "button" : "submit")}/>`, Tsx: true},
+		{Code: `var x = <button type={((("button")))}/>`, Tsx: true},
+		// Nested ternary
+		{Code: `var x = <button type={a ? "button" : b ? "submit" : "reset"}/>`, Tsx: true},
+		// Button with children
+		{Code: `var x = <button type="button">Click</button>`, Tsx: true},
+		{Code: `var x = <button type="button"><span>hi</span></button>`, Tsx: true},
+		// Spread after explicit type — type wins
+		{Code: `var x = <button type="button" {...props}/>`, Tsx: true},
+		{Code: `var x = <button {...props} type="button"/>`, Tsx: true},
+		// Not a button tag
+		{Code: `var x = <Button/>`, Tsx: true},
+		{Code: `var x = <Button.Primary/>`, Tsx: true},
+		{Code: `var x = <div/>`, Tsx: true},
+		{Code: `var x = <input/>`, Tsx: true},
+		{Code: `var x = <button-like type="foo"/>`, Tsx: true},
+		// Namespaced attr "ns:type" is not "type"
+		{Code: `var x = <button ns:type="foo" type="button"/>`, Tsx: true},
+		// Fragment / array of buttons
+		{Code: `var x = <>{[<button key="a" type="button"/>, <button key="b" type="submit"/>]}</>`, Tsx: true},
+
+		// ---- React.createElement ----
+		{Code: `React.createElement("span")`, Tsx: true},
+		{Code: `React.createElement("span", {type: "foo"})`, Tsx: true},
+		{Code: `React.createElement("button", {type: "button"})`, Tsx: true},
+		{Code: `React.createElement("button", {type: 'button'})`, Tsx: true},
+		{Code: "React.createElement(\"button\", {type: `button`})", Tsx: true},
+		{Code: `React.createElement("button", {type: "submit"})`, Tsx: true},
+		{Code: `React.createElement("button", {type: 'submit'})`, Tsx: true},
+		{Code: "React.createElement(\"button\", {type: `submit`})", Tsx: true},
+		{Code: `React.createElement("button", {type: "reset"})`, Tsx: true},
+		{Code: `React.createElement("button", {type: 'reset'})`, Tsx: true},
+		{Code: "React.createElement(\"button\", {type: `reset`})", Tsx: true},
+		{Code: `React.createElement("button", {type: condition ? "button" : "submit"})`, Tsx: true},
+		{Code: `React.createElement("button", {type: condition ? 'button' : 'submit'})`, Tsx: true},
+		{Code: "React.createElement(\"button\", {type: condition ? `button` : `submit`})", Tsx: true},
+		{
+			Code:    `React.createElement("button", {type: "button"})`,
+			Options: resetFalse,
+			Tsx:     true,
+		},
+		// Non-React createElement
+		{Code: `document.createElement("button")`, Tsx: true},
+		// createElement where first arg isn't "button"
+		{Code: `React.createElement("div", {})`, Tsx: true},
+		{Code: `React.createElement(Component, {type: "foo"})`, Tsx: true},
+		// createElement first arg is template literal without substitutions — not a StringLiteral,
+		// so rslint does not treat it as "button" (matches ESLint, which requires Literal with string).
+		{Code: "React.createElement(`button`, {type: \"button\"})", Tsx: true},
+		// Empty args
+		{Code: `React.createElement()`, Tsx: true},
+		// Spread type prop — type found statically
+		{Code: `React.createElement("button", {...extraProps, type: "button"})`, Tsx: true},
+		// Paren-wrapped callee / args — ESTree-flattening parity
+		{Code: `(React).createElement("button", {type: "button"})`, Tsx: true},
+		{Code: `(React.createElement)("button", {type: "button"})`, Tsx: true},
+		{Code: `React.createElement(("button"), {type: "button"})`, Tsx: true},
+		{Code: `React.createElement("button", ({type: "button"}))`, Tsx: true},
+		{Code: `((React).createElement)(("button"), ({type: "button"}))`, Tsx: true},
+		// Foo.createElement without pragma — not recognized, so no report.
+		{Code: `Foo.createElement("span")`, Tsx: true},
+		{Code: `Foo.createElement("button")`, Tsx: true},
+		// With pragma: "Foo" — first arg isn't "button" so nothing to check.
+		{
+			Code:     `Foo.createElement("span")`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+		},
+		// With pragma: "Foo" — Foo.createElement("button", …) with valid type.
+		{
+			Code:     `Foo.createElement("button", {type: "button"})`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+		},
+		// With pragma: "Foo" — default React.createElement(…) is no longer recognized.
+		{
+			Code:     `React.createElement("button")`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+		},
+		// Spread at JSX side: we don't inspect spread values
+		{Code: `var x = <button type="button" {...props}/>`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- JSX: missing (self-closing, position with End*) ----
+		{
+			Code: `var x = <button/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingType",
+					Line:      1, Column: 9,
+					EndLine: 1, EndColumn: 18,
+				},
+			},
+		},
+		// ---- JSX: missing with children (JsxElement span with End*) ----
+		{
+			Code: `var x = <button>Click</button>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingType",
+					Line:      1, Column: 9,
+					EndLine: 1, EndColumn: 31,
+				},
+			},
+		},
+		// ---- JSX: missing, multi-line with children ----
+		{
+			Code: "var x = (\n\t\t\t\t<button>\n\t\t\t\t\tClick\n\t\t\t\t</button>\n\t\t\t)",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingType",
+					Line:      2, Column: 5,
+					EndLine: 4, EndColumn: 14,
+				},
+			},
+		},
+		// ---- JSX: invalid literal value ----
+		{
+			Code: `var x = <button type="foo"/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"foo" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		// ---- JSX: complex identifier expression ----
+		{
+			Code: `var x = <button type={foo}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "complexType",
+					Message:   "The button type attribute must be specified by a static string or a trivial ternary expression",
+					Line:      1, Column: 23,
+				},
+			},
+		},
+		{
+			Code: `var x = <button type={"foo"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code: `var x = <button type={'foo'}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code: "var x = <button type={`foo`}/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		// ---- JSX: template with substitution ----
+		{
+			Code: "var x = <button type={`button${foo}`}/>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		// ---- JSX: forbidden value ----
+		{
+			Code:    `var x = <button type="reset"/>`,
+			Options: resetFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "forbiddenValue",
+					Message:   `"reset" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		// ---- JSX: conditional expression ----
+		{
+			Code: `var x = <button type={condition ? "button" : foo}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 46},
+			},
+		},
+		{
+			Code: `var x = <button type={condition ? "button" : "foo"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code:    `var x = <button type={condition ? "button" : "reset"}/>`,
+			Options: resetFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenValue", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code: `var x = <button type={condition ? foo : "button"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 35},
+			},
+		},
+		{
+			Code: `var x = <button type={condition ? "foo" : "button"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		// ---- JSX: valueless attribute ----
+		{
+			Code: `var x = <button type/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"true" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		{
+			Code:    `var x = <button type={condition ? "reset" : "button"}/>`,
+			Options: resetFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenValue", Line: 1, Column: 9},
+			},
+		},
+		// ---- React.createElement (positions with End*) ----
+		{
+			Code: `React.createElement("button")`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingType",
+					Line:      1, Column: 1,
+					EndLine: 1, EndColumn: 30,
+				},
+			},
+		},
+		{
+			Code: `React.createElement("button", {type: foo})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "complexType",
+					Line:      1, Column: 38,
+					EndLine: 1, EndColumn: 41,
+				},
+			},
+		},
+		{
+			Code: `React.createElement("button", {type: "foo"})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"foo" is an invalid value for button type attribute`,
+					Line:      1, Column: 1,
+				},
+			},
+		},
+		{
+			Code:    `React.createElement("button", {type: "reset"})`,
+			Options: resetFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenValue", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("button", {type: condition ? "button" : foo})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 61},
+			},
+		},
+		{
+			Code: `React.createElement("button", {type: condition ? "button" : "foo"})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `React.createElement("button", {type: condition ? "button" : "reset"})`,
+			Options: resetFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenValue", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("button", {type: condition ? foo : "button"})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 50},
+			},
+		},
+		{
+			Code: `React.createElement("button", {type: condition ? "foo" : "button"})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `React.createElement("button", {type: condition ? "reset" : "button"})`,
+			Options: resetFalse,
+			Tsx:     true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "forbiddenValue", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("button", {...extraProps})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		// With pragma: "Foo" — Foo.createElement("button") reports missingType (upstream parity).
+		{
+			Code:     `Foo.createElement("button")`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:     `Foo.createElement("button", {type: "foo"})`,
+			Settings: pragmaFoo,
+			Tsx:      true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"foo" is an invalid value for button type attribute`,
+					Line:      1, Column: 1,
+				},
+			},
+		},
+		{
+			Code: `function Button({ type, ...extraProps }) { const button = type; return <button type={button} {...extraProps} />; }`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 86},
+			},
+		},
+		// ---- Multi-line ----
+		{
+			Code: `var x = (
+				<button
+					type={foo}
+				/>
+			)`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 3, Column: 12},
+			},
+		},
+		// ---- Numeric / boolean / null literal values (not string type values) ----
+		{
+			Code: `var x = <button type={0}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"0" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		{
+			// Numeric normalization: ESLint's String(0x1) === "1"
+			Code: `var x = <button type={0x1}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"1" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		{
+			Code: `var x = <button type={true}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"true" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		{
+			Code: `var x = <button type={null}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		// ---- JSX spread — no explicit type ----
+		{
+			Code: `var x = <button {...props}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 9},
+			},
+		},
+		{
+			Code: `var x = <button {...props} type/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"true" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		// ---- LogicalOr fallback — complex ----
+		{
+			Code: `var x = <button type={foo || "button"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		// ---- Nested ternary, inner alternate invalid ----
+		{
+			Code: `var x = <button type={a ? "button" : b ? "submit" : "foo"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"foo" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		// ---- Multiple reports: ternary with both sides invalid ----
+		{
+			Code: `var x = <button type={a ? "foo" : "bar"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		// ---- Duplicate type attribute: first wins (rslint matches ESLint's jsx-ast-utils getProp) ----
+		{
+			Code: `var x = <button type="foo" type="button"/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidValue", Line: 1, Column: 9},
+			},
+		},
+		// ---- Shorthand object property ----
+		{
+			Code: `React.createElement("button", {type})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 32},
+			},
+		},
+		// ---- createElement with template literal substitution ----
+		{
+			Code: "React.createElement(\"button\", {type: `button${foo}`})",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 38},
+			},
+		},
+		// ---- Complex expression types → complexType ----
+		{
+			Code: `var x = <button type={getType()}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code: `var x = <button type={obj.type}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code: `var x = <button type={arr[0]}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		// ---- TS assertions / non-null / satisfies → complexType (matches ESLint with @typescript-eslint-parser) ----
+		{
+			Code: `var x = <button type={foo as "button"}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code: `var x = <button type={foo!}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		{
+			Code: `var x = <button type={"button" satisfies string}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "complexType", Line: 1, Column: 23},
+			},
+		},
+		// ---- BigInt literal value — normalized to decimal ----
+		{
+			Code: `var x = <button type={1n}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"1" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		// ---- Regex literal value ----
+		{
+			Code: `var x = <button type={/foo/}/>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"/foo/" is an invalid value for button type attribute`,
+					Line:      1, Column: 9,
+				},
+			},
+		},
+		// ---- createElement with non-object second argument → missingType ----
+		{
+			Code: `React.createElement("button", null)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("button", "foo")`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("button", undefined)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		// ---- Paren-wrapped callee / args — ESTree-flattening parity ----
+		{
+			Code: `(React).createElement("button")`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `(React.createElement)("button")`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement(("button"))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingType", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("button", ({type: "foo"}))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidValue",
+					Message:   `"foo" is an invalid value for button type attribute`,
+					Line:      1, Column: 1,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/style_prop_object/style_prop_object.go
+++ b/internal/plugins/react/rules/style_prop_object/style_prop_object.go
@@ -108,14 +108,12 @@ var StylePropObjectRule = rule.Rule{
 				}
 			},
 
-			// Handle React.createElement('div', { style: ... })
-			// NOTE: Only hardcodes "React.createElement". ESLint also supports:
-			// - Custom pragma via settings.react.pragma or @jsx comment (e.g. Preact.h)
-			// - Destructured createElement (e.g. import { createElement } from 'react')
-			// These are not supported here as rslint does not have pragma configuration infrastructure.
+			// Handle <pragma>.createElement('div', { style: ... })
+			// NOTE: Destructured createElement (e.g. import { createElement } from 'react')
+			// and @jsx comment pragmas are not supported.
 			ast.KindCallExpression: func(node *ast.Node) {
 				call := node.AsCallExpression()
-				if !reactutil.IsCreateElementCall(call.Expression) {
+				if !reactutil.IsCreateElementCall(call.Expression, reactutil.GetReactPragma(ctx.Settings)) {
 					return
 				}
 				args := call.Arguments

--- a/internal/plugins/react/rules/style_prop_object/style_prop_object.md
+++ b/internal/plugins/react/rules/style_prop_object/style_prop_object.md
@@ -24,7 +24,7 @@ Examples of **correct** code for this rule:
 
 ## Limitations
 
-- Only detects `React.createElement(...)` calls. Destructured `createElement` (e.g. `import { createElement } from 'react'`) and custom pragma (e.g. `Preact.h`) are not supported.
+- Detects `<pragma>.createElement(...)` where `<pragma>` defaults to `React` and can be overridden via `settings.react.pragma`. Destructured `createElement` (e.g. `import { createElement } from 'react'`) and `@jsx` comment pragmas are not supported.
 
 ## Original Documentation
 

--- a/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.go
+++ b/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.go
@@ -35,7 +35,7 @@ var VoidDomElementsNoChildrenRule = rule.Rule{
 		return rule.RuleListeners{
 			ast.KindCallExpression: func(node *ast.Node) {
 				call := node.AsCallExpression()
-				if !reactutil.IsCreateElementCall(call.Expression) {
+				if !reactutil.IsCreateElementCall(call.Expression, reactutil.GetReactPragma(ctx.Settings)) {
 					return
 				}
 				args := call.Arguments

--- a/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.md
+++ b/internal/plugins/react/rules/void_dom_elements_no_children/void_dom_elements_no_children.md
@@ -24,7 +24,7 @@ Examples of **correct** code for this rule:
 
 ## Limitations
 
-- Only detects `React.createElement(...)` calls. Destructured `createElement` (e.g. `import { createElement } from 'react'`) and custom pragma (e.g. `Preact.h`) are not supported.
+- Detects `<pragma>.createElement(...)` where `<pragma>` defaults to `React` and can be overridden via `settings.react.pragma`. Destructured `createElement` (e.g. `import { createElement } from 'react'`) and `@jsx` comment pragmas are not supported.
 
 ## Original Documentation
 

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -76,6 +76,7 @@ export default defineConfig({
     './tests/eslint-plugin-import/rules/no-webpack-loader-syntax.test.ts',
 
     // eslint-plugin-react
+    './tests/eslint-plugin-react/rules/button-has-type.test.ts',
     './tests/eslint-plugin-react/rules/self-closing-comp.test.ts',
     './tests/eslint-plugin-react/rules/void-dom-elements-no-children.test.ts',
     './tests/eslint-plugin-react/rules/style-prop-object.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/button-has-type.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/button-has-type.test.ts
@@ -1,0 +1,251 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('button-has-type', {} as never, {
+  valid: [
+    { code: `<span/>` },
+    { code: `<span type="foo"/>` },
+    { code: `<button type="button"/>` },
+    { code: `<button type="submit"/>` },
+    { code: `<button type="reset"/>` },
+    { code: `<button type={"button"}/>` },
+    { code: `<button type={'button'}/>` },
+    { code: '<button type={`button`}/>' },
+    { code: `<button type={condition ? "button" : "submit"}/>` },
+    { code: `<button type={condition ? 'button' : 'submit'}/>` },
+    { code: '<button type={condition ? `button` : `submit`}/>' },
+    { code: `<button type="button"/>`, options: [{ reset: false }] },
+    { code: `React.createElement("span")` },
+    { code: `React.createElement("span", {type: "foo"})` },
+    { code: `React.createElement("button", {type: "button"})` },
+    { code: `React.createElement("button", {type: 'button'})` },
+    { code: 'React.createElement("button", {type: `button`})' },
+    { code: `React.createElement("button", {type: "submit"})` },
+    { code: `React.createElement("button", {type: "reset"})` },
+    {
+      code: `React.createElement("button", {type: condition ? "button" : "submit"})`,
+    },
+    {
+      code: `React.createElement("button", {type: "button"})`,
+      options: [{ reset: false }],
+    },
+    { code: `document.createElement("button")` },
+    // Paren-wrapped expression
+    { code: `<button type={("button")}/>` },
+    // Nested ternary
+    { code: `<button type={a ? "button" : b ? "submit" : "reset"}/>` },
+    // Button with children
+    { code: `<button type="button">Click</button>` },
+    // Spread mixed with valid type (order doesn't matter for our detection)
+    { code: `<button type="button" {...props}/>` },
+    { code: `<button {...props} type="button"/>` },
+    // Not a button
+    { code: `<Button/>` },
+    { code: `<div/>` },
+    // createElement first arg is Component, not "button"
+    { code: `React.createElement(Component, {type: "foo"})` },
+    // Spread before explicit type prop
+    { code: `React.createElement("button", {...extraProps, type: "button"})` },
+    // Paren-wrapped callee / args — ESTree-flattening parity
+    { code: `(React).createElement("button", {type: "button"})` },
+    { code: `(React.createElement)("button", {type: "button"})` },
+    { code: `React.createElement(("button"), {type: "button"})` },
+    { code: `React.createElement("button", ({type: "button"}))` },
+  ],
+  invalid: [
+    {
+      code: `<button/>`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    {
+      code: `<button type="foo"/>`,
+      errors: [
+        {
+          messageId: 'invalidValue',
+          message: `"foo" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+    {
+      code: `<button type={foo}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `<button type={"foo"}/>`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: '<button type={`foo`}/>',
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: '<button type={`button${foo}`}/>',
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `<button type="reset"/>`,
+      options: [{ reset: false }],
+      errors: [
+        {
+          messageId: 'forbiddenValue',
+          message: `"reset" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+    {
+      code: `<button type={condition ? "button" : foo}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `<button type={condition ? "button" : "foo"}/>`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `<button type={condition ? "button" : "reset"}/>`,
+      options: [{ reset: false }],
+      errors: [{ messageId: 'forbiddenValue' }],
+    },
+    {
+      code: `<button type={condition ? foo : "button"}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `<button type={condition ? "foo" : "button"}/>`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `<button type/>`,
+      errors: [
+        {
+          messageId: 'invalidValue',
+          message: `"true" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+    {
+      code: `React.createElement("button")`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    {
+      code: `React.createElement("button", {type: foo})`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `React.createElement("button", {type: "foo"})`,
+      errors: [{ messageId: 'invalidValue' }],
+    },
+    {
+      code: `React.createElement("button", {type: "reset"})`,
+      options: [{ reset: false }],
+      errors: [{ messageId: 'forbiddenValue' }],
+    },
+    {
+      code: `React.createElement("button", {type: condition ? "button" : foo})`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `React.createElement("button", {...extraProps})`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    // Numeric value — normalized like ESLint's String(0x1) === "1"
+    {
+      code: `<button type={0x1}/>`,
+      errors: [
+        {
+          messageId: 'invalidValue',
+          message: `"1" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+    // Boolean value expression
+    {
+      code: `<button type={true}/>`,
+      errors: [
+        {
+          messageId: 'invalidValue',
+          message: `"true" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+    // Spread without type
+    {
+      code: `<button {...props}/>`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    // LogicalOr — complex expression
+    {
+      code: `<button type={foo || "button"}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    // Shorthand object key { type } — value is Identifier → complex
+    {
+      code: `React.createElement("button", {type})`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    // Ternary with both sides invalid — expect two reports
+    {
+      code: `<button type={a ? "foo" : "bar"}/>`,
+      errors: [{ messageId: 'invalidValue' }, { messageId: 'invalidValue' }],
+    },
+    // Complex expression types
+    {
+      code: `<button type={getType()}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `<button type={obj.type}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    {
+      code: `<button type={arr[0]}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    // TS `as` assertion — not unwrapped → complex
+    {
+      code: `<button type={foo as "button"}/>`,
+      errors: [{ messageId: 'complexType' }],
+    },
+    // createElement with non-object second argument → missingType
+    {
+      code: `React.createElement("button", null)`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    {
+      code: `React.createElement("button", "foo")`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    // BigInt literal — decimal-normalized
+    {
+      code: `<button type={1n}/>`,
+      errors: [
+        {
+          messageId: 'invalidValue',
+          message: `"1" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+    // Paren-wrapped callee / args — ESTree-flattening parity
+    {
+      code: `(React).createElement("button")`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    {
+      code: `(React.createElement)("button")`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    {
+      code: `React.createElement(("button"))`,
+      errors: [{ messageId: 'missingType' }],
+    },
+    {
+      code: `React.createElement("button", ({type: "foo"}))`,
+      errors: [
+        {
+          messageId: 'invalidValue',
+          message: `"foo" is an invalid value for button type attribute`,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the [`react/button-has-type`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md) rule from `eslint-plugin-react` to rslint.

Enforces an explicit `type` attribute on `<button>` elements and `React.createElement('button', …)` calls. Supports the three default option flags (`button`, `submit`, `reset`), static strings, no-substitution template literals, and trivial ternary expressions; reports `complexType` for any other expression shape.

Behavior is aligned 1:1 with the upstream rule, including numeric/BigInt/regex value normalization (e.g. `0x1` → `"1"`), paren/ESTree-flattening parity on the \`createElement\` callee and arguments, and TypeScript assertions (\`as\` / \`!\` / \`satisfies\`) reported as \`complexType\`.

This port also adds \`settings.react.pragma\` support to \`reactutil.IsCreateElementCall\`, which the existing \`react/style-prop-object\` and \`react/void-dom-elements-no-children\` rules pick up for free.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/button-has-type.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/button-has-type.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).