### PR TITLE
feat: port rule radix

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,6 +206,7 @@ import (
 	core_prefer_promise_reject_errors "github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
+	"github.com/web-infra-dev/rslint/internal/rules/radix"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
 	"github.com/web-infra-dev/rslint/internal/rules/strict"
@@ -610,6 +611,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-octal-escape", no_octal_escape.NoOctalEscapeRule)
 	GlobalRuleRegistry.Register("no-param-reassign", no_param_reassign.NoParamReassignRule)
 	GlobalRuleRegistry.Register("no-proto", no_proto.NoProtoRule)
+	GlobalRuleRegistry.Register("radix", radix.RadixRule)
 	GlobalRuleRegistry.Register("no-regex-spaces", no_regex_spaces.NoRegexSpacesRule)
 	GlobalRuleRegistry.Register("no-return-assign", no_return_assign.NoReturnAssignRule)
 	GlobalRuleRegistry.Register("no-script-url", no_script_url.NoScriptUrlRule)

--- a/internal/rules/radix/radix.go
+++ b/internal/rules/radix/radix.go
@@ -51,6 +51,11 @@ func isValidRadixValue(f float64) bool {
 func isValidRadix(radix *ast.Node) bool {
 	switch radix.Kind {
 	case ast.KindNumericLiteral:
+		// tsgo normalizes NumericLiteral.Text to its decimal form at parse
+		// time (e.g. `0x10` → "16", `0b10` → "2", `1.6e1` → "16"), so we
+		// don't have to handle non-decimal prefixes ourselves.
+		// NormalizeNumericLiteral stays as a defensive pass in case that
+		// invariant ever changes.
 		text := utils.NormalizeNumericLiteral(radix.AsNumericLiteral().Text)
 		f, err := strconv.ParseFloat(text, 64)
 		if err != nil {
@@ -156,7 +161,11 @@ func checkArguments(ctx rule.RuleContext, node *ast.Node, call *ast.CallExpressi
 	case 1:
 		lastArg := args[0]
 		sourceText := ctx.SourceFile.Text()
-		insertPos := node.End() - 1 // position of the closing ')'
+		// TS AST node End() excludes trailing trivia, and the last token of a
+		// CallExpression is always `)`, so End()-1 is the byte offset of `)`.
+		// Byte offsets are the rule-layer convention — the LSP layer converts
+		// them to UTF-16 code units via scanner.GetECMALineAndUTF16CharacterOfPosition.
+		insertPos := node.End() - 1
 		text := ", 10"
 		if hasTrailingComma(sourceText, lastArg.End(), node.End()) {
 			text = " 10,"

--- a/internal/rules/radix/radix.go
+++ b/internal/rules/radix/radix.go
@@ -1,0 +1,176 @@
+package radix
+
+import (
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var missingParametersMsg = rule.RuleMessage{
+	Id:          "missingParameters",
+	Description: "Missing parameters.",
+}
+
+var missingRadixMsg = rule.RuleMessage{
+	Id:          "missingRadix",
+	Description: "Missing radix parameter.",
+}
+
+var invalidRadixMsg = rule.RuleMessage{
+	Id:          "invalidRadix",
+	Description: "Invalid radix parameter, must be an integer between 2 and 36.",
+}
+
+var addRadixParameter10Msg = rule.RuleMessage{
+	Id:          "addRadixParameter10",
+	Description: "Add radix parameter `10` for parsing decimal numbers.",
+}
+
+// isValidRadixValue reports whether a numeric value is an integer in [2, 36].
+func isValidRadixValue(f float64) bool {
+	if f != float64(int64(f)) {
+		return false
+	}
+	n := int64(f)
+	return n >= 2 && n <= 36
+}
+
+// isValidRadix mirrors ESLint's isValidRadix: a radix argument is invalid if it
+// is a literal whose value is not an integer in [2, 36], or a bare `undefined`
+// identifier. Non-literal expressions (variables, calls, etc.) are assumed
+// valid because their value cannot be determined statically.
+//
+// NOTE: NoSubstitutionTemplateLiteral (e.g. `parseInt("10", ` + "`10`" + `)`) is
+// deliberately NOT treated as invalid — ESLint's AST models template literals
+// as a separate node type from Literal, so its isValidRadix never rejects
+// them.
+func isValidRadix(radix *ast.Node) bool {
+	switch radix.Kind {
+	case ast.KindNumericLiteral:
+		text := utils.NormalizeNumericLiteral(radix.AsNumericLiteral().Text)
+		f, err := strconv.ParseFloat(text, 64)
+		if err != nil {
+			return false
+		}
+		return isValidRadixValue(f)
+
+	case ast.KindStringLiteral,
+		ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral,
+		ast.KindNullKeyword,
+		ast.KindTrueKeyword,
+		ast.KindFalseKeyword:
+		// Non-numeric literals and booleans/null can never be integers in [2, 36].
+		return false
+
+	case ast.KindIdentifier:
+		// ESLint treats bare `undefined` as an invalid radix regardless of
+		// whether it is shadowed — mirror that here.
+		return radix.AsIdentifier().Text != "undefined"
+	}
+	return true
+}
+
+// isParseIntCallee reports whether a callee is a reference to the global
+// `parseInt` or `Number.parseInt` function that is not shadowed. Mirrors
+// ESLint's scope-based check, with the same constraints:
+//
+//   - `Number['parseInt']()` is NOT matched (ESLint's isParseIntMethod rejects
+//     computed member access).
+//   - `Number.#parseInt()` is NOT matched (PrivateIdentifier, not Identifier).
+//   - TS-only wrappers (`!`, `as`, `<T>`, `satisfies`) on the callee or on
+//     `Number` cause ESLint's check to fail because the callee node is no
+//     longer an Identifier. We mirror that by only peeling parentheses, not
+//     other outer expressions.
+func isParseIntCallee(callee *ast.Node) bool {
+	callee = ast.SkipParentheses(callee)
+	if callee == nil {
+		return false
+	}
+
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text == "parseInt" &&
+			!utils.IsShadowed(callee, "parseInt")
+
+	case ast.KindPropertyAccessExpression:
+		pae := callee.AsPropertyAccessExpression()
+		name := pae.Name()
+		if name == nil || !ast.IsIdentifier(name) {
+			return false
+		}
+		if name.AsIdentifier().Text != "parseInt" {
+			return false
+		}
+		obj := ast.SkipParentheses(pae.Expression)
+		if obj == nil || !ast.IsIdentifier(obj) {
+			return false
+		}
+		return obj.AsIdentifier().Text == "Number" &&
+			!utils.IsShadowed(obj, "Number")
+	}
+	return false
+}
+
+// hasTrailingComma reports whether the CallExpression source text has a
+// trailing comma after the last argument. It skips whitespace and comments
+// between the last argument and the closing paren.
+func hasTrailingComma(sourceText string, lastArgEnd, callEnd int) bool {
+	pos := scanner.SkipTrivia(sourceText, lastArgEnd)
+	return pos < callEnd && sourceText[pos] == ','
+}
+
+// https://eslint.org/docs/latest/rules/radix
+var RadixRule = rule.Rule{
+	Name: "radix",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if call == nil {
+					return
+				}
+				if !isParseIntCallee(call.Expression) {
+					return
+				}
+				checkArguments(ctx, node, call)
+			},
+		}
+	},
+}
+
+func checkArguments(ctx rule.RuleContext, node *ast.Node, call *ast.CallExpression) {
+	var args []*ast.Node
+	if call.Arguments != nil {
+		args = call.Arguments.Nodes
+	}
+
+	switch len(args) {
+	case 0:
+		ctx.ReportNode(node, missingParametersMsg)
+
+	case 1:
+		lastArg := args[0]
+		sourceText := ctx.SourceFile.Text()
+		insertPos := node.End() - 1 // position of the closing ')'
+		text := ", 10"
+		if hasTrailingComma(sourceText, lastArg.End(), node.End()) {
+			text = " 10,"
+		}
+		ctx.ReportNodeWithSuggestions(node, missingRadixMsg, rule.RuleSuggestion{
+			Message: addRadixParameter10Msg,
+			FixesArr: []rule.RuleFix{
+				rule.RuleFixReplaceRange(core.NewTextRange(insertPos, insertPos), text),
+			},
+		})
+
+	default:
+		if !isValidRadix(args[1]) {
+			ctx.ReportNode(node, invalidRadixMsg)
+		}
+	}
+}

--- a/internal/rules/radix/radix.md
+++ b/internal/rules/radix/radix.md
@@ -1,0 +1,51 @@
+# radix
+
+## Rule Details
+
+This rule enforces that `parseInt()` and `Number.parseInt()` are called with an
+explicit radix argument. Without a radix, `parseInt` defaults to decimal for
+most inputs but previously inferred `16` for strings starting with `0x` (and
+some implementations inferred `8` for strings starting with `0`), which made
+the behavior hard to predict. Passing an explicit radix eliminates the
+ambiguity.
+
+The rule reports three kinds of problems:
+
+- **No arguments** — `parseInt()` is called with no arguments at all.
+- **Missing radix** — `parseInt(s)` is called with only the string argument.
+  A suggestion fix is offered that inserts `, 10` (or ` 10,` when a trailing
+  comma is present) to pass the decimal radix explicitly.
+- **Invalid radix** — the second argument is a literal (or the identifier
+  `undefined`) that cannot be an integer between `2` and `36`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+parseInt();
+parseInt("071");
+parseInt("071", "abc");
+parseInt("071", 37);
+parseInt("071", 10.5);
+Number.parseInt();
+Number.parseInt("071");
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+parseInt("071", 10);
+parseInt("071", 8);
+parseInt("071", foo);
+Number.parseInt("071", 10);
+parseFloat(someValue);
+```
+
+## Options
+
+The rule accepts a deprecated string option (`"always"` or `"as-needed"`). It
+is preserved for backward compatibility and does not change the rule's
+behavior — a radix argument is always required regardless of the option.
+
+## Original Documentation
+
+- [ESLint rule documentation](https://eslint.org/docs/latest/rules/radix)

--- a/internal/rules/radix/radix_test.go
+++ b/internal/rules/radix/radix_test.go
@@ -802,6 +802,40 @@ func TestRadixRule(t *testing.T) {
 				},
 			},
 
+			// ---- Trailing trivia after `)` — verify insertion point is
+			//      immediately before `)` and does NOT move past the `)`.
+			//      If CallExpression.End() wrongly included trailing trivia,
+			//      this suggestion output would be malformed. ----
+			{
+				Code: "parseInt('x')   /* after */   ;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: "parseInt('x', 10)   /* after */   ;"},
+						},
+					},
+				},
+			},
+			{
+				// multi-byte (UTF-16 surrogate pair) in the argument — locks
+				// in the byte-range semantics used by rule fixes; LSP layer
+				// handles UTF-16 conversion externally.
+				Code: `parseInt("𝟙")`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt("𝟙", 10)`},
+						},
+					},
+				},
+			},
+
 			// ---- Multi-line case with EndLine/EndColumn assertion ----
 			{
 				Code: "parseInt(\n  \"10\",\n  37\n);",

--- a/internal/rules/radix/radix_test.go
+++ b/internal/rules/radix/radix_test.go
@@ -1,0 +1,820 @@
+package radix
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRadixRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&RadixRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Valid: integer radix literals ----
+			{Code: `parseInt("10", 10);`},
+			{Code: `parseInt("10", 2);`},
+			{Code: `parseInt("10", 36);`},
+			{Code: `parseInt("10", 0x10);`},
+			{Code: `parseInt("10", 1.6e1);`},
+			{Code: `parseInt("10", 10.0);`},
+
+			// ---- Valid: variable radix (cannot determine statically) ----
+			{Code: `parseInt("10", foo);`},
+			{Code: `Number.parseInt("10", foo);`},
+
+			// ---- Valid: non-literal radix expressions (ESLint only rejects Literal / bare undefined) ----
+			{Code: `parseInt("10", -1);`},             // UnaryExpression
+			{Code: `parseInt("10", x + 1);`},          // BinaryExpression
+			{Code: `parseInt("10", x ? 10 : 16);`},    // ConditionalExpression
+			{Code: `parseInt("10", Math.floor(x));`},  // CallExpression
+			{Code: "parseInt(\"10\", `10`);"},         // NoSubstitutionTemplateLiteral
+			{Code: `parseInt("10", NaN);`},            // Identifier other than `undefined`
+			{Code: `parseInt("10", Infinity);`},       // Identifier
+			{Code: `parseInt("10", (10));`},           // Parenthesized numeric literal
+			{Code: `parseInt("10", ((10)));`},         // Deeply parenthesized
+
+			// ---- Valid: numeric edge cases inside [2, 36] ----
+			{Code: `parseInt("10", 2.0);`},
+			{Code: `parseInt("10", 0b10);`},  // 2
+			{Code: `parseInt("10", 0o10);`},  // 8
+			{Code: `parseInt("10", 0x24);`},  // 36
+
+			// ---- Valid: more than 2 arguments (rule only inspects args[1]) ----
+			{Code: `parseInt("10", 10, extra);`},
+			{Code: `Number.parseInt("10", 10, extra);`},
+
+			// ---- Valid: not a call of the tracked functions ----
+			{Code: `parseInt`},
+			{Code: `Number.foo();`},
+			{Code: `Number[parseInt]();`},
+
+			// ---- Valid: private identifier Number.#parseInt (not the global) ----
+			{Code: `class C { #parseInt; foo() { Number.#parseInt(); } }`},
+			{Code: `class C { #parseInt; foo() { Number.#parseInt(foo); } }`},
+			{Code: `class C { #parseInt; foo() { Number.#parseInt(foo, 'bar'); } }`},
+
+			// ---- Valid: shadowing (various declaration kinds) ----
+			{Code: `var parseInt; parseInt();`},
+			{Code: `var Number; Number.parseInt();`},
+			{Code: `let parseInt = foo; parseInt();`},
+			{Code: `const parseInt = foo; parseInt();`},
+			{Code: `function parseInt() {} parseInt();`},
+			{Code: `function f(parseInt) { parseInt(); }`},
+			{Code: `function f(Number) { Number.parseInt('x', 1); }`},
+			{Code: `import parseInt from 'x'; parseInt();`},
+			{Code: `import { parseInt } from 'x'; parseInt();`},
+			{Code: `function f() { var parseInt; parseInt(); }`},
+			{Code: `function f() { var Number = {}; Number.parseInt('x', 1); }`},
+			// Shadow at intermediate scope blocks outer calls too
+			{Code: `function f() { var parseInt = g; function h() { parseInt(); } }`},
+
+			// ---- Valid: parseInt used in non-call positions ----
+			{Code: `const obj = { parseInt: 1 };`},
+			{Code: `const { parseInt } = obj;`},
+			{Code: `obj.parseInt();`},
+			{Code: `foo.parseInt('10');`},
+
+			// ---- Valid: NewExpression / TaggedTemplate are NOT call expressions ----
+			{Code: `new parseInt("10");`},
+			{Code: "parseInt`10`;"},
+
+			// ---- Valid: additional shadowing scopes ----
+			{Code: `try {} catch (parseInt) { parseInt(); }`},
+			{Code: `for (let parseInt = 0; parseInt < 1; parseInt++) {}`},
+			{Code: `for (const parseInt of []) { parseInt(); }`},
+			{Code: `for (const parseInt in {}) { parseInt(); }`},
+			{Code: `{ var parseInt = foo; parseInt(); }`}, // var hoists to source file
+
+			// ---- Valid: named function expression / class expression binding ----
+			{Code: `var fn = function parseInt() { parseInt(); };`},
+			{Code: `var fn = function Number() { Number.parseInt("x", 1); };`},
+			{Code: `const C = class parseInt { static foo() { parseInt(); } };`},
+			{Code: `const C = class Number { static foo() { Number.parseInt("x", 1); } };`},
+
+			// ---- Valid: destructuring binds parseInt ----
+			{Code: `const [parseInt] = arr; parseInt();`},
+			{Code: `const [...parseInt] = arr; parseInt();`},
+			{Code: `const { parseInt = foo } = obj; parseInt();`},
+			{Code: `const { x: parseInt } = obj; parseInt();`},
+
+			// ---- Valid: TS declare / export / namespace declarations ----
+			{Code: `declare const parseInt: any; parseInt();`},
+			{Code: `export const parseInt = foo; parseInt();`},
+
+			// ---- Valid: Unicode-escaped identifier still resolves to parseInt ----
+			// tsgo normalizes the Identifier.Text to "parseInt", so a local
+			// declaration using the escaped form shadows the global.
+			{Code: `var \u0070arseInt = foo; parseInt();`},
+
+			// ---- Valid: TS-only wrappers on callee — ESLint doesn't treat
+			//      these as an Identifier callee, so it never flags them.
+			//      We mirror that to stay 1:1 with ESLint. ----
+			{Code: `parseInt!("10");`},
+			{Code: `(parseInt as Function)("10");`},
+			{Code: `Number!.parseInt("10");`},
+			{Code: `(Number as any).parseInt("10");`},
+
+			// ---- Valid: labeled statement does NOT create a binding ----
+			// `parseInt:` here is a label, not a variable, so the rule still
+			// treats the inner `parseInt()` as a real call — but the outer
+			// labeled statement does not shadow.
+			// (Placed in valid because inside the loop we pass a radix.)
+			{Code: `parseInt: for (;;) { parseInt("10", 10); break parseInt; }`},
+
+			// ---- Valid: Number used in non-method-access positions ----
+			{Code: `const x = Number;`},
+			{Code: `const x = Number(foo);`},
+
+			// ---- Valid: deprecated options "always" / "as-needed" (no behavior change) ----
+			{Code: `parseInt("10", 10);`, Options: []any{"always"}},
+			{Code: `parseInt("10", 10);`, Options: []any{"as-needed"}},
+			{Code: `parseInt("10", 8);`, Options: []any{"always"}},
+			{Code: `parseInt("10", 8);`, Options: []any{"as-needed"}},
+			{Code: `parseInt("10", foo);`, Options: []any{"always"}},
+			{Code: `parseInt("10", foo);`, Options: []any{"as-needed"}},
+
+			// SKIP: rslint does not support ESLint's `/*global ... */` directive
+			// SKIP: rslint does not support ESLint's `languageOptions.globals` override
+			{Code: `/* globals parseInt:off */ parseInt(foo);`, Skip: true},
+			{Code: `Number.parseInt(foo);`, Skip: true},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Missing parameters (+ exact message + full range) ----
+			{
+				Code: `parseInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingParameters",
+						Message:   "Missing parameters.",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 11,
+					},
+				},
+			},
+
+			// ---- Missing radix with suggestion (+ exact message + full range) ----
+			{
+				Code: `parseInt("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Message:   "Missing radix parameter.",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 15,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `parseInt("10", 10);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				// Trailing comma: suggestion should preserve it.
+				Code: `parseInt("10",);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `parseInt("10", 10,);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				// Sequence expression (no trailing comma).
+				Code: `parseInt((0, "10"));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `parseInt((0, "10"), 10);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				// Sequence expression with trailing comma.
+				Code: `parseInt((0, "10"),);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `parseInt((0, "10"), 10,);`,
+							},
+						},
+					},
+				},
+			},
+
+			// ---- Invalid radix literals (+ exact message + full range) ----
+			{
+				Code: `parseInt("10", null);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidRadix",
+						Message:   "Invalid radix parameter, must be an integer between 2 and 36.",
+						Line:      1,
+						Column:    1,
+						EndLine:   1,
+						EndColumn: 21,
+					},
+				},
+			},
+			{
+				Code: `parseInt("10", undefined);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `parseInt("10", true);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `parseInt("10", "foo");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `parseInt("10", "123");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `parseInt("10", 1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `parseInt("10", 37);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `parseInt("10", 10.5);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Number.parseInt ----
+			{
+				Code: `Number.parseInt();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Number.parseInt("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `Number.parseInt("10", 10);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `Number.parseInt("10", 1);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Number.parseInt("10", 37);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Number.parseInt("10", 10.5);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Optional chaining ----
+			{
+				Code: `parseInt?.("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `parseInt?.("10", 10);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `Number.parseInt?.("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `Number.parseInt?.("10", 10);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `Number?.parseInt("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `Number?.parseInt("10", 10);`,
+							},
+						},
+					},
+				},
+			},
+			{
+				Code: `(Number?.parseInt)("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    `(Number?.parseInt)("10", 10);`,
+							},
+						},
+					},
+				},
+			},
+
+			// ---- Deprecated options still trigger (no behavior change) ----
+			{
+				Code:    `parseInt();`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `parseInt();`,
+				Options: []any{"as-needed"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `parseInt("10");`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt("10", 10);`},
+						},
+					},
+				},
+			},
+			{
+				Code:    `parseInt("10");`,
+				Options: []any{"as-needed"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt("10", 10);`},
+						},
+					},
+				},
+			},
+			{
+				Code:    `parseInt("10", 1);`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `parseInt("10", 1);`,
+				Options: []any{"as-needed"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `Number.parseInt();`,
+				Options: []any{"always"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code:    `Number.parseInt();`,
+				Options: []any{"as-needed"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Extra edge cases: position assertions with multi-line and various containers ----
+			{
+				Code: "foo(\n  parseInt()\n);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 2, Column: 3},
+				},
+			},
+			{
+				Code: "function f() { return parseInt('10'); }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{
+								MessageId: "addRadixParameter10",
+								Output:    "function f() { return parseInt('10', 10); }",
+							},
+						},
+					},
+				},
+			},
+			// Parenthesized callee
+			{
+				Code: `(parseInt)("10");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `(parseInt)("10", 10);`},
+						},
+					},
+				},
+			},
+			// BigInt literal as radix — not a valid integer-in-range literal
+			{
+				Code: `parseInt("10", 10n);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Numeric literal edge cases ----
+			{
+				// 0 is below range.
+				Code: `parseInt("10", 0);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+			{
+				// 0x25 = 37, above range.
+				Code: `parseInt("10", 0x25);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "invalidRadix", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Multiple errors in one file ----
+			{
+				Code: "parseInt();\nparseInt('10');\nparseInt('10', 1);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 1},
+					{
+						MessageId: "missingRadix",
+						Line:      2,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: "parseInt();\nparseInt('10', 10);\nparseInt('10', 1);"},
+						},
+					},
+					{MessageId: "invalidRadix", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Nested parseInt calls — both should be flagged ----
+			{
+				Code: `parseInt(parseInt("10"));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt(parseInt("10"), 10);`},
+						},
+					},
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    10,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt(parseInt("10", 10));`},
+						},
+					},
+				},
+			},
+
+			// ---- Class / arrow / IIFE contexts ----
+			{
+				Code: `class C { foo() { parseInt('x'); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    19,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `class C { foo() { parseInt('x', 10); } }`},
+						},
+					},
+				},
+			},
+			{
+				Code: `class C { x = parseInt('x'); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    15,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `class C { x = parseInt('x', 10); }`},
+						},
+					},
+				},
+			},
+			{
+				Code: `class C { static { parseInt('x'); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    20,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `class C { static { parseInt('x', 10); } }`},
+						},
+					},
+				},
+			},
+			{
+				Code: `const f = () => parseInt('x');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    17,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `const f = () => parseInt('x', 10);`},
+						},
+					},
+				},
+			},
+			{
+				Code: `(function () { parseInt('x'); })();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `(function () { parseInt('x', 10); })();`},
+						},
+					},
+				},
+			},
+
+			// ---- Shadow scope does not reach: inner call still flagged ----
+			{
+				Code: `function f() { parseInt(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "missingParameters", Line: 1, Column: 16},
+				},
+			},
+			{
+				// parseInt shadowed in inner function only; outer call still flagged.
+				Code: "parseInt('x');\nfunction f() { var parseInt; parseInt(); }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: "parseInt('x', 10);\nfunction f() { var parseInt; parseInt(); }"},
+						},
+					},
+				},
+			},
+
+			// ---- Suggestion with comments between tokens ----
+			{
+				// Comment inside the argument list should be preserved by the fix.
+				Code: `parseInt("10" /* hi */);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt("10" /* hi */, 10);`},
+						},
+					},
+				},
+			},
+
+			// ---- Spread argument (kept for ESLint parity even though the
+			//      suggestion is semantically questionable — ESLint emits the
+			//      same suggestion) ----
+			{
+				Code: `parseInt(...args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    1,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `parseInt(...args, 10);`},
+						},
+					},
+				},
+			},
+			// SpreadElement as args[1] is not a Literal / Identifier, so it is
+			// treated as valid (falls into the default branch).
+
+			// ---- Real-world containers: async / generator / object method /
+			//      throw / template literal arg / computed key / labeled stmt ----
+			{
+				Code: `async function f() { return parseInt("x"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    29,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `async function f() { return parseInt("x", 10); }`},
+						},
+					},
+				},
+			},
+			{
+				Code: `function* g() { yield parseInt("x"); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    23,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `function* g() { yield parseInt("x", 10); }`},
+						},
+					},
+				},
+			},
+			{
+				Code: `const obj = { m() { parseInt("x"); } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    21,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `const obj = { m() { parseInt("x", 10); } };`},
+						},
+					},
+				},
+			},
+			{
+				Code: `throw parseInt("x");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    7,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `throw parseInt("x", 10);`},
+						},
+					},
+				},
+			},
+			{
+				Code: "const x = parseInt(`${foo}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    11,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: "const x = parseInt(`${foo}`, 10);"},
+						},
+					},
+				},
+			},
+			{
+				// parseInt inside a computed class member key.
+				Code: `class C { [parseInt("x")]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    12,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `class C { [parseInt("x", 10)]() {} }`},
+						},
+					},
+				},
+			},
+			{
+				// Default parameter value expression.
+				Code: `function f(x = parseInt("x")) { return x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `function f(x = parseInt("x", 10)) { return x; }`},
+						},
+					},
+				},
+			},
+			{
+				// Export default.
+				Code: `export default parseInt("x");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "missingRadix",
+						Line:      1,
+						Column:    16,
+						Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+							{MessageId: "addRadixParameter10", Output: `export default parseInt("x", 10);`},
+						},
+					},
+				},
+			},
+
+			// ---- Multi-line case with EndLine/EndColumn assertion ----
+			{
+				Code: "parseInt(\n  \"10\",\n  37\n);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidRadix",
+						Line:      1,
+						Column:    1,
+						EndLine:   4,
+						EndColumn: 2,
+					},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -298,6 +298,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unneeded-ternary.test.ts',
     './tests/eslint/rules/no-delete-var.test.ts',
     './tests/eslint/rules/prefer-promise-reject-errors.test.ts',
+    './tests/eslint/rules/radix.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
     './tests/eslint/rules/require-yield.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/radix.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/radix.test.ts.snap
@@ -1373,3 +1373,55 @@ exports[`radix > invalid 51`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`radix > invalid 52`] = `
+{
+  "code": "parseInt("x")   /* after */   ;",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 53`] = `
+{
+  "code": "parseInt("𝟙")",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/radix.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/radix.test.ts.snap
@@ -1,0 +1,1375 @@
+// Rstest Snapshot v1
+
+exports[`radix > invalid 1`] = `
+{
+  "code": "parseInt();",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 2`] = `
+{
+  "code": "parseInt("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 3`] = `
+{
+  "code": "parseInt("10",);",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 4`] = `
+{
+  "code": "parseInt((0, "10"));",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 5`] = `
+{
+  "code": "parseInt((0, "10"),);",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 6`] = `
+{
+  "code": "parseInt("10", null);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 7`] = `
+{
+  "code": "parseInt("10", undefined);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 8`] = `
+{
+  "code": "parseInt("10", true);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 9`] = `
+{
+  "code": "parseInt("10", "foo");",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 10`] = `
+{
+  "code": "parseInt("10", "123");",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 11`] = `
+{
+  "code": "parseInt("10", 1);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 12`] = `
+{
+  "code": "parseInt("10", 37);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 13`] = `
+{
+  "code": "parseInt("10", 10.5);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 14`] = `
+{
+  "code": "Number.parseInt();",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 15`] = `
+{
+  "code": "Number.parseInt("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 16`] = `
+{
+  "code": "Number.parseInt("10", 1);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 17`] = `
+{
+  "code": "Number.parseInt("10", 37);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 18`] = `
+{
+  "code": "Number.parseInt("10", 10.5);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 19`] = `
+{
+  "code": "parseInt?.("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 20`] = `
+{
+  "code": "Number.parseInt?.("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 21`] = `
+{
+  "code": "Number?.parseInt("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 22`] = `
+{
+  "code": "(Number?.parseInt)("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 23`] = `
+{
+  "code": "parseInt();",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 24`] = `
+{
+  "code": "parseInt();",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 25`] = `
+{
+  "code": "parseInt("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 26`] = `
+{
+  "code": "parseInt("10");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 27`] = `
+{
+  "code": "parseInt("10", 1);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 28`] = `
+{
+  "code": "parseInt("10", 1);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 29`] = `
+{
+  "code": "Number.parseInt();",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 30`] = `
+{
+  "code": "Number.parseInt();",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 31`] = `
+{
+  "code": "parseInt("10", 0);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 32`] = `
+{
+  "code": "parseInt("10", 0x25);",
+  "diagnostics": [
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 33`] = `
+{
+  "code": "parseInt();
+parseInt('10');
+parseInt('10', 1);",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "radix",
+    },
+    {
+      "message": "Invalid radix parameter, must be an integer between 2 and 36.",
+      "messageId": "invalidRadix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 34`] = `
+{
+  "code": "parseInt(parseInt("10"));",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 35`] = `
+{
+  "code": "class C { foo() { parseInt('x'); } }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 36`] = `
+{
+  "code": "class C { x = parseInt('x'); }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 37`] = `
+{
+  "code": "class C { static { parseInt('x'); } }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 38`] = `
+{
+  "code": "const f = () => parseInt('x');",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 39`] = `
+{
+  "code": "(function () { parseInt('x'); })();",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 40`] = `
+{
+  "code": "function f() { parseInt(); }",
+  "diagnostics": [
+    {
+      "message": "Missing parameters.",
+      "messageId": "missingParameters",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 41`] = `
+{
+  "code": "parseInt('x');
+function f() { var parseInt; parseInt(); }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 42`] = `
+{
+  "code": "parseInt("10" /* hi */);",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 43`] = `
+{
+  "code": "parseInt(...args);",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 44`] = `
+{
+  "code": "async function f() { return parseInt("x"); }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 45`] = `
+{
+  "code": "function* g() { yield parseInt("x"); }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 46`] = `
+{
+  "code": "const obj = { m() { parseInt("x"); } };",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 47`] = `
+{
+  "code": "throw parseInt("x");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 48`] = `
+{
+  "code": "const x = parseInt(\`\${foo}\`);",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 49`] = `
+{
+  "code": "class C { [parseInt("x")]() {} }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 50`] = `
+{
+  "code": "function f(x = parseInt("x")) { return x; }",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`radix > invalid 51`] = `
+{
+  "code": "export default parseInt("x");",
+  "diagnostics": [
+    {
+      "message": "Missing radix parameter.",
+      "messageId": "missingRadix",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "radix",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/radix.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/radix.test.ts
@@ -1,0 +1,369 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('radix', {
+  valid: [
+    // ---- Valid: integer radix literals ----
+    'parseInt("10", 10);',
+    'parseInt("10", 2);',
+    'parseInt("10", 36);',
+    'parseInt("10", 0x10);',
+    'parseInt("10", 1.6e1);',
+    'parseInt("10", 10.0);',
+
+    // ---- Valid: variable radix ----
+    'parseInt("10", foo);',
+    'Number.parseInt("10", foo);',
+
+    // ---- Valid: non-literal radix / template literal ----
+    'parseInt("10", -1);',
+    'parseInt("10", x + 1);',
+    'parseInt("10", x ? 10 : 16);',
+    'parseInt("10", Math.floor(x));',
+    'parseInt("10", `10`);',
+    'parseInt("10", NaN);',
+    'parseInt("10", Infinity);',
+    'parseInt("10", (10));',
+    'parseInt("10", ((10)));',
+
+    // ---- Valid: numeric edge cases inside [2, 36] ----
+    'parseInt("10", 2.0);',
+    'parseInt("10", 0b10);',
+    'parseInt("10", 0o10);',
+    'parseInt("10", 0x24);',
+
+    // ---- Valid: more than 2 arguments ----
+    'parseInt("10", 10, extra);',
+    'Number.parseInt("10", 10, extra);',
+
+    // ---- Valid: not a call of the tracked functions ----
+    'parseInt',
+    'Number.foo();',
+    'Number[parseInt]();',
+
+    // ---- Valid: private identifier Number.#parseInt ----
+    'class C { #parseInt; foo() { Number.#parseInt(); } }',
+    'class C { #parseInt; foo() { Number.#parseInt(foo); } }',
+    'class C { #parseInt; foo() { Number.#parseInt(foo, "bar"); } }',
+
+    // ---- Valid: shadowing (various declaration kinds) ----
+    'var parseInt; parseInt();',
+    'var Number; Number.parseInt();',
+    'let parseInt = foo; parseInt();',
+    'const parseInt = foo; parseInt();',
+    'function parseInt() {} parseInt();',
+    'function f(parseInt) { parseInt(); }',
+    'function f(Number) { Number.parseInt("x", 1); }',
+    'import parseInt from "x"; parseInt();',
+    'import { parseInt } from "x"; parseInt();',
+    'function f() { var parseInt; parseInt(); }',
+    'function f() { var Number = {}; Number.parseInt("x", 1); }',
+    'function f() { var parseInt = g; function h() { parseInt(); } }',
+
+    // ---- Valid: parseInt used in non-call positions ----
+    'const obj = { parseInt: 1 };',
+    'const { parseInt } = obj;',
+    'obj.parseInt();',
+    'foo.parseInt("10");',
+
+    // ---- Valid: Number in non-method-access positions ----
+    'const x = Number;',
+    'const x = Number(foo);',
+
+    // ---- Valid: NewExpression / TaggedTemplate are not CallExpressions ----
+    'new parseInt("10");',
+    'parseInt`10`;',
+
+    // ---- Valid: additional shadowing scopes ----
+    'try {} catch (parseInt) { parseInt(); }',
+    'for (let parseInt = 0; parseInt < 1; parseInt++) {}',
+    'for (const parseInt of []) { parseInt(); }',
+    'for (const parseInt in {}) { parseInt(); }',
+    '{ var parseInt = foo; parseInt(); }',
+
+    // ---- Valid: named function expression / class expression binding ----
+    'var fn = function parseInt() { parseInt(); };',
+    'var fn = function Number() { Number.parseInt("x", 1); };',
+    'const C = class parseInt { static foo() { parseInt(); } };',
+    'const C = class Number { static foo() { Number.parseInt("x", 1); } };',
+
+    // ---- Valid: destructuring binds parseInt ----
+    'const [parseInt] = arr; parseInt();',
+    'const [...parseInt] = arr; parseInt();',
+    'const { parseInt = foo } = obj; parseInt();',
+    'const { x: parseInt } = obj; parseInt();',
+
+    // ---- Valid: TS declare / export ----
+    'declare const parseInt: any; parseInt();',
+    'export const parseInt = foo; parseInt();',
+
+    // ---- Valid: Unicode-escaped identifier resolves to parseInt ----
+    'var \\u0070arseInt = foo; parseInt();',
+
+    // ---- Valid: TS-only wrappers on callee (ESLint 1:1) ----
+    'parseInt!("10");',
+    '(parseInt as Function)("10");',
+    'Number!.parseInt("10");',
+    '(Number as any).parseInt("10");',
+
+    // ---- Valid: labeled statement ----
+    'parseInt: for (;;) { parseInt("10", 10); break parseInt; }',
+
+    // ---- Valid: deprecated options "always" / "as-needed" (no behavior change) ----
+    { code: 'parseInt("10", 10);', options: ['always'] as any },
+    { code: 'parseInt("10", 10);', options: ['as-needed'] as any },
+    { code: 'parseInt("10", 8);', options: ['always'] as any },
+    { code: 'parseInt("10", 8);', options: ['as-needed'] as any },
+    { code: 'parseInt("10", foo);', options: ['always'] as any },
+    { code: 'parseInt("10", foo);', options: ['as-needed'] as any },
+  ],
+  invalid: [
+    // ---- Missing parameters ----
+    {
+      code: 'parseInt();',
+      errors: [{ messageId: 'missingParameters', line: 1, column: 1 }],
+    },
+
+    // ---- Missing radix ----
+    {
+      code: 'parseInt("10");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10",);',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt((0, "10"));',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt((0, "10"),);',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Invalid radix literals ----
+    {
+      code: 'parseInt("10", null);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", undefined);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", true);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", "foo");',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", "123");',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", 1);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", 37);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", 10.5);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Number.parseInt ----
+    {
+      code: 'Number.parseInt();',
+      errors: [{ messageId: 'missingParameters', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt("10");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt("10", 1);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt("10", 37);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt("10", 10.5);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Optional chaining ----
+    {
+      code: 'parseInt?.("10");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt?.("10");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number?.parseInt("10");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: '(Number?.parseInt)("10");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Deprecated options still trigger ----
+    {
+      code: 'parseInt();',
+      options: ['always'] as any,
+      errors: [{ messageId: 'missingParameters', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt();',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'missingParameters', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10");',
+      options: ['always'] as any,
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10");',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", 1);',
+      options: ['always'] as any,
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", 1);',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt();',
+      options: ['always'] as any,
+      errors: [{ messageId: 'missingParameters', line: 1, column: 1 }],
+    },
+    {
+      code: 'Number.parseInt();',
+      options: ['as-needed'] as any,
+      errors: [{ messageId: 'missingParameters', line: 1, column: 1 }],
+    },
+
+    // ---- Numeric literal edge cases ----
+    {
+      code: 'parseInt("10", 0);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+    {
+      code: 'parseInt("10", 0x25);',
+      errors: [{ messageId: 'invalidRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Multiple errors per file ----
+    {
+      code: "parseInt();\nparseInt('10');\nparseInt('10', 1);",
+      errors: [
+        { messageId: 'missingParameters', line: 1, column: 1 },
+        { messageId: 'missingRadix', line: 2, column: 1 },
+        { messageId: 'invalidRadix', line: 3, column: 1 },
+      ],
+    },
+
+    // ---- Nested parseInt calls ----
+    {
+      code: 'parseInt(parseInt("10"));',
+      errors: [
+        { messageId: 'missingRadix', line: 1, column: 1 },
+        { messageId: 'missingRadix', line: 1, column: 10 },
+      ],
+    },
+
+    // ---- Class / arrow / IIFE contexts ----
+    {
+      code: "class C { foo() { parseInt('x'); } }",
+      errors: [{ messageId: 'missingRadix', line: 1, column: 19 }],
+    },
+    {
+      code: "class C { x = parseInt('x'); }",
+      errors: [{ messageId: 'missingRadix', line: 1, column: 15 }],
+    },
+    {
+      code: "class C { static { parseInt('x'); } }",
+      errors: [{ messageId: 'missingRadix', line: 1, column: 20 }],
+    },
+    {
+      code: "const f = () => parseInt('x');",
+      errors: [{ messageId: 'missingRadix', line: 1, column: 17 }],
+    },
+    {
+      code: "(function () { parseInt('x'); })();",
+      errors: [{ messageId: 'missingRadix', line: 1, column: 16 }],
+    },
+
+    // ---- Shadow scope does not reach ----
+    {
+      code: 'function f() { parseInt(); }',
+      errors: [{ messageId: 'missingParameters', line: 1, column: 16 }],
+    },
+    {
+      code: "parseInt('x');\nfunction f() { var parseInt; parseInt(); }",
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Suggestion preserves internal comments ----
+    {
+      code: 'parseInt("10" /* hi */);',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Spread argument ----
+    {
+      code: 'parseInt(...args);',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+
+    // ---- Real-world containers ----
+    {
+      code: 'async function f() { return parseInt("x"); }',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 29 }],
+    },
+    {
+      code: 'function* g() { yield parseInt("x"); }',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 23 }],
+    },
+    {
+      code: 'const obj = { m() { parseInt("x"); } };',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 21 }],
+    },
+    {
+      code: 'throw parseInt("x");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 7 }],
+    },
+    {
+      code: 'const x = parseInt(`${foo}`);',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 11 }],
+    },
+    {
+      code: 'class C { [parseInt("x")]() {} }',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 12 }],
+    },
+    {
+      code: 'function f(x = parseInt("x")) { return x; }',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 16 }],
+    },
+    {
+      code: 'export default parseInt("x");',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 16 }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/radix.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/radix.test.ts
@@ -365,5 +365,18 @@ ruleTester.run('radix', {
       code: 'export default parseInt("x");',
       errors: [{ messageId: 'missingRadix', line: 1, column: 16 }],
     },
+
+    // ---- Regression guards: insertion position ----
+    // Trailing trivia after `)` must not shift the insertion point.
+    {
+      code: 'parseInt("x")   /* after */   ;',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
+    // Multi-byte (UTF-16 surrogate pair) argument — locks in byte-range fix
+    // semantics; LSP layer handles UTF-16 conversion externally.
+    {
+      code: 'parseInt("𝟙")',
+      errors: [{ messageId: 'missingRadix', line: 1, column: 1 }],
+    },
   ],
 });


### PR DESCRIPTION
## Summary

Port the `radix` rule from ESLint to rslint.

The rule enforces that `parseInt()` and `Number.parseInt()` are called with an explicit radix argument, reporting three kinds of problems (matching ESLint 1:1):

- `missingParameters` — no arguments.
- `missingRadix` — only the string argument (comes with a suggestion that inserts `, 10` or preserves a trailing comma).
- `invalidRadix` — the second argument is a literal (or bare `undefined`) that cannot be an integer in `[2, 36]`.

Framework-level behaviors rslint does not support (`/* globals parseInt:off */`, `languageOptions.globals`) are kept as `Skip: true` cases with explanatory comments. Otherwise the port is aligned with ESLint, including optional chaining, shadowing, and TS wrapper handling (non-null assertion / type assertion / `satisfies` on the callee are not reported, matching ESLint + @typescript-eslint/parser).

Validated on real codebases:

- `rsbuild` — 1198 files, 0 diagnostics (only existing call is `Number.parseInt(port, 10)`).
- `rspack` — 582 files, 0 diagnostics (9 existing `parseInt` calls all have radix `10`).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/radix
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/radix.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).