### PR TITLE
feat: port rule no-useless-call

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -199,6 +199,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
@@ -658,6 +659,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("require-atomic-updates", require_atomic_updates.RequireAtomicUpdatesRule)
 	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
+	GlobalRuleRegistry.Register("no-useless-call", no_useless_call.NoUselessCallRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
 	GlobalRuleRegistry.Register("require-yield", require_yield.RequireYieldRule)

--- a/internal/rules/no_useless_call/no_useless_call.go
+++ b/internal/rules/no_useless_call/no_useless_call.go
@@ -1,0 +1,101 @@
+package no_useless_call
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// isCallOrNonVariadicApply mirrors ESLint's helper of the same name. It
+// recognizes a CallExpression whose callee is a non-computed `.call` or
+// `.apply` member access, and whose arguments shape matches the form the
+// rule cares about (`.call(thisArg, ...)` or `.apply(thisArg, [args])`).
+//
+// Returns the unwrapped PropertyAccessExpression (`<callee>.call` /
+// `<callee>.apply`) and the method name, or nil/"" if the call doesn't
+// match.
+func isCallOrNonVariadicApply(node *ast.Node) (*ast.Node, string) {
+	call := node.AsCallExpression()
+	if call == nil || call.Arguments == nil {
+		return nil, ""
+	}
+	args := call.Arguments.Nodes
+
+	// Skip parens around the callee. tsgo has no ChainExpression wrapper
+	// (optional chains are flag-based on the access node itself), so the
+	// only thing to unwrap here is parentheses — `(foo?.call)(...)`.
+	callee := ast.SkipParentheses(call.Expression)
+	if callee.Kind != ast.KindPropertyAccessExpression {
+		return nil, ""
+	}
+	prop := callee.AsPropertyAccessExpression()
+	name := prop.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return nil, ""
+	}
+	methodName := name.AsIdentifier().Text
+
+	switch methodName {
+	case "call":
+		if len(args) < 1 {
+			return nil, ""
+		}
+	case "apply":
+		if len(args) != 2 || args[1].Kind != ast.KindArrayLiteralExpression {
+			return nil, ""
+		}
+	default:
+		return nil, ""
+	}
+
+	return callee, methodName
+}
+
+// https://eslint.org/docs/latest/rules/no-useless-call
+var NoUselessCallRule = rule.Rule{
+	Name: "no-useless-call",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				callee, methodName := isCallOrNonVariadicApply(node)
+				if callee == nil {
+					return
+				}
+
+				// `applied` is the function being invoked via .call/.apply
+				// (i.e. `<applied>.call(...)`). Unwrap parens so things like
+				// `(obj?.foo).bar.call(obj?.foo, ...)` resolve correctly.
+				applied := ast.SkipParentheses(callee.AsPropertyAccessExpression().Expression)
+
+				// expectedThis is the receiver implied by `applied`. ESLint
+				// treats only MemberExpression receivers as having an
+				// implied `this`; tsgo splits that into PropertyAccessExpression
+				// and ElementAccessExpression.
+				var expectedThis *ast.Node
+				switch applied.Kind {
+				case ast.KindPropertyAccessExpression:
+					expectedThis = applied.AsPropertyAccessExpression().Expression
+				case ast.KindElementAccessExpression:
+					expectedThis = applied.AsElementAccessExpression().Expression
+				}
+
+				thisArg := node.AsCallExpression().Arguments.Nodes[0]
+
+				var matches bool
+				if expectedThis == nil {
+					matches = utils.IsNullOrUndefined(thisArg)
+				} else {
+					matches = utils.HasSameTokens(ctx.SourceFile, expectedThis, thisArg)
+				}
+				if !matches {
+					return
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "unnecessaryCall",
+					Description: "Unnecessary '." + methodName + "()'.",
+				})
+			},
+		}
+	},
+}

--- a/internal/rules/no_useless_call/no_useless_call.md
+++ b/internal/rules/no_useless_call/no_useless_call.md
@@ -47,17 +47,6 @@ foo.apply(null, args);
 obj.foo.apply(obj, args);
 ```
 
-## Known Limitations
-
-This rule compares the applied receiver and `thisArg` at the token level
-and does not model runtime side effects. Two source-identical expressions
-may produce different runtime values — most notably when they contain
-mutating operators. For example, `a[i++].foo.call(a[i++], 1, 2, 3)` is
-flagged as unnecessary, but rewriting it to `a[i++].foo(1, 2, 3)` would
-change behavior because `i` is incremented twice in the original and only
-once after the rewrite. Apply the suggested rewrite with care in such
-cases.
-
 ## Original Documentation
 
 - https://eslint.org/docs/latest/rules/no-useless-call

--- a/internal/rules/no_useless_call/no_useless_call.md
+++ b/internal/rules/no_useless_call/no_useless_call.md
@@ -49,10 +49,14 @@ obj.foo.apply(obj, args);
 
 ## Known Limitations
 
-This rule compares the applied receiver and `thisArg` at the token level, so
-it cannot reason about dynamic expressions whose runtime values may diverge
-even though their source forms differ. For example,
-`a[i++].foo.call(a[i++], 1, 2, 3)` is intentionally not reported.
+This rule compares the applied receiver and `thisArg` at the token level
+and does not model runtime side effects. Two source-identical expressions
+may produce different runtime values — most notably when they contain
+mutating operators. For example, `a[i++].foo.call(a[i++], 1, 2, 3)` is
+flagged as unnecessary, but rewriting it to `a[i++].foo(1, 2, 3)` would
+change behavior because `i` is incremented twice in the original and only
+once after the rewrite. Apply the suggested rewrite with care in such
+cases.
 
 ## Original Documentation
 

--- a/internal/rules/no_useless_call/no_useless_call.md
+++ b/internal/rules/no_useless_call/no_useless_call.md
@@ -1,0 +1,59 @@
+# no-useless-call
+
+## Rule Details
+
+`Function.prototype.call()` and `Function.prototype.apply()` are slower than the
+normal function invocation. This rule reports cases where `.call()` /
+`.apply()` does not change `this` (so the call could be a normal invocation).
+
+A call is reported when its `thisArg` matches the receiver implied by the
+applied expression:
+
+- `foo.call(undefined, …)` / `foo.apply(null, …)` — the applied expression has
+  no implied `this`, so `null`/`undefined`/`void 0` are equivalent to a plain
+  call.
+- `obj.foo.call(obj, …)` / `obj.foo.apply(obj, …)` — the `thisArg` is the same
+  expression (token-for-token) as the receiver of the applied member access.
+
+`.apply()` is only flagged when the second argument is an array literal — the
+variadic / spread case is the responsibility of `prefer-spread`.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+foo.call(undefined, 1, 2, 3);
+foo.apply(undefined, [1, 2, 3]);
+foo.call(null, 1, 2, 3);
+foo.apply(null, [1, 2, 3]);
+
+obj.foo.call(obj, 1, 2, 3);
+obj.foo.apply(obj, [1, 2, 3]);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// The `this` binding actually changes.
+foo.call(obj, 1, 2, 3);
+foo.apply(obj, [1, 2, 3]);
+obj.foo.call(null, 1, 2, 3);
+obj.foo.apply(null, [1, 2, 3]);
+obj.foo.call(otherObj, 1, 2, 3);
+obj.foo.apply(otherObj, [1, 2, 3]);
+
+// Variadic is delegated to `prefer-spread`.
+foo.apply(undefined, args);
+foo.apply(null, args);
+obj.foo.apply(obj, args);
+```
+
+## Known Limitations
+
+This rule compares the applied receiver and `thisArg` at the token level, so
+it cannot reason about dynamic expressions whose runtime values may diverge
+even though their source forms differ. For example,
+`a[i++].foo.call(a[i++], 1, 2, 3)` is intentionally not reported.
+
+## Original Documentation
+
+- https://eslint.org/docs/latest/rules/no-useless-call

--- a/internal/rules/no_useless_call/no_useless_call_test.go
+++ b/internal/rules/no_useless_call/no_useless_call_test.go
@@ -1,0 +1,312 @@
+package no_useless_call
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessCall(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoUselessCallRule,
+		[]rule_tester.ValidTestCase{
+			// `this` binding is different.
+			{Code: `foo.apply(obj, 1, 2);`},
+			{Code: `obj.foo.apply(null, 1, 2);`},
+			{Code: `obj.foo.apply(otherObj, 1, 2);`},
+			{Code: `a.b(x, y).c.foo.apply(a.b(x, z).c, 1, 2);`},
+			{Code: `foo.apply(obj, [1, 2]);`},
+			{Code: `obj.foo.apply(null, [1, 2]);`},
+			{Code: `obj.foo.apply(otherObj, [1, 2]);`},
+			{Code: `a.b(x, y).c.foo.apply(a.b(x, z).c, [1, 2]);`},
+			{Code: `a.b.foo.apply(a.b.c, [1, 2]);`},
+
+			// ignores variadic.
+			{Code: `foo.apply(null, args);`},
+			{Code: `obj.foo.apply(obj, args);`},
+
+			// ignores computed property.
+			{Code: `var call; foo[call](null, 1, 2);`},
+			{Code: `var apply; foo[apply](null, [1, 2]);`},
+
+			// ignores incomplete things.
+			{Code: `foo.call();`},
+			{Code: `obj.foo.call();`},
+			{Code: `foo.apply();`},
+			{Code: `obj.foo.apply();`},
+
+			// Optional chaining: receiver shape differs from thisArg.
+			{Code: `obj?.foo.bar.call(obj.foo, 1, 2);`},
+
+			// Private member: tsgo PropertyAccessExpression.Name() may be a
+			// PrivateIdentifier, which ESLint's `property.type === "Identifier"`
+			// check excludes.
+			{Code: `class C { #call: any; wrap(foo: any) { foo.#call(undefined, 1, 2); } }`},
+
+			// ---- tsgo-/TS-specific receiver shapes ----
+			// AsExpression in the receiver but not in thisArg → token streams
+			// differ (`obj as any` vs `obj`), so the rule must NOT report.
+			{Code: `(obj as any).foo.call(obj, 1, 2);`},
+			// NonNullAssertion in the receiver but not in thisArg.
+			{Code: `obj!.foo.call(obj, 1, 2);`},
+			// SatisfiesExpression in the receiver but not in thisArg.
+			{Code: `(obj satisfies any).foo.call(obj, 1, 2);`},
+			// Generic call: `.call<T>(thisArg, ...)` — type args don't change
+			// the call/apply detection but receiver still differs.
+			{Code: `obj.foo.call<number>(other, 1, 2);`},
+			// Spread thisArg → not null/undefined → ignored.
+			{Code: `foo.call(...args);`},
+			// Numeric literal as thisArg with no MemberExpression receiver
+			// → not null/undefined.
+			{Code: `foo.call(0, 1, 2);`},
+			// Nested .call.call chain with mismatched receiver.
+			{Code: `foo.call.call(other, 1, 2);`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- call ----
+			{
+				Code: `foo.call(undefined, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.call(void 0, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.call(null, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.foo.call(obj, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b.c.foo.call(a.b.c, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b(x, y).c.foo.call(a.b(x, y).c, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- apply ----
+			{
+				Code: `foo.apply(undefined, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.apply(void 0, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.apply(null, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.foo.apply(obj, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b.c.foo.apply(a.b.c, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b(x, y).c.foo.apply(a.b(x, y).c, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `[].concat.apply([ ], [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "[].concat.apply([\n/*empty*/\n], [1, 2]);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `abc.get("foo", 0).concat.apply(abc . get("foo",  0 ), [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Optional chaining ----
+			{
+				Code: `foo.call?.(undefined, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo?.call(undefined, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(foo?.call)(undefined, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.foo.call?.(obj, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj?.foo.call(obj, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(obj?.foo).call(obj, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(obj?.foo.call)(obj, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj?.foo.bar.call(obj?.foo, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(obj?.foo).bar.call(obj?.foo, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.foo?.bar.call(obj.foo, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- ElementAccessExpression as the applied function ----
+			// Exercises the `KindElementAccessExpression` branch of the
+			// receiver-extraction switch.
+			{
+				Code: `obj['foo'].call(obj, 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj['foo'].apply(obj, [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- `this` keyword as receiver/thisArg ----
+			{
+				Code: `class C { run() { this.foo.call(this, 1, 2); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `class C { run() { this.foo.apply(this, [1, 2]); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 19},
+				},
+			},
+
+			// ---- Direct function/arrow call via .call/.apply ----
+			// `applied` is not a member access, so expectedThis is nil and
+			// the rule falls back to IsNullOrUndefined(thisArg).
+			{
+				Code: `(() => 1).call(undefined);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(function () {}).apply(null, []);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Extra edge cases (token-level equivalence) ----
+			// thisArg wrapped in parens is unwrapped by IsNullOrUndefined.
+			{
+				Code: `foo.call((null), 1, 2);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.apply((undefined), [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			// Empty array receiver vs empty array thisArg — different
+			// internal whitespace must still token-match.
+			{
+				Code: `[].concat.apply([/*c*/], [1, 2]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+			// Empty object receiver token-stream-equal to whitespace-padded form.
+			{
+				Code: `({}).valueOf.call({ }, );`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.call()'.", Line: 1, Column: 1},
+				},
+			},
+			// `.apply(thisArg, [...args])` is a non-variadic apply (args[1] is
+			// ArrayLiteral); ESLint flags it the same way as a literal-array
+			// apply. The replacement would be `<applied>(...args)`.
+			{
+				Code: `foo.apply(null, [...args]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unnecessaryCall", Message: "Unnecessary '.apply()'.", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -151,6 +151,16 @@ func TestHasSameTokens(t *testing.T) {
 		{"array trailing comma", `[a,] === [a]`, false},
 		{"array trailing comma both", `[a,] === [a,]`, true},
 
+		// ---- Empty composite bodies — whitespace/comments are trivia. ----
+		// ForEachChild yields no children for `[]` / `{}` so they hit the
+		// "leaf" branch; raw-text comparison would wrongly distinguish them
+		// from `[ ]` / `{ }`. Token-stream equality is the right contract.
+		{"empty array space-padded", `[] === [ ]`, true},
+		{"empty array with comment", "[] === [/*c*/]", true},
+		{"empty array multiline", "[] === [\n]", true},
+		{"empty object space-padded", `({}) === ({ })`, true},
+		{"empty object with comment", "({}) === ({/*c*/})", true},
+
 		// ---- Regex ----
 		{"regex equal", `/a/ === /a/`, true},
 		{"regex differ", `/a/ === /b/`, false},

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1449,8 +1449,24 @@ func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node) bool {
 		return false
 	}
 	aKids, bKids := collectKids(a), collectKids(b)
-	// Leaves (no children via ForEachChild): compare raw source text.
+	// Leaves (no children via ForEachChild). Two sub-classes collide here:
+	//   1. True leaves (Identifier, Literal, keyword tokens) — raw source
+	//      text is exactly the single token's text, so raw-text equality
+	//      is correct.
+	//   2. Empty composites (`[]`, `{}`) — raw text includes the brackets
+	//      AND any whitespace/comments inside, so raw-text would
+	//      incorrectly distinguish `[]` from `[ ]` or `[\n/*c*/\n]`. ESLint's
+	//      `getTokens` treats these as equivalent (only `[`, `]` tokens).
+	// For class 2 we scan tokens; for class 1 we keep the raw-text shortcut
+	// because some leaf kinds (e.g. TemplateHead / TemplateTail inside a
+	// TemplateExpression) cannot be re-scanned standalone — the scanner
+	// needs `ReScanTemplateToken` context that isn't exposed through the
+	// shim.
 	if len(aKids) == 0 && len(bKids) == 0 {
+		switch a.Kind {
+		case ast.KindArrayLiteralExpression, ast.KindObjectLiteralExpression:
+			return sameTokensInRange(sf, a.Pos(), a.End(), b.Pos(), b.End())
+		}
 		return scanner.GetSourceTextOfNodeFromSourceFile(sf, a, false) ==
 			scanner.GetSourceTextOfNodeFromSourceFile(sf, b, false)
 	}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -273,6 +273,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unsafe-finally.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
+    './tests/eslint/rules/no-useless-call.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',
     './tests/eslint/rules/no-prototype-builtins.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-call.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-call.test.ts.snap
@@ -1,0 +1,939 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-call > invalid 1`] = `
+{
+  "code": "foo.call(undefined, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 2`] = `
+{
+  "code": "foo.call(void 0, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 3`] = `
+{
+  "code": "foo.call(null, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 4`] = `
+{
+  "code": "obj.foo.call(obj, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 5`] = `
+{
+  "code": "a.b.c.foo.call(a.b.c, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 6`] = `
+{
+  "code": "a.b(x, y).c.foo.call(a.b(x, y).c, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 7`] = `
+{
+  "code": "foo.apply(undefined, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 8`] = `
+{
+  "code": "foo.apply(void 0, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 9`] = `
+{
+  "code": "foo.apply(null, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 10`] = `
+{
+  "code": "obj.foo.apply(obj, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 11`] = `
+{
+  "code": "a.b.c.foo.apply(a.b.c, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 12`] = `
+{
+  "code": "a.b(x, y).c.foo.apply(a.b(x, y).c, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 13`] = `
+{
+  "code": "[].concat.apply([ ], [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 14`] = `
+{
+  "code": "[].concat.apply([
+/*empty*/
+], [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 15`] = `
+{
+  "code": "abc.get("foo", 0).concat.apply(abc . get("foo",  0 ), [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 16`] = `
+{
+  "code": "foo.call?.(undefined, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 17`] = `
+{
+  "code": "foo?.call(undefined, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 18`] = `
+{
+  "code": "(foo?.call)(undefined, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 19`] = `
+{
+  "code": "obj.foo.call?.(obj, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 20`] = `
+{
+  "code": "obj?.foo.call(obj, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 21`] = `
+{
+  "code": "(obj?.foo).call(obj, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 22`] = `
+{
+  "code": "(obj?.foo.call)(obj, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 23`] = `
+{
+  "code": "obj?.foo.bar.call(obj?.foo, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 24`] = `
+{
+  "code": "(obj?.foo).bar.call(obj?.foo, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 25`] = `
+{
+  "code": "obj.foo?.bar.call(obj.foo, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 26`] = `
+{
+  "code": "obj['foo'].call(obj, 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 27`] = `
+{
+  "code": "obj['foo'].apply(obj, [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 28`] = `
+{
+  "code": "class C { run() { this.foo.call(this, 1, 2); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 29`] = `
+{
+  "code": "class C { run() { this.foo.apply(this, [1, 2]); } }",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 30`] = `
+{
+  "code": "(() => 1).call(undefined);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 31`] = `
+{
+  "code": "(function () {}).apply(null, []);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 32`] = `
+{
+  "code": "foo.call((null), 1, 2);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 33`] = `
+{
+  "code": "foo.apply((undefined), [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 34`] = `
+{
+  "code": "[].concat.apply([/*c*/], [1, 2]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 35`] = `
+{
+  "code": "({}).valueOf.call({ }, );",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.call()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-call > invalid 36`] = `
+{
+  "code": "foo.apply(null, [...args]);",
+  "diagnostics": [
+    {
+      "message": "Unnecessary '.apply()'.",
+      "messageId": "unnecessaryCall",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-call",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-call.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-call.test.ts
@@ -1,0 +1,205 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-call', {
+  valid: [
+    // `this` binding is different.
+    'foo.apply(obj, 1, 2);',
+    'obj.foo.apply(null, 1, 2);',
+    'obj.foo.apply(otherObj, 1, 2);',
+    'a.b(x, y).c.foo.apply(a.b(x, z).c, 1, 2);',
+    'foo.apply(obj, [1, 2]);',
+    'obj.foo.apply(null, [1, 2]);',
+    'obj.foo.apply(otherObj, [1, 2]);',
+    'a.b(x, y).c.foo.apply(a.b(x, z).c, [1, 2]);',
+    'a.b.foo.apply(a.b.c, [1, 2]);',
+
+    // ignores variadic.
+    'foo.apply(null, args);',
+    'obj.foo.apply(obj, args);',
+
+    // ignores computed property.
+    'var call; foo[call](null, 1, 2);',
+    'var apply; foo[apply](null, [1, 2]);',
+
+    // ignores incomplete things.
+    'foo.call();',
+    'obj.foo.call();',
+    'foo.apply();',
+    'obj.foo.apply();',
+
+    // Optional chaining where receiver shape differs from thisArg.
+    'obj?.foo.bar.call(obj.foo, 1, 2);',
+
+    // TS-specific receiver shapes — token streams differ from thisArg.
+    '(obj as any).foo.call(obj, 1, 2);',
+    'obj!.foo.call(obj, 1, 2);',
+    '(obj satisfies any).foo.call(obj, 1, 2);',
+    'obj.foo.call<number>(other, 1, 2);',
+
+    // Spread / non-object first argument.
+    'foo.call(...args);',
+    'foo.call(0, 1, 2);',
+    'foo.call.call(other, 1, 2);',
+  ],
+  invalid: [
+    // call.
+    {
+      code: 'foo.call(undefined, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo.call(void 0, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo.call(null, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'obj.foo.call(obj, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'a.b.c.foo.call(a.b.c, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'a.b(x, y).c.foo.call(a.b(x, y).c, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+
+    // apply.
+    {
+      code: 'foo.apply(undefined, [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo.apply(void 0, [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo.apply(null, [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'obj.foo.apply(obj, [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'a.b.c.foo.apply(a.b.c, [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'a.b(x, y).c.foo.apply(a.b(x, y).c, [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '[].concat.apply([ ], [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '[].concat.apply([\n/*empty*/\n], [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'abc.get("foo", 0).concat.apply(abc . get("foo",  0 ), [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+
+    // Optional chaining.
+    {
+      code: 'foo.call?.(undefined, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo?.call(undefined, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '(foo?.call)(undefined, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'obj.foo.call?.(obj, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'obj?.foo.call(obj, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '(obj?.foo).call(obj, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '(obj?.foo.call)(obj, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'obj?.foo.bar.call(obj?.foo, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '(obj?.foo).bar.call(obj?.foo, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'obj.foo?.bar.call(obj.foo, 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+
+    // ElementAccessExpression as the applied function.
+    {
+      code: "obj['foo'].call(obj, 1, 2);",
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: "obj['foo'].apply(obj, [1, 2]);",
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+
+    // `this` keyword as receiver/thisArg.
+    {
+      code: 'class C { run() { this.foo.call(this, 1, 2); } }',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'class C { run() { this.foo.apply(this, [1, 2]); } }',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+
+    // Direct function/arrow call via .call/.apply.
+    {
+      code: '(() => 1).call(undefined);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '(function () {}).apply(null, []);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+
+    // Extra edge cases.
+    {
+      code: 'foo.call((null), 1, 2);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo.apply((undefined), [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '[].concat.apply([/*c*/], [1, 2]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: '({}).valueOf.call({ }, );',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+    {
+      code: 'foo.apply(null, [...args]);',
+      errors: [{ messageId: 'unnecessaryCall' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-useless-call` rule from ESLint to rslint.

The rule flags unnecessary uses of `Function.prototype.call()` /
`Function.prototype.apply()` whose `thisArg` matches the receiver implied by
the applied expression — i.e. cases where the call could be replaced with a
plain function invocation. `.apply()` is only flagged when the second
argument is an array literal; the variadic / spread case is delegated to
`prefer-spread`.

This port also fixes a pre-existing edge case in `utils.HasSameTokens`:
empty composite literals (`[]` vs `[ ]` / `[/*c*/]`, `{}` vs `{ }`) used to
fall through to a raw-text comparison and miscompare. They now go through
token-stream equality, matching ESLint's `equalTokens` semantics. Five
regression tests cover the fix.

Verified against ESLint upstream on `web-infra-dev/rsbuild` and
`web-infra-dev/rspack` (~360 source files): 1 true positive in
`rsbuild/packages/core/src/rspackConfig.ts:53` with byte-identical
`messageId` / message text / position to upstream ESLint; 0 false positives /
negatives.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-call
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-call.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).