### PR TITLE
feat: port rule no-useless-rename

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,6 +199,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
 	"github.com/web-infra-dev/rslint/internal/rules/object_shorthand"
@@ -652,6 +653,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
+	GlobalRuleRegistry.Register("no-useless-rename", no_useless_rename.NoUselessRenameRule)
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
 	GlobalRuleRegistry.Register("require-yield", require_yield.RequireYieldRule)
 }

--- a/internal/rules/no_useless_rename/no_useless_rename.go
+++ b/internal/rules/no_useless_rename/no_useless_rename.go
@@ -1,0 +1,303 @@
+package no_useless_rename
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-useless-rename
+
+type options struct {
+	ignoreDestructuring bool
+	ignoreImport        bool
+	ignoreExport        bool
+}
+
+func parseOptions(opts any) options {
+	out := options{}
+	m := utils.GetOptionsMap(opts)
+	if m == nil {
+		return out
+	}
+	if v, ok := m["ignoreDestructuring"].(bool); ok {
+		out.ignoreDestructuring = v
+	}
+	if v, ok := m["ignoreImport"].(bool); ok {
+		out.ignoreImport = v
+	}
+	if v, ok := m["ignoreExport"].(bool); ok {
+		out.ignoreExport = v
+	}
+	return out
+}
+
+var NoUselessRenameRule = rule.Rule{
+	Name: "no-useless-rename",
+	Run: func(ctx rule.RuleContext, optionsAny any) rule.RuleListeners {
+		opts := parseOptions(optionsAny)
+		sf := ctx.SourceFile
+
+		// report emits the diagnostic, attaching an autofix when possible.
+		// - `outerNode`: the node whose range is replaced by the fix (the
+		//   BindingElement / PropertyAssignment / ImportSpecifier / ExportSpecifier).
+		// - `displayName`: the name shown in the message (corresponds to the
+		//   ESLint rule's `initial.name || initial.value`).
+		// - `reportType`: one of "Destructuring assignment" / "Import" / "Export".
+		// - `fix`: precomputed fix or nil.
+		report := func(outerNode *ast.Node, displayName, reportType string, fix *rule.RuleFix) {
+			msg := rule.RuleMessage{
+				Id:          "unnecessarilyRenamed",
+				Description: reportType + " " + displayName + " unnecessarily renamed.",
+			}
+			if fix != nil {
+				ctx.ReportNodeWithFixes(outerNode, msg, *fix)
+				return
+			}
+			ctx.ReportNode(outerNode, msg)
+		}
+
+		// hasCommentBytes reports whether `//` or `/*` appears in the byte
+		// range [start, end). Scanner-based lookups (`utils.HasCommentsInRange`)
+		// are anchored at token boundaries and miss comments that sit between
+		// specific child nodes — here we just need to know whether the
+		// PropertyAssignment / BindingElement / specifier contains any
+		// comment between the "removed" prefix and the "kept" tail. Since
+		// these ranges only cover identifiers, colons, parentheses, and the
+		// `as` keyword, a raw byte scan can't be confused by string or regex
+		// literals the way it could in general code.
+		sourceText := sf.Text()
+		hasCommentBytes := func(start, end int) bool {
+			if end > len(sourceText) {
+				end = len(sourceText)
+			}
+			for i := start; i+1 < end; i++ {
+				if sourceText[i] == '/' && (sourceText[i+1] == '/' || sourceText[i+1] == '*') {
+					return true
+				}
+			}
+			return false
+		}
+
+		// buildRangeFix replaces `outerRange` with the source text at
+		// `keepRange`. Returns nil if any comment sits in the portion of
+		// `outerRange` outside `keepRange` (the "removed" prefix
+		// [outer.Pos, keep.Pos) or suffix [keep.End, outer.End)) — dropping
+		// comments silently would lose information.
+		buildRangeFix := func(outerRange, keepRange core.TextRange) *rule.RuleFix {
+			if hasCommentBytes(outerRange.Pos(), keepRange.Pos()) {
+				return nil
+			}
+			if hasCommentBytes(keepRange.End(), outerRange.End()) {
+				return nil
+			}
+			text := sourceText[keepRange.Pos():keepRange.End()]
+			fix := rule.RuleFixReplaceRange(outerRange, text)
+			return &fix
+		}
+
+		// ---- ImportSpecifier: `import { foo as foo } from '...'` ----
+		// In tsgo's AST, `propertyName` is the name before `as` (= ESTree's
+		// `imported`), `name` is after `as` (= ESTree's `local`). ESLint only
+		// fires when an explicit `as` is written (imported.range !== local.range);
+		// tsgo encodes that as `propertyName != nil`.
+		checkImport := func(node *ast.Node) {
+			if opts.ignoreImport {
+				return
+			}
+			spec := node.AsImportSpecifier()
+			if spec == nil || spec.PropertyName == nil {
+				return
+			}
+			// `spec.PropertyName` is a ModuleExportName (Identifier | StringLiteral);
+			// `spec.Name()` is always an Identifier (the local binding).
+			// `utils.GetStaticPropertyName` resolves both to their canonical text.
+			importedName, ok := utils.GetStaticPropertyName(spec.PropertyName)
+			if !ok {
+				return
+			}
+			localName := spec.Name().AsIdentifier().Text
+			if importedName != localName {
+				return
+			}
+			outerRange := utils.TrimNodeTextRange(sf, node)
+			replRange := utils.TrimNodeTextRange(sf, spec.Name())
+			fix := buildRangeFix(outerRange, replRange)
+			report(node, importedName, "Import", fix)
+		}
+
+		// ---- ExportSpecifier: `export { foo as foo }` ----
+		// Both `propertyName` (before `as`) and `name` (after `as`) are
+		// ModuleExportName (Identifier | StringLiteral). ESLint only fires when
+		// `as` is explicit (local.range !== exported.range); in tsgo that's
+		// `propertyName != nil`.
+		checkExport := func(node *ast.Node) {
+			if opts.ignoreExport {
+				return
+			}
+			spec := node.AsExportSpecifier()
+			if spec == nil || spec.PropertyName == nil {
+				return
+			}
+			// Both ends are ModuleExportName — accept Identifier and StringLiteral.
+			localName, ok := utils.GetStaticPropertyName(spec.PropertyName)
+			if !ok {
+				return
+			}
+			exportedName, ok := utils.GetStaticPropertyName(spec.Name())
+			if !ok {
+				return
+			}
+			if localName != exportedName {
+				return
+			}
+			outerRange := utils.TrimNodeTextRange(sf, node)
+			replRange := utils.TrimNodeTextRange(sf, spec.PropertyName)
+			fix := buildRangeFix(outerRange, replRange)
+			report(node, localName, "Export", fix)
+		}
+
+		// ---- Destructuring declaration: `let {foo: foo} = obj;` / `function f({foo: foo}) {}` ----
+		// tsgo represents these as BindingElement children of ObjectBindingPattern.
+		// - `PropertyName` is the source key (before `:`); `Name()` is the binding
+		//   target (after `:`, an Identifier, another pattern, or a rest binding).
+		// - Rest elements and shorthand bindings have `PropertyName == nil`.
+		// - Computed keys can't be resolved statically — the rule skips them
+		//   (matching ESLint's `property.computed` check).
+		checkBindingElement := func(node *ast.Node) {
+			if opts.ignoreDestructuring {
+				return
+			}
+			// Parent guard: only object destructuring; array-binding elements
+			// don't carry a `propertyName` so this is belt-and-braces.
+			if node.Parent == nil || node.Parent.Kind != ast.KindObjectBindingPattern {
+				return
+			}
+			be := node.AsBindingElement()
+			if be == nil || be.PropertyName == nil {
+				return
+			}
+			// Skip computed property names — ESLint: "we have no idea if a
+			// rename is useless or not". `GetStaticPropertyName` can resolve
+			// `['foo']` statically, but the rule intentionally treats computed
+			// keys as opaque regardless of whether they're constant-foldable.
+			if be.PropertyName.Kind == ast.KindComputedPropertyName {
+				return
+			}
+			keyName, ok := utils.GetStaticPropertyName(be.PropertyName)
+			if !ok {
+				return
+			}
+			bindingName := be.Name()
+			if bindingName == nil || bindingName.Kind != ast.KindIdentifier {
+				return
+			}
+			if keyName != bindingName.AsIdentifier().Text {
+				return
+			}
+			// Replacement text runs from the binding name through the end of
+			// the element, so it includes any default (`= init`). For
+			// `{foo: foo = 1}` the output becomes `{foo = 1}`.
+			outerRange := utils.TrimNodeTextRange(sf, node)
+			nameRange := utils.TrimNodeTextRange(sf, bindingName)
+			keepRange := core.NewTextRange(nameRange.Pos(), outerRange.End())
+			fix := buildRangeFix(outerRange, keepRange)
+			report(node, keyName, "Destructuring assignment", fix)
+		}
+
+		// ---- Destructuring assignment pattern: `({foo: foo} = obj);` ----
+		// tsgo keeps the outer node as `ObjectLiteralExpression`; only the
+		// assignment context reclassifies it semantically. `ast.IsAssignmentTarget`
+		// walks up through parentheses / arrays / nested object literals to
+		// confirm we're in an assignment target position.
+		checkAssignmentProperty := func(node *ast.Node) {
+			if opts.ignoreDestructuring {
+				return
+			}
+			parent := node.Parent
+			if parent == nil || parent.Kind != ast.KindObjectLiteralExpression {
+				return
+			}
+			if !ast.IsAssignmentTarget(parent) {
+				return
+			}
+			pa := node.AsPropertyAssignment()
+			if pa == nil {
+				return
+			}
+			nameNode := pa.Name()
+			if nameNode == nil {
+				return
+			}
+			// Skip computed keys (see BindingElement branch for the rationale).
+			if nameNode.Kind == ast.KindComputedPropertyName {
+				return
+			}
+			keyName, ok := utils.GetStaticPropertyName(nameNode)
+			if !ok {
+				return
+			}
+			init := pa.Initializer
+			if init == nil {
+				return
+			}
+
+			// Classify the initializer:
+			//  - ParenthesizedExpression wrapping Identifier → useless rename
+			//    with no default; unwrap to reach the identifier.
+			//  - BinaryExpression(=) → destructuring default; treat like
+			//    ESLint's AssignmentPattern. The identifier being renamed
+			//    is the (unwrapped) left side.
+			//  - Anything else → not a rename.
+			targetIdent := init
+			hasDefault := false
+			if targetIdent.Kind == ast.KindBinaryExpression {
+				bin := targetIdent.AsBinaryExpression()
+				if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken {
+					hasDefault = true
+					targetIdent = bin.Left
+				}
+			}
+			// Autofix can't handle `({foo: (foo) = a} = obj)` — shorthand
+			// properties don't accept parenthesised identifiers. ESLint emits
+			// the diagnostic with a null fix in this case.
+			leftParenthesized := hasDefault && targetIdent.Kind == ast.KindParenthesizedExpression
+			targetIdent = ast.SkipParentheses(targetIdent)
+			if targetIdent == nil || targetIdent.Kind != ast.KindIdentifier {
+				return
+			}
+			if keyName != targetIdent.AsIdentifier().Text {
+				return
+			}
+
+			var fix *rule.RuleFix
+			if !leftParenthesized {
+				outerRange := utils.TrimNodeTextRange(sf, node)
+				// Replacement spans the logical "value" — either the bare
+				// identifier (no default) or the full `ident = init`
+				// expression. When the identifier sits inside explicit parens
+				// like `(foo)`, we deliberately take only the identifier's
+				// range so the emitted shorthand is `{foo}`, not `{(foo)}`.
+				var replRange core.TextRange
+				if hasDefault {
+					// Keep the full BinaryExpression range — this includes any
+					// default value. The left was not parenthesized (checked
+					// above), so emitting the raw text is safe.
+					replRange = utils.TrimNodeTextRange(sf, init)
+				} else {
+					replRange = utils.TrimNodeTextRange(sf, targetIdent)
+				}
+				fix = buildRangeFix(outerRange, replRange)
+			}
+			report(node, keyName, "Destructuring assignment", fix)
+		}
+
+		return rule.RuleListeners{
+			ast.KindImportSpecifier:    checkImport,
+			ast.KindExportSpecifier:    checkExport,
+			ast.KindBindingElement:     checkBindingElement,
+			ast.KindPropertyAssignment: checkAssignmentProperty,
+		}
+	},
+}

--- a/internal/rules/no_useless_rename/no_useless_rename.md
+++ b/internal/rules/no_useless_rename/no_useless_rename.md
@@ -1,0 +1,101 @@
+# no-useless-rename
+
+Disallow renaming import, export, and destructured assignments to the same name.
+
+## Rule Details
+
+ES2015 allows for the renaming of references in import statements, export statements, and destructuring assignments. This gives programmers a concise syntax for performing these operations while renaming these references:
+
+```javascript
+import { foo as bar } from "baz";
+export { foo as bar };
+let { foo: bar } = baz;
+```
+
+With this syntax, it is possible to rename a reference to the same name. This is a completely redundant operation, as this is the same as not renaming at all.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+import { foo as foo } from "bar";
+export { foo as foo };
+export { foo as foo } from "bar";
+let { foo: foo } = bar;
+let { 'foo': foo } = bar;
+function foo({ bar: bar }) {}
+({ foo: foo }) => {};
+({ foo: foo } = bar);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+import * as foo from "foo";
+import { foo } from "bar";
+import { foo as bar } from "baz";
+
+export { foo };
+export { foo as bar };
+export { foo as bar } from "foo";
+
+let { foo } = bar;
+let { foo: bar } = baz;
+let { [foo]: foo } = bar;
+
+function foo({ bar }) {}
+function foo({ bar: baz }) {}
+
+({ foo }) => {};
+({ foo: bar }) => {};
+```
+
+## Options
+
+This rule has an object option:
+
+- `"ignoreDestructuring": false` (default) — disallow useless renaming in destructuring patterns.
+- `"ignoreImport": false` (default) — disallow useless renaming in import statements.
+- `"ignoreExport": false` (default) — disallow useless renaming in export statements.
+
+### ignoreDestructuring
+
+Examples of **correct** code for this rule with `{ "ignoreDestructuring": true }`:
+
+```json
+{ "no-useless-rename": ["error", { "ignoreDestructuring": true }] }
+```
+
+```javascript
+let { foo: foo } = bar;
+function foo({ bar: bar }) {}
+```
+
+### ignoreImport
+
+Examples of **correct** code for this rule with `{ "ignoreImport": true }`:
+
+```json
+{ "no-useless-rename": ["error", { "ignoreImport": true }] }
+```
+
+```javascript
+import { foo as foo } from "bar";
+```
+
+### ignoreExport
+
+Examples of **correct** code for this rule with `{ "ignoreExport": true }`:
+
+```json
+{ "no-useless-rename": ["error", { "ignoreExport": true }] }
+```
+
+```javascript
+export { foo as foo };
+export { foo as foo } from "bar";
+```
+
+## Original Documentation
+
+- [ESLint rule](https://eslint.org/docs/latest/rules/no-useless-rename)
+- [Source code](https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-rename.js)

--- a/internal/rules/no_useless_rename/no_useless_rename_test.go
+++ b/internal/rules/no_useless_rename/no_useless_rename_test.go
@@ -1,0 +1,1011 @@
+package no_useless_rename
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessRenameRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessRenameRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Destructuring (declarations) ----
+			{Code: `let {foo} = obj;`},
+			{Code: `let {foo: bar} = obj;`},
+			{Code: `let {foo: bar, baz: qux} = obj;`},
+			{Code: `let {foo: {bar: baz}} = obj;`},
+			{Code: `let {foo, bar: {baz: qux}} = obj;`},
+			{Code: `let {'foo': bar} = obj;`},
+			{Code: `let {'foo': bar, 'baz': qux} = obj;`},
+			{Code: `let {'foo': {'bar': baz}} = obj;`},
+			{Code: `let {foo, 'bar': {'baz': qux}} = obj;`},
+			{Code: `let {['foo']: bar} = obj;`},
+			{Code: `let {['foo']: bar, ['baz']: qux} = obj;`},
+			{Code: `let {['foo']: {['bar']: baz}} = obj;`},
+			{Code: `let {foo, ['bar']: {['baz']: qux}} = obj;`},
+			{Code: `let {[foo]: foo} = obj;`},
+			{Code: `let {['foo']: foo} = obj;`},
+			{Code: `let {[foo]: bar} = obj;`},
+			{Code: `function func({foo}) {}`},
+			{Code: `function func({foo: bar}) {}`},
+			{Code: `function func({foo: bar, baz: qux}) {}`},
+			{Code: `({foo}) => {}`},
+			{Code: `({foo: bar}) => {}`},
+			{Code: `({foo: bar, baz: qui}) => {}`},
+
+			// ---- Imports ----
+			{Code: `import * as foo from 'foo';`},
+			{Code: `import foo from 'foo';`},
+			{Code: `import {foo} from 'foo';`},
+			{Code: `import {foo as bar} from 'foo';`},
+			{Code: `import {foo as bar, baz as qux} from 'foo';`},
+			{Code: `import {'foo' as bar} from 'baz';`},
+
+			// ---- Exports ----
+			{Code: `export {foo} from 'foo';`},
+			{Code: `var foo = 0;export {foo as bar};`},
+			{Code: `var foo = 0; var baz = 0; export {foo as bar, baz as qux};`},
+			{Code: `export {foo as bar} from 'foo';`},
+			{Code: `export {foo as bar, baz as qux} from 'foo';`},
+			{Code: `var foo = 0; export {foo as 'bar'};`},
+			{Code: `export {foo as 'bar'} from 'baz';`},
+			{Code: `export {'foo' as bar} from 'baz';`},
+			{Code: `export {'foo' as 'bar'} from 'baz';`},
+			{Code: `export {'' as ' '} from 'baz';`},
+			{Code: `export {' ' as ''} from 'baz';`},
+			{Code: `export {'foo'} from 'bar';`},
+
+			// ---- Rest elements ----
+			{Code: `const {...stuff} = myObject;`},
+			{Code: `const {foo, ...stuff} = myObject;`},
+			{Code: `const {foo: bar, ...stuff} = myObject;`},
+
+			// ---- { ignoreDestructuring: true } ----
+			{Code: `let {foo: foo} = obj;`, Options: map[string]interface{}{"ignoreDestructuring": true}},
+			{Code: `let {foo: foo, bar: baz} = obj;`, Options: map[string]interface{}{"ignoreDestructuring": true}},
+			{Code: `let {foo: foo, bar: bar} = obj;`, Options: map[string]interface{}{"ignoreDestructuring": true}},
+
+			// ---- { ignoreImport: true } ----
+			{Code: `import {foo as foo} from 'foo';`, Options: map[string]interface{}{"ignoreImport": true}},
+			{Code: `import {foo as foo, bar as baz} from 'foo';`, Options: map[string]interface{}{"ignoreImport": true}},
+			{Code: `import {foo as foo, bar as bar} from 'foo';`, Options: map[string]interface{}{"ignoreImport": true}},
+
+			// ---- { ignoreExport: true } ----
+			{Code: `var foo = 0;export {foo as foo};`, Options: map[string]interface{}{"ignoreExport": true}},
+			{Code: `var foo = 0;var bar = 0;export {foo as foo, bar as baz};`, Options: map[string]interface{}{"ignoreExport": true}},
+			{Code: `var foo = 0;var bar = 0;export {foo as foo, bar as bar};`, Options: map[string]interface{}{"ignoreExport": true}},
+			{Code: `export {foo as foo} from 'foo';`, Options: map[string]interface{}{"ignoreExport": true}},
+			{Code: `export {foo as foo, bar as baz} from 'foo';`, Options: map[string]interface{}{"ignoreExport": true}},
+			{Code: `export {foo as foo, bar as bar} from 'foo';`, Options: map[string]interface{}{"ignoreExport": true}},
+
+			// ---- Extra coverage beyond ESLint's suite ----
+			// Numeric keys can't collide with identifier bindings — no rename.
+			{Code: `let {0: foo} = obj;`},
+			// Empty options object behaves the same as no options at all —
+			// all three flags default to false.
+			{Code: `let {foo} = obj;`, Options: map[string]interface{}{}},
+			// Options explicitly set to false — same as defaults.
+			{
+				Code: `let {foo: bar} = obj;`,
+				Options: map[string]interface{}{
+					"ignoreDestructuring": false,
+					"ignoreImport":        false,
+					"ignoreExport":        false,
+				},
+			},
+			// Array destructuring has no propertyName, so never triggers.
+			{Code: `let [foo, bar] = arr;`},
+			{Code: `let [{foo}] = arr;`},
+			// Plain object literal — not an assignment target, don't touch.
+			{Code: `const x = {foo: foo};`},
+			{Code: `const y = {foo: foo, bar: bar};`},
+			{Code: `const z = {...obj, foo: foo};`},
+			// RHS of assignment — not an assignment pattern.
+			{Code: `x = {foo: foo};`},
+			// TS: destructuring with a type annotation still supports shorthand.
+			{Code: `const {foo}: {foo: string} = obj;`},
+			{Code: `function fn({foo: bar}: {foo: string}) {}`},
+			// TS: type-only imports/exports without rename.
+			{Code: `import type {foo as bar} from 'foo';`},
+			{Code: `import {type foo as bar} from 'foo';`},
+			{Code: `export type {foo as bar};`, Options: map[string]interface{}{}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Destructuring (declarations) — basic ----
+			// Full Line/Column/EndLine/EndColumn position coverage for the
+			// destructuring-declaration container.
+			{
+				Code:   `let {foo: foo} = obj;`,
+				Output: []string{`let {foo} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6, EndLine: 1, EndColumn: 14},
+				},
+			},
+			// Assignment-pattern container — full position coverage.
+			{
+				Code:   `({foo: (foo)} = obj);`,
+				Output: []string{`({foo} = obj);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:   `let {\u0061: a} = obj;`,
+				Output: []string{`let {a} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment a unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {a: \u0061} = obj;`,
+				Output: []string{`let {\u0061} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment a unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {\u0061: \u0061} = obj;`,
+				Output: []string{`let {\u0061} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment a unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				// StringLiteral key with a unicode escape — decoded value is
+				// "a", matches the identifier binding `a`.
+				Code:   `let {'\u0061': a} = obj;`,
+				Output: []string{`let {a} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment a unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {a, foo: foo} = obj;`,
+				Output: []string{`let {a, foo} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `let {foo: foo, bar: baz} = obj;`,
+				Output: []string{`let {foo, bar: baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {foo: bar, baz: baz} = obj;`,
+				Output: []string{`let {foo: bar, baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `let {foo: foo, bar: bar} = obj;`,
+				Output: []string{`let {foo, bar} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `let {foo: {bar: bar}} = obj;`,
+				Output: []string{`let {foo: {bar}} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 12},
+				},
+			},
+			{
+				Code:   `let {foo: {bar: bar}, baz: baz} = obj;`,
+				Output: []string{`let {foo: {bar}, baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 12},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 23},
+				},
+			},
+
+			// ---- String-literal keys ----
+			{
+				Code:   `let {'foo': foo} = obj;`,
+				Output: []string{`let {foo} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {'foo': foo, 'bar': baz} = obj;`,
+				Output: []string{`let {foo, 'bar': baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {'foo': bar, 'baz': baz} = obj;`,
+				Output: []string{`let {'foo': bar, baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   `let {'foo': foo, 'bar': bar} = obj;`,
+				Output: []string{`let {foo, bar} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   `let {'foo': {'bar': bar}} = obj;`,
+				Output: []string{`let {'foo': {bar}} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code:   `let {'foo': {'bar': bar}, 'baz': baz} = obj;`,
+				Output: []string{`let {'foo': {bar}, baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 14},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 27},
+				},
+			},
+
+			// ---- Destructuring with defaults ----
+			{
+				Code:   `let {foo: foo = 1, 'bar': bar = 1, baz: baz} = obj;`,
+				Output: []string{`let {foo = 1, bar = 1, baz} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 20},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code:   `let {foo: {bar: bar = 1, 'baz': baz = 1}} = obj;`,
+				Output: []string{`let {foo: {bar = 1, baz = 1}} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 12},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:   `let {foo: {bar: bar = {}} = {}} = obj;`,
+				Output: []string{`let {foo: {bar = {}} = {}} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 12},
+				},
+			},
+
+			// ---- Assignment-pattern edge cases ----
+			{
+				// Parenthesised target of an assignment-pattern — shorthand
+				// properties can't carry parens around an identifier, so no fix.
+				Code: `({foo: (foo) = a} = obj);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   `let {foo: foo = (a)} = obj;`,
+				Output: []string{`let {foo = (a)} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+			{
+				Code:   `let {foo: foo = (a, b)} = obj;`,
+				Output: []string{`let {foo = (a, b)} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 6},
+				},
+			},
+
+			// ---- Destructuring in function parameters ----
+			{
+				Code:   `function func({foo: foo}) {}`,
+				Output: []string{`function func({foo}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `function func({foo: foo, bar: baz}) {}`,
+				Output: []string{`function func({foo, bar: baz}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `function func({foo: bar, baz: baz}) {}`,
+				Output: []string{`function func({foo: bar, baz}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:   `function func({foo: foo, bar: bar}) {}`,
+				Output: []string{`function func({foo, bar}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 16},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:   `function func({foo: foo = 1, 'bar': bar = 1, baz: baz}) {}`,
+				Output: []string{`function func({foo = 1, bar = 1, baz}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 16},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 30},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code:   `function func({foo: {bar: bar = 1, 'baz': baz = 1}}) {}`,
+				Output: []string{`function func({foo: {bar = 1, baz = 1}}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 22},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code:   `function func({foo: {bar: bar = {}} = {}}) {}`,
+				Output: []string{`function func({foo: {bar = {}} = {}}) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- Destructuring in arrow parameters ----
+			{
+				Code:   `({foo: foo}) => {}`,
+				Output: []string{`({foo}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   `({foo: foo, bar: baz}) => {}`,
+				Output: []string{`({foo, bar: baz}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   `({foo: bar, baz: baz}) => {}`,
+				Output: []string{`({foo: bar, baz}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `({foo: foo, bar: bar}) => {}`,
+				Output: []string{`({foo, bar}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `({foo: foo = 1, 'bar': bar = 1, baz: baz}) => {}`,
+				Output: []string{`({foo = 1, bar = 1, baz}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 17},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 33},
+				},
+			},
+			{
+				Code:   `({foo: {bar: bar = 1, 'baz': baz = 1}}) => {}`,
+				Output: []string{`({foo: {bar = 1, baz = 1}}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 9},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment baz unnecessarily renamed.", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:   `({foo: {bar: bar = {}} = {}}) => {}`,
+				Output: []string{`({foo: {bar = {}} = {}}) => {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+
+			// ---- Rest element mixed with renames ----
+			{
+				Code:   `const {foo: foo, ...stuff} = myObject;`,
+				Output: []string{`const {foo, ...stuff} = myObject;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `const {foo: foo, bar: baz, ...stuff} = myObject;`,
+				Output: []string{`const {foo, bar: baz, ...stuff} = myObject;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `const {foo: foo, bar: bar, ...stuff} = myObject;`,
+				Output: []string{`const {foo, bar, ...stuff} = myObject;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 8},
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+
+			// ---- Imports ----
+			// Import container — full position coverage.
+			{
+				Code:   `import {foo as foo} from 'foo';`,
+				Output: []string{`import {foo} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9, EndLine: 1, EndColumn: 19},
+				},
+			},
+			{
+				Code:   `import {'foo' as foo} from 'foo';`,
+				Output: []string{`import {foo} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {\u0061 as a} from 'foo';`,
+				Output: []string{`import {a} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import a unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {a as \u0061} from 'foo';`,
+				Output: []string{`import {\u0061} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import a unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {\u0061 as \u0061} from 'foo';`,
+				Output: []string{`import {\u0061} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import a unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {foo as foo, bar as baz} from 'foo';`,
+				Output: []string{`import {foo, bar as baz} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {foo as bar, baz as baz} from 'foo';`,
+				Output: []string{`import {foo as bar, baz} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import baz unnecessarily renamed.", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:   `import {foo as foo, bar as bar} from 'foo';`,
+				Output: []string{`import {foo, bar} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+					{MessageId: "unnecessarilyRenamed", Message: "Import bar unnecessarily renamed.", Line: 1, Column: 21},
+				},
+			},
+
+			// ---- Exports ----
+			// Export container — full position coverage.
+			{
+				Code:   `var foo = 0; export {foo as foo};`,
+				Output: []string{`var foo = 0; export {foo};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 22, EndLine: 1, EndColumn: 32},
+				},
+			},
+			{
+				Code:   `var foo = 0; export {foo as 'foo'};`,
+				Output: []string{`var foo = 0; export {foo};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code:   `export {foo as 'foo'} from 'bar';`,
+				Output: []string{`export {foo} from 'bar';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {'foo' as foo} from 'bar';`,
+				Output: []string{`export {'foo'} from 'bar';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {'foo' as 'foo'} from 'bar';`,
+				Output: []string{`export {'foo'} from 'bar';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {' 👍 ' as ' 👍 '} from 'bar';`,
+				Output: []string{`export {' 👍 '} from 'bar';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export  👍  unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {'' as ''} from 'bar';`,
+				Output: []string{`export {''} from 'bar';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export  unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `var a = 0; export {a as \u0061};`,
+				Output: []string{`var a = 0; export {a};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export a unnecessarily renamed.", Line: 1, Column: 20},
+				},
+			},
+			{
+				Code:   `var \u0061 = 0; export {\u0061 as a};`,
+				Output: []string{`var \u0061 = 0; export {\u0061};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export a unnecessarily renamed.", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:   `var \u0061 = 0; export {\u0061 as \u0061};`,
+				Output: []string{`var \u0061 = 0; export {\u0061};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export a unnecessarily renamed.", Line: 1, Column: 25},
+				},
+			},
+			{
+				Code:   `var foo = 0; var bar = 0; export {foo as foo, bar as baz};`,
+				Output: []string{`var foo = 0; var bar = 0; export {foo, bar as baz};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 35},
+				},
+			},
+			{
+				Code:   `var foo = 0; var baz = 0; export {foo as bar, baz as baz};`,
+				Output: []string{`var foo = 0; var baz = 0; export {foo as bar, baz};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export baz unnecessarily renamed.", Line: 1, Column: 47},
+				},
+			},
+			{
+				Code:   `var foo = 0; var bar = 0;export {foo as foo, bar as bar};`,
+				Output: []string{`var foo = 0; var bar = 0;export {foo, bar};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 34},
+					{MessageId: "unnecessarilyRenamed", Message: "Export bar unnecessarily renamed.", Line: 1, Column: 46},
+				},
+			},
+			{
+				Code:   `export {foo as foo} from 'foo';`,
+				Output: []string{`export {foo} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {a as \u0061} from 'foo';`,
+				Output: []string{`export {a} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export a unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {\u0061 as a} from 'foo';`,
+				Output: []string{`export {\u0061} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export a unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {\u0061 as \u0061} from 'foo';`,
+				Output: []string{`export {\u0061} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export a unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `export {foo as foo, bar as baz} from 'foo';`,
+				Output: []string{`export {foo, bar as baz} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `var foo = 0; var bar = 0; export {foo as bar, baz as baz} from 'foo';`,
+				Output: []string{`var foo = 0; var bar = 0; export {foo as bar, baz} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export baz unnecessarily renamed.", Line: 1, Column: 47},
+				},
+			},
+			{
+				Code:   `export {foo as foo, bar as bar} from 'foo';`,
+				Output: []string{`export {foo, bar} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 9},
+					{MessageId: "unnecessarilyRenamed", Message: "Export bar unnecessarily renamed.", Line: 1, Column: 21},
+				},
+			},
+
+			// ---- Comment preservation: destructuring ----
+			{
+				// Comment before the key — outside the property assignment, so
+				// the fix still runs.
+				Code:   `({/* comment */foo: foo} = {});`,
+				Output: []string{`({/* comment */foo} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `({/* comment */foo: foo = 1} = {});`,
+				Output: []string{`({/* comment */foo = 1} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code:   `({foo, /* comment */bar: bar} = {});`,
+				Output: []string{`({foo, /* comment */bar} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment bar unnecessarily renamed.", Line: 1, Column: 21},
+				},
+			},
+			{
+				// Comment between key and colon — would be lost, reject fix.
+				Code: `({foo/**/ : foo} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo/**/ : foo = 1} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo /**/: foo} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo /**/: foo = 1} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: "({foo://\nfoo} = {});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				// Comment between colon and value — would be lost, reject fix.
+				Code: `({foo: /**/foo} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				// Parenthesised value with leading comment inside parens — still lost.
+				Code: `({foo: (/**/foo)} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo: (foo/**/)} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: "({foo: (foo //\n)} = {});",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo: /**/foo = 1} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo: (/**/foo) = 1} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code: `({foo: (foo/**/) = 1} = {});`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				// Comment after the value is outside the property range — fix applies.
+				Code:   `({foo: foo/* comment */} = {});`,
+				Output: []string{`({foo/* comment */} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   "({foo: foo//comment\n,bar} = {});",
+				Output: []string{"({foo//comment\n,bar} = {});"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				// Comment inside the AssignmentPattern — preserved by the fix.
+				Code:   `({foo: foo/* comment */ = 1} = {});`,
+				Output: []string{`({foo/* comment */ = 1} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   "({foo: foo // comment\n = 1} = {});",
+				Output: []string{"({foo // comment\n = 1} = {});"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   `({foo: foo = /* comment */ 1} = {});`,
+				Output: []string{`({foo = /* comment */ 1} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   "({foo: foo = // comment\n 1} = {});",
+				Output: []string{"({foo = // comment\n 1} = {});"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			{
+				Code:   `({foo: foo = (1/* comment */)} = {});`,
+				Output: []string{`({foo = (1/* comment */)} = {});`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+
+			// ---- Comment preservation: import specifiers ----
+			{
+				Code:   `import {/* comment */foo as foo} from 'foo';`,
+				Output: []string{`import {/* comment */foo} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 22},
+				},
+			},
+			{
+				Code:   `import {foo,/* comment */bar as bar} from 'foo';`,
+				Output: []string{`import {foo,/* comment */bar} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import bar unnecessarily renamed.", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code: `import {foo/**/ as foo} from 'foo';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `import {foo /**/as foo} from 'foo';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: "import {foo //\nas foo} from 'foo';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code: `import {foo as/**/foo} from 'foo';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {foo as foo/* comment */} from 'foo';`,
+				Output: []string{`import {foo/* comment */} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `import {foo as foo/* comment */,bar} from 'foo';`,
+				Output: []string{`import {foo/* comment */,bar} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+
+			// ---- Comment preservation: export specifiers ----
+			{
+				Code:   `let foo; export {/* comment */foo as foo};`,
+				Output: []string{`let foo; export {/* comment */foo};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code:   `let foo, bar; export {foo,/* comment */bar as bar};`,
+				Output: []string{`let foo, bar; export {foo,/* comment */bar};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export bar unnecessarily renamed.", Line: 1, Column: 40},
+				},
+			},
+			{
+				Code: `let foo; export {foo/**/as foo};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `let foo; export {foo as/**/ foo};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `let foo; export {foo as /**/foo};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: "let foo; export {foo as//comment\n foo};",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   `let foo; export {foo as foo/* comment*/};`,
+				Output: []string{`let foo; export {foo/* comment*/};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code:   `let foo, bar; export {foo as foo/* comment*/,bar};`,
+				Output: []string{`let foo, bar; export {foo/* comment*/,bar};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:   "let foo, bar; export {foo as foo//comment\n,bar};",
+				Output: []string{"let foo, bar; export {foo//comment\n,bar};"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export foo unnecessarily renamed.", Line: 1, Column: 23},
+				},
+			},
+
+			// ---- Extra coverage: real-world scenarios beyond ESLint's suite ----
+
+			// Multi-line destructuring — the report's position must track the
+			// actual line the BindingElement sits on, not the enclosing
+			// statement. Full position coverage (required per port-rule guide).
+			{
+				Code: `let {
+  foo: foo,
+  bar: baz
+} = obj;`,
+				Output: []string{`let {
+  foo,
+  bar: baz
+} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 2, Column: 3, EndLine: 2, EndColumn: 11},
+				},
+			},
+			// Multi-line assignment pattern.
+			{
+				Code: `({
+  foo: foo,
+  bar: baz
+} = obj);`,
+				Output: []string{`({
+  foo,
+  bar: baz
+} = obj);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 2, Column: 3},
+				},
+			},
+			// Nested assignment pattern — the inner ObjectLiteralExpression is
+			// not a direct LHS, but `ast.IsAssignmentTarget` walks up through
+			// PropertyAssignment / ObjectLiteralExpression to confirm the
+			// outer `=`. Tests that the listener fires on nested patterns.
+			{
+				Code:   `({a: {foo: foo}} = obj);`,
+				Output: []string{`({a: {foo}} = obj);`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 7},
+				},
+			},
+			// Array-containing-object assignment pattern.
+			{
+				Code:   `[{foo: foo}] = arr;`,
+				Output: []string{`[{foo}] = arr;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 3},
+				},
+			},
+			// `for-of` with object destructuring as the iteration target.
+			{
+				Code:   `for ({foo: foo} of arr) {}`,
+				Output: []string{`for ({foo} of arr) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 7},
+				},
+			},
+			// TS: destructuring with a type annotation — the annotation is
+			// attached to the VariableDeclaration, not the BindingElement, so
+			// the autofix range is unaffected.
+			{
+				Code:   `const {foo: foo}: {foo: string} = obj;`,
+				Output: []string{`const {foo}: {foo: string} = obj;`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Destructuring assignment foo unnecessarily renamed.", Line: 1, Column: 8},
+				},
+			},
+			// TS: type-only import with useless rename.
+			{
+				Code:   `import type {foo as foo} from 'foo';`,
+				Output: []string{`import type {foo} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 14},
+				},
+			},
+			// TS: inline `type` modifier on an individual import specifier.
+			// Matches ESLint's behavior: the fix replaces the entire
+			// ImportSpecifier range with the local name, so the `type`
+			// modifier is dropped from the output.
+			{
+				Code:   `import {type foo as foo} from 'foo';`,
+				Output: []string{`import {foo} from 'foo';`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Import foo unnecessarily renamed.", Line: 1, Column: 9},
+				},
+			},
+			// TS: type-only export with useless rename.
+			{
+				Code:   `type Foo = string; export type {Foo as Foo};`,
+				Output: []string{`type Foo = string; export type {Foo};`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyRenamed", Message: "Export Foo unnecessarily renamed.", Line: 1, Column: 33},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -272,6 +272,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',
+    './tests/eslint/rules/no-useless-rename.test.ts',
     './tests/eslint/rules/no-prototype-builtins.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-rename.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-rename.test.ts.snap
@@ -1,0 +1,644 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-rename > invalid 1`] = `
+{
+  "code": "let {foo: foo} = obj;",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 2`] = `
+{
+  "code": "let {foo: foo, bar: bar} = obj;",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+    {
+      "message": "Destructuring assignment bar unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 3`] = `
+{
+  "code": "let {foo: {bar: bar}} = obj;",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment bar unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 4`] = `
+{
+  "code": "let {'foo': foo} = obj;",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 5`] = `
+{
+  "code": "let {foo: foo = 1} = obj;",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 6`] = `
+{
+  "code": "function func({foo: foo}) {}",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 7`] = `
+{
+  "code": "({foo: foo}) => {}",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 8`] = `
+{
+  "code": "({foo: foo} = obj);",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 9`] = `
+{
+  "code": "({foo: (foo)} = obj);",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 10`] = `
+{
+  "code": "({foo: foo = 1} = obj);",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 11`] = `
+{
+  "code": "const {foo: foo, ...stuff} = myObject;",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 12`] = `
+{
+  "code": "import {foo as foo} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Import foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 13`] = `
+{
+  "code": "import {'foo' as foo} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Import foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 14`] = `
+{
+  "code": "import {foo as foo, bar as baz} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Import foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 15`] = `
+{
+  "code": "import {foo as foo, bar as bar} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Import foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+    {
+      "message": "Import bar unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 16`] = `
+{
+  "code": "var foo = 0; export {foo as foo};",
+  "diagnostics": [
+    {
+      "message": "Export foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 17`] = `
+{
+  "code": "var foo = 0; export {foo as 'foo'};",
+  "diagnostics": [
+    {
+      "message": "Export foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 18`] = `
+{
+  "code": "export {'foo' as 'foo'} from 'bar';",
+  "diagnostics": [
+    {
+      "message": "Export foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 19`] = `
+{
+  "code": "export {foo as foo} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Export foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 20`] = `
+{
+  "code": "export {foo as foo, bar as bar} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Export foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+    {
+      "message": "Export bar unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 21`] = `
+{
+  "code": "({foo/**/ : foo} = {});",
+  "diagnostics": [
+    {
+      "message": "Destructuring assignment foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 22`] = `
+{
+  "code": "import {foo/**/ as foo} from 'foo';",
+  "diagnostics": [
+    {
+      "message": "Import foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-rename > invalid 23`] = `
+{
+  "code": "let foo; export {foo/**/as foo};",
+  "diagnostics": [
+    {
+      "message": "Export foo unnecessarily renamed.",
+      "messageId": "unnecessarilyRenamed",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-rename",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-rename.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-rename.test.ts
@@ -1,0 +1,188 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-rename', {
+  valid: [
+    // ---- Destructuring (declarations) ----
+    'let {foo} = obj;',
+    'let {foo: bar} = obj;',
+    'let {foo: bar, baz: qux} = obj;',
+    'let {foo: {bar: baz}} = obj;',
+    "let {'foo': bar} = obj;",
+    "let {'foo': {'bar': baz}} = obj;",
+    "let {['foo']: bar} = obj;",
+    "let {['foo']: foo} = obj;",
+    'let {[foo]: foo} = obj;',
+    'function func({foo}) {}',
+    'function func({foo: bar}) {}',
+    '({foo}) => {};',
+    '({foo: bar}) => {};',
+    // rest elements cannot be renamed
+    'const {...stuff} = myObject;',
+    'const {foo: bar, ...stuff} = myObject;',
+
+    // ---- Imports ----
+    "import * as foo from 'foo';",
+    "import foo from 'foo';",
+    "import {foo} from 'foo';",
+    "import {foo as bar} from 'foo';",
+    "import {'foo' as bar} from 'baz';",
+
+    // ---- Exports ----
+    "export {foo} from 'foo';",
+    'var foo = 0;export {foo as bar};',
+    "export {foo as bar} from 'foo';",
+    "var foo = 0; export {foo as 'bar'};",
+    "export {'foo' as bar} from 'baz';",
+    "export {'foo' as 'bar'} from 'baz';",
+    "export {'foo'} from 'bar';",
+
+    // ---- { ignoreDestructuring: true } ----
+    { code: 'let {foo: foo} = obj;', options: { ignoreDestructuring: true } },
+    {
+      code: 'let {foo: foo, bar: bar} = obj;',
+      options: { ignoreDestructuring: true },
+    },
+
+    // ---- { ignoreImport: true } ----
+    {
+      code: "import {foo as foo} from 'foo';",
+      options: { ignoreImport: true },
+    },
+    {
+      code: "import {foo as foo, bar as bar} from 'foo';",
+      options: { ignoreImport: true },
+    },
+
+    // ---- { ignoreExport: true } ----
+    {
+      code: 'var foo = 0;export {foo as foo};',
+      options: { ignoreExport: true },
+    },
+    {
+      code: "export {foo as foo} from 'foo';",
+      options: { ignoreExport: true },
+    },
+  ],
+  invalid: [
+    // ---- Destructuring (declarations) ----
+    {
+      code: 'let {foo: foo} = obj;',
+      errors: [
+        {
+          messageId: 'unnecessarilyRenamed',
+          line: 1,
+          column: 6,
+        },
+      ],
+    },
+    {
+      code: 'let {foo: foo, bar: bar} = obj;',
+      errors: [
+        { messageId: 'unnecessarilyRenamed', line: 1, column: 6 },
+        { messageId: 'unnecessarilyRenamed', line: 1, column: 16 },
+      ],
+    },
+    {
+      code: 'let {foo: {bar: bar}} = obj;',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 12 }],
+    },
+    {
+      code: "let {'foo': foo} = obj;",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 6 }],
+    },
+    {
+      code: 'let {foo: foo = 1} = obj;',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 6 }],
+    },
+    {
+      code: 'function func({foo: foo}) {}',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 16 }],
+    },
+    {
+      code: '({foo: foo}) => {}',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 3 }],
+    },
+
+    // ---- Destructuring (assignment pattern) ----
+    {
+      code: '({foo: foo} = obj);',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 3 }],
+    },
+    {
+      code: '({foo: (foo)} = obj);',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 3 }],
+    },
+    {
+      code: '({foo: foo = 1} = obj);',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 3 }],
+    },
+
+    // ---- Rest mixed with useless rename ----
+    {
+      code: 'const {foo: foo, ...stuff} = myObject;',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 8 }],
+    },
+
+    // ---- Imports ----
+    {
+      code: "import {foo as foo} from 'foo';",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 9 }],
+    },
+    {
+      code: "import {'foo' as foo} from 'foo';",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 9 }],
+    },
+    {
+      code: "import {foo as foo, bar as baz} from 'foo';",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 9 }],
+    },
+    {
+      code: "import {foo as foo, bar as bar} from 'foo';",
+      errors: [
+        { messageId: 'unnecessarilyRenamed', line: 1, column: 9 },
+        { messageId: 'unnecessarilyRenamed', line: 1, column: 21 },
+      ],
+    },
+
+    // ---- Exports ----
+    {
+      code: 'var foo = 0; export {foo as foo};',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 22 }],
+    },
+    {
+      code: "var foo = 0; export {foo as 'foo'};",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 22 }],
+    },
+    {
+      code: "export {'foo' as 'foo'} from 'bar';",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 9 }],
+    },
+    {
+      code: "export {foo as foo} from 'foo';",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 9 }],
+    },
+    {
+      code: "export {foo as foo, bar as bar} from 'foo';",
+      errors: [
+        { messageId: 'unnecessarilyRenamed', line: 1, column: 9 },
+        { messageId: 'unnecessarilyRenamed', line: 1, column: 21 },
+      ],
+    },
+
+    // ---- Comment cases (fix is suppressed, diagnostic still fires) ----
+    {
+      code: '({foo/**/ : foo} = {});',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 3 }],
+    },
+    {
+      code: "import {foo/**/ as foo} from 'foo';",
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 9 }],
+    },
+    {
+      code: 'let foo; export {foo/**/as foo};',
+      errors: [{ messageId: 'unnecessarilyRenamed', line: 1, column: 18 }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-useless-rename` rule from ESLint to rslint. Disallows renaming import, export, and destructured assignments to the same name (e.g. `import { foo as foo }`, `let { foo: foo }`, `export { foo as foo }`).

Semantics are aligned 1:1 with ESLint's core rule, including the three options (`ignoreDestructuring` / `ignoreImport` / `ignoreExport`), the `unnecessarilyRenamed` messageId with identical message text, the autofix (plus the two reject conditions: comment loss and parenthesised left side of an assignment pattern), and behaviour on TypeScript's inline `type` modifier on import specifiers (the modifier is dropped from the fix, matching ESLint).

Covers all four containers: `ObjectBindingPattern` / `BindingElement`, `ObjectLiteralExpression` assignment pattern / `PropertyAssignment` (including nested patterns via `ast.IsAssignmentTarget`), `ImportSpecifier`, `ExportSpecifier`. Comment-loss detection uses a raw byte scan (scanner-anchored `utils.HasCommentsInRange` misses between-token trivia) — same approach as `object-shorthand`.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-rename
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-rename.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).