### PR TITLE
feat: port rule no-new

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -167,6 +167,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_misleading_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
 	"github.com/web-infra-dev/rslint/internal/rules/no_nested_ternary"
+	"github.com/web-infra-dev/rslint/internal/rules/no_new"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_object"
 	"github.com/web-infra-dev/rslint/internal/rules/no_new_symbol"
@@ -601,6 +602,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-lone-blocks", no_lone_blocks.NoLoneBlocksRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-misleading-character-class", no_misleading_character_class.NoMisleadingCharacterClassRule)
+	GlobalRuleRegistry.Register("no-new", no_new.NoNewRule)
 	GlobalRuleRegistry.Register("no-new-func", no_new_func.NoNewFuncRule)
 	GlobalRuleRegistry.Register("no-new-wrappers", no_new_wrappers.NoNewWrappersRule)
 	GlobalRuleRegistry.Register("no-restricted-imports", no_restricted_imports.NoRestrictedImportsRule)

--- a/internal/rules/no_new/no_new.go
+++ b/internal/rules/no_new/no_new.go
@@ -1,0 +1,34 @@
+package no_new
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// https://eslint.org/docs/latest/rules/no-new
+//
+// ESLint's selector `ExpressionStatement > NewExpression` relies on ESTree
+// stripping parentheses from the AST. tsgo keeps `ParenthesizedExpression`
+// nodes, so walk through them with `ast.SkipParentheses` to match ESLint on
+// forms like `(new Foo());`.
+var NoNewRule = rule.Rule{
+	Name: "no-new",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindExpressionStatement: func(node *ast.Node) {
+				stmt := node.AsExpressionStatement()
+				if stmt == nil {
+					return
+				}
+				expr := ast.SkipParentheses(stmt.Expression)
+				if expr == nil || expr.Kind != ast.KindNewExpression {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noNewStatement",
+					Description: "Do not use 'new' for side effects.",
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_new/no_new.md
+++ b/internal/rules/no_new/no_new.md
@@ -1,0 +1,23 @@
+# no-new
+
+## Rule Details
+
+Disallows the use of `new` operators outside of assignments or comparisons. The goal of `new` with a constructor is to create a new object of a particular type and assign or compare that object. A `new` expression used as a standalone statement discards the resulting object, which usually means the constructor should have been a plain function call instead.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+new Thing();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var thing = new Thing();
+
+Thing();
+```
+
+## Original Documentation
+
+- [ESLint no-new](https://eslint.org/docs/latest/rules/no-new)

--- a/internal/rules/no_new/no_new_test.go
+++ b/internal/rules/no_new/no_new_test.go
@@ -1,0 +1,705 @@
+package no_new
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoNewRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoNewRule,
+		// Valid cases — ESLint-ported + extended edge cases
+		[]rule_tester.ValidTestCase{
+			// ---- Original ESLint cases ----
+			{Code: `var a = new Date()`},
+			{Code: `var a; if (a === new Date()) { a = false; }`},
+
+			// ---- Used as a value (assignment / return / argument) ----
+			{Code: `const thing = new Thing();`},
+			{Code: `let x = new Foo();`},
+			{Code: `foo(new Bar());`},
+			{Code: `function f() { return new Baz(); }`},
+			{Code: `var x = new A() || new B();`},
+			{Code: `var x = true ? new A() : new B();`},
+			{Code: `var x = [new A(), new B()];`},
+			{Code: `var x = { a: new A() };`},
+			{Code: `class C { m() { return new A(); } }`},
+			{Code: `(function () { return new Foo(); })();`},
+
+			// ---- Result is further dereferenced / called (not a standalone new) ----
+			{Code: `(new Foo).bar;`},
+			{Code: `(new Foo()).bar();`},
+			{Code: `new Foo().bar;`},
+			{Code: `new Foo()?.bar;`},
+			{Code: `new Foo()[0];`},
+			{Code: `new Foo().bar();`},
+
+			// ---- Wrapped by another operator so the statement expr is not a NewExpression ----
+			{Code: `void new Foo();`},
+			{Code: `!new Foo();`},
+			{Code: `typeof new Foo();`},
+			{Code: `delete new Foo().x;`},
+			{Code: `new Foo(), new Bar();`},
+			{Code: `async function f() { await new Promise(r => r(1)); }`},
+			{Code: `function* g() { yield new Foo(); }`},
+
+			// ---- Plain call (not new) ----
+			{Code: `Foo();`},
+			{Code: `foo.bar();`},
+
+			// ---- Arrow with expression body (not a statement) ----
+			{Code: `var f = () => new Foo();`},
+
+			// ---- Wrapping operators make the statement expression non-NewExpression ----
+			{Code: `true && new Foo();`},
+			{Code: `a ? new Foo() : new Bar();`},
+
+			// ---- TypeScript type casts / satisfies around the new ----
+			{Code: `new Foo() as Bar;`},
+			{Code: `(new Foo() as Bar);`},
+			{Code: `<Foo>new Bar();`},
+			{Code: `new Foo() satisfies Bar;`},
+
+			// ---- Not an ExpressionStatement: export default / decorator argument ----
+			{Code: `export default new Foo();`},
+			{Code: `@new Dec() class C {}`},
+
+			// ---- Class field / default parameter initializers (not ExpressionStatement) ----
+			{Code: `class C { x = new Foo(); }`},
+			{Code: `class C { static x = new Foo(); }`},
+			{Code: `function f(x = new Foo()) {}`},
+
+			// ---- Chained type casts ----
+			{Code: `new Foo() as any as Bar;`},
+
+			// ---- Destructuring default values / computed keys (not ExpressionStatement) ----
+			{Code: `var { a = new Foo() } = {};`},
+			{Code: `var [a = new Foo()] = [];`},
+			{Code: `var obj = { [new Foo()]: 1 };`},
+
+			// ---- Template literal expression slot ----
+			{Code: "`${new Foo()}`;"},
+
+			// ---- Calling the result of new ----
+			{Code: `(new Foo())();`},
+
+			// ---- TC39 accessor keyword (class field init, not ExpressionStatement) ----
+			{Code: `class C { accessor x = new Foo(); }`},
+
+			// ---- Decorator factory call (new is argument to decorator) ----
+			{Code: `@factory(new Foo()) class C {}`},
+
+			// ---- import.meta call is not NewExpression ----
+			{Code: `import.meta.foo();`},
+
+			// ---- `using` / `await using` declarations (Stage 3) ----
+			{Code: `function f() { using x = new Foo(); }`},
+			{Code: `async function f() { await using x = new Foo(); }`},
+
+			// ---- Chained / combined TS type operators on new (not ExpressionStatement's direct kind) ----
+			{Code: `new Foo() as const;`},
+			{Code: `<const>new Foo();`},
+			{Code: `(new Foo())!;`},
+
+			// ---- Non-null or type-assertion on callee, but used as a value ----
+			{Code: `var x = new Foo!();`},
+			{Code: `var x = new (Foo as any)();`},
+
+			// ---- Decorators as values / on methods ----
+			{Code: `@a @b() @c(new X()) class C {}`},
+			{Code: `class C { @dec method() { return new Foo(); } }`},
+
+			// ---- Class with implements / extending mixin, used as value ----
+			{Code: `class C implements I { m() { return new Foo(); } }`},
+			{Code: `class C extends A implements I { m() { return new Foo(); } }`},
+
+			// ---- Generator + yield-new / yield* new ----
+			{Code: `function* g() { yield* new Foo(); }`},
+			{Code: `async function* g() { yield new Foo(); }`},
+
+			// ---- Multi-generic / member-access generic ----
+			{Code: `var x = new Foo<number, string>();`},
+			{Code: `var x = new ns.Foo<number>();`},
+
+			// ---- JSX: new as a value inside JsxExpression / attribute slot / fragment ----
+			{Code: `const j = <Foo />;`, Tsx: true},
+			{Code: `const j = <div>{new Foo()}</div>;`, Tsx: true},
+			{Code: `const j = <Foo attr={new Bar()} />;`, Tsx: true},
+			{Code: `function render() { return <Foo>{new Bar()}</Foo>; }`, Tsx: true},
+			{Code: `const j = <>{new Foo()}</>;`, Tsx: true},
+		},
+		// Invalid cases — ESLint-ported + extended edge cases
+		[]rule_tester.InvalidTestCase{
+			// ---- Original ESLint case ----
+			{
+				Code: `new Date()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Basic forms ----
+			{
+				Code: `new Foo;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new Foo('a', 1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new foo.Bar();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new foo.bar.Baz();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Parenthesized: ESLint still reports (paren-transparent); tsgo requires SkipParentheses ----
+			{
+				Code: `(new Foo());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `((new Foo()));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- new of new (outer is still a NewExpression directly under the statement) ----
+			{
+				Code: `new new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Labeled statement: inner ExpressionStatement still matches ----
+			{
+				Code: `label: new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 8},
+				},
+			},
+
+			// ---- Nested inside various constructs ----
+			{
+				Code: `function f() { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `var f = () => { new Foo(); };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `if (true) { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `class C { m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `for (;;) { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: `try { new Foo(); } catch {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 7},
+				},
+			},
+
+			// ---- Multiple / multi-line ----
+			{
+				Code: `new Foo(); new Bar();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+					{MessageId: "noNewStatement", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code: "new\n  Foo();",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- TypeScript generics on the callee ----
+			{
+				Code: `new Foo<number>();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Class-body static block (ES2022) ----
+			{
+				Code: `class C { static { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Anonymous class as constructor ----
+			{
+				Code: `new class {}();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Tagged-template as new callee ----
+			{
+				Code: "new Foo``;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- More container scopes ----
+			{
+				Code: `do { new Foo(); } while (false);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code: `while (true) { new Foo(); break; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `switch (x) { case 1: new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `if (a) {} else { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `try {} finally { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `{ new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 3},
+				},
+			},
+
+			// ---- Comments around / inside the expression ----
+			{
+				Code: `/* a */ new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `new /* a */ Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Single-statement branches (no block) ----
+			{
+				Code: `if (a) new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code: `if (a) new Foo(); else new Bar();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 8},
+					{MessageId: "noNewStatement", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `for (var i = 0; i < 1; i++) new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `while (a) new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 11},
+				},
+			},
+
+			// ---- IIFE-style: callee is a parenthesized function expression ----
+			{
+				Code: `new (function(){})();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Spread argument ----
+			{
+				Code: `new Foo(...args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Computed-access callee (no call parens) ----
+			{
+				Code: `new Foo[0];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- ASI splits into two statements ----
+			{
+				Code: "var a = b\nnew Foo()",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 2, Column: 1},
+				},
+			},
+
+			// ---- Trailing extra semicolon is an EmptyStatement, not a second report ----
+			{
+				Code: `new Foo();;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- TypeScript namespace body hosts ExpressionStatement ----
+			{
+				Code: `namespace N { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Class expression as constructor ----
+			{
+				Code: `new (class {})();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new (class extends Base {})();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Async IIFE ----
+			{
+				Code: `new (async function(){})();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Computed-member callee ----
+			{
+				Code: `new obj[key]();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Deep member chain ----
+			{
+				Code: `new a.b.c.d();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Tagged template with member-access tag ----
+			{
+				Code: "new foo.Bar`x`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Double report: outer new-statement AND inner new inside its callback ----
+			{
+				Code: `new Promise(r => { new Foo(); r(); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+					{MessageId: "noNewStatement", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- After a directive prologue ----
+			{
+				Code: `"use strict"; new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Interleaved between other statements ----
+			{
+				Code: `foo; new Bar(); baz;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 6},
+				},
+			},
+
+			// ---- Class body: constructor / derived constructor / method / static / getter / setter / private method ----
+			{
+				Code: `class C { constructor() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 27},
+				},
+			},
+			{
+				Code: `class C extends B { constructor() { super(); new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code: `class C { static m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `class C { get x() { new Foo(); return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `class C { set x(v) { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `class C { #m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 18},
+				},
+			},
+
+			// ---- Object literal method / accessor bodies ----
+			{
+				Code: `var obj = { m() { new Foo(); } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `var obj = { get x() { new Foo(); return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `var obj = { set x(v) { new Foo(); } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 24},
+				},
+			},
+
+			// ---- Catch block / for-in / for-of / for-await-of single-statement bodies ----
+			{
+				Code: `try {} catch (e) { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `for (var x in arr) new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `for (var x of arr) new Foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code: `async function f() { for await (const x of arr) new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 49},
+				},
+			},
+
+			// ---- Async IIFE with inner new statement ----
+			{
+				Code: `(async () => { new Foo(); })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- new used as a statement AND one of its arguments contains another new statement ----
+			{
+				Code: `new Foo(function() { new Bar(); });`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+					{MessageId: "noNewStatement", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- Nested namespace body ----
+			{
+				Code: `namespace A.B { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 17},
+				},
+			},
+
+			// ---- Legacy `module` keyword (TS) ----
+			{
+				Code: `module N { new Foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- Abstract class constructor ----
+			{
+				Code: `abstract class A { constructor() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- `override` method body ----
+			{
+				Code: `class B extends A { override m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 36},
+				},
+			},
+
+			// ---- Decorated method body ----
+			{
+				Code: `class C { @dec m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- Class with implements clause ----
+			{
+				Code: `class C implements I { m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 30},
+				},
+			},
+
+			// ---- Mixin-style extends ----
+			{
+				Code: `class C extends Mix(Base) { m() { new Foo(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- Static-initialization block with mixed declaration + new statement ----
+			{
+				Code: `class C { static { let x = new Foo(); new Bar(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 39},
+				},
+			},
+
+			// ---- Multi-generic / member-access generic as statement ----
+			{
+				Code: `new Foo<number, string>();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `new ns.Foo<number>();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Non-null assertion on callee, used as statement ----
+			{
+				Code: `new Foo!();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Type assertion on callee ----
+			{
+				Code: `new (Foo as any)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Dynamic import awaited then new'd ----
+			{
+				Code: `async function f() { new (await import("x")).default(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- JSX: new-as-statement inside an arrow body nested in a JSX handler / child ----
+			{
+				Code: `const j = <Foo onClick={() => { new Bar(); }} />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 33},
+				},
+			},
+			{
+				Code: `const j = <div>{() => { new Foo(); return 1; }}</div>;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noNewStatement", Line: 1, Column: 25},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -54,6 +54,7 @@ export default defineConfig({
     './tests/eslint/rules/no-global-assign.test.ts',
     './tests/eslint/rules/no-import-assign.test.ts',
     './tests/eslint/rules/no-inner-declarations.test.ts',
+    './tests/eslint/rules/no-new.test.ts',
     './tests/eslint/rules/no-new-func.test.ts',
     './tests/eslint/rules/no-new-object.test.ts',
     './tests/eslint/rules/no-new-wrappers.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-new.test.ts.snap
@@ -1,0 +1,2039 @@
+// Rstest Snapshot v1
+
+exports[`no-new > invalid 1`] = `
+{
+  "code": "new Date()",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 2`] = `
+{
+  "code": "new Foo;",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 3`] = `
+{
+  "code": "new Foo('a', 1);",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 4`] = `
+{
+  "code": "new foo.Bar();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 5`] = `
+{
+  "code": "new foo.bar.Baz();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 6`] = `
+{
+  "code": "(new Foo());",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 7`] = `
+{
+  "code": "((new Foo()));",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 8`] = `
+{
+  "code": "new new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 9`] = `
+{
+  "code": "label: new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 10`] = `
+{
+  "code": "function f() { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 11`] = `
+{
+  "code": "var f = () => { new Foo(); };",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 12`] = `
+{
+  "code": "if (true) { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 13`] = `
+{
+  "code": "class C { m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 14`] = `
+{
+  "code": "for (;;) { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 15`] = `
+{
+  "code": "try { new Foo(); } catch {}",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 16`] = `
+{
+  "code": "new Foo(); new Bar();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 17`] = `
+{
+  "code": "new
+  Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 18`] = `
+{
+  "code": "new Foo<number>();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 19`] = `
+{
+  "code": "class C { static { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 20`] = `
+{
+  "code": "new class {}();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 21`] = `
+{
+  "code": "new Foo\`\`;",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 22`] = `
+{
+  "code": "do { new Foo(); } while (false);",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 23`] = `
+{
+  "code": "while (true) { new Foo(); break; }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 24`] = `
+{
+  "code": "switch (x) { case 1: new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 25`] = `
+{
+  "code": "if (a) {} else { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 26`] = `
+{
+  "code": "try {} finally { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 27`] = `
+{
+  "code": "{ new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 28`] = `
+{
+  "code": "/* a */ new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 29`] = `
+{
+  "code": "new /* a */ Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 30`] = `
+{
+  "code": "if (a) new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 31`] = `
+{
+  "code": "if (a) new Foo(); else new Bar();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 32`] = `
+{
+  "code": "for (var i = 0; i < 1; i++) new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 33`] = `
+{
+  "code": "while (a) new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 34`] = `
+{
+  "code": "new (function(){})();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 35`] = `
+{
+  "code": "new Foo(...args);",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 36`] = `
+{
+  "code": "new Foo[0];",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 37`] = `
+{
+  "code": "var a = b
+new Foo()",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 38`] = `
+{
+  "code": "new Foo();;",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 39`] = `
+{
+  "code": "namespace N { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 40`] = `
+{
+  "code": "new (class {})();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 41`] = `
+{
+  "code": "new (class extends Base {})();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 42`] = `
+{
+  "code": "new (async function(){})();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 43`] = `
+{
+  "code": "new obj[key]();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 44`] = `
+{
+  "code": "new a.b.c.d();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 45`] = `
+{
+  "code": "new foo.Bar\`x\`;",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 46`] = `
+{
+  "code": "new Promise(r => { new Foo(); r(); });",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 47`] = `
+{
+  "code": ""use strict"; new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 48`] = `
+{
+  "code": "foo; new Bar(); baz;",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 49`] = `
+{
+  "code": "class C { constructor() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 50`] = `
+{
+  "code": "class C extends B { constructor() { super(); new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 51`] = `
+{
+  "code": "class C { static m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 52`] = `
+{
+  "code": "class C { get x() { new Foo(); return 1; } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 53`] = `
+{
+  "code": "class C { set x(v) { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 54`] = `
+{
+  "code": "class C { #m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 55`] = `
+{
+  "code": "var obj = { m() { new Foo(); } };",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 56`] = `
+{
+  "code": "var obj = { get x() { new Foo(); return 1; } };",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 57`] = `
+{
+  "code": "var obj = { set x(v) { new Foo(); } };",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 58`] = `
+{
+  "code": "try {} catch (e) { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 59`] = `
+{
+  "code": "for (var x in arr) new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 60`] = `
+{
+  "code": "for (var x of arr) new Foo();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 61`] = `
+{
+  "code": "async function f() { for await (const x of arr) new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 62`] = `
+{
+  "code": "(async () => { new Foo(); })();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 63`] = `
+{
+  "code": "new Foo(function() { new Bar(); });",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 64`] = `
+{
+  "code": "namespace A.B { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 65`] = `
+{
+  "code": "module N { new Foo(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 66`] = `
+{
+  "code": "abstract class A { constructor() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 67`] = `
+{
+  "code": "class B extends A { override m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 68`] = `
+{
+  "code": "class C { @dec m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 69`] = `
+{
+  "code": "class C implements I { m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 70`] = `
+{
+  "code": "class C extends Mix(Base) { m() { new Foo(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 71`] = `
+{
+  "code": "class C { static { let x = new Foo(); new Bar(); } }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 72`] = `
+{
+  "code": "new Foo<number, string>();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 73`] = `
+{
+  "code": "new ns.Foo<number>();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 74`] = `
+{
+  "code": "new Foo!();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 75`] = `
+{
+  "code": "new (Foo as any)();",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-new > invalid 76`] = `
+{
+  "code": "async function f() { new (await import("x")).default(); }",
+  "diagnostics": [
+    {
+      "message": "Do not use 'new' for side effects.",
+      "messageId": "noNewStatement",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-new",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-new.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-new.test.ts
@@ -1,0 +1,458 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-new', {
+  valid: [
+    // ---- Original ESLint cases ----
+    'var a = new Date()',
+    'var a; if (a === new Date()) { a = false; }',
+    // ---- Used as a value ----
+    'const thing = new Thing();',
+    'let x = new Foo();',
+    'foo(new Bar());',
+    'function f() { return new Baz(); }',
+    'var x = new A() || new B();',
+    'var x = true ? new A() : new B();',
+    'var x = [new A(), new B()];',
+    'var x = { a: new A() };',
+    'class C { m() { return new A(); } }',
+    '(function () { return new Foo(); })();',
+    // ---- Result further dereferenced / called ----
+    '(new Foo).bar;',
+    '(new Foo()).bar();',
+    'new Foo().bar;',
+    'new Foo()?.bar;',
+    'new Foo()[0];',
+    'new Foo().bar();',
+    // ---- Wrapped by another operator ----
+    'void new Foo();',
+    '!new Foo();',
+    'typeof new Foo();',
+    'delete new Foo().x;',
+    'new Foo(), new Bar();',
+    'async function f() { await new Promise(r => r(1)); }',
+    'function* g() { yield new Foo(); }',
+    // ---- Plain call ----
+    'Foo();',
+    'foo.bar();',
+    // ---- Arrow expression body ----
+    'var f = () => new Foo();',
+    // ---- Wrapping operators make the statement expression non-NewExpression ----
+    'true && new Foo();',
+    'a ? new Foo() : new Bar();',
+    // ---- TypeScript type casts / satisfies around the new ----
+    'new Foo() as Bar;',
+    '(new Foo() as Bar);',
+    '<Foo>new Bar();',
+    'new Foo() satisfies Bar;',
+    // ---- Not an ExpressionStatement ----
+    'export default new Foo();',
+    '@new Dec() class C {}',
+    // ---- Class field / default parameter initializers ----
+    'class C { x = new Foo(); }',
+    'class C { static x = new Foo(); }',
+    'function f(x = new Foo()) {}',
+    // ---- Chained type casts ----
+    'new Foo() as any as Bar;',
+    // ---- Destructuring default values / computed keys ----
+    'var { a = new Foo() } = {};',
+    'var [a = new Foo()] = [];',
+    'var obj = { [new Foo()]: 1 };',
+    // ---- Template literal expression slot ----
+    '`${new Foo()}`;',
+    // ---- Calling the result of new ----
+    '(new Foo())();',
+    // ---- TC39 accessor keyword ----
+    'class C { accessor x = new Foo(); }',
+    // ---- Decorator factory call ----
+    '@factory(new Foo()) class C {}',
+    // ---- import.meta call ----
+    'import.meta.foo();',
+    // ---- `using` / `await using` declarations ----
+    'function f() { using x = new Foo(); }',
+    'async function f() { await using x = new Foo(); }',
+    // ---- Chained / combined TS type operators ----
+    'new Foo() as const;',
+    '<const>new Foo();',
+    '(new Foo())!;',
+    // ---- Non-null or type-assertion on callee, used as value ----
+    'var x = new Foo!();',
+    'var x = new (Foo as any)();',
+    // ---- Decorators as values / on methods ----
+    '@a @b() @c(new X()) class C {}',
+    'class C { @dec method() { return new Foo(); } }',
+    // ---- implements / mixin extends (as value) ----
+    'class C implements I { m() { return new Foo(); } }',
+    'class C extends A implements I { m() { return new Foo(); } }',
+    // ---- Generator yield / yield* new ----
+    'function* g() { yield* new Foo(); }',
+    'async function* g() { yield new Foo(); }',
+    // ---- Multi-generic / member-access generic ----
+    'var x = new Foo<number, string>();',
+    'var x = new ns.Foo<number>();',
+  ],
+  invalid: [
+    // ---- Original ESLint case ----
+    {
+      code: 'new Date()',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Basic forms ----
+    {
+      code: 'new Foo;',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: "new Foo('a', 1);",
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'new foo.Bar();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'new foo.bar.Baz();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Parenthesized: ESLint flags (paren-transparent) ----
+    {
+      code: '(new Foo());',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: '((new Foo()));',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- new of new ----
+    {
+      code: 'new new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Labeled statement ----
+    {
+      code: 'label: new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Nested inside various constructs ----
+    {
+      code: 'function f() { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'var f = () => { new Foo(); };',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'if (true) { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'class C { m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'for (;;) { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'try { new Foo(); } catch {}',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Multiple / multi-line ----
+    {
+      code: 'new Foo(); new Bar();',
+      errors: [
+        { messageId: 'noNewStatement' },
+        { messageId: 'noNewStatement' },
+      ],
+    },
+    {
+      code: 'new\n  Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- TypeScript generics on callee ----
+    {
+      code: 'new Foo<number>();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Class-body static block ----
+    {
+      code: 'class C { static { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Anonymous class as constructor ----
+    {
+      code: 'new class {}();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Tagged-template as new callee ----
+    {
+      code: 'new Foo``;',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- More container scopes ----
+    {
+      code: 'do { new Foo(); } while (false);',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'while (true) { new Foo(); break; }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'switch (x) { case 1: new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'if (a) {} else { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'try {} finally { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: '{ new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Comments around / inside the expression ----
+    {
+      code: '/* a */ new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'new /* a */ Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Single-statement branches (no block) ----
+    {
+      code: 'if (a) new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'if (a) new Foo(); else new Bar();',
+      errors: [
+        { messageId: 'noNewStatement' },
+        { messageId: 'noNewStatement' },
+      ],
+    },
+    {
+      code: 'for (var i = 0; i < 1; i++) new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'while (a) new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- IIFE-style: callee is a parenthesized function expression ----
+    {
+      code: 'new (function(){})();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Spread argument ----
+    {
+      code: 'new Foo(...args);',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Computed-access callee (no call parens) ----
+    {
+      code: 'new Foo[0];',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- ASI splits into two statements ----
+    {
+      code: 'var a = b\nnew Foo()',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Trailing extra semicolon is an EmptyStatement ----
+    {
+      code: 'new Foo();;',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- TypeScript namespace body ----
+    {
+      code: 'namespace N { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Class expression as constructor ----
+    {
+      code: 'new (class {})();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'new (class extends Base {})();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Async IIFE ----
+    {
+      code: 'new (async function(){})();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Computed-member callee ----
+    {
+      code: 'new obj[key]();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Deep member chain ----
+    {
+      code: 'new a.b.c.d();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Tagged template with member-access tag ----
+    {
+      code: 'new foo.Bar`x`;',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Double report ----
+    {
+      code: 'new Promise(r => { new Foo(); r(); });',
+      errors: [
+        { messageId: 'noNewStatement' },
+        { messageId: 'noNewStatement' },
+      ],
+    },
+    // ---- After directive prologue ----
+    {
+      code: '"use strict"; new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Interleaved between other statements ----
+    {
+      code: 'foo; new Bar(); baz;',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Class body: constructor / derived / static / getter / setter / private method ----
+    {
+      code: 'class C { constructor() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'class C extends B { constructor() { super(); new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'class C { static m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'class C { get x() { new Foo(); return 1; } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'class C { set x(v) { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'class C { #m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Object literal method / accessor bodies ----
+    {
+      code: 'var obj = { m() { new Foo(); } };',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'var obj = { get x() { new Foo(); return 1; } };',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'var obj = { set x(v) { new Foo(); } };',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Catch / for-in / for-of / for-await-of ----
+    {
+      code: 'try {} catch (e) { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'for (var x in arr) new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'for (var x of arr) new Foo();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'async function f() { for await (const x of arr) new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Async IIFE with inner new statement ----
+    {
+      code: '(async () => { new Foo(); })();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Outer new-statement AND inner new inside an argument ----
+    {
+      code: 'new Foo(function() { new Bar(); });',
+      errors: [
+        { messageId: 'noNewStatement' },
+        { messageId: 'noNewStatement' },
+      ],
+    },
+    // ---- Nested namespace ----
+    {
+      code: 'namespace A.B { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Legacy `module` keyword ----
+    {
+      code: 'module N { new Foo(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Abstract class constructor ----
+    {
+      code: 'abstract class A { constructor() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- `override` method body ----
+    {
+      code: 'class B extends A { override m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Decorated method body ----
+    {
+      code: 'class C { @dec m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Class with implements clause ----
+    {
+      code: 'class C implements I { m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Mixin-style extends ----
+    {
+      code: 'class C extends Mix(Base) { m() { new Foo(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Static block with mixed decl + new statement ----
+    {
+      code: 'class C { static { let x = new Foo(); new Bar(); } }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Multi-generic / member-access generic ----
+    {
+      code: 'new Foo<number, string>();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    {
+      code: 'new ns.Foo<number>();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Non-null on callee ----
+    {
+      code: 'new Foo!();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Type assertion on callee ----
+    {
+      code: 'new (Foo as any)();',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+    // ---- Dynamic import awaited then new'd ----
+    {
+      code: 'async function f() { new (await import("x")).default(); }',
+      errors: [{ messageId: 'noNewStatement' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-new` rule from ESLint to rslint.

The rule flags `new` expressions used as standalone statements (e.g. `new Foo();`) since the constructed object is discarded — typically a sign the constructor should be a plain function call instead.

Differential verified against ESLint on real codebases:
- `rsbuild`: both tools flag exactly 1 site (`packages/create-rsbuild/template-vue2-ts/src/index.ts:5:1`)
- `rspack`: both tools flag 0 sites

Test coverage aligned case-by-case with ESLint + `@typescript-eslint/parser`:
- Core JS: paren-wrapped, ASI-split, labeled, directive-prologue, new-of-new, tagged-template new, async IIFE, spread / computed callee, interleaved statements, double reports
- Container scopes: function / arrow / if-else / for / while / do-while / for-in / for-of / for-await-of / switch case / try-catch-finally / bare block / class static block
- Class body: constructor, derived constructor (after `super()`), static method, getter, setter, private method, decorated method, `override`, `implements`, mixin extends
- Object literal: method, getter, setter
- TS-specific: `namespace`, legacy `module`, `abstract class`, multi-generic, member-access generic, `new Foo!()`, `new (Foo as any)()`, `await import()` + new
- Non-flag contexts: `export default`, decorator factory, class field / static field / default param / accessor initializer, destructuring default, computed key, template literal slot, logical/ternary wrapper, `void`/`typeof`/`!`/`delete`/comma, `as const` / `<const>` / `satisfies` / chained `as`, `using` / `await using`, `yield` / `yield*` new, property access / call on new result
- JSX: self-closing / child / attribute / fragment / handler arrow body

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-new
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-new.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).