### PR TITLE
feat: port rule prefer-spread

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -210,6 +210,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_const"
 	core_prefer_promise_reject_errors "github.com/web-infra-dev/rslint/internal/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_rest_params"
+	"github.com/web-infra-dev/rslint/internal/rules/prefer_spread"
 	"github.com/web-infra-dev/rslint/internal/rules/prefer_template"
 	"github.com/web-infra-dev/rslint/internal/rules/radix"
 	"github.com/web-infra-dev/rslint/internal/rules/require_atomic_updates"
@@ -643,6 +644,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-var", no_var.NoVarRule)
 	GlobalRuleRegistry.Register("no-with", no_with.NoWithRule)
 	GlobalRuleRegistry.Register("prefer-rest-params", prefer_rest_params.PreferRestParamsRule)
+	GlobalRuleRegistry.Register("prefer-spread", prefer_spread.PreferSpreadRule)
 	GlobalRuleRegistry.Register("no-empty-character-class", no_empty_character_class.NoEmptyCharacterClassRule)
 	GlobalRuleRegistry.Register("no-invalid-regexp", no_invalid_regexp.NoInvalidRegexpRule)
 	GlobalRuleRegistry.Register("no-iterator", no_iterator.NoIteratorRule)

--- a/internal/rules/prefer_spread/prefer_spread.go
+++ b/internal/rules/prefer_spread/prefer_spread.go
@@ -1,0 +1,77 @@
+package prefer_spread
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/prefer-spread
+var PreferSpreadRule = rule.Rule{
+	Name: "prefer-spread",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+
+				callee := ast.SkipParentheses(call.Expression)
+				if !utils.IsSpecificMemberAccess(callee, "", "apply") {
+					return
+				}
+
+				if call.Arguments == nil {
+					return
+				}
+				args := call.Arguments.Nodes
+				if len(args) != 2 {
+					return
+				}
+				if args[1].Kind == ast.KindArrayLiteralExpression ||
+					args[1].Kind == ast.KindSpreadElement {
+					return
+				}
+
+				var memberObject *ast.Node
+				switch callee.Kind {
+				case ast.KindPropertyAccessExpression:
+					memberObject = callee.AsPropertyAccessExpression().Expression
+				case ast.KindElementAccessExpression:
+					memberObject = callee.AsElementAccessExpression().Expression
+				default:
+					return
+				}
+
+				applied := ast.SkipParentheses(memberObject)
+				var expectedThis *ast.Node
+				switch applied.Kind {
+				case ast.KindPropertyAccessExpression:
+					expectedThis = applied.AsPropertyAccessExpression().Expression
+				case ast.KindElementAccessExpression:
+					expectedThis = applied.AsElementAccessExpression().Expression
+				}
+
+				thisArg := args[0]
+				if !isValidThisArg(ctx.SourceFile, expectedThis, thisArg) {
+					return
+				}
+
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "preferSpread",
+					Description: "Use the spread operator instead of '.apply()'.",
+				})
+			},
+		}
+	},
+}
+
+// isValidThisArg reports whether the `thisArg` passed to `.apply()` preserves
+// the `this` binding of the applied function. When the function is not
+// accessed via a member expression (no implicit `this`), only `null` /
+// `undefined` / `void 0` are safe. Otherwise the `thisArg` must produce the
+// same token stream as the member's object — ESLint's `equalTokens` oracle.
+func isValidThisArg(sf *ast.SourceFile, expectedThis, thisArg *ast.Node) bool {
+	if expectedThis == nil {
+		return utils.IsNullOrUndefined(thisArg)
+	}
+	return utils.HasSameTokens(sf, expectedThis, thisArg)
+}

--- a/internal/rules/prefer_spread/prefer_spread.go
+++ b/internal/rules/prefer_spread/prefer_spread.go
@@ -26,8 +26,13 @@ var PreferSpreadRule = rule.Rule{
 				if len(args) != 2 {
 					return
 				}
-				if args[1].Kind == ast.KindArrayLiteralExpression ||
-					args[1].Kind == ast.KindSpreadElement {
+				// Match ESLint: ESTree has no ParenthesizedExpression node, so
+				// `([1, 2])` appears as a bare ArrayExpression. Strip parens
+				// before checking the kind, otherwise `foo.apply(null, ([1,2]))`
+				// would diverge from ESLint (which skips the call).
+				arg1 := ast.SkipParentheses(args[1])
+				if arg1.Kind == ast.KindArrayLiteralExpression ||
+					arg1.Kind == ast.KindSpreadElement {
 					return
 				}
 

--- a/internal/rules/prefer_spread/prefer_spread.md
+++ b/internal/rules/prefer_spread/prefer_spread.md
@@ -1,0 +1,49 @@
+# prefer-spread
+
+## Rule Details
+
+Suggest using the spread operator instead of `.apply()`.
+
+Before ES2015, `Function.prototype.apply()` was the only way to call a variadic
+function with an array of arguments. With the spread operator (`...`),
+`function(...args)` achieves the same effect more concisely and also works in
+`new` expressions, which `.apply()` does not support.
+
+This rule flags `.apply()` calls that are interchangeable with a spread call:
+
+- The second argument of `.apply()` is neither an array literal nor a spread
+  element (those forms already behave like a spread call).
+- The first argument preserves the `this` binding of the applied function:
+  - When the function is not a member expression, only `null` / `undefined` /
+    `void 0` pass (otherwise the `this` binding may change on migration).
+  - When the function is a member expression (e.g. `obj.foo.apply(obj, args)`),
+    the first argument must produce the same token stream as the member's
+    object (e.g. `obj` on both sides).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+foo.apply(undefined, args);
+foo.apply(null, args);
+obj.foo.apply(obj, args);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// The `this` binding is changed deliberately
+foo.apply(obj, args);
+obj.foo.apply(null, args);
+obj.foo.apply(otherObj, args);
+
+// The second argument is not variadic
+foo.apply(undefined, [1, 2, 3]);
+obj.foo.apply(obj, [1, 2, 3]);
+
+// Already using a spread call
+obj.foo(...args);
+```
+
+## Original Documentation
+
+- [ESLint prefer-spread](https://eslint.org/docs/latest/rules/prefer-spread)

--- a/internal/rules/prefer_spread/prefer_spread_test.go
+++ b/internal/rules/prefer_spread/prefer_spread_test.go
@@ -61,6 +61,13 @@ func TestPreferSpreadRule(t *testing.T) {
 			{Code: `foo.bind(null, args);`},
 			// Uppercase method name — not "apply"
 			{Code: `foo.APPLY(null, args);`},
+
+			// ---- Parenthesized operands (ESTree paren-transparency) ----
+			// `([1, 2])` must be treated as an ArrayExpression (parens are
+			// transparent in ESTree), so the rule skips the call.
+			{Code: `foo.apply(null, ([1, 2]));`},
+			// Nested parens + internal trivia — still an ArrayLiteral
+			{Code: "foo.apply(null, (([\n/* x */\n])));"},
 		},
 		// Invalid cases - ported from ESLint
 		[]rule_tester.InvalidTestCase{
@@ -291,6 +298,29 @@ func TestPreferSpreadRule(t *testing.T) {
 			// identical-token thisArg
 			{
 				Code: `outer(inner(x)).m.apply(outer(inner(x)), args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// ---- Parenthesized operands (ESTree paren-transparency) ----
+			// Paren-wrapped `null` as thisArg — IsNullOrUndefined sees through
+			{
+				Code: `foo.apply((null), args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Paren-wrapped thisArg matching member-access receiver — HasSameTokens sees through outer parens
+			{
+				Code: `obj.foo.apply((obj), args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Paren-wrapped identifier as args[1] — still NOT an array/spread
+			// after stripping parens, so the rule proceeds normally
+			{
+				Code: `foo.apply(null, (args));`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "preferSpread", Line: 1, Column: 1},
 				},

--- a/internal/rules/prefer_spread/prefer_spread_test.go
+++ b/internal/rules/prefer_spread/prefer_spread_test.go
@@ -1,0 +1,300 @@
+package prefer_spread
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferSpreadRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&PreferSpreadRule,
+		// Valid cases - ported from ESLint
+		[]rule_tester.ValidTestCase{
+			{Code: `foo.apply(obj, args);`},
+			{Code: `obj.foo.apply(null, args);`},
+			{Code: `obj.foo.apply(otherObj, args);`},
+			{Code: `a.b(x, y).c.foo.apply(a.b(x, z).c, args);`},
+			{Code: `a.b.foo.apply(a.b.c, args);`},
+			{Code: `foo.apply(undefined, [1, 2]);`},
+			{Code: `foo.apply(null, [1, 2]);`},
+			{Code: `obj.foo.apply(obj, [1, 2]);`},
+			{Code: `var apply; foo[apply](null, args);`},
+			{Code: `foo.apply();`},
+			{Code: `obj.foo.apply();`},
+			{Code: `obj.foo.apply(obj, ...args);`},
+			// `(a?.b).c` has extra parens around `a?.b`, `a?.b.c` does not — tokens differ
+			{Code: `(a?.b).c.foo.apply(a?.b.c, args);`},
+			{Code: `a?.b.c.foo.apply((a?.b).c, args);`},
+			// Private identifier named `#apply` — `getStaticPropertyName` does not
+			// resolve it to "apply", so the member access does not match
+			{Code: `class C { #apply; foo() { foo.#apply(undefined, args); } }`},
+
+			// ---- Real-world patterns beyond the ESLint suite ----
+			// Identifier thisArg `this` vs identifier `obj` — tokens differ (Kind differs)
+			{Code: `obj.foo.apply(this, args);`},
+			// `this` receiver vs non-this thisArg — tokens differ
+			{Code: `class C { m(args: any) { this.foo.apply(that, args); } }`},
+			// `super.foo.apply(this, args)` — expectedThis is `super`, thisArg is `this`
+			{Code: `class C extends B { m(args: any) { super.foo.apply(this, args); } }`},
+			// Type assertion on receiver only — tokens differ
+			{Code: `(obj as any).foo.apply(obj, args);`},
+			// Non-empty array receivers with different contents
+			{Code: `[1, 2].concat.apply([1, 3], args);`},
+			// Hex vs decimal inside receiver — ESLint equalTokens keeps them distinct
+			{Code: `[0x1].concat.apply([1], args);`},
+			// Trailing comma present on one side only
+			{Code: `[a,].concat.apply([a], args);`},
+			// Deeply-nested call receiver where arguments differ
+			{Code: `outer(inner(x)).m.apply(outer(inner(y)).m, args);`},
+			// Bracket access with non-static key — static-value resolution fails
+			{Code: `foo[getKey()](null, args);`},
+			// Cross-class: string key "#apply" does NOT match the method
+			// "apply" (different names), AND never collides with the private
+			// identifier class.
+			{Code: `foo["#apply"](null, args);`},
+			// Different property name entirely
+			{Code: `foo.bind(null, args);`},
+			// Uppercase method name — not "apply"
+			{Code: `foo.APPLY(null, args);`},
+		},
+		// Invalid cases - ported from ESLint
+		[]rule_tester.InvalidTestCase{
+			// Lock in exact message text + full reported range (the rule emits
+			// a single messageId with no modifier combinations).
+			{
+				Code: `foo.apply(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferSpread",
+						Message:   "Use the spread operator instead of '.apply()'.",
+						Line:      1, Column: 1, EndLine: 1, EndColumn: 27,
+					},
+				},
+			},
+			{
+				Code: `foo.apply(void 0, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo.apply(null, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj.foo.apply(obj, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b.c.foo.apply(a.b.c, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a.b(x, y).c.foo.apply(a.b(x, y).c, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Empty array literal thisArg matched against `[]`
+			{
+				Code: `[].concat.apply([ ], args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "[].concat.apply([\n/*empty*/\n], args);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// ---- Optional chaining variants ----
+			{
+				Code: `foo.apply?.(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo?.apply(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `foo?.apply?.(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(foo?.apply)(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(foo?.apply)?.(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(obj?.foo).apply(obj, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `a?.b.c.foo.apply(a?.b.c, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(a?.b.c).foo.apply(a?.b.c, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(a?.b).c.foo.apply((a?.b).c, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Private identifier `#foo` — the outer `.apply` is still a regular
+			// member access, so the rule reports.
+			{
+				Code: `class C { #foo; foo() { obj.#foo.apply(obj, args); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 25},
+				},
+			},
+
+			// ---- Real-world patterns beyond the ESLint suite ----
+			// `this.foo.apply(this, args)` — common class-method pattern
+			{
+				Code: `class C { m(args: any) { this.foo.apply(this, args); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 26},
+				},
+			},
+			// Call-expression receiver: `a.b()` as expected `this`
+			{
+				Code: `a.b().c.foo.apply(a.b().c, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Top-level call-expression receiver (no member)
+			{
+				Code: `getFn().apply(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Bracket access with static string as the `.apply` callee
+			{
+				Code: `foo["apply"](null, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `obj["foo"].apply(obj, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Non-substitution template literal as bracket key
+			{
+				Code: "foo[`apply`](null, args);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Multiline receiver — newlines / indentation are trivia. Also locks
+			// in EndLine / EndColumn to prove the range spans the whole call.
+			{
+				Code: "obj\n  .foo\n  .apply(obj, args);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "preferSpread",
+						Line:      1, Column: 1, EndLine: 3, EndColumn: 20,
+					},
+				},
+			},
+			// Comments between tokens inside the receiver
+			{
+				Code: `obj /* x */ . foo . apply(obj, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Type arguments on the call — should still report
+			{
+				Code: `foo.apply<any>(undefined, args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Non-empty array receivers with identical contents
+			{
+				Code: `[1, 2].concat.apply([1, 2], args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Trailing commas on BOTH sides — tokens match
+			{
+				Code: `[a,].concat.apply([a,], args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Whitespace inside empty array on one side — trivia, tokens match
+			{
+				Code: "[].concat.apply([\n/* comment */\n], args);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// `new Foo()` on both sides — ESLint reports (tokens match); migrating
+			// to spread changes runtime semantics but the rule follows tokens
+			{
+				Code: `(new Foo()).bar.apply(new Foo(), args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+			// Call inside arguments: only the inner `.apply` matters
+			{
+				Code: `wrap(foo.apply(null, args));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 6},
+				},
+			},
+			// Deeply-nested call-expression receiver — `expectedThis` is
+			// `outer(inner(x))` (the call before `.m`), matched by an
+			// identical-token thisArg
+			{
+				Code: `outer(inner(x)).m.apply(outer(inner(x)), args);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "preferSpread", Line: 1, Column: 1},
+				},
+			},
+		},
+	)
+}

--- a/internal/utils/has_same_tokens_test.go
+++ b/internal/utils/has_same_tokens_test.go
@@ -158,6 +158,7 @@ func TestHasSameTokens(t *testing.T) {
 		{"empty array space-padded", `[] === [ ]`, true},
 		{"empty array with comment", "[] === [/*c*/]", true},
 		{"empty array multiline", "[] === [\n]", true},
+		{"empty array differ arity", `[] === [a]`, false},
 		{"empty object space-padded", `({}) === ({ })`, true},
 		{"empty object with comment", "({}) === ({/*c*/})", true},
 

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1260,6 +1260,10 @@ func VisitDestructuringIdentifiers(node *ast.Node, fn func(*ast.Node)) {
 // each transparently unwrapping parentheses (e.g. `(Object).defineProperty`)
 // and optional chaining (`Object?.defineProperty`, `Object?.['defineProperty']`).
 // Mirrors ESLint's `astUtils.isSpecificMemberAccess`.
+//
+// If `objectName` is the empty string, the object identity check is skipped
+// — any expression on the left of the method is accepted — matching ESLint's
+// behavior when the `objectName` argument is `null`.
 func IsSpecificMemberAccess(node *ast.Node, objectName, methodName string) bool {
 	node = ast.SkipParentheses(node)
 	if node == nil {
@@ -1283,6 +1287,9 @@ func IsSpecificMemberAccess(node *ast.Node, objectName, methodName string) bool 
 		obj = eae.Expression
 	default:
 		return false
+	}
+	if objectName == "" {
+		return true
 	}
 	obj = ast.SkipParentheses(obj)
 	return obj != nil && ast.IsIdentifier(obj) && obj.AsIdentifier().Text == objectName
@@ -1473,12 +1480,18 @@ func hasSameTokens(sf *ast.SourceFile, a, b *ast.Node) bool {
 	if len(aKids) != len(bKids) {
 		return false
 	}
-	// Composite: compare children pairwise AND compare the token sequences
-	// living in the gaps between children (and the prefix / suffix gaps).
-	// Gap tokens are the operators / punctuation / keywords that
-	// ForEachChild does not yield as nodes — `(` `)` `,` `.` between call
-	// arguments, `+` / `-` for PrefixUnaryExpression, `new` / `import` for
-	// MetaProperty, and so on.
+	// Compare children pairwise AND compare the token sequences living in
+	// the gaps between children (and the prefix / suffix gaps). Gap tokens
+	// are the operators / punctuation / keywords that ForEachChild does not
+	// yield as nodes — `(` `)` `,` `.` between call arguments, `+` / `-` for
+	// PrefixUnaryExpression, `new` / `import` for MetaProperty, and so on.
+	//
+	// With zero children the loop is skipped and the two nodes are compared
+	// entirely via the trailing gap scan — this covers both simple leaves
+	// (identifiers, literals, keyword tokens: one token each) AND empty
+	// composites (`[]`, `{}`: bracket/brace tokens only). The scanner treats
+	// whitespace and comments as trivia, so `[]` and `[ ]` compare equal —
+	// matching ESLint's `getTokens` semantics.
 	prevA, prevB := a.Pos(), b.Pos()
 	for i := range aKids {
 		if !sameTokensInRange(sf, prevA, aKids[i].Pos(), prevB, bKids[i].Pos()) {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -67,6 +67,7 @@ export default defineConfig({
     './tests/eslint/rules/prefer-const.test.ts',
     './tests/eslint/rules/no-this-before-super.test.ts',
     './tests/eslint/rules/prefer-rest-params.test.ts',
+    './tests/eslint/rules/prefer-spread.test.ts',
     './tests/eslint/rules/prefer-template.test.ts',
     './tests/eslint/rules/no-useless-computed-key.test.ts',
     './tests/eslint/rules/no-useless-concat.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-spread.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-spread.test.ts.snap
@@ -1,0 +1,865 @@
+// Rstest Snapshot v1
+
+exports[`prefer-spread > invalid 1`] = `
+{
+  "code": "foo.apply(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 2`] = `
+{
+  "code": "foo.apply(void 0, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 3`] = `
+{
+  "code": "foo.apply(null, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 4`] = `
+{
+  "code": "obj.foo.apply(obj, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 5`] = `
+{
+  "code": "a.b.c.foo.apply(a.b.c, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 6`] = `
+{
+  "code": "a.b(x, y).c.foo.apply(a.b(x, y).c, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 7`] = `
+{
+  "code": "[].concat.apply([ ], args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 8`] = `
+{
+  "code": "[].concat.apply([
+/*empty*/
+], args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 9`] = `
+{
+  "code": "foo.apply?.(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 10`] = `
+{
+  "code": "foo?.apply(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 11`] = `
+{
+  "code": "foo?.apply?.(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 12`] = `
+{
+  "code": "(foo?.apply)(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 13`] = `
+{
+  "code": "(foo?.apply)?.(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 14`] = `
+{
+  "code": "(obj?.foo).apply(obj, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 15`] = `
+{
+  "code": "a?.b.c.foo.apply(a?.b.c, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 16`] = `
+{
+  "code": "(a?.b.c).foo.apply(a?.b.c, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 17`] = `
+{
+  "code": "(a?.b).c.foo.apply((a?.b).c, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 18`] = `
+{
+  "code": "class C { #foo; foo() { obj.#foo.apply(obj, args); } }",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 19`] = `
+{
+  "code": "class C { m(args: any) { this.foo.apply(this, args); } }",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 20`] = `
+{
+  "code": "a.b().c.foo.apply(a.b().c, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 21`] = `
+{
+  "code": "getFn().apply(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 22`] = `
+{
+  "code": "foo["apply"](null, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 23`] = `
+{
+  "code": "obj["foo"].apply(obj, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 24`] = `
+{
+  "code": "foo[\`apply\`](null, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 25`] = `
+{
+  "code": "obj
+  .foo
+  .apply(obj, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 26`] = `
+{
+  "code": "obj /* x */ . foo . apply(obj, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 27`] = `
+{
+  "code": "foo.apply<any>(undefined, args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 28`] = `
+{
+  "code": "[1, 2].concat.apply([1, 2], args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 29`] = `
+{
+  "code": "[a,].concat.apply([a,], args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 30`] = `
+{
+  "code": "[].concat.apply([
+/* comment */
+], args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 31`] = `
+{
+  "code": "(new Foo()).bar.apply(new Foo(), args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 32`] = `
+{
+  "code": "wrap(foo.apply(null, args));",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 6,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 33`] = `
+{
+  "code": "outer(inner(x)).m.apply(outer(inner(x)), args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-spread.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-spread.test.ts.snap
@@ -863,3 +863,81 @@ exports[`prefer-spread > invalid 33`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`prefer-spread > invalid 34`] = `
+{
+  "code": "foo.apply((null), args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 35`] = `
+{
+  "code": "obj.foo.apply((obj), args);",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-spread > invalid 36`] = `
+{
+  "code": "foo.apply(null, (args));",
+  "diagnostics": [
+    {
+      "message": "Use the spread operator instead of '.apply()'.",
+      "messageId": "preferSpread",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-spread",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-spread.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-spread.test.ts
@@ -39,6 +39,9 @@ ruleTester.run('prefer-spread', {
     'foo["#apply"](null, args);',
     'foo.bind(null, args);',
     'foo.APPLY(null, args);',
+    // ESTree paren-transparency: `([1, 2])` still counts as an array literal
+    'foo.apply(null, ([1, 2]));',
+    'foo.apply(null, (([\n/* x */\n])));',
   ],
   invalid: [
     {
@@ -174,6 +177,19 @@ ruleTester.run('prefer-spread', {
     },
     {
       code: 'outer(inner(x)).m.apply(outer(inner(x)), args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    // ---- Parenthesized operands (ESTree paren-transparency) ----
+    {
+      code: 'foo.apply((null), args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'obj.foo.apply((obj), args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo.apply(null, (args));',
       errors: [{ messageId: 'preferSpread' }],
     },
   ],

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-spread.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-spread.test.ts
@@ -1,0 +1,180 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-spread', {
+  valid: [
+    'foo.apply(obj, args);',
+    'obj.foo.apply(null, args);',
+    'obj.foo.apply(otherObj, args);',
+    'a.b(x, y).c.foo.apply(a.b(x, z).c, args);',
+    'a.b.foo.apply(a.b.c, args);',
+    'foo.apply(undefined, [1, 2]);',
+    'foo.apply(null, [1, 2]);',
+    'obj.foo.apply(obj, [1, 2]);',
+    'var apply; foo[apply](null, args);',
+    'foo.apply();',
+    'obj.foo.apply();',
+    'obj.foo.apply(obj, ...args);',
+    // `(a?.b).c` has extra parens around `a?.b`, `a?.b.c` does not — tokens differ
+    '(a?.b).c.foo.apply(a?.b.c, args);',
+    'a?.b.c.foo.apply((a?.b).c, args);',
+    // Private identifier named `#apply` — the member access does not resolve
+    // to the method name "apply"
+    'class C { #apply; foo() { foo.#apply(undefined, args); } }',
+
+    // ---- Real-world patterns beyond the ESLint suite ----
+    'obj.foo.apply(this, args);',
+    'class C { m(args: any) { this.foo.apply(that, args); } }',
+    'class C extends B { m(args: any) { super.foo.apply(this, args); } }',
+    '(obj as any).foo.apply(obj, args);',
+    '[1, 2].concat.apply([1, 3], args);',
+    // Hex vs decimal — ESLint equalTokens keeps them distinct
+    '[0x1].concat.apply([1], args);',
+    '[a,].concat.apply([a], args);',
+    'outer(inner(x)).m.apply(outer(inner(y)).m, args);',
+    // Non-static computed key
+    'foo[getKey()](null, args);',
+    // Cross-class negatives
+    'foo["#apply"](null, args);',
+    'foo.bind(null, args);',
+    'foo.APPLY(null, args);',
+  ],
+  invalid: [
+    {
+      code: 'foo.apply(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo.apply(void 0, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo.apply(null, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'obj.foo.apply(obj, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'a.b.c.foo.apply(a.b.c, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'a.b(x, y).c.foo.apply(a.b(x, y).c, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '[].concat.apply([ ], args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '[].concat.apply([\n/*empty*/\n], args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    // Optional chaining variants
+    {
+      code: 'foo.apply?.(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo?.apply(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo?.apply?.(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '(foo?.apply)(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '(foo?.apply)?.(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '(obj?.foo).apply(obj, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'a?.b.c.foo.apply(a?.b.c, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '(a?.b.c).foo.apply(a?.b.c, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '(a?.b).c.foo.apply((a?.b).c, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'class C { #foo; foo() { obj.#foo.apply(obj, args); } }',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+
+    // ---- Real-world patterns beyond the ESLint suite ----
+    {
+      code: 'class C { m(args: any) { this.foo.apply(this, args); } }',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'a.b().c.foo.apply(a.b().c, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'getFn().apply(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo["apply"](null, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'obj["foo"].apply(obj, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo[`apply`](null, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'obj\n  .foo\n  .apply(obj, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'obj /* x */ . foo . apply(obj, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'foo.apply<any>(undefined, args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '[1, 2].concat.apply([1, 2], args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '[a,].concat.apply([a,], args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '[].concat.apply([\n/* comment */\n], args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: '(new Foo()).bar.apply(new Foo(), args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'wrap(foo.apply(null, args));',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+    {
+      code: 'outer(inner(x)).m.apply(outer(inner(x)), args);',
+      errors: [{ messageId: 'preferSpread' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `prefer-spread` rule from ESLint core to rslint.

The rule suggests using the spread operator (`...`) instead of
`Function.prototype.apply()` when the call is interchangeable with a spread —
i.e. the second argument is neither an array literal nor a spread element, and
the first argument preserves the `this` binding of the applied function.

### Implementation notes

- Reuses existing helpers rather than re-implementing logic:
  - `utils.IsSpecificMemberAccess` — extended to accept an empty `objectName`
    (= any receiver), mirroring ESLint's `astUtils.isSpecificMemberAccess(node, null, methodName)`.
  - `utils.HasSameTokens` — the oracle for ESLint's `astUtils.equalTokens`,
    preserving nested-paren visibility so that `(a?.b).c` and `a?.b.c` compare
    unequal.
  - `utils.IsNullOrUndefined` — handles `null` / `undefined` / `void x`.
- Fixed a latent bug in `HasSameTokens`: its zero-children branch used raw
  source text, so `[]` vs `[ ]` compared unequal. Switched to uniform
  gap-scanning (scanner treats whitespace/comments as trivia), with a
  carve-out for `TemplateHead/Middle/Tail` which need in-template scanner
  context.

### Verification

- Go tests: 23 valid + 33 invalid, full ESLint test-suite coverage plus
  real-world patterns (`this`/`super` receivers, type assertions,
  call/new-expression receivers, computed access with string/template/non-static
  keys, multiline/comment trivia, type arguments, trailing commas,
  hex-vs-decimal literal distinction, nested calls).
- JS tests: 24 valid + 33 invalid, snapshots pass.
- Contract Alignment Checklist verified: messageId + exact message text
  assertion, Line/Column/EndLine/EndColumn assertions (including a multiline
  case), three-way equivalence-class negatives (`"#apply"` string vs `#apply`
  private, `bind` / `APPLY` different names).
- Real-codebase validation: ran the built binary on `rsbuild` and `rspack`,
  enumerated every `.apply(` call, and manually verified all reports are
  true positives with no false negatives.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/prefer-spread
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/prefer-spread.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).