### PR TITLE
feat: port rule symbol-description

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -209,6 +209,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
 	"github.com/web-infra-dev/rslint/internal/rules/require_yield"
 	"github.com/web-infra-dev/rslint/internal/rules/strict"
+	"github.com/web-infra-dev/rslint/internal/rules/symbol_description"
 	"github.com/web-infra-dev/rslint/internal/rules/use_isnan"
 	"github.com/web-infra-dev/rslint/internal/rules/valid_typeof"
 )
@@ -654,6 +655,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
 	GlobalRuleRegistry.Register("require-yield", require_yield.RequireYieldRule)
+	GlobalRuleRegistry.Register("symbol-description", symbol_description.SymbolDescriptionRule)
 }
 
 // isFileIgnored checks if a file is matched by ignore patterns, evaluated sequentially.

--- a/internal/rules/symbol_description/symbol_description.go
+++ b/internal/rules/symbol_description/symbol_description.go
@@ -1,0 +1,81 @@
+package symbol_description
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/symbol-description
+var SymbolDescriptionRule = rule.Rule{
+	Name: "symbol-description",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				// Unwrap parentheses so `(Symbol)()` / `((Symbol))()` resolve
+				// to the inner identifier — ESTree drops parens at parse time,
+				// tsgo keeps them as explicit nodes.
+				callee := ast.SkipParentheses(call.Expression)
+				if callee == nil || callee.Kind != ast.KindIdentifier || callee.Text() != "Symbol" {
+					return
+				}
+				if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+					return
+				}
+				if isUserBoundSymbol(ctx, callee) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "expected",
+					Description: "Expected Symbol to have a description.",
+				})
+			},
+		}
+	},
+}
+
+// isUserBoundSymbol returns true when the `Symbol` identifier at `callee`
+// resolves to any user-site declaration — meaning it's shadowed/redeclared
+// and the rule should not report.
+//
+// Primary signal is `utils.IsShadowed` (scope-based, mirrors ESLint's
+// `getVariableByName` + `variable.defs.length === 0`). This is the authoritative
+// semantics ESLint uses; the TypeChecker cannot fully replace it because TS's
+// symbol resolution disagrees with ESLint's scope manager on hoisted function
+// declarations, `let`/`const`/`class` shadowing, and `interface`+`const`
+// declaration merging (same root cause noted in `no-new-symbol`).
+//
+// When TypeChecker is available, it's used as an *additional* shadow signal:
+// any `Symbol` symbol whose declarations include a non-lib source file is
+// treated as shadowed too. This catches rare TS-only bindings that the
+// scope-based walker could miss (e.g. exotic declaration merging shapes),
+// without regressing the ESLint-aligned behavior.
+func isUserBoundSymbol(ctx rule.RuleContext, callee *ast.Node) bool {
+	if utils.IsShadowed(callee, "Symbol") {
+		return true
+	}
+	if ctx.TypeChecker == nil || ctx.Program == nil {
+		return false
+	}
+	sym := ctx.TypeChecker.GetSymbolAtLocation(callee)
+	if sym == nil {
+		return false
+	}
+	for _, decl := range sym.Declarations {
+		if decl == nil {
+			continue
+		}
+		// Skip pure-type declarations — they share a symbol with the value via
+		// TS namespace merging but don't shadow the runtime binding.
+		switch decl.Kind {
+		case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+			continue
+		}
+		sf := ast.GetSourceFileOfNode(decl)
+		if sf != nil && !utils.IsSourceFileDefaultLibrary(ctx.Program, sf) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/rules/symbol_description/symbol_description.md
+++ b/internal/rules/symbol_description/symbol_description.md
@@ -1,0 +1,24 @@
+# symbol-description
+
+## Rule Details
+
+Requires a description when creating a `Symbol`. A description makes logged and debugged symbols easier to identify.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var foo = Symbol();
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var foo = Symbol("some description");
+
+var someString = "some description";
+var bar = Symbol(someString);
+```
+
+## Original Documentation
+
+- [ESLint symbol-description](https://eslint.org/docs/latest/rules/symbol-description)

--- a/internal/rules/symbol_description/symbol_description_test.go
+++ b/internal/rules/symbol_description/symbol_description_test.go
@@ -1,0 +1,387 @@
+package symbol_description
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestSymbolDescriptionRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&SymbolDescriptionRule,
+		[]rule_tester.ValidTestCase{
+			// ---- From ESLint upstream ----
+			{Code: `Symbol("Foo");`},
+			{Code: `var foo = "foo"; Symbol(foo);`},
+			// Ignore if it's shadowed.
+			{Code: `var Symbol = function () {}; Symbol();`},
+			{Code: `Symbol(); var Symbol = function () {};`},
+			{Code: `function bar() { var Symbol = function () {}; Symbol(); }`},
+			// Ignore if it's an argument.
+			{Code: `function bar(Symbol) { Symbol(); }`},
+
+			// ---- Argument shapes (any non-empty arg is OK) ----
+			{Code: `Symbol("");`},
+			{Code: "Symbol(`foo`);"},
+			{Code: "Symbol(`${x}`);"},
+			{Code: `Symbol(undefined);`},
+			{Code: `Symbol(null);`},
+			{Code: `Symbol(42);`},
+			{Code: `Symbol(cond ? "a" : "b");`},
+			{Code: `Symbol(getName());`},
+			{Code: `Symbol(...args);`},
+			{Code: `Symbol("a", "b");`},
+
+			// ---- Not the global `Symbol` identifier being called ----
+			{Code: `foo.Symbol();`},
+			{Code: `obj["Symbol"]();`},
+			{Code: `new Symbol();`},
+			{Code: `Symbol;`}, // referenced but not called
+
+			// ---- Shadowing — declaration forms ----
+			{Code: `let Symbol = 1; Symbol();`},
+			{Code: `const Symbol = () => {}; Symbol();`},
+			{Code: `function Symbol() {} Symbol();`},
+			{Code: `class Symbol {} new Symbol();`},
+			{Code: `const f = (Symbol) => { Symbol(); };`},
+			{Code: `function f(...Symbol) { Symbol(); }`},
+			{Code: `function f({ Symbol }) { Symbol(); }`},
+			{Code: `var { Symbol } = obj; Symbol();`},
+			{Code: `var [Symbol] = arr; Symbol();`},
+			{Code: `try {} catch (Symbol) { Symbol(); }`},
+			{Code: `for (let Symbol of arr) { Symbol(); }`},
+			{Code: `for (var Symbol = 0;;) { Symbol(); }`},
+			// Hoisting — the call precedes the declaration in the same scope.
+			{Code: `Symbol(); function Symbol() {}`},
+
+			// ---- Outer shadow propagates into inner scopes ----
+			{Code: `var Symbol = 1; function f() { Symbol(); }`},
+			{Code: `var Symbol = 1; const f = () => Symbol();`},
+			{Code: `var Symbol = 1; class C { m() { Symbol(); } }`},
+
+			// ---- Import forms shadow the global Symbol ----
+			{Code: `import { Symbol } from "x"; Symbol();`},
+			{Code: `import Symbol from "x"; Symbol();`},
+			{Code: `import * as Symbol from "x"; Symbol();`},
+			{Code: `import { Foo as Symbol } from "x"; Symbol();`},
+
+			// ---- Tagged template is not a CallExpression ----
+			{Code: "Symbol`foo`;"},
+
+			// ---- Named expression self-reference shadows inside its own body ----
+			{Code: `const f = function Symbol() { Symbol(); };`},
+			{Code: `const c = class Symbol { m() { Symbol(); } };`},
+
+			// ---- TypeScript enum/class shadows the global value ----
+			{Code: `enum Symbol { A } Symbol();`},
+
+			// ---- TypeScript namespace/module with identifier name shadows
+			//      (both at file scope and inside a function block).
+			{Code: `namespace Symbol {} Symbol();`},
+			{Code: `module Symbol {} Symbol();`},
+			{Code: `function f() { namespace Symbol {} Symbol(); }`},
+
+			// ---- `declare` value declarations shadow like runtime ones.
+			{Code: `declare var Symbol: any; Symbol();`},
+			{Code: `declare function Symbol(): any; Symbol();`},
+			{Code: `declare const Symbol: any; Symbol();`},
+
+			// ---- Class body computed key & class name — inner class name wins.
+			{Code: `class Symbol { [Symbol()]() {} }`},
+			{Code: `class X { static E = class Symbol { m() { Symbol(); } }; }`},
+
+			// ---- Declaration merging: interface (type) + const (value) = shadowed.
+			{Code: `interface Symbol {} const Symbol = 1; Symbol();`},
+
+			// ---- `import type` — treated as a binding by ts-eslint's scope manager.
+			{Code: `import type { Symbol } from "x"; Symbol();`},
+			{Code: `import type Symbol from "x"; Symbol();`},
+			{Code: `import { type Symbol } from "x"; Symbol();`},
+
+			// ---- `export declare` value forms shadow.
+			{Code: `export declare var Symbol: any; Symbol();`},
+			{Code: `export declare function Symbol(): any; Symbol();`},
+			{Code: `export declare namespace Symbol {} Symbol();`},
+			{Code: `declare namespace Symbol {} Symbol();`},
+			{Code: `declare class Symbol {} new Symbol(); Symbol();`},
+
+			// ---- Inside a namespace block, local `var`/`function` shadow.
+			{Code: `namespace NS { var Symbol = 1; Symbol(); }`},
+			{Code: `namespace NS { function Symbol() {} Symbol(); }`},
+
+			// ---- Nested-scope shadowing.
+			{Code: `for (const Symbol = foo; ;) { Symbol(); }`},
+			{Code: `class C { m() { function Symbol() {} Symbol(); } }`},
+			{Code: `const f = () => { class Symbol {} return Symbol(); };`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- From ESLint upstream ----
+			{
+				Code: `Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "expected",
+						Message:   "Expected Symbol to have a description.",
+						Line:      1,
+						Column:    1,
+					},
+				},
+			},
+			{
+				// Bare `Symbol = ...` is reassignment, not a declaration — still global.
+				Code: `Symbol(); Symbol = function () {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Position / nested-scope assertions ----
+			{
+				Code: `var foo = Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 11, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code: `function f() { return Symbol(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 23, EndLine: 1, EndColumn: 31},
+				},
+			},
+			{
+				Code: "Symbol(\n);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+
+			// ---- Parenthesized callee: ESTree drops parens so ESLint reports;
+			//      tsgo keeps them as explicit nodes, so SkipParentheses is required.
+			{
+				Code: `(Symbol)();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `((Symbol))();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Optional call — `Symbol?.()` still has zero arguments.
+			{
+				Code: `Symbol?.();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Comments don't count as arguments.
+			{
+				Code: `Symbol(/* no description */);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Block-scoped shadow doesn't leak out.
+			{
+				Code: `{ let Symbol = 1; } Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 21},
+				},
+			},
+			// Nested shadow doesn't affect outer call.
+			{
+				Code: `function f(Symbol) { Symbol(); } Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 34},
+				},
+			},
+			// IIFE parameter is scoped to the IIFE.
+			{
+				Code: `(function (Symbol) {})(1); Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 28},
+				},
+			},
+
+			// ---- Call sites inside various containers, no shadow in scope.
+			{
+				Code: `const f = () => Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `class C { m() { Symbol(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 17},
+				},
+			},
+			{
+				Code: `class C { static { Symbol(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Multi-line: report spans from callee start to closing paren.
+			{
+				Code: "var s = Symbol(\n\n);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 9, EndLine: 3, EndColumn: 2},
+				},
+			},
+
+			// ---- Call embedded in various expression positions.
+			{
+				Code: `throw Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 7},
+				},
+			},
+			{
+				// Chained MemberExpression around the bare Symbol() call.
+				Code: `Symbol().toString();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1, EndLine: 1, EndColumn: 9},
+				},
+			},
+			{
+				Code: `x || Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 6},
+				},
+			},
+			{
+				// Sequence expression via comma operator — inner Symbol() is still a CallExpression.
+				Code: `(a, Symbol());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 5},
+				},
+			},
+
+			// ---- Class bodies: field initializer and computed method key.
+			{
+				Code: `class C { x = Symbol(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `class C { [Symbol()]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 12},
+				},
+			},
+			// Object literal computed property key — different AST path than class.
+			{
+				Code: `const obj = { [Symbol()]: 1 };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Type-only declarations do NOT shadow the runtime value.
+			{
+				Code: `type Symbol = string; Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `interface Symbol {} Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 21},
+				},
+			},
+			// Ambient module with string-literal name does NOT bind `Symbol`.
+			{
+				Code: `declare module "x" {} Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 23},
+				},
+			},
+			// Type alias followed by runtime use still reports — `type` is type-only.
+			{
+				Code: `type Symbol = string; var s: Symbol = "x"; Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 44},
+				},
+			},
+			// Decorator position — the CallExpression is still detected.
+			{
+				Code: `class C { @Symbol() method() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- Class field named Symbol does NOT shadow the global.
+			{
+				Code: `class C { accessor Symbol = 1; m() { Symbol(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 38},
+				},
+			},
+
+			// ---- Destructuring assignment is not a declaration — global stays.
+			{
+				Code: `({ Symbol } = obj); Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `[Symbol] = arr; Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 17},
+				},
+			},
+
+			// ---- `declare global { var Symbol }` augments the global type but
+			//      the rule still reports — declaration isn't in file scope.
+			{
+				Code: `declare global { var Symbol: any; } Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 37},
+				},
+			},
+
+			// ---- Type-position usage doesn't shadow the runtime value.
+			{
+				Code: `const x: Symbol = null as any; Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code: `const x: { Symbol: any } = {} as any; Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 39},
+				},
+			},
+
+			// ---- Each call evaluated independently.
+			{
+				Code: `Symbol(); Symbol("b");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Symbol("a"); Symbol();`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "expected", Line: 1, Column: 14},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/shadowing.go
+++ b/internal/utils/shadowing.go
@@ -193,7 +193,7 @@ func HasShadowingParameter(node *ast.Node, name string) bool {
 }
 
 // HasShadowingDeclaration checks if a block contains a variable, function,
-// or class declaration whose name matches the given name.
+// class, enum, or namespace declaration whose name matches the given name.
 func HasShadowingDeclaration(node *ast.Node, name string) bool {
 	if node.Kind != ast.KindBlock {
 		return false
@@ -242,6 +242,19 @@ func HasShadowingDeclaration(node *ast.Node, name string) bool {
 			}
 		case ast.KindClassDeclaration:
 			if n := stmt.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		case ast.KindEnumDeclaration:
+			if n := stmt.Name(); n != nil && n.Kind == ast.KindIdentifier && n.Text() == name {
+				return true
+			}
+		case ast.KindModuleDeclaration:
+			// `namespace X {}` / `module X {}` introduce a value binding when
+			// named by an identifier. Skip ambient modules (`declare module "x"`),
+			// which use a string literal name and don't bind a variable.
+			modDecl := stmt.AsModuleDeclaration()
+			if modDecl != nil && modDecl.Name() != nil &&
+				modDecl.Name().Kind == ast.KindIdentifier && modDecl.Name().Text() == name {
 				return true
 			}
 		}
@@ -293,8 +306,11 @@ func HasLocalDeclarationInStatements(statements []*ast.Node, name string) bool {
 			}
 
 		case ast.KindModuleDeclaration:
+			// Ambient module (`declare module "x"`) uses a string-literal name
+			// and doesn't bind a variable — only identifier-named namespaces do.
 			modDecl := stmt.AsModuleDeclaration()
-			if modDecl != nil && modDecl.Name() != nil && modDecl.Name().Text() == name {
+			if modDecl != nil && modDecl.Name() != nil &&
+				modDecl.Name().Kind == ast.KindIdentifier && modDecl.Name().Text() == name {
 				return true
 			}
 

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -300,6 +300,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-promise-reject-errors.test.ts',
     './tests/eslint/rules/require-atomic-updates.test.ts',
     './tests/eslint/rules/require-yield.test.ts',
+    './tests/eslint/rules/symbol-description.test.ts',
 
     // eslint-plugin-jest
     './tests/eslint-plugin-jest/rules/no-alias-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/symbol-description.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/symbol-description.test.ts.snap
@@ -1,0 +1,940 @@
+// Rstest Snapshot v1
+
+exports[`symbol-description > invalid 1`] = `
+{
+  "code": "Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 2`] = `
+{
+  "code": "Symbol(); Symbol = function () {};",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 3`] = `
+{
+  "code": "var foo = Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 4`] = `
+{
+  "code": "function f() { return Symbol(); }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 5`] = `
+{
+  "code": "Symbol(
+);",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 6`] = `
+{
+  "code": "(Symbol)();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 7`] = `
+{
+  "code": "((Symbol))();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 8`] = `
+{
+  "code": "Symbol?.();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 9`] = `
+{
+  "code": "Symbol(/* no description */);",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 10`] = `
+{
+  "code": "{ let Symbol = 1; } Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 11`] = `
+{
+  "code": "function f(Symbol) { Symbol(); } Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 12`] = `
+{
+  "code": "(function (Symbol) {})(1); Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 13`] = `
+{
+  "code": "const f = () => Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 14`] = `
+{
+  "code": "class C { m() { Symbol(); } }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 15`] = `
+{
+  "code": "class C { static { Symbol(); } }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 16`] = `
+{
+  "code": "var s = Symbol(
+
+);",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 17`] = `
+{
+  "code": "throw Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 18`] = `
+{
+  "code": "Symbol().toString();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 19`] = `
+{
+  "code": "x || Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 20`] = `
+{
+  "code": "(a, Symbol());",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 21`] = `
+{
+  "code": "class C { x = Symbol(); }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 22`] = `
+{
+  "code": "class C { [Symbol()]() {} }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 23`] = `
+{
+  "code": "const obj = { [Symbol()]: 1 };",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 24`] = `
+{
+  "code": "type Symbol = string; Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 25`] = `
+{
+  "code": "interface Symbol {} Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 26`] = `
+{
+  "code": "declare module "x" {} Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 27`] = `
+{
+  "code": "type Symbol = string; var s: Symbol = "x"; Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 28`] = `
+{
+  "code": "class C { @Symbol() method() {} }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 29`] = `
+{
+  "code": "class C { accessor Symbol = 1; m() { Symbol(); } }",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 30`] = `
+{
+  "code": "({ Symbol } = obj); Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 31`] = `
+{
+  "code": "[Symbol] = arr; Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 32`] = `
+{
+  "code": "declare global { var Symbol: any; } Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 33`] = `
+{
+  "code": "const x: Symbol = null as any; Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 34`] = `
+{
+  "code": "const x: { Symbol: any } = {} as any; Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 35`] = `
+{
+  "code": "Symbol(); Symbol("b");",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`symbol-description > invalid 36`] = `
+{
+  "code": "Symbol("a"); Symbol();",
+  "diagnostics": [
+    {
+      "message": "Expected Symbol to have a description.",
+      "messageId": "expected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "symbol-description",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/symbol-description.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/symbol-description.test.ts
@@ -1,0 +1,240 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('symbol-description', {
+  valid: [
+    // From ESLint upstream
+    'Symbol("Foo");',
+    'var foo = "foo"; Symbol(foo);',
+    'var Symbol = function () {}; Symbol();',
+    'Symbol(); var Symbol = function () {};',
+    'function bar() { var Symbol = function () {}; Symbol(); }',
+    'function bar(Symbol) { Symbol(); }',
+
+    // Argument shapes — any non-empty arg satisfies the rule
+    'Symbol("");',
+    'Symbol(`foo`);',
+    'Symbol(`${x}`);',
+    'Symbol(undefined);',
+    'Symbol(null);',
+    'Symbol(42);',
+    'Symbol(cond ? "a" : "b");',
+    'Symbol(getName());',
+    'Symbol(...args);',
+    'Symbol("a", "b");',
+
+    // Not the global `Symbol` identifier being called
+    'foo.Symbol();',
+    'obj["Symbol"]();',
+    'new Symbol();',
+    'Symbol;',
+
+    // Shadowing — various declaration forms
+    'let Symbol = 1; Symbol();',
+    'const Symbol = () => {}; Symbol();',
+    'function Symbol() {} Symbol();',
+    'class Symbol {} new Symbol();',
+    'const f = (Symbol) => { Symbol(); };',
+    'function f(...Symbol) { Symbol(); }',
+    'function f({ Symbol }) { Symbol(); }',
+    'var { Symbol } = obj; Symbol();',
+    'var [Symbol] = arr; Symbol();',
+    'try {} catch (Symbol) { Symbol(); }',
+    'for (let Symbol of arr) { Symbol(); }',
+    'for (var Symbol = 0;;) { Symbol(); }',
+    'Symbol(); function Symbol() {}',
+
+    // Outer shadow propagates into inner scopes
+    'var Symbol = 1; function f() { Symbol(); }',
+    'var Symbol = 1; const f = () => Symbol();',
+    'var Symbol = 1; class C { m() { Symbol(); } }',
+
+    // Import forms shadow the global Symbol
+    'import { Symbol } from "x"; Symbol();',
+    'import Symbol from "x"; Symbol();',
+    'import * as Symbol from "x"; Symbol();',
+    'import { Foo as Symbol } from "x"; Symbol();',
+
+    // Tagged template is not a CallExpression
+    'Symbol`foo`;',
+
+    // Named expression self-reference shadows inside its own body
+    'const f = function Symbol() { Symbol(); };',
+    'const c = class Symbol { m() { Symbol(); } };',
+
+    // TypeScript enum shadows the global value
+    'enum Symbol { A } Symbol();',
+
+    // Namespace / module with identifier name shadows
+    'namespace Symbol {} Symbol();',
+    'module Symbol {} Symbol();',
+    'function f() { namespace Symbol {} Symbol(); }',
+
+    // `declare` value declarations shadow like runtime ones
+    'declare var Symbol: any; Symbol();',
+    'declare function Symbol(): any; Symbol();',
+    'declare const Symbol: any; Symbol();',
+
+    // Class body computed key + class name — inner class name wins
+    'class Symbol { [Symbol()]() {} }',
+    'class X { static E = class Symbol { m() { Symbol(); } }; }',
+
+    // Declaration merging: interface + const shadows
+    'interface Symbol {} const Symbol = 1; Symbol();',
+
+    // `import type` — ts-eslint scope manager treats as binding
+    'import type { Symbol } from "x"; Symbol();',
+    'import type Symbol from "x"; Symbol();',
+    'import { type Symbol } from "x"; Symbol();',
+
+    // `export declare` value forms shadow
+    'export declare var Symbol: any; Symbol();',
+    'export declare function Symbol(): any; Symbol();',
+    'export declare namespace Symbol {} Symbol();',
+    'declare namespace Symbol {} Symbol();',
+    'declare class Symbol {} new Symbol(); Symbol();',
+
+    // Inside a namespace block, local var/function shadow
+    'namespace NS { var Symbol = 1; Symbol(); }',
+    'namespace NS { function Symbol() {} Symbol(); }',
+
+    // Nested-scope shadowing
+    'for (const Symbol = foo; ;) { Symbol(); }',
+    'class C { m() { function Symbol() {} Symbol(); } }',
+    'const f = () => { class Symbol {} return Symbol(); };',
+  ],
+  invalid: [
+    // From ESLint upstream
+    { code: 'Symbol();', errors: [{ messageId: 'expected' }] },
+    {
+      code: 'Symbol(); Symbol = function () {};',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Position / nested-scope
+    { code: 'var foo = Symbol();', errors: [{ messageId: 'expected' }] },
+    {
+      code: 'function f() { return Symbol(); }',
+      errors: [{ messageId: 'expected' }],
+    },
+    { code: 'Symbol(\n);', errors: [{ messageId: 'expected' }] },
+
+    // Parenthesized callee
+    { code: '(Symbol)();', errors: [{ messageId: 'expected' }] },
+    { code: '((Symbol))();', errors: [{ messageId: 'expected' }] },
+
+    // Optional call
+    { code: 'Symbol?.();', errors: [{ messageId: 'expected' }] },
+
+    // Comments don't count as arguments
+    {
+      code: 'Symbol(/* no description */);',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Block-scoped shadow doesn't leak out
+    {
+      code: '{ let Symbol = 1; } Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    {
+      code: 'function f(Symbol) { Symbol(); } Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    {
+      code: '(function (Symbol) {})(1); Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Call sites inside various containers, no shadow
+    { code: 'const f = () => Symbol();', errors: [{ messageId: 'expected' }] },
+    {
+      code: 'class C { m() { Symbol(); } }',
+      errors: [{ messageId: 'expected' }],
+    },
+    {
+      code: 'class C { static { Symbol(); } }',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Multi-line
+    { code: 'var s = Symbol(\n\n);', errors: [{ messageId: 'expected' }] },
+
+    // Call embedded in various expression positions
+    { code: 'throw Symbol();', errors: [{ messageId: 'expected' }] },
+    { code: 'Symbol().toString();', errors: [{ messageId: 'expected' }] },
+    { code: 'x || Symbol();', errors: [{ messageId: 'expected' }] },
+    { code: '(a, Symbol());', errors: [{ messageId: 'expected' }] },
+
+    // Class bodies: field initializer and computed method key
+    { code: 'class C { x = Symbol(); }', errors: [{ messageId: 'expected' }] },
+    {
+      code: 'class C { [Symbol()]() {} }',
+      errors: [{ messageId: 'expected' }],
+    },
+    // Object literal computed property key — different AST path than class
+    {
+      code: 'const obj = { [Symbol()]: 1 };',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Type-only declarations do NOT shadow the runtime value
+    {
+      code: 'type Symbol = string; Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    {
+      code: 'interface Symbol {} Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    // Ambient module with string-literal name does not bind `Symbol`
+    {
+      code: 'declare module "x" {} Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    // Type alias followed by runtime use — `type` is type-only
+    {
+      code: 'type Symbol = string; var s: Symbol = "x"; Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    // Decorator position — the CallExpression is still detected
+    {
+      code: 'class C { @Symbol() method() {} }',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Class field named Symbol does NOT shadow the global
+    {
+      code: 'class C { accessor Symbol = 1; m() { Symbol(); } }',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Destructuring assignment is not a declaration
+    {
+      code: '({ Symbol } = obj); Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    { code: '[Symbol] = arr; Symbol();', errors: [{ messageId: 'expected' }] },
+
+    // declare global { var Symbol } doesn't bring a file-scope var
+    {
+      code: 'declare global { var Symbol: any; } Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Type-position usage doesn't shadow the runtime value
+    {
+      code: 'const x: Symbol = null as any; Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+    {
+      code: 'const x: { Symbol: any } = {} as any; Symbol();',
+      errors: [{ messageId: 'expected' }],
+    },
+
+    // Each call evaluated independently
+    { code: 'Symbol(); Symbol("b");', errors: [{ messageId: 'expected' }] },
+    { code: 'Symbol("a"); Symbol();', errors: [{ messageId: 'expected' }] },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the \`symbol-description\` rule from ESLint to rslint.

Requires a description argument when calling \`Symbol()\`. Helps debugging by making logged symbols identifiable.

Scope determination for whether \`Symbol\` is the global value uses a two-tier strategy to stay aligned with ESLint's scope manager across both ESLint-core and TypeScript-specific language features:

1. \`utils.IsShadowed\` (scope-based, mirrors \`getVariableByName\` + \`variable.defs.length === 0\`) as the primary signal — authoritative for every ESLint test case.
2. \`TypeChecker.GetSymbolAtLocation\` as an additive shadow signal when available: any declaration on a non-lib source file counts as user-bound, except pure-type ones (\`InterfaceDeclaration\` / \`TypeAliasDeclaration\`) which share a symbol via TS namespace merging without shadowing the runtime binding.

Also extends \`utils.IsShadowed\`'s Block branch to recognize \`KindEnumDeclaration\` and identifier-named \`KindModuleDeclaration\` (namespace/module), and guards \`HasLocalDeclarationInStatements\` against ambient modules like \`declare module \"x\"\` whose string-literal name doesn't bind a variable.

Alignment verified against real ESLint v10.2.1 (with \`@typescript-eslint/parser\`) across 102 probe inputs — 66 valid, 36 invalid — covering ESLint upstream cases, argument shapes, every shadowing form (\`var\`/\`let\`/\`const\`/\`function\`/\`class\`/params/destructuring/catch/for-of/hoisting/named function expression self-reference/named class expression self-reference), all import forms (\`import\`, \`import type\`, \`import { type X }\`, \`import * as\`, default, aliased), TypeScript-specific bindings (\`namespace\`, \`module\`, \`enum\`, \`declare var/function/const/class\`, \`declare namespace\`, \`export declare\`, \`interface\` + \`const\` merging, ambient module with string-literal name, \`declare global\`, type-position usage, \`accessor\` class field, \`@Symbol()\` decorator), and call positions (parens, optional call, comments, chained calls, throw, logical, sequence, class field initializer, class/object computed key, multi-line). 0 mismatches.

End-to-end sanity checks on [rsbuild](https://github.com/web-infra-dev/rsbuild) (1197 files) and [rspack](https://github.com/web-infra-dev/rspack) (392 files): no false positives; a probe injection of \`Symbol()\`, \`(Symbol)()\`, \`Symbol?.()\`, and an IIFE-shadowed \`Symbol()\` reproduced exactly 3 diagnostics with correct ranges.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/symbol-description
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/symbol-description.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).