### PR TITLE
feat: port rule no-useless-constructor

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_expressions"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_unused_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_use_before_define"
-	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
+	ts_no_useless_constructor "github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_useless_empty_export"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/no_var_requires"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/non_nullable_type_assertion_style"
@@ -202,6 +202,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_computed_key"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
@@ -518,7 +519,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-expressions", no_unused_expressions.NoUnusedExpressionsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-unused-vars", no_unused_vars.NoUnusedVarsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-use-before-define", no_use_before_define.NoUseBeforeDefineRule)
-	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", no_useless_constructor.NoUselessConstructorRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-constructor", ts_no_useless_constructor.NoUselessConstructorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-useless-empty-export", no_useless_empty_export.NoUselessEmptyExportRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/no-var-requires", no_var_requires.NoVarRequiresRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/non-nullable-type-assertion-style", non_nullable_type_assertion_style.NonNullableTypeAssertionStyleRule)
@@ -665,6 +666,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-useless-call", no_useless_call.NoUselessCallRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 	GlobalRuleRegistry.Register("no-useless-rename", no_useless_rename.NoUselessRenameRule)
+	GlobalRuleRegistry.Register("no-useless-constructor", no_useless_constructor.NoUselessConstructorRule)
 	GlobalRuleRegistry.Register("no-prototype-builtins", no_prototype_builtins.NoPrototypeBuiltinsRule)
 	GlobalRuleRegistry.Register("require-yield", require_yield.RequireYieldRule)
 	GlobalRuleRegistry.Register("symbol-description", symbol_description.SymbolDescriptionRule)

--- a/internal/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/rules/no_useless_constructor/no_useless_constructor.go
@@ -1,0 +1,323 @@
+package no_useless_constructor
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildNoUselessConstructorMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "noUselessConstructor",
+		Description: "Useless constructor.",
+	}
+}
+
+func buildRemoveConstructorMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "removeConstructor",
+		Description: "Remove the constructor.",
+	}
+}
+
+func checkAccessibility(node *ast.Node, classHasSuperClass bool) bool {
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPrivate) {
+		return false
+	}
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsProtected) {
+		return false
+	}
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsPublic) {
+		if classHasSuperClass {
+			return false
+		}
+	}
+	return true
+}
+
+func checkParams(node *ast.Node, params []*ast.Node) bool {
+	for _, param := range params {
+		if !ast.IsParameter(param) {
+			continue
+		}
+		if ast.IsParameterPropertyDeclaration(param, node) {
+			return false
+		}
+		if ast.HasDecorators(param) {
+			return false
+		}
+	}
+	return true
+}
+
+func isSimpleParam(param *ast.Node) bool {
+	if !ast.IsParameter(param) {
+		return false
+	}
+	pd := param.AsParameterDeclaration()
+	if pd == nil || pd.Initializer != nil {
+		return false
+	}
+	// Rest params are considered simple regardless of binding pattern
+	// (`...[x,y]` counts). `isValidRestSpreadPair` still checks that the
+	// rest binding is a plain identifier for passing-through; `...arguments`
+	// forwarding is detected separately and does not require a plain name.
+	if utils.IsRestParameterDeclaration(param) {
+		return true
+	}
+	name := param.Name()
+	return name != nil && name.Kind == ast.KindIdentifier
+}
+
+func isSingleSuperCall(statements []*ast.Node) bool {
+	if len(statements) != 1 {
+		return false
+	}
+	stmt := statements[0]
+	if !ast.IsExpressionStatement(stmt) {
+		return false
+	}
+	expr := ast.SkipParentheses(stmt.Expression())
+	return ast.IsSuperCall(expr)
+}
+
+// superCallOf returns the CallExpression node of the single super() call
+// body, after stripping any parentheses around the expression statement.
+func superCallOf(statements []*ast.Node) *ast.Node {
+	return ast.SkipParentheses(statements[0].Expression())
+}
+
+func isSpreadArguments(args []*ast.Node) bool {
+	if len(args) != 1 {
+		return false
+	}
+	arg := args[0]
+	if !ast.IsSpreadElement(arg) {
+		return false
+	}
+	inner := ast.SkipParentheses(arg.AsSpreadElement().Expression)
+	return inner != nil && inner.Kind == ast.KindIdentifier && inner.Text() == "arguments"
+}
+
+func isValidIdentifierPair(paramName *ast.Node, superArg *ast.Node) bool {
+	superArg = ast.SkipParentheses(superArg)
+	return paramName.Kind == ast.KindIdentifier &&
+		superArg != nil &&
+		superArg.Kind == ast.KindIdentifier &&
+		paramName.Text() == superArg.Text()
+}
+
+func isValidRestSpreadPair(param *ast.Node, superArg *ast.Node) bool {
+	if !utils.IsRestParameterDeclaration(param) {
+		return false
+	}
+	if !ast.IsSpreadElement(superArg) {
+		return false
+	}
+	inner := ast.SkipParentheses(superArg.AsSpreadElement().Expression)
+	if inner == nil {
+		return false
+	}
+	paramName := param.Name()
+	return paramName != nil && isValidIdentifierPair(paramName, inner)
+}
+
+func isPassingThrough(params []*ast.Node, args []*ast.Node) bool {
+	if len(params) != len(args) {
+		return false
+	}
+	for i := range params {
+		paramName := params[i].Name()
+		if paramName == nil {
+			return false
+		}
+		if utils.IsRestParameterDeclaration(params[i]) {
+			if !isValidRestSpreadPair(params[i], args[i]) {
+				return false
+			}
+		} else {
+			if !isValidIdentifierPair(paramName, args[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isRedundantSuperCall(statements []*ast.Node, params []*ast.Node) bool {
+	if !isSingleSuperCall(statements) {
+		return false
+	}
+	for _, p := range params {
+		if !isSimpleParam(p) {
+			return false
+		}
+	}
+	call := superCallOf(statements).AsCallExpression()
+	var args []*ast.Node
+	if call.Arguments != nil {
+		args = call.Arguments.Nodes
+	}
+	return isSpreadArguments(args) || isPassingThrough(params, args)
+}
+
+// reportRange returns the range from the start of the constructor node (first
+// non-trivia position) to the end of the `constructor` keyword (or the
+// `'constructor'` string-literal key) — mirroring ESLint's reported location,
+// which stops just before the parameter list's `(`.
+func reportRange(ctx rule.RuleContext, node *ast.Node, constructor *ast.ConstructorDeclaration) core.TextRange {
+	start := utils.TrimNodeTextRange(ctx.SourceFile, node).Pos()
+	end := node.End()
+	if constructor.Parameters != nil {
+		text := ctx.SourceFile.Text()
+		// Walk backward from the first position inside `(...)` until we find
+		// `(`, then strip whitespace between the keyword and `(`.
+		p := constructor.Parameters.Pos()
+		for p > start && text[p-1] != '(' {
+			p--
+		}
+		if p > start && text[p-1] == '(' {
+			p--
+		}
+		for p > start && isAsciiSpace(text[p-1]) {
+			p--
+		}
+		end = p
+	}
+	return core.NewTextRange(start, end)
+}
+
+func isAsciiSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// needsLeadingSemicolon reports whether removing `node` outright would cause
+// an ASI hazard with the following class member. Mirrors ESLint's fix for
+// cases like `foo = 'bar'\n constructor() {}\n [0]() {}` where simply dropping
+// the constructor would leave `foo = 'bar'` followed by `[0]()` and ASI would
+// reparse that as `foo = 'bar'[0]()`. A preceding `;` is inserted in its place.
+func needsLeadingSemicolon(sf *ast.SourceFile, classNode *ast.Node, node *ast.Node) bool {
+	members := classNode.Members()
+	idx := -1
+	for i, m := range members {
+		if m == node {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 || idx+1 >= len(members) {
+		return false
+	}
+	nextName := members[idx+1].Name()
+	if nextName == nil || !ast.IsComputedPropertyName(nextName) {
+		return false
+	}
+	if idx == 0 {
+		return false
+	}
+	prev := members[idx-1]
+	// Only a PropertyDeclaration's initializer can greedily consume the next
+	// `[...]`. Method / accessor / constructor / static-block / index-signature
+	// all terminate at their own boundary, so the class body parser resumes
+	// cleanly for the next member regardless of the final character.
+	if !ast.IsPropertyDeclaration(prev) {
+		return false
+	}
+	text := sf.Text()
+	i := prev.End() - 1
+	for i > prev.Pos() && isAsciiSpace(text[i]) {
+		i--
+	}
+	if text[i] == ';' {
+		return false
+	}
+	pd := prev.AsPropertyDeclaration()
+	if pd != nil && pd.Initializer != nil {
+		init := pd.Initializer
+		// Postfix `++`/`--` are restricted productions — ASI always fires
+		// after them. Mirrors ESLint's PUNCTUATORS allowlist.
+		if init.Kind == ast.KindPostfixUnaryExpression {
+			return false
+		}
+		// Arrow functions with a block body terminate at their own `}`, so
+		// the following `[...]` cannot member-access into them. Mirrors
+		// ESLint's needsPrecedingSemicolon (the `}` → ObjectExpression /
+		// function-expr / class-expr branches explicitly exclude arrows).
+		if init.Kind == ast.KindArrowFunction {
+			if arrow := init.AsArrowFunction(); arrow != nil && arrow.Body != nil && arrow.Body.Kind == ast.KindBlock {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+var NoUselessConstructorRule = rule.Rule{
+	Name: "no-useless-constructor",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindConstructor: func(node *ast.Node) {
+				constructor := node.AsConstructorDeclaration()
+				if constructor == nil || constructor.Body == nil {
+					return
+				}
+				// tsgo parses `static constructor()` as KindConstructor, but per
+				// the class semantics a static method named `constructor` is a
+				// regular method — not the class's constructor — so it cannot
+				// be "useless" the way this rule means it.
+				if ast.IsStatic(node) {
+					return
+				}
+
+				classNode := ast.GetContainingClass(node)
+				if classNode == nil {
+					return
+				}
+
+				hasSuper := ast.GetExtendsHeritageClauseElement(classNode) != nil
+
+				if !checkAccessibility(node, hasSuper) {
+					return
+				}
+
+				var params []*ast.Node
+				if constructor.Parameters != nil {
+					params = constructor.Parameters.Nodes
+				}
+				if !checkParams(node, params) {
+					return
+				}
+
+				body := constructor.Body.Statements()
+
+				var useless bool
+				if hasSuper {
+					useless = isRedundantSuperCall(body, params)
+				} else {
+					useless = len(body) == 0
+				}
+
+				if !useless {
+					return
+				}
+
+				var fix rule.RuleFix
+				if needsLeadingSemicolon(ctx.SourceFile, classNode, node) {
+					fix = rule.RuleFixReplace(ctx.SourceFile, node, ";")
+				} else {
+					fix = rule.RuleFixRemove(ctx.SourceFile, node)
+				}
+
+				ctx.ReportRangeWithSuggestions(
+					reportRange(ctx, node, constructor),
+					buildNoUselessConstructorMessage(),
+					rule.RuleSuggestion{
+						Message:  buildRemoveConstructorMessage(),
+						FixesArr: []rule.RuleFix{fix},
+					},
+				)
+			},
+		}
+	},
+}

--- a/internal/rules/no_useless_constructor/no_useless_constructor.go
+++ b/internal/rules/no_useless_constructor/no_useless_constructor.go
@@ -3,6 +3,7 @@ package no_useless_constructor
 import (
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
@@ -197,7 +198,20 @@ func isAsciiSpace(b byte) bool {
 // cases like `foo = 'bar'\n constructor() {}\n [0]() {}` where simply dropping
 // the constructor would leave `foo = 'bar'` followed by `[0]()` and ASI would
 // reparse that as `foo = 'bar'[0]()`. A preceding `;` is inserted in its place.
+//
+// Matches ESLint's token-level check (`nextToken.value === "["`): any class
+// element whose first non-trivia token is `[` is an ASI risk — this covers
+// computed property names, computed methods/accessors, and TS index
+// signatures. A decorator `@`, modifier keyword (`static`/`readonly`/`public`/
+// `private`/`protected`/`override`/`abstract`/`declare`/`async`), plain name,
+// or a stray `;` (SemicolonClassElement) all shift the first token away from
+// `[` and therefore are safe.
 func needsLeadingSemicolon(sf *ast.SourceFile, classNode *ast.Node, node *ast.Node) bool {
+	text := sf.Text()
+	nextTokPos := scanner.SkipTrivia(text, node.End())
+	if nextTokPos >= len(text) || text[nextTokPos] != '[' {
+		return false
+	}
 	members := classNode.Members()
 	idx := -1
 	for i, m := range members {
@@ -206,14 +220,7 @@ func needsLeadingSemicolon(sf *ast.SourceFile, classNode *ast.Node, node *ast.No
 			break
 		}
 	}
-	if idx < 0 || idx+1 >= len(members) {
-		return false
-	}
-	nextName := members[idx+1].Name()
-	if nextName == nil || !ast.IsComputedPropertyName(nextName) {
-		return false
-	}
-	if idx == 0 {
+	if idx <= 0 {
 		return false
 	}
 	prev := members[idx-1]
@@ -224,7 +231,6 @@ func needsLeadingSemicolon(sf *ast.SourceFile, classNode *ast.Node, node *ast.No
 	if !ast.IsPropertyDeclaration(prev) {
 		return false
 	}
-	text := sf.Text()
 	i := prev.End() - 1
 	for i > prev.Pos() && isAsciiSpace(text[i]) {
 		i--

--- a/internal/rules/no_useless_constructor/no_useless_constructor.md
+++ b/internal/rules/no_useless_constructor/no_useless_constructor.md
@@ -1,0 +1,50 @@
+# no-useless-constructor
+
+## Rule Details
+
+Disallow unnecessary constructors.
+
+ES2015 provides a default class constructor if one is not specified. As such, it is unnecessary to provide an empty constructor or one that simply delegates into its parent class.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class A {
+  constructor() {}
+}
+
+class B extends A {
+  constructor(...args) {
+    super(...args);
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class A {}
+
+class B {
+  constructor() {
+    doSomething();
+  }
+}
+
+class C extends A {
+  constructor() {
+    super('foo');
+  }
+}
+
+class D extends A {
+  constructor() {
+    super();
+    doSomething();
+  }
+}
+```
+
+## Original Documentation
+
+- [ESLint no-useless-constructor](https://eslint.org/docs/latest/rules/no-useless-constructor)

--- a/internal/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -1,0 +1,1074 @@
+package no_useless_constructor
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUselessConstructorRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUselessConstructorRule, []rule_tester.ValidTestCase{
+		// ---- No constructor ----
+		{Code: `class A { }`},
+		// ---- Constructor with body logic ----
+		{Code: `class A { constructor(){ doSomething(); } }`},
+		{Code: `class A { dummyMethod(){ doSomething(); } }`},
+
+		// ---- extends: non-forwarding bodies ----
+		{Code: `class A extends B { constructor(){} }`},
+		{Code: `class A extends B { constructor(){ super('foo'); } }`},
+		{Code: `class A extends B { constructor(foo, bar){ super(foo, bar, 1); } }`},
+		{Code: `class A extends B { constructor(){ super(); doSomething(); } }`},
+		{Code: `class A extends B { constructor(...args){ super(...args); doSomething(); } }`},
+
+		// ---- extends with property/call expression ----
+		{Code: `class A extends B.C { constructor() { super(foo); } }`},
+		{Code: `class A extends B.C { constructor([a, b, c]) { super(...arguments); } }`},
+		{Code: `class A extends B.C { constructor(a = f()) { super(...arguments); } }`},
+
+		// ---- Fewer/different args than params ----
+		{Code: `class A extends B { constructor(a, b, c) { super(a, b); } }`},
+		{Code: `class A extends B { constructor(foo, bar){ super(foo); } }`},
+		{Code: `class A extends B { constructor(test) { super(); } }`},
+		{Code: `class A extends B { constructor() { foo; } }`},
+		{Code: `class A extends B { constructor(foo, bar) { super(bar); } }`},
+
+		// ---- Constructor declaration without body (TS overload / declare / abstract) ----
+		{Code: `declare class A { constructor(options: any); }`},
+		{Code: `class A { constructor(); }`},
+		{Code: `abstract class A { constructor(); }`},
+		{Code: `
+class A {
+  constructor(x: number);
+  constructor(x: string);
+  constructor(x: number | string) {
+    doSomething(x);
+  }
+}`},
+
+		// ---- Parameter properties (useful → skip) ----
+		{Code: `class A { constructor(private name: string) {} }`},
+		{Code: `class A { constructor(public name: string) {} }`},
+		{Code: `class A { constructor(protected name: string) {} }`},
+		{Code: `class A { constructor(readonly name: string) {} }`},
+		{Code: `class A { constructor(public x: number, public y: number) {} }`},
+		{Code: `class A { constructor(public name: string, age: number) {} }`},
+		{Code: `class A { constructor(private readonly id: number) {} }`},
+		{Code: `class A extends B { constructor(public name: string) { super(name); } }`},
+
+		// ---- Access modifier on constructor (useful → skip) ----
+		{Code: `class A { private constructor() {} }`},
+		{Code: `class A { protected constructor() {} }`},
+		{Code: `class A extends B { public constructor() {} }`},
+		{Code: `class A extends B { public constructor() { super(); } }`},
+		{Code: `class A extends B { public constructor(foo) { super(foo); } }`},
+		{Code: `class A extends B { public constructor(foo) {} }`},
+		{Code: `class A extends B { protected constructor(foo, bar) { super(bar); } }`},
+		{Code: `class A extends B { private constructor(foo, bar) { super(bar); } }`},
+
+		// ---- Decorator on params (useful → skip) ----
+		{Code: `class A extends Object { constructor(@Foo foo: string) { super(foo); } }`},
+		{Code: `class A extends Object { constructor(foo: string, @Bar() bar) { super(foo, bar); } }`},
+		{Code: `class A { constructor(@Inject service: Service) {} }`},
+
+		// ---- Body statements that are not a forwarding super() ----
+		{Code: `class A extends B { constructor() { super.init(); } }`},
+		{Code: `class A extends B { constructor() { void super(); } }`},
+		{Code: `class A extends B { constructor() { super(), doSomething(); } }`},
+		{Code: `class A extends B { constructor(x) { if (x) { super(x); } else { super(); } } }`},
+		{Code: `class A extends B { constructor() { try { super(); } catch(e) {} } }`},
+
+		// ---- Non-simple params (destructuring, defaults) that don't match ----
+		{Code: `class A extends B { constructor({ x, y }) { super(...arguments); } }`},
+		{Code: `class A extends B { constructor(a = 1) { super(a); } }`},
+		// Rest with destructuring + super(...rest) where rest's binding pattern
+		// isn't a plain identifier — isValidRestSpreadPair requires identifier
+		// name pairing, so this stays valid.
+		{Code: `class A extends B { constructor(...[x, y]) { super(...[x, y]); } }`},
+
+		// ---- Type-assertion / call in super args ----
+		{Code: `class A extends B { constructor(x) { super(x as any); } }`},
+		{Code: `class A extends B { constructor(...args) { super(...args.slice(0)); } }`},
+		{Code: `class A extends B { constructor(a, b) { super(a, ...b); } }`},
+		{Code: `class A extends B { constructor(...args) { super(args); } }`},
+		{Code: `class A extends B { constructor(x) { super(x, 'extra'); } }`},
+		{Code: `class A extends B { constructor(a, b, c) { super(c, b, a); } }`},
+		{Code: `class A extends B { constructor(a, ...rest) { super(a); } }`},
+
+		// ---- Class expressions ----
+		{Code: `const A = class {}`},
+		{Code: `const A = class { constructor() { doSomething(); } }`},
+		{Code: `const A = class extends B { constructor() { super(); doSomething(); } }`},
+
+		// ---- Nested classes ----
+		{Code: `class Outer { constructor() { class Inner { constructor() { doSomething(); } } } }`},
+		{Code: `class Outer { method() { return class Inner extends Base { constructor() { super(); this.init(); } } } }`},
+		{Code: `class Outer { constructor() { this.inner = class Inner { constructor() { doSomething(); } } } }`},
+
+		// ---- Useful body logic ----
+		{Code: `class A { constructor(x) { this.x = x; } }`},
+		{Code: `class A extends B { constructor(x) { super(x); this.extra = true; } }`},
+		{Code: `class A extends B { constructor() { super(); console.log('constructed'); } }`},
+		{Code: `class A { constructor() { if (new.target === A) throw new Error(); } }`},
+
+		// ---- implements only (no extends → no superClass) ----
+		{Code: `class A implements Serializable { constructor() { this.init(); } }`},
+
+		// ---- extends null with non-empty body ----
+		{Code: `class A extends null { constructor() { doSomething(); } }`},
+
+		// ---- Generic class ----
+		{Code: `class A<T> extends B<T> { constructor(x: T) { super(x); this.data = x; } }`},
+
+		// ---- Directive prologue ----
+		{Code: `class A extends B { constructor() { "use strict"; super(); } }`},
+
+		// ---- TypeScript "this" parameter in extending class (not simple forwarding) ----
+		{Code: `class A extends B { constructor(this: Foo) { super(); } }`},
+
+		// ---- Optional param with different body ----
+		{Code: `class A extends B { constructor(x?: number) {} }`},
+
+		// ---- Single-statement empty body (semicolon) ----
+		{Code: `class A { constructor() { ; } }`},
+		{Code: `class A { constructor() { return; } }`},
+
+		// ---- Decorated param in extending class with forwarding ----
+		{Code: `class A extends B { constructor(@D x) { super(x); } }`},
+
+		// ---- 'static constructor' is a static method, not a constructor ----
+		{Code: `class A { static constructor() {} }`},
+		{Code: `class A extends B { static constructor() {} }`},
+
+		// ---- get/set with name 'constructor' are accessors, not constructors ----
+		{Code: `class A { get constructor() { return 1; } }`},
+		{Code: `class A { set constructor(v) { this.v = v; } }`},
+
+		// ---- Computed key ['constructor'] is a method, not a constructor ----
+		{Code: `class A { ['constructor']() {} }`},
+
+		// ---- Overload signatures + non-empty implementation ----
+		{Code: `
+class A {
+  constructor(x: number);
+  constructor(x: string);
+  constructor(x: number | string) {
+    this.x = x;
+  }
+}`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Basic invalid: empty constructor (full range assertion) ----
+		{
+			Code: `class A { constructor(){} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, EndLine: 1, EndColumn: 22, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
+		// Whitespace between `constructor` and `(` — end column still at end of keyword
+		{
+			Code: `class A { constructor     (){} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, EndLine: 1, EndColumn: 22, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A { constructor     (){} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A { 'constructor'(){} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, EndLine: 1, EndColumn: 24, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
+
+		// ---- extends: redundant super() ----
+		{
+			Code: `class A extends B { constructor() { super(); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, EndLine: 1, EndColumn: 32, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+
+		// ---- Parenthesized super call (paren wrapper must not hide the useless pattern) ----
+		{
+			Code: `class A extends B { constructor() { (super()); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		// ---- Parenthesized super arg (single param identifier) ----
+		{
+			Code: `class A extends B { constructor(foo) { super((foo)); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		// ---- Spread with parenthesized identifier inside ----
+		{
+			Code: `class A extends B { constructor(...args) { super(...(args)); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		// ---- Spread of parenthesized `arguments` ----
+		{
+			Code: `class A extends B { constructor() { super(...(arguments)); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		// ---- Nested parentheses ----
+		{
+			Code: `class A extends B { constructor() { (((super()))); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+
+		// ---- Body containing only comments (no statements) ----
+		{
+			Code: `class A { constructor() { /* noop */ } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 11, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A {  }"},
+				}},
+			},
+		},
+
+		// ---- ASI hazard: property (no trailing `;`) → useless ctor → computed-name member.
+		//      Fix must emit `;` instead of removing outright.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() { }
+  [0]() { }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  ;\n  [0]() { }\n}"},
+				}},
+			},
+		},
+		// ---- Previous property ends with `;` → safe, plain remove.
+		{
+			Code: `
+class A {
+  foo = 'bar';
+  constructor() { }
+  [0]() { }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar';\n  \n  [0]() { }\n}"},
+				}},
+			},
+		},
+		// ---- Constructor is first member → previous token is `{` → safe.
+		{
+			Code: `
+class A {
+  constructor() { }
+  [0]() { }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n  [0]() { }\n}"},
+				}},
+			},
+		},
+		// ---- Previous member is a method (ends with `}`) → safe.
+		{
+			Code: `
+class A {
+  m() {}
+  constructor() { }
+  [0]() { }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  m() {}\n  \n  [0]() { }\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with initializer ending in `}` still needs `;`
+		//      (function expression would be member-accessed by `[0]()`).
+		{
+			Code: `
+class A {
+  foo = function () {}
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = function () {}\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with initializer ending in `]` still needs `;`.
+		{
+			Code: `
+class A {
+  foo = [1, 2]
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = [1, 2]\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with object-literal initializer still needs `;`.
+		{
+			Code: `
+class A {
+  foo = {}
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = {}\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Previous accessor (`}` = block end, safe): no `;` needed.
+		{
+			Code: `
+class A {
+  get prop() { return 1; }
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  get prop() { return 1; }\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with arrow-block initializer: arrow `}` terminates
+		//      the arrow, so the following `[...]` cannot fuse — ESLint does NOT
+		//      add `;`, and neither should we.
+		{
+			Code: `
+class A {
+  foo = () => {}
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = () => {}\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with async arrow-block initializer: same as arrow.
+		{
+			Code: `
+class A {
+  foo = async () => {}
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = async () => {}\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with arrow-expression initializer: ends in identifier
+		//      → needs `;`.
+		{
+			Code: `
+class A {
+  foo = () => x
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = () => x\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with class-expression initializer: still needs `;`
+		//      (`class{}[0]` is member access on the class expression).
+		{
+			Code: `
+class A {
+  foo = class {}
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = class {}\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with call-expression initializer: `)` ending → needs `;`.
+		{
+			Code: `
+class A {
+  foo = bar()
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = bar()\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with identifier initializer → needs `;`.
+		{
+			Code: `
+class A {
+  foo = bar
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = bar\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with template-literal initializer → needs `;`.
+		{
+			Code: "\nclass A {\n  foo = `t`\n  constructor() {}\n  [0]() {}\n}",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = `t`\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with postfix `++` initializer: ASI fires
+		//      unconditionally after `++`, so no explicit `;` needed.
+		{
+			Code: `
+class A {
+  foo = x++
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = x++\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- PropertyDeclaration with postfix `--` initializer: same as `++`.
+		{
+			Code: `
+class A {
+  foo = x--
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = x--\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Postfix `++` on member access: `this.x++` — still AST kind postfix.
+		{
+			Code: `
+class A {
+  foo = this.x++
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = this.x++\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Parenthesized `(x++)` — initializer kind is ParenthesizedExpression,
+		//      not PostfixUnary — so needs `;` (matches ESLint's closing-paren path).
+		{
+			Code: `
+class A {
+  foo = (x++)
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = (x++)\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Multiple stray `;` between members: tsgo treats extras as
+		//      SemicolonClassElement; prev is a `;` → safe.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  ;
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 5, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  ;\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Nested useless constructor inside class-expression initializer of
+		//      an outer class where the outer ctor is also useless with ASI risk.
+		//      Both get reported; fixes apply independently.
+		{
+			Code: `
+class Outer extends Base {
+  foo = class Inner { constructor() {} }
+  constructor() { super(); }
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 23, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer extends Base {\n  foo = class Inner {  }\n  constructor() { super(); }\n  [0]() {}\n}"},
+				}},
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer extends Base {\n  foo = class Inner { constructor() {} }\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- `x` + binary `+ 1` ending in digit is NOT postfix — still needs `;`.
+		{
+			Code: `
+class A {
+  foo = x + 1
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = x + 1\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+
+		// ---- PropertyDeclaration with type annotation only, no initializer → needs `;`.
+		{
+			Code: `
+class A {
+  foo: string
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo: string\n  ;\n  [0]() {}\n}"},
+				}},
+			},
+		},
+
+		// ---- Previous static block: safe (terminates at its own `}`).
+		{
+			Code: `
+class A {
+  static { doSomething(); }
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  static { doSomething(); }\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+
+		// ---- Previous set accessor (`}` = block end, safe): no `;` needed.
+		{
+			Code: `
+class A {
+  set prop(v) { this._v = v; }
+  constructor() {}
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  set prop(v) { this._v = v; }\n  \n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Next member has a string-literal name → not computed, safe.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  'key'() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  'key'() {}\n}"},
+				}},
+			},
+		},
+		// ---- Next member has a private-identifier name → not computed, safe.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  #secret() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  #secret() {}\n}"},
+				}},
+			},
+		},
+		// ---- Next member has a numeric-literal name → not computed, safe.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  1() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  1() {}\n}"},
+				}},
+			},
+		},
+
+		// ---- Next member has a plain (non-computed) name → no ASI risk.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() { }
+  bar() { }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  bar() { }\n}"},
+				}},
+			},
+		},
+
+		// ---- Public constructor with full end-range assertion (multi-line) ----
+		{
+			Code: `
+class A {
+  public constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, EndLine: 3, EndColumn: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Overload signatures with empty implementation body ----
+		{
+			Code: `
+class A {
+  constructor(x: number);
+  constructor(x: string);
+  constructor(x: number | string) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 5, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  constructor(x: number);\n  constructor(x: string);\n  \n}"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(foo){ super(foo); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(foo, bar){ super(foo, bar); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(...args){ super(...args); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B.C { constructor() { super(...arguments); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 23, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B.C {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(a, b, ...c) { super(...arguments); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+		{
+			Code: `class A extends B { constructor(a, b, ...c) { super(a, b, ...c); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 21, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "class A extends B {  }"},
+				}},
+			},
+		},
+
+		// ---- Public constructor without superClass (useless) ----
+		{
+			Code: `
+class A {
+  public constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Multi-line basic ----
+		{
+			Code: `
+class A {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Class expressions ----
+		{
+			Code: `const A = class { constructor() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 19, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "const A = class {  }"},
+				}},
+			},
+		},
+		{
+			Code: `const A = class MyClass { constructor() {} }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 27, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "const A = class MyClass {  }"},
+				}},
+			},
+		},
+		{
+			Code: `const A = class extends B { constructor() { super(); } }`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 1, Column: 29, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "const A = class extends B {  }"},
+				}},
+			},
+		},
+
+		// ---- Nested classes: inner class with useless constructor ----
+		{
+			Code: `
+class Outer {
+  method() {
+    class Inner {
+      constructor() {}
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 5, Column: 7, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  method() {\n    class Inner {\n      \n    }\n  }\n}"},
+				}},
+			},
+		},
+
+		// ---- Outer + inner both useless → two errors ----
+		{
+			Code: `
+class Outer {
+  constructor() {}
+  method() {
+    class Inner {
+      constructor() {}
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  \n  method() {\n    class Inner {\n      constructor() {}\n    }\n  }\n}"},
+				}},
+				{MessageId: "noUselessConstructor", Line: 6, Column: 7, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass Outer {\n  constructor() {}\n  method() {\n    class Inner {\n      \n    }\n  }\n}"},
+				}},
+			},
+		},
+
+		// ---- Complex extends expressions ----
+		{
+			Code: `
+class A extends a.b.c.D {
+  constructor() {
+    super(...arguments);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends a.b.c.D {\n  \n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A extends Mixin(Base) {
+  constructor(...args) {
+    super(...args);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends Mixin(Base) {\n  \n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A extends Base<string> {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends Base<string> {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Type-annotated params (annotations don't make it useful) ----
+		{
+			Code: `
+class A extends B {
+  constructor(x: number) {
+    super(x);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A extends B {
+  constructor(...args: any[]) {
+    super(...args);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Abstract class with empty/redundant body ----
+		{
+			Code: `
+abstract class A {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nabstract class A {\n  \n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+abstract class A extends B {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nabstract class A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- implements only (no extends) ----
+		{
+			Code: `
+class A implements Serializable {
+  constructor() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A implements Serializable {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- extends null ----
+		{
+			Code: `
+class A extends null {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends null {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Generic class ----
+		{
+			Code: `
+class A<T> extends B<T> {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A<T> extends B<T> {\n  \n}"},
+				}},
+			},
+		},
+		{
+			Code: `
+class A<T> extends B<T> {
+  constructor(x: T) {
+    super(x);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A<T> extends B<T> {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- export default class ----
+		{
+			Code: `
+export default class extends B {
+  constructor() {
+    super();
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nexport default class extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Many params forwarding to super ----
+		{
+			Code: `
+class A extends B {
+  constructor(a, b, c, d, e) {
+    super(a, b, c, d, e);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Rest with destructuring + super(...arguments): ESLint treats any
+		//      RestElement as "simple" so spread-arguments forwarding still
+		//      fires.
+		{
+			Code: `
+class A extends B {
+  constructor(...[x, y]) {
+    super(...arguments);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- Only rest param forwarding ----
+		{
+			Code: `
+class A extends B {
+  constructor(...rest) {
+    super(...rest);
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A extends B {\n  \n}"},
+				}},
+			},
+		},
+
+		// ---- `this` parameter in non-extended class: empty body → useless ----
+		{
+			Code: `
+class A {
+  constructor(this: Foo) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 3, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  \n}"},
+				}},
+			},
+		},
+	})
+}

--- a/internal/rules/no_useless_constructor/no_useless_constructor_test.go
+++ b/internal/rules/no_useless_constructor/no_useless_constructor_test.go
@@ -649,6 +649,65 @@ class A {
 				}},
 			},
 		},
+		// ---- Next member is a TS IndexSignature `[key: string]: any` — also
+		//      starts with `[`, so ASI fires; must insert `;`.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  [key: string]: any;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  ;\n  [key: string]: any;\n}"},
+				}},
+			},
+		},
+		// ---- Next computed member is preceded by a decorator — first token
+		//      after the constructor is `@`, not `[`, so ESLint does NOT add `;`.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  @Dec
+  [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  @Dec\n  [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Next member is `static [x]()` — first token is `static`, not `[`.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  static [0]() {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  static [0]() {}\n}"},
+				}},
+			},
+		},
+		// ---- Next member is `readonly [x] = 1` — first token is `readonly`.
+		{
+			Code: `
+class A {
+  foo = 'bar'
+  constructor() {}
+  readonly [x] = 1
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUselessConstructor", Line: 4, Column: 3, Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+					{MessageId: "removeConstructor", Output: "\nclass A {\n  foo = 'bar'\n  \n  readonly [x] = 1\n}"},
+				}},
+			},
+		},
 		// ---- Next member has a numeric-literal name → not computed, safe.
 		{
 			Code: `

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -277,6 +277,7 @@ export default defineConfig({
     './tests/eslint/rules/no-useless-call.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',
     './tests/eslint/rules/no-useless-rename.test.ts',
+    './tests/eslint/rules/no-useless-constructor.test.ts',
     './tests/eslint/rules/no-prototype-builtins.test.ts',
     './tests/eslint/rules/use-isnan.test.ts',
     './tests/eslint/rules/eqeqeq.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-constructor.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-useless-constructor.test.ts.snap
@@ -1,0 +1,265 @@
+// Rstest Snapshot v1
+
+exports[`no-useless-constructor > invalid 1`] = `
+{
+  "code": "class A { constructor(){} }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 2`] = `
+{
+  "code": "class A { 'constructor'(){} }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 3`] = `
+{
+  "code": "class A extends B { constructor() { super(); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 4`] = `
+{
+  "code": "class A extends B { constructor(foo){ super(foo); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 5`] = `
+{
+  "code": "class A extends B { constructor(foo, bar){ super(foo, bar); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 6`] = `
+{
+  "code": "class A extends B { constructor(...args){ super(...args); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 7`] = `
+{
+  "code": "class A extends B.C { constructor() { super(...arguments); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 8`] = `
+{
+  "code": "class A extends B { constructor(a, b, ...c) { super(...arguments); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 9`] = `
+{
+  "code": "class A extends B { constructor(a, b, ...c) { super(a, b, ...c); } }",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-useless-constructor > invalid 10`] = `
+{
+  "code": "
+class A {
+  public constructor() {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Useless constructor.",
+      "messageId": "noUselessConstructor",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-useless-constructor",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-useless-constructor.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-useless-constructor.test.ts
@@ -1,0 +1,228 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-useless-constructor', {
+  valid: [
+    'class A { }',
+    'class A { constructor(){ doSomething(); } }',
+    'class A extends B { constructor(){} }',
+    "class A extends B { constructor(){ super('foo'); } }",
+    'class A extends B { constructor(foo, bar){ super(foo, bar, 1); } }',
+    'class A extends B { constructor(){ super(); doSomething(); } }',
+    'class A extends B { constructor(...args){ super(...args); doSomething(); } }',
+    'class A { dummyMethod(){ doSomething(); } }',
+    'class A extends B.C { constructor() { super(foo); } }',
+    'class A extends B.C { constructor([a, b, c]) { super(...arguments); } }',
+    'class A extends B.C { constructor(a = f()) { super(...arguments); } }',
+    'class A extends B { constructor(a, b, c) { super(a, b); } }',
+    'class A extends B { constructor(foo, bar){ super(foo); } }',
+    'class A extends B { constructor(test) { super(); } }',
+    'class A extends B { constructor() { foo; } }',
+    'class A extends B { constructor(foo, bar) { super(bar); } }',
+
+    // TypeScript overload / declare / abstract constructors (no body)
+    'declare class A { constructor(options: any); }',
+    `
+class A {
+  constructor();
+}
+    `,
+    `
+abstract class A {
+  constructor();
+}
+    `,
+
+    // Parameter properties
+    `
+class A {
+  constructor(private name: string) {}
+}
+    `,
+    `
+class A {
+  constructor(public name: string) {}
+}
+    `,
+    `
+class A {
+  constructor(protected name: string) {}
+}
+    `,
+
+    // Access modifier on constructor
+    `
+class A {
+  private constructor() {}
+}
+    `,
+    `
+class A {
+  protected constructor() {}
+}
+    `,
+    `
+class A extends B {
+  public constructor() {}
+}
+    `,
+    `
+class A extends B {
+  public constructor() {
+    super();
+  }
+}
+    `,
+    `
+class A extends B {
+  protected constructor(foo, bar) {
+    super(bar);
+  }
+}
+    `,
+    `
+class A extends B {
+  private constructor(foo, bar) {
+    super(bar);
+  }
+}
+    `,
+    `
+class A extends B {
+  public constructor(foo) {
+    super(foo);
+  }
+}
+    `,
+    `
+class A extends B {
+  public constructor(foo) {}
+}
+    `,
+
+    // Decorator on params
+    `
+class A extends Object {
+  constructor(@Foo foo: string) {
+    super(foo);
+  }
+}
+    `,
+    `
+class A extends Object {
+  constructor(foo: string, @Bar() bar) {
+    super(foo, bar);
+  }
+}
+    `,
+  ],
+  invalid: [
+    {
+      code: 'class A { constructor(){} }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: "class A { 'constructor'(){} }",
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 11,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B { constructor() { super(); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B { constructor(foo){ super(foo); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B { constructor(foo, bar){ super(foo, bar); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B { constructor(...args){ super(...args); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B.C { constructor() { super(...arguments); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 23,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B { constructor(a, b, ...c) { super(...arguments); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+    {
+      code: 'class A extends B { constructor(a, b, ...c) { super(a, b, ...c); } }',
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 1,
+          column: 21,
+        },
+      ],
+    },
+
+    // Public constructor without superClass
+    {
+      code: `
+class A {
+  public constructor() {}
+}
+      `,
+      errors: [
+        {
+          messageId: 'noUselessConstructor',
+          line: 3,
+          column: 3,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the ESLint core `no-useless-constructor` rule to rslint. Coexists with the existing `@typescript-eslint/no-useless-constructor` — two independent rules, as in the upstream ESLint ecosystem.

The check flags class constructors that can be safely removed: empty bodies in classes without `extends`, and constructors that only forward params to `super()` in classes with `extends`. Access modifiers (`private`/`protected`, `public` in `extends`), parameter properties, and parameter decorators suppress the report.

The rule's check logic is aligned function-by-function with ESLint's source (`isSimple`, `isSingleSuperCall`, `isSpreadArguments`, `isValidIdentifierPair`, `isValidRestSpreadPair`, `isPassingThrough`, `hasUsefulAccessibility`, `hasDecoratorsOrParameterProperty`). tsgo↔ESTree structural differences (parenthesized expressions, static `constructor` parsed as `KindConstructor`) are compensated so semantics match ESLint.

The suggestion fix mirrors ESLint's `needsPrecedingSemicolon`: if the next member has a computed name and the previous member is a `PropertyDeclaration` whose initializer can greedily consume `[...]`, replace the constructor with `;` instead of removing outright; arrow-with-block initializers and postfix `++`/`--` are correctly excluded.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-useless-constructor
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-useless-constructor.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).