### PR TITLE
feat: port rule no-useless-computed-key

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_computed_key"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
@@ -619,6 +620,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-shadow-restricted-names", no_shadow_restricted_names.NoShadowRestrictedNamesRule)
 	GlobalRuleRegistry.Register("strict", strict.StrictRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)
+	GlobalRuleRegistry.Register("no-useless-computed-key", no_useless_computed_key.NoUselessComputedKeyRule)
 	GlobalRuleRegistry.Register("no-useless-concat", no_useless_concat.NoUselessConcatRule)
 	GlobalRuleRegistry.Register("no-sparse-arrays", no_sparse_arrays.NoSparseArraysRule)
 	GlobalRuleRegistry.Register("no-extra-boolean-cast", no_extra_boolean_cast.NoExtraBooleanCastRule)

--- a/internal/rules/no_useless_computed_key/no_useless_computed_key.go
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key.go
@@ -1,0 +1,324 @@
+package no_useless_computed_key
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type Options struct {
+	EnforceForClassMembers bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{EnforceForClassMembers: true}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["enforceForClassMembers"].(bool); ok {
+			opts.EnforceForClassMembers = v
+		}
+	}
+	return opts
+}
+
+// isIdentPart reports whether c can appear inside a JS identifier (ASCII).
+// Used to decide if two adjacent tokens would fuse when we delete the
+// surrounding brackets. Mirrors `astUtils.canTokensBeAdjacent` enough for
+// the cases the rule can emit (tokens before `[` are keywords / `*` / `{`;
+// the key text starts with either an identifier char, a digit, a quote,
+// or `.`).
+func isIdentPart(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') || c == '_' || c == '$'
+}
+
+// isObjectLiteralAssignmentPattern reports whether an ObjectLiteralExpression
+// is being used as a destructuring target — either directly as the LHS of
+// `=`, the Initializer of a for-in/of statement, or nested inside another
+// such pattern. tsgo reuses ObjectLiteralExpression for assignment patterns
+// (unlike ESTree's ObjectPattern), so we have to recover the distinction
+// from context to match ESLint's Property-vs-Property behavior: the
+// `__proto__` carve-out applies only to value-position object literals.
+func isObjectLiteralAssignmentPattern(objLit *ast.Node) bool {
+	cur := objLit
+	for {
+		parent := cur.Parent
+		if parent == nil {
+			return false
+		}
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+			cur = parent
+		case ast.KindBinaryExpression:
+			be := parent.AsBinaryExpression()
+			if be == nil || be.OperatorToken == nil {
+				return false
+			}
+			return be.OperatorToken.Kind == ast.KindEqualsToken && be.Left == cur
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			fs := parent.AsForInOrOfStatement()
+			return fs != nil && fs.Initializer == cur
+		case ast.KindPropertyAssignment, ast.KindShorthandPropertyAssignment:
+			// Nested in an outer object pattern (e.g. `({y: {['x']: a}} = b)`).
+			// Walk up to the enclosing ObjectLiteralExpression, then continue.
+			cur = parent.Parent
+			if cur == nil {
+				return false
+			}
+		case ast.KindArrayLiteralExpression, ast.KindSpreadAssignment, ast.KindSpreadElement:
+			cur = parent
+		default:
+			return false
+		}
+	}
+}
+
+// hasCommentsBetween reports whether a line or block comment starts inside
+// `[start, end)`, skipping over the contents of string and template literals
+// so that an embedded `//` or `/*` sequence doesn't false-positive.
+func hasCommentsBetween(text string, start, end int) bool {
+	i := start
+	for i < end {
+		c := text[i]
+		switch c {
+		case '/':
+			if i+1 < end && (text[i+1] == '/' || text[i+1] == '*') {
+				return true
+			}
+			i++
+		case '\'', '"':
+			quote := c
+			i++
+			for i < end && text[i] != quote {
+				if text[i] == '\\' && i+1 < end {
+					i += 2
+					continue
+				}
+				i++
+			}
+			if i < end {
+				i++
+			}
+		case '`':
+			i++
+			for i < end && text[i] != '`' {
+				if text[i] == '\\' && i+1 < end {
+					i += 2
+					continue
+				}
+				i++
+			}
+			if i < end {
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return false
+}
+
+// https://eslint.org/docs/latest/rules/no-useless-computed-key
+var NoUselessComputedKeyRule = rule.Rule{
+	Name: "no-useless-computed-key",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+
+		// check inspects a container node (PropertyAssignment / Method /
+		// PropertyDeclaration / BindingElement), determines whether it has
+		// a useless computed key, and reports + fixes accordingly.
+		//
+		// Listening on containers (not ComputedPropertyName) is required so
+		// the rule also fires inside destructuring patterns: rslint's
+		// `patternVisitor` does not recurse into property-name positions.
+		check := func(container *ast.Node, cpn *ast.Node) {
+			computed := cpn.AsComputedPropertyName()
+			if computed == nil || computed.Expression == nil {
+				return
+			}
+
+			// Only literal values (string / number) qualify. Parentheses
+			// around the literal are transparent to the check, matching
+			// ESLint's paren-insensitive AST.
+			inner := ast.SkipParentheses(computed.Expression)
+			var value string
+			isString := false
+			switch inner.Kind {
+			case ast.KindStringLiteral:
+				value = inner.AsStringLiteral().Text
+				isString = true
+			case ast.KindNumericLiteral:
+				value = inner.AsNumericLiteral().Text
+			default:
+				return
+			}
+
+			switch container.Kind {
+			case ast.KindPropertyAssignment:
+				gp := container.Parent
+				if gp == nil || gp.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				// In a value-position object literal, `{ ["__proto__"]: v }`
+				// defines an own property whereas `{ __proto__: v }` sets
+				// the prototype — the computed form carries distinct
+				// meaning. In a destructuring pattern (assignment LHS,
+				// for-in/of target), no such distinction exists, so the
+				// computed form is genuinely useless.
+				if isString && value == "__proto__" && !isObjectLiteralAssignmentPattern(gp) {
+					return
+				}
+			case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+				gp := container.Parent
+				if gp == nil {
+					return
+				}
+				switch gp.Kind {
+				case ast.KindObjectLiteralExpression:
+					if isString && value == "__proto__" && !isObjectLiteralAssignmentPattern(gp) {
+						return
+					}
+				case ast.KindClassDeclaration, ast.KindClassExpression:
+					if !opts.EnforceForClassMembers {
+						return
+					}
+					// typescript-eslint emits `TSAbstractMethodDefinition` for
+					// abstract methods/accessors, which ESLint's core rule
+					// does not listen for — so the rule is a no-op there.
+					// Match that behavior exactly.
+					if ast.HasSyntacticModifier(container, ast.ModifierFlagsAbstract) {
+						return
+					}
+					if ast.IsStatic(container) {
+						if isString && value == "prototype" {
+							return
+						}
+					} else {
+						if isString && value == "constructor" {
+							return
+						}
+					}
+				default:
+					return
+				}
+			case ast.KindPropertyDeclaration:
+				gp := container.Parent
+				if gp == nil {
+					return
+				}
+				if gp.Kind != ast.KindClassDeclaration && gp.Kind != ast.KindClassExpression {
+					return
+				}
+				if !opts.EnforceForClassMembers {
+					return
+				}
+				// Same framework-level gaps as methods:
+				//   - `abstract` fields → `TSAbstractPropertyDefinition`
+				//   - `accessor` fields (auto-accessor) → `AccessorProperty`
+				// Neither matches ESLint's `PropertyDefinition` selector, so
+				// ESLint's rule skips them. Skip here too.
+				if ast.HasSyntacticModifier(container, ast.ModifierFlagsAbstract) {
+					return
+				}
+				if ast.HasSyntacticModifier(container, ast.ModifierFlagsAccessor) {
+					return
+				}
+				if ast.IsStatic(container) {
+					if isString && (value == "constructor" || value == "prototype") {
+						return
+					}
+				} else {
+					if isString && value == "constructor" {
+						return
+					}
+				}
+			case ast.KindBindingElement:
+				// Destructuring pattern — always report.
+			default:
+				return
+			}
+
+			sf := ctx.SourceFile
+			sourceText := sf.Text()
+
+			leftBracketPos := scanner.SkipTrivia(sourceText, cpn.Pos())
+			endPos := cpn.End()
+			keyStart := scanner.SkipTrivia(sourceText, inner.Pos())
+			keyEnd := inner.End()
+			keyRaw := sourceText[keyStart:keyEnd]
+
+			msg := rule.RuleMessage{
+				Id:          "unnecessarilyComputedProperty",
+				Description: fmt.Sprintf("Unnecessarily computed property [%s] found.", keyRaw),
+			}
+
+			// Suppress auto-fix when a comment sits anywhere between the
+			// brackets — preserving comments across a token replacement
+			// would require splicing them back in and isn't worth the
+			// complexity, matching ESLint's behavior.
+			if hasCommentsBetween(sourceText, leftBracketPos+1, endPos-1) {
+				ctx.ReportNode(container, msg)
+				return
+			}
+
+			replacement := keyRaw
+			if leftBracketPos > 0 && len(keyRaw) > 0 {
+				prev := sourceText[leftBracketPos-1]
+				// Only add a separator space when the previous token and
+				// the key would fuse into one identifier (e.g. `get` + `2`
+				// → `get2`). `get` + `'foo'` is fine because `'` can't
+				// continue an identifier.
+				if isIdentPart(prev) && isIdentPart(keyRaw[0]) {
+					replacement = " " + keyRaw
+				}
+			}
+
+			fix := rule.RuleFixReplaceRange(
+				core.NewTextRange(leftBracketPos, endPos),
+				replacement,
+			)
+			ctx.ReportNodeWithFixes(container, msg, fix)
+		}
+
+		nameIfComputed := func(n *ast.Node) *ast.Node {
+			if n == nil {
+				return nil
+			}
+			name := n.Name()
+			if name == nil || name.Kind != ast.KindComputedPropertyName {
+				return nil
+			}
+			return name
+		}
+
+		handle := func(node *ast.Node) {
+			if cpn := nameIfComputed(node); cpn != nil {
+				check(node, cpn)
+			}
+		}
+
+		bindingElementHandle := func(node *ast.Node) {
+			be := node.AsBindingElement()
+			if be == nil || be.PropertyName == nil {
+				return
+			}
+			if be.PropertyName.Kind != ast.KindComputedPropertyName {
+				return
+			}
+			check(node, be.PropertyName)
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAssignment:  handle,
+			ast.KindMethodDeclaration:   handle,
+			ast.KindGetAccessor:         handle,
+			ast.KindSetAccessor:         handle,
+			ast.KindPropertyDeclaration: handle,
+			ast.KindBindingElement:      bindingElementHandle,
+		}
+	},
+}

--- a/internal/rules/no_useless_computed_key/no_useless_computed_key.md
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key.md
@@ -1,0 +1,65 @@
+# no-useless-computed-key
+
+## Rule Details
+
+Disallow computed property keys when their use is unnecessary. For example, `{ ["a"]: 1 }` can be rewritten as `{ a: 1 }` with the same behavior. The rule applies to object literals, destructuring patterns, and (by default) class members. A few keys retain distinct semantics in computed form and are therefore exempt:
+
+- `{ ["__proto__"]: v }` defines a regular property, whereas `{ __proto__: v }` sets the object's prototype.
+- In a class, `["constructor"]()` is a regular method whereas `constructor()` is the constructor.
+- In a class, `static ["prototype"]` / `static ["prototype"]()` produce only a runtime error, whereas the unbracketed form is a parse error that breaks the whole script.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+({ ['0']: 0 });
+({ ['x']: 0 });
+({ [0]: 0 });
+({ ['x']() {} });
+({ get ['foo']() {} });
+var { ['x']: a } = obj;
+class Foo {
+  ['x']() {}
+}
+class Foo {
+  ['0'];
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+({ a: 0, b() {} });
+({ [x]: 0 });
+({ ['__proto__']: [] });
+class Foo {
+  [x]() {}
+}
+class Foo {
+  ['constructor']() {}
+}
+class Foo {
+  static ['prototype']() {}
+}
+```
+
+## Options
+
+This rule has one option, an object with a single key:
+
+- `enforceForClassMembers` (default `true`): when `false`, the rule only flags object literals and destructuring patterns and leaves class members alone.
+
+Examples of **correct** code for this rule with `{ "enforceForClassMembers": false }`:
+
+```json
+{ "no-useless-computed-key": ["error", { "enforceForClassMembers": false }] }
+```
+
+```javascript
+class Foo {
+  ['x']() {}
+}
+```
+
+## Original Documentation
+
+- [ESLint — no-useless-computed-key](https://eslint.org/docs/latest/rules/no-useless-computed-key)

--- a/internal/rules/no_useless_computed_key/no_useless_computed_key_test.go
+++ b/internal/rules/no_useless_computed_key/no_useless_computed_key_test.go
@@ -1,0 +1,1014 @@
+package no_useless_computed_key
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessComputedKeyRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessComputedKeyRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Object literals ----
+			{Code: `({ 'a': 0, b(){} })`},
+			{Code: `({ [x]: 0 });`},
+			{Code: `({ a: 0, [b](){} })`},
+			// Computed __proto__ in an object literal defines a property
+			// named __proto__; non-computed __proto__ sets the prototype.
+			{Code: `({ ['__proto__']: [] })`},
+
+			// ---- Object destructuring ----
+			{Code: `var { 'a': foo } = obj`},
+			{Code: `var { [a]: b } = obj;`},
+			{Code: `var { a } = obj;`},
+			{Code: `var { a: a } = obj;`},
+			{Code: `var { a: b } = obj;`},
+
+			// ---- Class members with enforceForClassMembers: true ----
+			{Code: `class Foo { a() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { 'a'() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { [x]() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { ['constructor']() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { static ['prototype']() {} }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `(class { 'a'() {} })`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `(class { [x]() {} })`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `(class { ['constructor']() {} })`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `(class { static ['prototype']() {} })`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+
+			// ---- Class members with default options ----
+			{Code: `class Foo { 'x'() {} }`},
+			{Code: `(class { [x]() {} })`},
+			{Code: `class Foo { static constructor() {} }`},
+			{Code: `class Foo { prototype() {} }`},
+
+			// ---- Class members with enforceForClassMembers: false ----
+			{Code: `class Foo { ['x']() {} }`, Options: map[string]interface{}{"enforceForClassMembers": false}},
+			{Code: `(class { ['x']() {} })`, Options: map[string]interface{}{"enforceForClassMembers": false}},
+			{Code: `class Foo { static ['constructor']() {} }`, Options: map[string]interface{}{"enforceForClassMembers": false}},
+			{Code: `class Foo { ['prototype']() {} }`, Options: map[string]interface{}{"enforceForClassMembers": false}},
+
+			// ---- Class fields ----
+			{Code: `class Foo { a }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { ['constructor'] }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { static ['constructor'] }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+			{Code: `class Foo { static ['prototype'] }`, Options: map[string]interface{}{"enforceForClassMembers": true}},
+
+			// BigInt literals: browsers throw on bigint property names, so
+			// the rule deliberately leaves them alone.
+			{Code: `({ [99999999999999999n]: 0 })`},
+
+			// ---- Non-literal expressions are ineligible regardless of shape ----
+			{Code: `const k = 'x'; const o = { [k]: 1 }`},
+			{Code: `const x = { [Symbol()]: 1 }`},
+
+			// ---- Namespace / module containing object literal is value position ----
+			{Code: "namespace N { export const v = { ['__proto__']: [] } }"},
+
+			// ---- TS 'as' / 'satisfies' wrappers inside computed brackets
+			//      mean the key is no longer a plain literal; not reported. ----
+			{Code: `const x = { [('x' as const)]: 1 }`},
+			{Code: `const x = { [('x' satisfies string)]: 1 }`},
+
+			// ---- Non-literal computed key kinds (structurally ineligible) ----
+			// Template literals (even no-substitution) aren't flagged — matches
+			// ESLint, which only inspects `Literal` nodes.
+			{Code: "({ [`x`]: 0 })"},
+			{Code: "class Foo { [`x`]() {} }"},
+			// Unary-negative and other expressions are not literals.
+			{Code: `({ [-1]: 0 })`},
+			{Code: `({ [void 0]: 0 })`},
+			// Regex literals: non-string/non-number.
+			{Code: `({ [/x/]: 0 })`},
+
+			// ---- Auto-accessor: typescript-eslint maps `accessor x` to
+			//      `AccessorProperty`, which ESLint's core rule does not
+			//      listen for. Match that (no report). ----
+			{Code: `class Foo { accessor ['x'] = 1 }`},
+			{Code: `class Foo { static accessor ['x'] = 1 }`},
+			{Code: `class Foo { accessor ['constructor'] = 1 }`},
+			{Code: `class Foo { static accessor ['prototype'] = 1 }`},
+
+			// ---- Abstract class members surface as TSAbstract* nodes in
+			//      typescript-eslint, which the core rule doesn't listen for.
+			//      Match that (no report) for methods, getters, setters,
+			//      and fields. ----
+			{Code: `abstract class Foo { abstract ['x'](): void }`},
+			{Code: `abstract class Foo { abstract ['x']: string }`},
+			{Code: `abstract class Foo { abstract get ['x'](): number }`},
+			{Code: `abstract class Foo { abstract set ['x'](v: number) }`},
+			{Code: `abstract class Foo { abstract readonly ['x']: number }`},
+
+			// ---- TypeScript-only containers must not be flagged ----
+			{Code: `interface I { ['foo']: number }`},
+			{Code: `type T = { ['foo']: number }`},
+			{Code: `interface I { ['foo'](): void }`},
+			// Signature-style members inside a type literal.
+			{Code: `type T = { readonly ['foo']: number }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Object literal property keys ----
+			{
+				Code:   `({ ['0']: 0 })`,
+				Output: []string{`({ '0': 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4, Message: "Unnecessarily computed property ['0'] found."},
+				},
+			},
+			{
+				Code:   `var { ['0']: a } = obj`,
+				Output: []string{`var { '0': a } = obj`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 7, EndLine: 1, EndColumn: 15, Message: "Unnecessarily computed property ['0'] found."},
+				},
+			},
+			{
+				Code:   `({ ['0+1,234']: 0 })`,
+				Output: []string{`({ '0+1,234': 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ [0]: 0 })`,
+				Output: []string{`({ 0: 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4, Message: "Unnecessarily computed property [0] found."},
+				},
+			},
+			{
+				Code:   `var { [0]: a } = obj`,
+				Output: []string{`var { 0: a } = obj`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code:   `({ ['x']: 0 })`,
+				Output: []string{`({ 'x': 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `var { ['x']: a } = obj`,
+				Output: []string{`var { 'x': a } = obj`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code:   `var { ['__proto__']: a } = obj`,
+				Output: []string{`var { '__proto__': a } = obj`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code:   `({ ['x']() {} })`,
+				Output: []string{`({ 'x'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Comments block auto-fix ----
+			{
+				Code: `({ [/* this comment prevents a fix */ 'x']: 0 })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code: `({ ['x' /* this comment also prevents a fix */]: 0 })`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Parenthesized literals ----
+			{
+				Code:   `({ [('x')]: 0 })`,
+				Output: []string{`({ 'x': 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `var { [('x')]: a } = obj`,
+				Output: []string{`var { 'x': a } = obj`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 7},
+				},
+			},
+
+			// ---- Generator / async object methods ----
+			{
+				Code:   `({ *['x']() {} })`,
+				Output: []string{`({ *'x'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ async ['x']() {} })`,
+				Output: []string{`({ async 'x'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Adjacency between prefix keyword and numeric `.2` is safe;
+			//      between keyword and digit-initial numeric requires a space.
+			{
+				Code:   `({ get[.2]() {} })`,
+				Output: []string{`({ get.2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4, Message: "Unnecessarily computed property [.2] found."},
+				},
+			},
+			{
+				Code:   `({ set[.2](value) {} })`,
+				Output: []string{`({ set.2(value) {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ async[.2]() {} })`,
+				Output: []string{`({ async.2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ [2]() {} })`,
+				Output: []string{`({ 2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ get [2]() {} })`,
+				Output: []string{`({ get 2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ set [2](value) {} })`,
+				Output: []string{`({ set 2(value) {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ async [2]() {} })`,
+				Output: []string{`({ async 2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ get[2]() {} })`,
+				Output: []string{`({ get 2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ set[2](value) {} })`,
+				Output: []string{`({ set 2(value) {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ async[2]() {} })`,
+				Output: []string{`({ async 2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ get['foo']() {} })`,
+				Output: []string{`({ get'foo'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ *[2]() {} })`,
+				Output: []string{`({ *2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ async*[2]() {} })`,
+				Output: []string{`({ async*2() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Object literal reserved-name keys that need no carve-out
+			//      in value position (only __proto__ does).
+			{
+				Code:   `({ ['constructor']: 1 })`,
+				Output: []string{`({ 'constructor': 1 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+			{
+				Code:   `({ ['prototype']: 1 })`,
+				Output: []string{`({ 'prototype': 1 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Class methods ----
+			{
+				Code:    `class Foo { ['0']() {} }`,
+				Output:  []string{`class Foo { '0'() {} }`},
+				Options: map[string]interface{}{"enforceForClassMembers": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:    `class Foo { ['0+1,234']() {} }`,
+				Output:  []string{`class Foo { '0+1,234'() {} }`},
+				Options: map[string]interface{}{},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { ['x']() {} }`,
+				Output: []string{`class Foo { 'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code: `class Foo { [/* this comment prevents a fix */ 'x']() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code: `class Foo { ['x' /* this comment also prevents a fix */]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `class Foo { [('x')]() {} }`,
+				Output: []string{`class Foo { 'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { *['x']() {} }`,
+				Output: []string{`class Foo { *'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { async ['x']() {} }`,
+				Output: []string{`class Foo { async 'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { get[.2]() {} }`,
+				Output: []string{`class Foo { get.2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { set[.2](value) {} }`,
+				Output: []string{`class Foo { set.2(value) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { async[.2]() {} }`,
+				Output: []string{`class Foo { async.2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { [2]() {} }`,
+				Output: []string{`class Foo { 2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { get [2]() {} }`,
+				Output: []string{`class Foo { get 2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { set [2](value) {} }`,
+				Output: []string{`class Foo { set 2(value) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { async [2]() {} }`,
+				Output: []string{`class Foo { async 2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { get[2]() {} }`,
+				Output: []string{`class Foo { get 2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { set[2](value) {} }`,
+				Output: []string{`class Foo { set 2(value) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { async[2]() {} }`,
+				Output: []string{`class Foo { async 2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { get['foo']() {} }`,
+				Output: []string{`class Foo { get'foo'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { *[2]() {} }`,
+				Output: []string{`class Foo { *2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { async*[2]() {} }`,
+				Output: []string{`class Foo { async*2() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+
+			// ---- Class reserved-name method carve-outs ----
+			{
+				Code:   `class Foo { static ['constructor']() {} }`,
+				Output: []string{`class Foo { static 'constructor'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { ['prototype']() {} }`,
+				Output: []string{`class Foo { 'prototype'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `(class { ['x']() {} })`,
+				Output: []string{`(class { 'x'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   `(class { ['__proto__']() {} })`,
+				Output: []string{`(class { '__proto__'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   `(class { static ['__proto__']() {} })`,
+				Output: []string{`(class { static '__proto__'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   `(class { static ['constructor']() {} })`,
+				Output: []string{`(class { static 'constructor'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   `(class { ['prototype']() {} })`,
+				Output: []string{`(class { 'prototype'() {} })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+
+			// ---- Class fields ----
+			{
+				Code:   `class Foo { ['0'] }`,
+				Output: []string{`class Foo { '0' }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { ['0'] = 0 }`,
+				Output: []string{`class Foo { '0' = 0 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { static[0] }`,
+				Output: []string{`class Foo { static 0 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13},
+				},
+			},
+			{
+				Code:   `class Foo { ['#foo'] }`,
+				Output: []string{`class Foo { '#foo' }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13, EndLine: 1, EndColumn: 21, Message: "Unnecessarily computed property ['#foo'] found."},
+				},
+			},
+			{
+				Code:   `(class { ['__proto__'] })`,
+				Output: []string{`(class { '__proto__' })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   `(class { static ['__proto__'] })`,
+				Output: []string{`(class { static '__proto__' })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+			{
+				Code:   `(class { ['prototype'] })`,
+				Output: []string{`(class { 'prototype' })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 10},
+				},
+			},
+
+			// ---- Multi-line: lock EndLine / EndColumn ----
+			{
+				Code: `({
+  ['x']: 0
+})`,
+				Output: []string{`({
+  'x': 0
+})`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 2, Column: 3, EndLine: 2, EndColumn: 11, Message: "Unnecessarily computed property ['x'] found."},
+				},
+			},
+			{
+				Code: `class Foo {
+  static ['x']() {
+    return 1;
+  }
+}`,
+				Output: []string{`class Foo {
+  static 'x'() {
+    return 1;
+  }
+}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 2, Column: 3, EndLine: 4, EndColumn: 4, Message: "Unnecessarily computed property ['x'] found."},
+				},
+			},
+
+			// ---- Numeric literal raw text is preserved (hex / exponent) ----
+			{
+				Code:   `({ [0x1]: 0 })`,
+				Output: []string{`({ 0x1: 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4, Message: "Unnecessarily computed property [0x1] found."},
+				},
+			},
+			{
+				Code:   `({ [1e2]: 0 })`,
+				Output: []string{`({ 1e2: 0 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4, Message: "Unnecessarily computed property [1e2] found."},
+				},
+			},
+
+			// ---- PROBE: plain assignment destructuring (non-__proto__) ----
+			{
+				Code:   `({ ['y']: a } = b)`,
+				Output: []string{`({ 'y': a } = b)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Assignment destructuring: the __proto__ carve-out is for
+			//      value-position literals only. tsgo reuses
+			//      ObjectLiteralExpression for the LHS of `=` / for-in/of, so
+			//      the rule must treat those as patterns. ----
+			{
+				Code:   `({ ['__proto__']: a } = b)`,
+				Output: []string{`({ '__proto__': a } = b)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4, Message: "Unnecessarily computed property ['__proto__'] found."},
+				},
+			},
+			{
+				Code:   `({ y: { ['__proto__']: a } } = b)`,
+				Output: []string{`({ y: { '__proto__': a } } = b)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 9},
+				},
+			},
+			{
+				Code:   `for ({ ['__proto__']: a } of arr) {}`,
+				Output: []string{`for ({ '__proto__': a } of arr) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `for ({ ['__proto__']: a } in arr) {}`,
+				Output: []string{`for ({ '__proto__': a } in arr) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 8},
+				},
+			},
+			{
+				Code:   `[{ ['__proto__']: a }] = [b]`,
+				Output: []string{`[{ '__proto__': a }] = [b]`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- Destructuring with default value ----
+			{
+				Code:   `var { ['x']: a = 1 } = obj`,
+				Output: []string{`var { 'x': a = 1 } = obj`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 7},
+				},
+			},
+			{
+				Code:   `({ ['x']: a = 1 } = b)`,
+				Output: []string{`({ 'x': a = 1 } = b)`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 4},
+				},
+			},
+
+			// ---- `override` modifier is a plain MethodDefinition in TSESTree,
+			//      so it should report. ----
+			{
+				Code:   `class Base { x() {} }; class Sub extends Base { override ['x']() {} }`,
+				Output: []string{`class Base { x() {} }; class Sub extends Base { override 'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- `declare class` members surface as regular
+			//      MethodDefinition/PropertyDefinition — should report. ----
+			{
+				Code:   `declare class Foo { ['x']: string }`,
+				Output: []string{`declare class Foo { 'x': string }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:   `declare class Foo { ['x'](): void }`,
+				Output: []string{`declare class Foo { 'x'(): void }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 21},
+				},
+			},
+
+			// ---- Object literal wrapped in type assertion / as / satisfies ----
+			{
+				Code:   `const x = <const>{ ['x']: 1 }`,
+				Output: []string{`const x = <const>{ 'x': 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { ['x']: 1 } as const`,
+				Output: []string{`const x = { 'x': 1 } as const`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { ['x']: 1 } satisfies Record<string, number>`,
+				Output: []string{`const x = { 'x': 1 } satisfies Record<string, number>`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- String-literal variants ----
+			{
+				Code:   `const x = { ["x"]: 1 }`,
+				Output: []string{`const x = { "x": 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Message: `Unnecessarily computed property ["x"] found.`},
+				},
+			},
+			{
+				Code:   `const x = { [""]: 1 }`,
+				Output: []string{`const x = { "": 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { ["\u00e9"]: 1 }`,
+				Output: []string{`const x = { "\u00e9": 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { ["delete"]: 1 }`,
+				Output: []string{`const x = { "delete": 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Numeric-literal variants (raw text preserved) ----
+			{
+				Code:   `const x = { [0b10]: 1 }`,
+				Output: []string{`const x = { 0b10: 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Message: "Unnecessarily computed property [0b10] found."},
+				},
+			},
+			{
+				Code:   `const x = { [0o7]: 1 }`,
+				Output: []string{`const x = { 0o7: 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { [1_000]: 1 }`,
+				Output: []string{`const x = { 1_000: 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { [1e-2]: 1 }`,
+				Output: []string{`const x = { 1e-2: 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Multiple parenthesis levels ----
+			{
+				Code:   `const x = { [(('x'))]: 1 }`,
+				Output: []string{`const x = { 'x': 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Multi-modifier class members ----
+			{
+				Code:   `class Foo { public static ['x']() {} }`,
+				Output: []string{`class Foo { public static 'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `class Foo { static readonly ['x'] = 1 }`,
+				Output: []string{`class Foo { static readonly 'x' = 1 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `class Foo { static async *['x']() {} }`,
+				Output: []string{`class Foo { static async *'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `class Foo { static get ['x']() { return 1 } }`,
+				Output: []string{`class Foo { static get 'x'() { return 1 } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Position in expression contexts ----
+			{
+				Code:   `const arrow = () => ({ ['x']: 1 })`,
+				Output: []string{`const arrow = () => ({ 'x': 1 })`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const cond = true ? { ['x']: 1 } : { a: 2 }`,
+				Output: []string{`const cond = true ? { 'x': 1 } : { a: 2 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `function f() { return { ['x']: 1 } }`,
+				Output: []string{`function f() { return { 'x': 1 } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Nested & parameter destructuring ----
+			{
+				Code:   `function f({ ['x']: a } = {} as any) { return a }`,
+				Output: []string{`function f({ 'x': a } = {} as any) { return a }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const { ['x']: a, ...rest } = { x: 1, y: 2 }`,
+				Output: []string{`const { 'x': a, ...rest } = { x: 1, y: 2 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `try {} catch ({ ['x']: e }) {}`,
+				Output: []string{`try {} catch ({ 'x': e }) {}`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Multiple diagnostics inside a single object ----
+			{
+				Code:   `const x = { ['x']: 1, ['y']: 2, a: 3, ['z']: 4 }`,
+				Output: []string{`const x = { 'x': 1, 'y': 2, a: 3, 'z': 4 }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+					{MessageId: "unnecessarilyComputedProperty"},
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Multi-line computed bracket span (newline is not a comment,
+			//      so auto-fix still applies) ----
+			{
+				Code:   "const x = {\n  [\n    'x'\n  ]: 1,\n}",
+				Output: []string{"const x = {\n  'x': 1,\n}"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 2, Column: 3, EndLine: 4, EndColumn: 7},
+				},
+			},
+
+			// ---- Class implementing interface with computed literal key ----
+			{
+				Code:   `interface I { x(): void } class C implements I { ['x']() {} }`,
+				Output: []string{`interface I { x(): void } class C implements I { 'x'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Class extending generic with computed field ----
+			{
+				Code:   `class Box<T> { ['x']: T | undefined }`,
+				Output: []string{`class Box<T> { 'x': T | undefined }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Namespace containing class with computed method ----
+			{
+				Code:   `namespace N { export class C { ['x']() {} } }`,
+				Output: []string{`namespace N { export class C { 'x'() {} } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Multiple pattern destructuring in for-of ----
+			{
+				Code:   `for (const { a: { ['x']: b } } of [{ a: { x: 1 } }]) { void b }`,
+				Output: []string{`for (const { a: { 'x': b } } of [{ a: { x: 1 } }]) { void b }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Fix produces valid syntax even when key value is a
+			//      context-sensitive keyword (async/get/set). ----
+			{
+				Code:   `const x = { async ['async']() {} }`,
+				Output: []string{`const x = { async 'async'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { get ['get']() { return 1 } }`,
+				Output: []string{`const x = { get 'get'() { return 1 } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+			{
+				Code:   `const x = { set ['set'](v) {} }`,
+				Output: []string{`const x = { set 'set'(v) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Non-static class method named 'prototype' should report
+			//      (only non-static 'constructor' is carved out). ----
+			{
+				Code:   `class Foo { ['prototype']() {} }`,
+				Output: []string{`class Foo { 'prototype'() {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- Object with same literal key repeated as get + set ----
+			{
+				Code:   `class Foo { get ['k']() { return 1 } set ['k'](v) {} }`,
+				Output: []string{`class Foo { get 'k'() { return 1 } set 'k'(v) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty"},
+					{MessageId: "unnecessarilyComputedProperty"},
+				},
+			},
+
+			// ---- TypeScript type-modifying wrappers inside the bracket do
+			//      NOT make the key a string literal. `('x' as const)` is an
+			//      AsExpression, not a Literal — should NOT report. ----
+			// (Valid — covered in valid section below.)
+
+			// ---- Class getter/setter with computed literal key ----
+			{
+				Code:   `class Foo { get ['x']() { return 1 } }`,
+				Output: []string{`class Foo { get 'x'() { return 1 } }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13, Message: "Unnecessarily computed property ['x'] found."},
+				},
+			},
+			{
+				Code:   `class Foo { set ['x'](v) {} }`,
+				Output: []string{`class Foo { set 'x'(v) {} }`},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessarilyComputedProperty", Line: 1, Column: 13, Message: "Unnecessarily computed property ['x'] found."},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -66,6 +66,7 @@ export default defineConfig({
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
     './tests/eslint/rules/prefer-template.test.ts',
+    './tests/eslint/rules/no-useless-computed-key.test.ts',
     './tests/eslint/rules/no-useless-concat.test.ts',
     // eslint-plugin-import
     './tests/eslint-plugin-import/rules/first.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-computed-key.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-computed-key.test.ts.snap
@@ -1,0 +1,2994 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-computed-key > invalid 1`] = `
+{
+  "code": "({ ['0']: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 2`] = `
+{
+  "code": "var { ['0']: a } = obj",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 3`] = `
+{
+  "code": "({ ['0+1,234']: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0+1,234'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 4`] = `
+{
+  "code": "({ [0]: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [0] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 5`] = `
+{
+  "code": "var { [0]: a } = obj",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [0] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 6`] = `
+{
+  "code": "({ ['x']: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 7`] = `
+{
+  "code": "var { ['x']: a } = obj",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 8`] = `
+{
+  "code": "var { ['__proto__']: a } = obj",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 9`] = `
+{
+  "code": "({ ['x']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 10`] = `
+{
+  "code": "({ [/* this comment prevents a fix */ 'x']: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 11`] = `
+{
+  "code": "({ ['x' /* this comment also prevents a fix */]: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 12`] = `
+{
+  "code": "({ [('x')]: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 13`] = `
+{
+  "code": "var { [('x')]: a } = obj",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 14`] = `
+{
+  "code": "({ *['x']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 15`] = `
+{
+  "code": "({ async ['x']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 16`] = `
+{
+  "code": "({ get[.2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [.2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 17`] = `
+{
+  "code": "({ set[.2](value) {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [.2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 18`] = `
+{
+  "code": "({ async[.2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [.2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 19`] = `
+{
+  "code": "({ [2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 20`] = `
+{
+  "code": "({ get [2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 21`] = `
+{
+  "code": "({ set [2](value) {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 22`] = `
+{
+  "code": "({ async [2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 23`] = `
+{
+  "code": "({ get[2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 24`] = `
+{
+  "code": "({ set[2](value) {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 25`] = `
+{
+  "code": "({ async[2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 26`] = `
+{
+  "code": "({ get['foo']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['foo'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 27`] = `
+{
+  "code": "({ *[2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 28`] = `
+{
+  "code": "({ async*[2]() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 29`] = `
+{
+  "code": "({ ['constructor']: 1 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['constructor'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 30`] = `
+{
+  "code": "({ ['prototype']: 1 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['prototype'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 31`] = `
+{
+  "code": "class Foo { ['0']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 32`] = `
+{
+  "code": "class Foo { ['0+1,234']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0+1,234'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 33`] = `
+{
+  "code": "class Foo { ['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 34`] = `
+{
+  "code": "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 35`] = `
+{
+  "code": "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 36`] = `
+{
+  "code": "class Foo { [('x')]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 37`] = `
+{
+  "code": "class Foo { *['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 38`] = `
+{
+  "code": "class Foo { async ['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 39`] = `
+{
+  "code": "class Foo { get[.2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [.2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 40`] = `
+{
+  "code": "class Foo { set[.2](value) {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [.2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 41`] = `
+{
+  "code": "class Foo { async[.2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [.2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 42`] = `
+{
+  "code": "class Foo { [2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 43`] = `
+{
+  "code": "class Foo { get [2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 44`] = `
+{
+  "code": "class Foo { set [2](value) {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 45`] = `
+{
+  "code": "class Foo { async [2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 46`] = `
+{
+  "code": "class Foo { get[2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 47`] = `
+{
+  "code": "class Foo { set[2](value) {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 48`] = `
+{
+  "code": "class Foo { async[2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 49`] = `
+{
+  "code": "class Foo { get['foo']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['foo'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 50`] = `
+{
+  "code": "class Foo { *[2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 51`] = `
+{
+  "code": "class Foo { async*[2]() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 52`] = `
+{
+  "code": "class Foo { static ['constructor']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['constructor'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 53`] = `
+{
+  "code": "class Foo { ['prototype']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['prototype'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 54`] = `
+{
+  "code": "(class { ['x']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 55`] = `
+{
+  "code": "(class { ['__proto__']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 56`] = `
+{
+  "code": "(class { static ['__proto__']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 57`] = `
+{
+  "code": "(class { static ['constructor']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['constructor'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 58`] = `
+{
+  "code": "(class { ['prototype']() {} })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['prototype'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 59`] = `
+{
+  "code": "class Foo { ['0'] }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 60`] = `
+{
+  "code": "class Foo { ['0'] = 0 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['0'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 61`] = `
+{
+  "code": "class Foo { static[0] }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [0] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 62`] = `
+{
+  "code": "class Foo { ['#foo'] }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['#foo'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 63`] = `
+{
+  "code": "(class { ['__proto__'] })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 64`] = `
+{
+  "code": "(class { static ['__proto__'] })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 65`] = `
+{
+  "code": "(class { ['prototype'] })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['prototype'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 10,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 66`] = `
+{
+  "code": "({
+  ['x']: 0
+})",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 67`] = `
+{
+  "code": "class Foo {
+  static ['x']() {
+    return 1;
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 68`] = `
+{
+  "code": "({ [0x1]: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [0x1] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 69`] = `
+{
+  "code": "({ [1e2]: 0 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [1e2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 70`] = `
+{
+  "code": "const x = { ["x"]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ["x"] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 71`] = `
+{
+  "code": "const x = { [""]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [""] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 72`] = `
+{
+  "code": "const x = { ["\\u00e9"]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ["\\u00e9"] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 73`] = `
+{
+  "code": "const x = { ["delete"]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ["delete"] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 74`] = `
+{
+  "code": "const x = { [0b10]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [0b10] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 75`] = `
+{
+  "code": "const x = { [0o7]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [0o7] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 76`] = `
+{
+  "code": "const x = { [1_000]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [1_000] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 77`] = `
+{
+  "code": "const x = { [1e-2]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property [1e-2] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 78`] = `
+{
+  "code": "const x = { [(('x'))]: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 79`] = `
+{
+  "code": "class Foo { public static ['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 80`] = `
+{
+  "code": "class Foo { static readonly ['x'] = 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 81`] = `
+{
+  "code": "class Foo { static async *['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 82`] = `
+{
+  "code": "const arrow = () => ({ ['x']: 1 })",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 83`] = `
+{
+  "code": "const cond = true ? { ['x']: 1 } : { a: 2 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 84`] = `
+{
+  "code": "function f() { return { ['x']: 1 } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 85`] = `
+{
+  "code": "function f({ ['x']: a } = {} as any) { return a }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 86`] = `
+{
+  "code": "const { ['x']: a, ...rest } = { x: 1, y: 2 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 87`] = `
+{
+  "code": "try {} catch ({ ['x']: e }) {}",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 17,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 88`] = `
+{
+  "code": "const x = { ['x']: 1, ['y']: 2, a: 3, ['z']: 4 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+    {
+      "message": "Unnecessarily computed property ['y'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+    {
+      "message": "Unnecessarily computed property ['z'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 89`] = `
+{
+  "code": "const x = {
+  [
+    'x'
+  ]: 1,
+}",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 90`] = `
+{
+  "code": "interface I { x(): void } class C implements I { ['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 91`] = `
+{
+  "code": "class Box<T> { ['x']: T | undefined }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 92`] = `
+{
+  "code": "namespace N { export class C { ['x']() {} } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 93`] = `
+{
+  "code": "for (const { a: { ['x']: b } } of [{ a: { x: 1 } }]) { void b }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 94`] = `
+{
+  "code": "const x = { async ['async']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['async'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 95`] = `
+{
+  "code": "const x = { get ['get']() { return 1 } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['get'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 96`] = `
+{
+  "code": "const x = { set ['set'](v) {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['set'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 97`] = `
+{
+  "code": "class Foo { ['prototype']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['prototype'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 98`] = `
+{
+  "code": "class Foo { get ['k']() { return 1 } set ['k'](v) {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['k'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+    {
+      "message": "Unnecessarily computed property ['k'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 99`] = `
+{
+  "code": "class Foo { get ['x']() { return 1 } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 100`] = `
+{
+  "code": "class Foo { set ['x'](v) {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 101`] = `
+{
+  "code": "var { ['x']: a = 1 } = obj",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 102`] = `
+{
+  "code": "({ ['x']: a = 1 } = b)",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 103`] = `
+{
+  "code": "class Base { x() {} }; class Sub extends Base { override ['x']() {} }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 104`] = `
+{
+  "code": "declare class Foo { ['x']: string }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 105`] = `
+{
+  "code": "declare class Foo { ['x'](): void }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 106`] = `
+{
+  "code": "const x = <const>{ ['x']: 1 }",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 107`] = `
+{
+  "code": "const x = { ['x']: 1 } as const",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 108`] = `
+{
+  "code": "const x = { ['x']: 1 } satisfies Record<string, number>",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['x'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 109`] = `
+{
+  "code": "({ ['__proto__']: a } = b)",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 110`] = `
+{
+  "code": "({ y: { ['__proto__']: a } } = b)",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 111`] = `
+{
+  "code": "for ({ ['__proto__']: a } of arr) {}",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 112`] = `
+{
+  "code": "for ({ ['__proto__']: a } in arr) {}",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 8,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-computed-key > invalid 113`] = `
+{
+  "code": "[{ ['__proto__']: a }] = [b]",
+  "diagnostics": [
+    {
+      "message": "Unnecessarily computed property ['__proto__'] found.",
+      "messageId": "unnecessarilyComputedProperty",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-computed-key",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-computed-key.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-computed-key.test.ts
@@ -1,0 +1,684 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-computed-key', {
+  valid: [
+    // ---- Object literals ----
+    "({ 'a': 0, b(){} })",
+    '({ [x]: 0 });',
+    '({ a: 0, [b](){} })',
+    "({ ['__proto__']: [] })",
+
+    // ---- Object destructuring ----
+    "var { 'a': foo } = obj",
+    'var { [a]: b } = obj;',
+    'var { a } = obj;',
+    'var { a: a } = obj;',
+    'var { a: b } = obj;',
+
+    // ---- Class members with enforceForClassMembers: true ----
+    {
+      code: 'class Foo { a() {} }',
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "class Foo { 'a'() {} }",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: 'class Foo { [x]() {} }',
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "class Foo { ['constructor']() {} }",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "class Foo { static ['prototype']() {} }",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "(class { 'a'() {} })",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: '(class { [x]() {} })',
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "(class { ['constructor']() {} })",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "(class { static ['prototype']() {} })",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+
+    // ---- Class members with default options ----
+    "class Foo { 'x'() {} }",
+    '(class { [x]() {} })',
+    'class Foo { static constructor() {} }',
+    'class Foo { prototype() {} }',
+
+    // ---- Class members with enforceForClassMembers: false ----
+    {
+      code: "class Foo { ['x']() {} }",
+      options: [{ enforceForClassMembers: false }] as any,
+    },
+    {
+      code: "(class { ['x']() {} })",
+      options: [{ enforceForClassMembers: false }] as any,
+    },
+    {
+      code: "class Foo { static ['constructor']() {} }",
+      options: [{ enforceForClassMembers: false }] as any,
+    },
+    {
+      code: "class Foo { ['prototype']() {} }",
+      options: [{ enforceForClassMembers: false }] as any,
+    },
+
+    // ---- Class fields ----
+    {
+      code: 'class Foo { a }',
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "class Foo { ['constructor'] }",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "class Foo { static ['constructor'] }",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+    {
+      code: "class Foo { static ['prototype'] }",
+      options: [{ enforceForClassMembers: true }] as any,
+    },
+
+    // BigInt literals are left alone — browsers throw on bigint property
+    // names, so the rule deliberately doesn't touch them.
+    '({ [99999999999999999n]: 0 })',
+
+    // Template literals (even no-substitution) are not flagged.
+    '({ [`x`]: 0 })',
+    'class Foo { [`x`]() {} }',
+    // Unary-negated / non-literal expressions are not literals.
+    '({ [-1]: 0 })',
+    '({ [void 0]: 0 })',
+    '({ [/x/]: 0 })',
+    "const k = 'x'; const o = { [k]: 1 }",
+    'const x = { [Symbol()]: 1 }',
+
+    // Value-position __proto__ in namespace — still carved out.
+    "namespace N { export const v = { ['__proto__']: [] } }",
+
+    // TS wrapping the inner expression makes it non-literal.
+    "const x = { [('x' as const)]: 1 }",
+    "const x = { [('x' satisfies string)]: 1 }",
+
+    // Auto-accessor (TS 5 / ES stage-3) surfaces as AccessorProperty in
+    // TSESTree, which the core rule doesn't listen for — match: no report.
+    "class Foo { accessor ['x'] = 1 }",
+    "class Foo { static accessor ['x'] = 1 }",
+    "class Foo { accessor ['constructor'] = 1 }",
+    "class Foo { static accessor ['constructor'] = 1 }",
+    "class Foo { static accessor ['prototype'] = 1 }",
+
+    // Abstract class members map to TSAbstract* nodes in TSESTree, which
+    // the core rule doesn't listen for — match: no report.
+    "abstract class Foo { abstract ['x'](): void }",
+    "abstract class Foo { abstract ['x']: string }",
+    "abstract class Foo { abstract get ['x'](): number }",
+    "abstract class Foo { abstract set ['x'](v: number) }",
+    "abstract class Foo { abstract readonly ['x']: number }",
+
+    // TypeScript-only containers must not be flagged.
+    "interface I { ['foo']: number }",
+    "type T = { ['foo']: number }",
+    "interface I { ['foo'](): void }",
+    "type T = { readonly ['foo']: number }",
+  ],
+  invalid: [
+    {
+      code: "({ ['0']: 0 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "var { ['0']: a } = obj",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ ['0+1,234']: 0 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ [0]: 0 })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'var { [0]: a } = obj',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ ['x']: 0 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "var { ['x']: a } = obj",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "var { ['__proto__']: a } = obj",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ ['x']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Comments block auto-fix ----
+    {
+      code: "({ [/* this comment prevents a fix */ 'x']: 0 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ ['x' /* this comment also prevents a fix */]: 0 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Parenthesized literals ----
+    {
+      code: "({ [('x')]: 0 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "var { [('x')]: a } = obj",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Generator / async object methods ----
+    {
+      code: "({ *['x']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ async ['x']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Adjacency ----
+    {
+      code: '({ get[.2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ set[.2](value) {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ async[.2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ [2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ get [2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ set [2](value) {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ async [2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ get[2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ set[2](value) {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ async[2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ get['foo']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ *[2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ async*[2]() {} })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Object reserved-name keys ----
+    {
+      code: "({ ['constructor']: 1 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ ['prototype']: 1 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Class methods ----
+    {
+      code: "class Foo { ['0']() {} }",
+      options: [{ enforceForClassMembers: true }] as any,
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { ['0+1,234']() {} }",
+      options: [{}] as any,
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { ['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { [/* this comment prevents a fix */ 'x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { ['x' /* this comment also prevents a fix */]() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { [('x')]() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { *['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { async ['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { get[.2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { set[.2](value) {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { async[.2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { [2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { get [2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { set [2](value) {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { async [2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { get[2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { set[2](value) {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { async[2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { get['foo']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { *[2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { async*[2]() {} }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { static ['constructor']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { ['prototype']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { ['x']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { ['__proto__']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { static ['__proto__']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { static ['constructor']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { ['prototype']() {} })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // ---- Class fields ----
+    {
+      code: "class Foo { ['0'] }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { ['0'] = 0 }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'class Foo { static[0] }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { ['#foo'] }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { ['__proto__'] })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { static ['__proto__'] })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "(class { ['prototype'] })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Multi-line cases — lock line/column & end-position via snapshot.
+    {
+      code: "({\n  ['x']: 0\n})",
+      errors: [
+        {
+          messageId: 'unnecessarilyComputedProperty',
+          line: 2,
+          column: 3,
+          endLine: 2,
+          endColumn: 11,
+        },
+      ],
+    },
+    {
+      code: "class Foo {\n  static ['x']() {\n    return 1;\n  }\n}",
+      errors: [
+        {
+          messageId: 'unnecessarilyComputedProperty',
+          line: 2,
+          column: 3,
+        },
+      ],
+    },
+
+    // Numeric raw text preserved (hex, exponent).
+    {
+      code: '({ [0x1]: 0 })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: '({ [1e2]: 0 })',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // String-literal key variants.
+    {
+      code: 'const x = { ["x"]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'const x = { [""]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'const x = { ["\\u00e9"]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'const x = { ["delete"]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Numeric-literal raw preserved.
+    {
+      code: 'const x = { [0b10]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'const x = { [0o7]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'const x = { [1_000]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: 'const x = { [1e-2]: 1 }',
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Multiple paren levels.
+    {
+      code: "const x = { [(('x'))]: 1 }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Multi-modifier class members.
+    {
+      code: "class Foo { public static ['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { static readonly ['x'] = 1 }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { static async *['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Expression contexts.
+    {
+      code: "const arrow = () => ({ ['x']: 1 })",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "const cond = true ? { ['x']: 1 } : { a: 2 }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "function f() { return { ['x']: 1 } }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Parameter destructuring with default.
+    {
+      code: "function f({ ['x']: a } = {} as any) { return a }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "const { ['x']: a, ...rest } = { x: 1, y: 2 }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "try {} catch ({ ['x']: e }) {}",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Multiple diagnostics in one object.
+    {
+      code: "const x = { ['x']: 1, ['y']: 2, a: 3, ['z']: 4 }",
+      errors: [
+        { messageId: 'unnecessarilyComputedProperty' },
+        { messageId: 'unnecessarilyComputedProperty' },
+        { messageId: 'unnecessarilyComputedProperty' },
+      ],
+    },
+
+    // Multi-line computed bracket span.
+    {
+      code: "const x = {\n  [\n    'x'\n  ]: 1,\n}",
+      errors: [
+        { messageId: 'unnecessarilyComputedProperty', line: 2, column: 3 },
+      ],
+    },
+
+    // Class implementing interface.
+    {
+      code: "interface I { x(): void } class C implements I { ['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Class with generic.
+    {
+      code: "class Box<T> { ['x']: T | undefined }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Namespace containing class.
+    {
+      code: "namespace N { export class C { ['x']() {} } }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Nested for-of pattern.
+    {
+      code: "for (const { a: { ['x']: b } } of [{ a: { x: 1 } }]) { void b }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Fix remains valid when key value is a context-sensitive keyword.
+    {
+      code: "const x = { async ['async']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "const x = { get ['get']() { return 1 } }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "const x = { set ['set'](v) {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Non-static class method named 'prototype' reports (only
+    // non-static 'constructor' is carved out).
+    {
+      code: "class Foo { ['prototype']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Same literal key on get + set, both report.
+    {
+      code: "class Foo { get ['k']() { return 1 } set ['k'](v) {} }",
+      errors: [
+        { messageId: 'unnecessarilyComputedProperty' },
+        { messageId: 'unnecessarilyComputedProperty' },
+      ],
+    },
+
+    // Class getter/setter with computed literal key.
+    {
+      code: "class Foo { get ['x']() { return 1 } }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "class Foo { set ['x'](v) {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Destructuring with default value.
+    {
+      code: "var { ['x']: a = 1 } = obj",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ ['x']: a = 1 } = b)",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // `override` modifier is a plain MethodDefinition in TSESTree.
+    {
+      code: "class Base { x() {} }; class Sub extends Base { override ['x']() {} }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // `declare class` members are plain MethodDefinition/PropertyDefinition.
+    {
+      code: "declare class Foo { ['x']: string }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "declare class Foo { ['x'](): void }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Object literal wrapped in type-assertion / as / satisfies.
+    {
+      code: "const x = <const>{ ['x']: 1 }",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "const x = { ['x']: 1 } as const",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "const x = { ['x']: 1 } satisfies Record<string, number>",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+
+    // Assignment destructuring must not get the __proto__ carve-out that
+    // value-position object literals get.
+    {
+      code: "({ ['__proto__']: a } = b)",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "({ y: { ['__proto__']: a } } = b)",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "for ({ ['__proto__']: a } of arr) {}",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "for ({ ['__proto__']: a } in arr) {}",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+    {
+      code: "[{ ['__proto__']: a }] = [b]",
+      errors: [{ messageId: 'unnecessarilyComputedProperty' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-useless-computed-key` rule from ESLint core to rslint.

Disallow unnecessary computed property keys in object literals, destructuring patterns, and class members (e.g. `{ ['x']: 1 }` → `{ 'x': 1 }`). Supports the `enforceForClassMembers` option (default `true`) and preserves all carve-outs:

- object-literal `__proto__` (distinct prototype-setter semantics)
- class non-static `constructor` / static `prototype` (method & field carve-outs)

### Alignment with ESLint

Verified against the upstream ESLint rule via differential validation on 7 synthetic probe files + 2 real repos (rsbuild, rspack) across both `enforceForClassMembers: true` and `false`:

- 144 + 99 diagnostics across both option configurations — byte-level match on `file`/`line`/`column`/`endLine`/`endColumn`/`message`
- 134 auto-fix operations — `--fix` output byte-level identical to ESLint `--fix`
- rsbuild / rspack scans: 0 reports on both sides (codebases are clean)

Key tsgo ↔ ESTree gaps handled:
- rslint's `patternVisitor` skips property names in destructuring — rule listens on containers (`PropertyAssignment` / `MethodDeclaration` / `PropertyDeclaration` / `BindingElement` / …), not on `ComputedPropertyName`
- tsgo reuses `ObjectLiteralExpression` for assignment-destructuring LHS — a context walk distinguishes value position from pattern position so the `__proto__` carve-out only applies to value literals
- typescript-eslint's `TSAbstractMethodDefinition` / `TSAbstractPropertyDefinition` / `AccessorProperty` are not matched by ESLint core selectors — rule skips class members with `abstract` or `accessor` modifiers

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-computed-key
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-computed-key.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).