### PR TITLE
feat: port rule no-dupe-class-members

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,7 +35,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_array_delete"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_base_to_string"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_confusing_void_expression"
-	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dupe_class_members"
+	ts_no_dupe_class_members "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dupe_class_members"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_duplicate_enum_values"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_duplicate_type_constituents"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_dynamic_delete"
@@ -140,6 +140,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_debugger"
 	"github.com/web-infra-dev/rslint/internal/rules/no_delete_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_args"
+	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_class_members"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_else_if"
 	"github.com/web-infra-dev/rslint/internal/rules/no_dupe_keys"
 	"github.com/web-infra-dev/rslint/internal/rules/no_duplicate_case"
@@ -467,7 +468,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-array-delete", no_array_delete.NoArrayDeleteRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-base-to-string", no_base_to_string.NoBaseToStringRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-confusing-void-expression", no_confusing_void_expression.NoConfusingVoidExpressionRule)
-	GlobalRuleRegistry.Register("@typescript-eslint/no-dupe-class-members", no_dupe_class_members.NoDupeClassMembersRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-dupe-class-members", ts_no_dupe_class_members.NoDupeClassMembersRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-duplicate-enum-values", no_duplicate_enum_values.NoDuplicateEnumValuesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-duplicate-type-constituents", no_duplicate_type_constituents.NoDuplicateTypeConstituentsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-dynamic-delete", no_dynamic_delete.NoDynamicDeleteRule)
@@ -582,6 +583,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-debugger", no_debugger.NoDebuggerRule)
 	GlobalRuleRegistry.Register("no-delete-var", no_delete_var.NoDeleteVarRule)
 	GlobalRuleRegistry.Register("no-dupe-args", no_dupe_args.NoDupeArgsRule)
+	GlobalRuleRegistry.Register("no-dupe-class-members", no_dupe_class_members.NoDupeClassMembersRule)
 	GlobalRuleRegistry.Register("no-dupe-keys", no_dupe_keys.NoDupeKeysRule)
 	GlobalRuleRegistry.Register("no-duplicate-case", no_duplicate_case.NoDuplicateCaseRule)
 	GlobalRuleRegistry.Register("no-empty", no_empty.NoEmptyRule)

--- a/internal/rules/no_dupe_class_members/no_dupe_class_members.go
+++ b/internal/rules/no_dupe_class_members/no_dupe_class_members.go
@@ -1,0 +1,122 @@
+package no_dupe_class_members
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var NoDupeClassMembersRule = rule.Rule{
+	Name: "no-dupe-class-members",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		checkClass := func(node *ast.Node) {
+			type memberState struct {
+				init bool
+				get  bool
+				set  bool
+			}
+			type stateEntry struct {
+				nonStatic memberState
+				static    memberState
+			}
+			stateMap := make(map[string]*stateEntry)
+
+			for _, member := range node.Members() {
+				// Skip non-static constructors. In TypeScript-Go's AST, both the
+				// constructor keyword and string-literal 'constructor'() parse as
+				// KindConstructor. ESLint skips both (kind="constructor"). Static
+				// constructor() is a regular static method (kind="method") in ESLint.
+				if ast.IsConstructorDeclaration(member) && !ast.IsStatic(member) {
+					continue
+				}
+				// Overload signatures and abstract declarations (methods, getters,
+				// setters) have no body. Skip them so only concrete implementations
+				// participate in duplicate checking. PropertyDeclaration never has a
+				// body and must not be skipped.
+				if !ast.IsPropertyDeclaration(member) && member.Body() == nil {
+					continue
+				}
+
+				// Determine the duplicate-detection category.
+				// A get + set pair for the same name is allowed; anything else collides.
+				var kind string
+				switch {
+				case ast.IsGetAccessorDeclaration(member):
+					kind = "get"
+				case ast.IsSetAccessorDeclaration(member):
+					kind = "set"
+				case ast.IsMethodDeclaration(member), ast.IsPropertyDeclaration(member):
+					kind = "init"
+				case ast.IsConstructorDeclaration(member):
+					// Static constructor — treated as a static method named "constructor".
+					kind = "init"
+				default:
+					continue
+				}
+
+				// Static constructors have name=nil in TypeScript-Go's AST; use "constructor".
+				var name string
+				nameNode := ast.GetNameOfDeclaration(member)
+				if nameNode != nil {
+					var ok bool
+					name, ok = utils.GetStaticPropertyName(nameNode)
+					if !ok {
+						continue // computed property with non-static expression
+					}
+				} else if ast.IsConstructorDeclaration(member) {
+					name = "constructor"
+				} else {
+					continue
+				}
+
+				// "$" prefix avoids collisions with built-in map keys.
+				key := "$" + name
+				if stateMap[key] == nil {
+					stateMap[key] = &stateEntry{}
+				}
+
+				state := &stateMap[key].nonStatic
+				if ast.IsStatic(member) {
+					state = &stateMap[key].static
+				}
+
+				var isDuplicate bool
+				switch kind {
+				case "get":
+					isDuplicate = state.init || state.get
+					state.get = true
+				case "set":
+					isDuplicate = state.init || state.set
+					state.set = true
+				default: // "init"
+					isDuplicate = state.init || state.get || state.set
+					state.init = true
+				}
+
+				if isDuplicate {
+					reportNode := nameNode
+					// For computed names (e.g. ['foo']), ESLint reports at the inner
+					// expression (the resolved key). The tsgo ComputedPropertyName
+					// node starts at `[`, so unwrap it to match ESLint's position.
+					if reportNode != nil && ast.IsComputedPropertyName(reportNode) {
+						reportNode = reportNode.AsComputedPropertyName().Expression
+					}
+					if reportNode == nil {
+						reportNode = member // static constructor (no name node)
+					}
+					ctx.ReportNode(reportNode, rule.RuleMessage{
+						Id:          "unexpected",
+						Description: fmt.Sprintf("Duplicate name '%s'.", name),
+					})
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: checkClass,
+			ast.KindClassExpression:  checkClass,
+		}
+	},
+}

--- a/internal/rules/no_dupe_class_members/no_dupe_class_members.go
+++ b/internal/rules/no_dupe_class_members/no_dupe_class_members.go
@@ -73,13 +73,15 @@ var NoDupeClassMembersRule = rule.Rule{
 
 				// "$" prefix avoids collisions with built-in map keys.
 				key := "$" + name
-				if stateMap[key] == nil {
-					stateMap[key] = &stateEntry{}
+				entry, ok := stateMap[key]
+				if !ok {
+					entry = &stateEntry{}
+					stateMap[key] = entry
 				}
 
-				state := &stateMap[key].nonStatic
+				state := &entry.nonStatic
 				if ast.IsStatic(member) {
-					state = &stateMap[key].static
+					state = &entry.static
 				}
 
 				var isDuplicate bool

--- a/internal/rules/no_dupe_class_members/no_dupe_class_members.md
+++ b/internal/rules/no_dupe_class_members/no_dupe_class_members.md
@@ -1,0 +1,77 @@
+# no-dupe-class-members
+
+## Rule Details
+
+Disallow duplicate names in class members. If there are declarations of the same name in class members, the last declaration silently overwrites the earlier ones, which can cause unexpected behavior.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class A {
+  bar() {}
+  bar() {}
+}
+
+class B {
+  bar() {}
+  get bar() {}
+}
+
+class C {
+  bar;
+  bar;
+}
+
+class D {
+  bar;
+  bar() {}
+}
+
+class E {
+  static bar() {}
+  static bar() {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class A {
+  bar() {}
+  qux() {}
+}
+
+class B {
+  get bar() {}
+  set bar(value) {}
+}
+
+class C {
+  bar;
+  qux;
+}
+
+class D {
+  bar;
+  qux() {}
+}
+
+class E {
+  static bar() {}
+  bar() {}
+}
+```
+
+TypeScript method overload signatures are allowed:
+
+```typescript
+class A {
+  foo(value: string): void;
+  foo(value: number): void;
+  foo(value: string | number) {}
+}
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-dupe-class-members

--- a/internal/rules/no_dupe_class_members/no_dupe_class_members_test.go
+++ b/internal/rules/no_dupe_class_members/no_dupe_class_members_test.go
@@ -1,0 +1,515 @@
+package no_dupe_class_members
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDupeClassMembersRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoDupeClassMembersRule,
+		[]rule_tester.ValidTestCase{
+			// ---- basic: different names ----
+			{Code: `class A { foo() {} bar() {} }`},
+			{Code: `class A { static foo() {} foo() {} }`},
+			{Code: `class A { get foo() {} set foo(value) {} }`},
+			{Code: `class A { static foo() {} get foo() {} set foo(value) {} }`},
+			{Code: `class A { foo() { } } class B { foo() { } }`},
+			{Code: `class A { [foo]() {} foo() {} }`},
+			{Code: `class A { 'foo'() {} 'bar'() {} baz() {} }`},
+			{Code: `class A { *'foo'() {} *'bar'() {} *baz() {} }`},
+			{Code: `class A { get 'foo'() {} get 'bar'() {} get baz() {} }`},
+			{Code: `class A { 1() {} 2() {} }`},
+			{Code: `class A { ['foo']() {} ['bar']() {} }`},
+			{Code: "class A { [`foo`]() {} [`bar`]() {} }"},
+			{Code: `class A { [12]() {} [123]() {} }`},
+			{Code: `class A { [1.0]() {} ['1.0']() {} }`},
+			{Code: `class A { [0x1]() {} [` + "`0x1`" + `]() {} }`},
+			{Code: `class A { [null]() {} ['']() {} }`},
+			{Code: `class A { get ['foo']() {} set ['foo'](value) {} }`},
+			{Code: `class A { ['foo']() {} static ['foo']() {} }`},
+
+			// ---- computed "constructor" key doesn't create constructor ----
+			{Code: `class A { ['constructor']() {} constructor() {} }`},
+			{Code: "class A { 'constructor'() {} [`constructor`]() {} }"},
+			{Code: "class A { constructor() {} get [`constructor`]() {} }"},
+			{Code: `class A { 'constructor'() {} set ['constructor'](value) {} }`},
+
+			// ---- not assumed to be statically-known values ----
+			{Code: `class A { ['foo' + '']() {} ['foo']() {} }`},
+			{Code: "class A { [`foo${''}`]() {} [`foo`]() {} }"},
+			{Code: `class A { [-1]() {} ['-1']() {} }`},
+
+			// ---- computed with non-literal expression (ESLint: "not supported by this rule") ----
+			{Code: `class A { [foo]() {} [foo]() {} }`},
+
+			// ---- private and public ----
+			{Code: `class A { foo; static foo; }`},
+			{Code: `class A { foo; #foo; }`},
+			{Code: `class A { '#foo'; #foo; }`},
+
+			// ---- TypeScript method overloads (upstream ts parser suite) ----
+			{Code: `class Foo { foo(a: string): string; foo(a: number): number; foo(a: any): any {} }`},
+			{Code: `class A { foo(a: string): void; foo(a: number): void; foo(a: boolean): void; foo(a: any) {} }`},
+			{Code: `class A { static foo(a: string): void; static foo(a: number): void; static foo(a: any) {} }`},
+			{Code: `class A { constructor(a: string); constructor(a: number); constructor(a: any) {} }`},
+			{Code: `class A { foo(a: string): void; get foo() { return ''; } }`},
+
+			// ---- abstract methods (no body, like overloads) ----
+			{Code: `abstract class A { abstract foo(): void; foo() {} }`},
+			{Code: `abstract class A { abstract foo(): void; abstract bar(): void; }`},
+			{Code: `abstract class A { abstract get foo(): string; foo = 1; }`},
+			{Code: `abstract class A { abstract set foo(v: string); foo = 1; }`},
+			{Code: `abstract class A { abstract get foo(): string; abstract set foo(v: string); }`},
+
+			// ---- nested classes: inner members don't conflict with outer ----
+			{Code: `class Outer { foo() {} bar() { class Inner { foo() {} } } }`},
+			{Code: `class Outer { foo = class Inner { foo() {} }; }`},
+			{Code: `class L1 { foo() {} bar() { class L2 { foo() {} baz() { class L3 { foo() {} } } } } }`},
+			{Code: `class Outer { static foo() {} static { class Inner { foo() {} } } }`},
+
+			// ---- extends does not create conflicts across classes ----
+			{Code: `class Base { foo() {} } class Child extends Base { foo() {} }`},
+
+			// ---- empty / single member ----
+			{Code: `class A {}`},
+			{Code: `class A { foo() {} }`},
+
+			// ---- mixed async / generator / property types ----
+			{Code: `class A { async foo() {} bar() {} }`},
+			{Code: `class A { *foo() {} bar() {} }`},
+			{Code: `class A { async *foo() {} bar() {} }`},
+			{Code: `class A { get foo() {} set foo(v) {} bar() {} baz; }`},
+
+			// ---- property with function-expression initializer (single, no dup) ----
+			{Code: `class A { foo = () => {} }`},
+			{Code: `class A { foo = function() {} }`},
+
+			// ---- computed + identifier mixed accessor pair (allowed) ----
+			{Code: `class A { get ['foo']() {} set foo(v) {} }`},
+
+			// ---- index signature does not participate ----
+			{Code: `class A { [key: string]: any; foo() {} bar() {} }`},
+
+			// ---- declare property alone (no dup) ----
+			{Code: `class A { declare foo: string; }`},
+
+			// ---- non-static string-literal 'constructor' (parsed as constructor — skipped) ----
+			{Code: `class A { 'constructor'() {} }`},
+			{Code: `class A { 'constructor'() {} constructor() {} }`},
+			{Code: `class A { 'constructor'() {} 'constructor'() {} }`},
+
+			// ---- static + non-static constructor don't conflict ----
+			{Code: `class A { static constructor() {} constructor() {} }`},
+
+			// ---- Symbol as computed key: dynamic, not deduplicated ----
+			{Code: `class A { [Symbol.iterator]() {} [Symbol.hasInstance]() {} }`},
+
+			// ---- expressions with side effects: not statically analyzed ----
+			{Code: `class A { [a++]() {} [a++]() {} }`},
+			{Code: `class A { [foo + bar]() {} [foo + bar]() {} }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- basic duplicates ----
+			{
+				Code: `class A { foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20, Message: "Duplicate name 'foo'."},
+				},
+			},
+			{
+				Code: `!class A { foo() {} foo() {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `class A { 'foo'() {} 'foo'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `class A { 10() {} 1e1() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 19, Message: "Duplicate name '10'."},
+				},
+			},
+			{
+				Code: `class A { ['foo']() {} ['foo']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: `class A { static ['foo']() {} static foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: `class A { set 'foo'(value) {} set ['foo'](val) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `class A { ''() {} ['']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20, Message: "Duplicate name ''."},
+				},
+			},
+			{
+				Code: "class A { [`foo`]() {} [`foo`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code: "class A { static get [`foo`]() {} static get ['foo']() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 47},
+				},
+			},
+			{
+				Code: "class A { foo() {} [`foo`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: "class A { get [`foo`]() {} 'foo'() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+			{
+				Code: "class A { static 'foo'() {} static [`foo`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 37},
+				},
+			},
+
+			// ---- computed 'constructor' duplicates (not the keyword constructor) ----
+			{
+				Code: `class A { ['constructor']() {} ['constructor']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 33, Message: "Duplicate name 'constructor'."},
+				},
+			},
+			// Divergence: tsgo parses `static constructor()` and `static 'constructor'()`
+			// as KindConstructor (no name node), so we fall back to reporting at the
+			// member start (including `static`) rather than ESLint's name position.
+			{
+				Code: "class A { static [`constructor`]() {} static constructor() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 39},
+				},
+			},
+			{
+				Code: `class A { static constructor() {} static 'constructor'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+
+			// ---- numeric literal equivalence ----
+			{
+				Code: `class A { [123]() {} [123]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23, Message: "Duplicate name '123'."},
+				},
+			},
+			{
+				Code: `class A { [0x10]() {} 16() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23, Message: "Duplicate name '16'."},
+				},
+			},
+			{
+				Code: `class A { [100]() {} [1e2]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: "class A { [123.00]() {} [`123`]() {} }",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `class A { static '65'() {} static [0o101]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code: `class A { [123n]() {} 123() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23, Message: "Duplicate name '123'."},
+				},
+			},
+			{
+				Code: `class A { [null]() {} 'null'() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 23, Message: "Duplicate name 'null'."},
+				},
+			},
+
+			// ---- triple / multi-duplicates ----
+			{
+				Code: `class A { foo() {} foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 20},
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+
+			// ---- static duplicates ----
+			{
+				Code: `class A { static foo() {} static foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 34},
+				},
+			},
+
+			// ---- method / accessor cross-kind conflicts ----
+			{
+				Code: `class A { foo() {} get foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+			{
+				Code: `class A { set foo(value) {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+				},
+			},
+
+			// ---- property declarations ----
+			{
+				Code: `class A { foo; foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- TypeScript overload edge case: two implementations after overloads ----
+			{
+				Code: `class A { foo(a: string): void; foo(a: any) {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 48},
+				},
+			},
+			// Property + method (TS-specific scenario)
+			{
+				Code: `class A { foo; foo = 42; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `class A { foo; foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 16},
+				},
+			},
+			// Multi-line class body (position assertion with EndLine / EndColumn)
+			{
+				Code: "class A {\n  foo() {}\n  foo() {}\n}",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 3, Column: 3, EndLine: 3, EndColumn: 6},
+				},
+			},
+
+			// ---- async / generator duplicates ----
+			{
+				Code: `class A { async foo() {} async foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code: `class A { *foo() {} *foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code: `class A { foo() {} async foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- class expression with duplicates ----
+			{
+				Code: `var x = class { foo() {} foo() {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- nested classes: duplicates inside the inner class only ----
+			{
+				Code: `class Outer { bar() {} foo() { class Inner { baz() {} baz() {} } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 55},
+				},
+			},
+			// duplicates in both outer and inner class
+			{
+				Code: `class Outer { foo() {} foo() {} bar() { class Inner { baz() {} baz() {} } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+					{MessageId: "unexpected", Line: 1, Column: 64},
+				},
+			},
+			// deeply nested: duplicate at innermost level
+			{
+				Code: `class L1 { a() { class L2 { b() { class L3 { foo() {} foo() {} } } } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 55},
+				},
+			},
+
+			// ---- state isolation: independent names tracked separately ----
+			{
+				Code: `class A { foo() {} bar() {} foo() {} bar() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 29},
+					{MessageId: "unexpected", Line: 1, Column: 38},
+				},
+			},
+
+			// ---- init-before-accessor-pair: init taints both get and set ----
+			{
+				Code: `class A { foo = 1; get foo() {} set foo(v) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+					{MessageId: "unexpected", Line: 1, Column: 37},
+				},
+			},
+
+			// ---- dup getter then setter: only getter errors; setter still pairs ----
+			{
+				Code: `class A { get foo() {} get foo() {} set foo(v) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 28},
+				},
+			},
+
+			// ---- method taints get; dup getter + setter after ----
+			{
+				Code: `class A { foo() {} get foo() {} get foo() {} set foo(v) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+					{MessageId: "unexpected", Line: 1, Column: 37},
+					{MessageId: "unexpected", Line: 1, Column: 50},
+				},
+			},
+
+			// ---- class with extends: child duplicates still detected ----
+			{
+				Code: `class Base { foo() {} } class Child extends Base { foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 61},
+				},
+			},
+
+			// ---- __proto__ as class method is a regular name, duplicates detected ----
+			{
+				Code: `class A { __proto__() {} __proto__() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 26},
+				},
+			},
+
+			// ---- property with arrow function initializer duplicate ----
+			{
+				Code: `class A { foo = () => {}; foo = () => {}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 27},
+				},
+			},
+
+			// ---- index signature doesn't participate but other duplicates still caught ----
+			{
+				Code: `class A { [key: string]: any; foo() {} foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 40},
+				},
+			},
+
+			// ---- definite assignment (!) doesn't affect name resolution ----
+			{
+				Code: `class A { foo!: string; foo!: number; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- access modifiers (public/private/protected) don't affect name ----
+			{
+				Code: `class A { private foo() {} public foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code: `class A { protected foo: string; foo: number; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 34},
+				},
+			},
+
+			// ---- readonly doesn't affect name ----
+			{
+				Code: `class A { readonly foo: string; foo: number; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 33},
+				},
+			},
+
+			// ---- optional property doesn't affect name ----
+			{
+				Code: `class A { foo?: string; foo: number; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- PropertyDeclaration with computed name ----
+			{
+				Code: `class A { ['foo'] = 1; foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 24},
+				},
+			},
+
+			// ---- declare property + method (declare is still a PropertyDeclaration) ----
+			{
+				Code: `class A { declare foo: string; foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 32},
+				},
+			},
+
+			// ---- static and non-static each independently duplicated ----
+			{
+				Code: `class A { foo() {} static foo() {} foo() {} static foo() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unexpected", Line: 1, Column: 36},
+					{MessageId: "unexpected", Line: 1, Column: 52},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -32,6 +32,7 @@ export default defineConfig({
     './tests/eslint/rules/no-case-declarations.test.ts',
     './tests/eslint/rules/no-console.test.ts',
     './tests/eslint/rules/no-dupe-args.test.ts',
+    './tests/eslint/rules/no-dupe-class-members.test.ts',
     './tests/eslint/rules/no-dupe-keys.test.ts',
     './tests/eslint/rules/no-duplicate-case.test.ts',
     './tests/eslint/rules/no-empty.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-dupe-class-members.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-dupe-class-members.test.ts.snap
@@ -1,0 +1,1458 @@
+// Rstest Snapshot v1
+
+exports[`no-dupe-class-members > invalid 1`] = `
+{
+  "code": "class A { foo() {} foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 2`] = `
+{
+  "code": "!class A { foo() {} foo() {} };",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 3`] = `
+{
+  "code": "class A { 'foo'() {} 'foo'() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 4`] = `
+{
+  "code": "class A { 10() {} 1e1() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '10'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 5`] = `
+{
+  "code": "class A { ['foo']() {} ['foo']() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 6`] = `
+{
+  "code": "class A { static ['foo']() {} static foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 7`] = `
+{
+  "code": "class A { set 'foo'(value) {} set ['foo'](val) {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 8`] = `
+{
+  "code": "class A { ''() {} ['']() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name ''.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 9`] = `
+{
+  "code": "class A { [\`foo\`]() {} [\`foo\`]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 10`] = `
+{
+  "code": "class A { static get [\`foo\`]() {} static get ['foo']() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 11`] = `
+{
+  "code": "class A { foo() {} [\`foo\`]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 12`] = `
+{
+  "code": "class A { get [\`foo\`]() {} 'foo'() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 13`] = `
+{
+  "code": "class A { static 'foo'() {} static [\`foo\`]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 14`] = `
+{
+  "code": "class A { ['constructor']() {} ['constructor']() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'constructor'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 15`] = `
+{
+  "code": "class A { static [\`constructor\`]() {} static constructor() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'constructor'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 16`] = `
+{
+  "code": "class A { static constructor() {} static 'constructor'() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'constructor'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 17`] = `
+{
+  "code": "class A { [123]() {} [123]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '123'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 18`] = `
+{
+  "code": "class A { [0x10]() {} 16() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '16'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 19`] = `
+{
+  "code": "class A { [100]() {} [1e2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '100'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 20`] = `
+{
+  "code": "class A { [123.00]() {} [\`123\`]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '123'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 21`] = `
+{
+  "code": "class A { static '65'() {} static [0o101]() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '65'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 22`] = `
+{
+  "code": "class A { [123n]() {} 123() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '123'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 23`] = `
+{
+  "code": "class A { [null]() {} 'null'() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'null'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 24`] = `
+{
+  "code": "class A { foo() {} foo() {} foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 25`] = `
+{
+  "code": "class A { static foo() {} static foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 26`] = `
+{
+  "code": "class A { foo() {} get foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 27`] = `
+{
+  "code": "class A { set foo(value) {} foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 28`] = `
+{
+  "code": "class A { foo; foo; }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 29`] = `
+{
+  "code": "class A { foo; foo = 42; }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 30`] = `
+{
+  "code": "class A { foo; foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 31`] = `
+{
+  "code": "class A { foo(a: string): void; foo(a: any) {} foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 32`] = `
+{
+  "code": "class A { async foo() {} async foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 33`] = `
+{
+  "code": "class A { *foo() {} *foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 34`] = `
+{
+  "code": "class A { foo() {} async foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 35`] = `
+{
+  "code": "var x = class { foo() {} foo() {} };",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 36`] = `
+{
+  "code": "class Outer { bar() {} foo() { class Inner { baz() {} baz() {} } } }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'baz'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 37`] = `
+{
+  "code": "class Outer { foo() {} foo() {} bar() { class Inner { baz() {} baz() {} } } }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'baz'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 64,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 38`] = `
+{
+  "code": "class A { foo() {} bar() {} foo() {} bar() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'bar'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 39`] = `
+{
+  "code": "class A { foo = 1; get foo() {} set foo(v) {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 40`] = `
+{
+  "code": "class A { get foo() {} get foo() {} set foo(v) {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 41`] = `
+{
+  "code": "class A { foo() {} get foo() {} get foo() {} set foo(v) {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 42`] = `
+{
+  "code": "class Base { foo() {} } class Child extends Base { foo() {} foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 43`] = `
+{
+  "code": "class A { __proto__() {} __proto__() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name '__proto__'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 44`] = `
+{
+  "code": "class A { foo = () => {}; foo = () => {}; }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 45`] = `
+{
+  "code": "class A { [key: string]: any; foo() {} foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 46`] = `
+{
+  "code": "class A { foo!: string; foo!: number; }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 47`] = `
+{
+  "code": "class A { private foo() {} public foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 48`] = `
+{
+  "code": "class A { readonly foo: string; foo: number; }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 49`] = `
+{
+  "code": "class A { foo?: string; foo: number; }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 50`] = `
+{
+  "code": "class A { ['foo'] = 1; foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 51`] = `
+{
+  "code": "class A { declare foo: string; foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-dupe-class-members > invalid 52`] = `
+{
+  "code": "class A { foo() {} static foo() {} foo() {} static foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+    {
+      "message": "Duplicate name 'foo'.",
+      "messageId": "unexpected",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-dupe-class-members",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-dupe-class-members.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-dupe-class-members.test.ts
@@ -1,0 +1,314 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-dupe-class-members', {
+  valid: [
+    'class A { foo() {} bar() {} }',
+    'class A { static foo() {} foo() {} }',
+    'class A { get foo() {} set foo(value) {} }',
+    'class A { static foo() {} get foo() {} set foo(value) {} }',
+    'class A { foo() { } } class B { foo() { } }',
+    'class A { [foo]() {} foo() {} }',
+    "class A { 'foo'() {} 'bar'() {} baz() {} }",
+    "class A { *'foo'() {} *'bar'() {} *baz() {} }",
+    "class A { get 'foo'() {} get 'bar'() {} get baz() {} }",
+    'class A { 1() {} 2() {} }',
+    "class A { ['foo']() {} ['bar']() {} }",
+    'class A { [`foo`]() {} [`bar`]() {} }',
+    'class A { [12]() {} [123]() {} }',
+    "class A { [1.0]() {} ['1.0']() {} }",
+    'class A { [0x1]() {} [`0x1`]() {} }',
+    "class A { [null]() {} ['']() {} }",
+    "class A { get ['foo']() {} set ['foo'](value) {} }",
+    "class A { ['foo']() {} static ['foo']() {} }",
+    // computed "constructor" key doesn't create a constructor
+    "class A { ['constructor']() {} constructor() {} }",
+    "class A { 'constructor'() {} [`constructor`]() {} }",
+    'class A { constructor() {} get [`constructor`]() {} }',
+    "class A { 'constructor'() {} set ['constructor'](value) {} }",
+    // not assumed to be statically-known values
+    "class A { ['foo' + '']() {} ['foo']() {} }",
+    "class A { [`foo${''}`]() {} [`foo`]() {} }",
+    "class A { [-1]() {} ['-1']() {} }",
+    // non-literal computed key (not statically analyzed)
+    'class A { [foo]() {} [foo]() {} }',
+    // private and public
+    'class A { foo; static foo; }',
+    'class A { foo; #foo; }',
+    "class A { '#foo'; #foo; }",
+    // TypeScript method overloads
+    'class Foo { foo(a: string): string; foo(a: number): number; foo(a: any): any {} }',
+    'class A { static foo(a: string): void; static foo(a: number): void; static foo(a: any) {} }',
+    'class A { constructor(a: string); constructor(a: number); constructor(a: any) {} }',
+    'class A { foo(a: string): void; get foo() { return ""; } }',
+    // abstract methods (no body)
+    'abstract class A { abstract foo(): void; foo() {} }',
+    'abstract class A { abstract get foo(): string; abstract set foo(v: string); }',
+    // nested classes: outer and inner don't conflict
+    'class Outer { foo() {} bar() { class Inner { foo() {} } } }',
+    'class L1 { foo() {} bar() { class L2 { foo() {} baz() { class L3 { foo() {} } } } } }',
+    // extends: same name across parent and child is fine
+    'class Base { foo() {} } class Child extends Base { foo() {} }',
+    // property with function-expression initializer
+    'class A { foo = () => {} }',
+    // mixed async / generator / accessor
+    'class A { async foo() {} bar() {} }',
+    'class A { *foo() {} bar() {} }',
+    'class A { async *foo() {} bar() {} }',
+    // index signature is not a class member for this rule
+    'class A { [key: string]: any; foo() {} bar() {} }',
+    // declare property alone
+    'class A { declare foo: string; }',
+    // empty / single-member class
+    'class A {}',
+    // non-static string-literal 'constructor' is still a constructor → skipped
+    "class A { 'constructor'() {} constructor() {} }",
+    // static + non-static constructor don't conflict (static is a method)
+    'class A { static constructor() {} constructor() {} }',
+    // Symbol-based computed key: dynamic, not deduplicated
+    'class A { [Symbol.iterator]() {} [Symbol.hasInstance]() {} }',
+    // side-effect expressions: not statically analyzed
+    'class A { [a++]() {} [a++]() {} }',
+  ],
+  invalid: [
+    {
+      code: 'class A { foo() {} foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: '!class A { foo() {} foo() {} };',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { 'foo'() {} 'foo'() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { 10() {} 1e1() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { ['foo']() {} ['foo']() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { static ['foo']() {} static foo() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { set 'foo'(value) {} set ['foo'](val) {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { ''() {} ['']() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { [`foo`]() {} [`foo`]() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { static get [`foo`]() {} static get ['foo']() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { foo() {} [`foo`]() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { get [`foo`]() {} 'foo'() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { static 'foo'() {} static [`foo`]() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // computed 'constructor' duplicates (not the keyword constructor)
+    {
+      code: "class A { ['constructor']() {} ['constructor']() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static [`constructor`]() {} static constructor() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { static constructor() {} static 'constructor'() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // numeric literal equivalence
+    {
+      code: 'class A { [123]() {} [123]() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { [0x10]() {} 16() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { [100]() {} [1e2]() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { [123.00]() {} [`123`]() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { static '65'() {} static [0o101]() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { [123n]() {} 123() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: "class A { [null]() {} 'null'() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // triple duplicate
+    {
+      code: 'class A { foo() {} foo() {} foo() {} }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { static foo() {} static foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // method / accessor cross-kind conflicts
+    {
+      code: 'class A { foo() {} get foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { set foo(value) {} foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // property declarations
+    {
+      code: 'class A { foo; foo; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // TS-specific: property + method
+    {
+      code: 'class A { foo; foo = 42; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { foo; foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // Overload + two implementations → duplicate only on the extra impl
+    {
+      code: 'class A { foo(a: string): void; foo(a: any) {} foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // async / generator duplicates
+    {
+      code: 'class A { async foo() {} async foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { *foo() {} *foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    {
+      code: 'class A { foo() {} async foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // class expression with duplicates
+    {
+      code: 'var x = class { foo() {} foo() {} };',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // nested classes: duplicate inside the inner class only
+    {
+      code: 'class Outer { bar() {} foo() { class Inner { baz() {} baz() {} } } }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // duplicates in both outer and inner class
+    {
+      code: 'class Outer { foo() {} foo() {} bar() { class Inner { baz() {} baz() {} } } }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    // state isolation: independent names reported independently
+    {
+      code: 'class A { foo() {} bar() {} foo() {} bar() {} }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    // init taints both accessors → 2 errors
+    {
+      code: 'class A { foo = 1; get foo() {} set foo(v) {} }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+    // duplicate getter followed by valid setter → 1 error (getter), setter still pairs
+    {
+      code: 'class A { get foo() {} get foo() {} set foo(v) {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // method + dup getter + setter → 3 errors
+    {
+      code: 'class A { foo() {} get foo() {} get foo() {} set foo(v) {} }',
+      errors: [
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+        { messageId: 'unexpected' },
+      ],
+    },
+    // extends: child duplicates still detected
+    {
+      code: 'class Base { foo() {} } class Child extends Base { foo() {} foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // __proto__ as class method: duplicates detected
+    {
+      code: 'class A { __proto__() {} __proto__() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // property with arrow function initializer
+    {
+      code: 'class A { foo = () => {}; foo = () => {}; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // index signature present, duplicates elsewhere still caught
+    {
+      code: 'class A { [key: string]: any; foo() {} foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // definite assignment (!) doesn't affect the name
+    {
+      code: 'class A { foo!: string; foo!: number; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // access modifiers don't affect name
+    {
+      code: 'class A { private foo() {} public foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // readonly doesn't affect name
+    {
+      code: 'class A { readonly foo: string; foo: number; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // optional property doesn't affect name
+    {
+      code: 'class A { foo?: string; foo: number; }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // PropertyDeclaration with computed name
+    {
+      code: "class A { ['foo'] = 1; foo() {} }",
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // declare property + method
+    {
+      code: 'class A { declare foo: string; foo() {} }',
+      errors: [{ messageId: 'unexpected' }],
+    },
+    // static and non-static each independently duplicated
+    {
+      code: 'class A { foo() {} static foo() {} foo() {} static foo() {} }',
+      errors: [{ messageId: 'unexpected' }, { messageId: 'unexpected' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint core `no-dupe-class-members` rule to rslint.

The rule disallows duplicate names in class members (methods, properties, getters, setters). A getter and setter with the same name are allowed; any other combination (method+method, property+method, method+getter, etc.) is reported. `static` and non-`static` members are tracked independently. TypeScript method overloads and abstract declarations (bodyless) are skipped, matching the upstream handling of `TSEmptyBodyFunctionExpression`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-dupe-class-members
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-dupe-class-members.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).