### PR TITLE
feat: port rule no-throw-literal

### DIFF
--- a/agents/UTILS_REFERENCE.md
+++ b/agents/UTILS_REFERENCE.md
@@ -58,6 +58,15 @@ heritageClauses := utils.GetHeritageClauses(classNode) // *ast.NodeList
 
 // Check if a node has a specific modifier (e.g., async, static, public)
 isAsync := utils.IncludesModifier(funcNode, ast.KindAsyncKeyword)
+
+// Whether a node could plausibly evaluate to an Error object — mirrors
+// ESLint's astUtils.couldBeError. Unwraps parens + TS assertions internally.
+// Used by no-throw-literal, prefer-promise-reject-errors, etc.
+mayBeError := utils.CouldBeError(node)
+
+// Whether a node, after unwrapping parens + TS assertions, is the literal
+// identifier `undefined`. Lexical check only — does not detect `void 0`.
+isUndef := utils.IsUndefinedIdentifier(node)
 ```
 
 ### Collection Operations (Generic)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,6 +198,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
+	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
@@ -665,6 +666,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("require-atomic-updates", require_atomic_updates.RequireAtomicUpdatesRule)
 	GlobalRuleRegistry.Register("object-shorthand", object_shorthand.ObjectShorthandRule)
 	GlobalRuleRegistry.Register("no-dupe-else-if", no_dupe_else_if.NoDupeElseIfRule)
+	GlobalRuleRegistry.Register("no-throw-literal", no_throw_literal.NoThrowLiteralRule)
 	GlobalRuleRegistry.Register("no-useless-call", no_useless_call.NoUselessCallRule)
 	GlobalRuleRegistry.Register("no-useless-catch", no_useless_catch.NoUselessCatchRule)
 	GlobalRuleRegistry.Register("no-useless-rename", no_useless_rename.NoUselessRenameRule)

--- a/internal/rules/no_throw_literal/no_throw_literal.go
+++ b/internal/rules/no_throw_literal/no_throw_literal.go
@@ -1,0 +1,38 @@
+package no_throw_literal
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-throw-literal
+var NoThrowLiteralRule = rule.Rule{
+	Name: "no-throw-literal",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindThrowStatement: func(node *ast.Node) {
+				throwStmt := node.AsThrowStatement()
+				if throwStmt == nil || throwStmt.Expression == nil {
+					return
+				}
+				expr := throwStmt.Expression
+
+				if !utils.CouldBeError(expr) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "object",
+						Description: "Expected an error object to be thrown.",
+					})
+					return
+				}
+
+				if utils.IsUndefinedIdentifier(expr) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "undef",
+						Description: "Do not throw undefined.",
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/rules/no_throw_literal/no_throw_literal.md
+++ b/internal/rules/no_throw_literal/no_throw_literal.md
@@ -1,0 +1,44 @@
+# no-throw-literal
+
+## Rule Details
+
+This rule restricts what can be thrown as an exception. When ESLint was originally written, only literals were forbidden, but the rule has since been expanded to disallow any expression which cannot possibly be an `Error` object.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+throw "error";
+
+throw 0;
+
+throw undefined;
+
+throw null;
+
+const err = new Error();
+throw "an " + err;
+
+const err2 = new Error();
+throw `${err2}`;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+throw new Error();
+
+throw new Error("error");
+
+const e = new Error("error");
+throw e;
+
+try {
+  throw new Error("error");
+} catch (e) {
+  throw e;
+}
+```
+
+## Original Documentation
+
+- [ESLint: no-throw-literal](https://eslint.org/docs/latest/rules/no-throw-literal)

--- a/internal/rules/no_throw_literal/no_throw_literal_test.go
+++ b/internal/rules/no_throw_literal/no_throw_literal_test.go
@@ -1,0 +1,403 @@
+package no_throw_literal
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoThrowLiteral(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoThrowLiteralRule,
+		[]rule_tester.ValidTestCase{
+			// ---- ESLint upstream valid cases ----
+			{Code: `throw new Error();`},
+			{Code: `throw new Error('error');`},
+			{Code: `throw Error('error');`},
+			{Code: `var e = new Error(); throw e;`},
+			{Code: `try {throw new Error();} catch (e) {throw e;};`},
+			{Code: `throw a;`},          // Identifier
+			{Code: `throw foo();`},      // CallExpression
+			{Code: `throw new foo();`},  // NewExpression
+			{Code: `throw foo.bar;`},    // PropertyAccessExpression (ESTree MemberExpression)
+			{Code: `throw foo[bar];`},   // ElementAccessExpression (ESTree MemberExpression)
+			{Code: `class C { #field: any; foo() { throw foo.#field; } }`}, // private field member access
+			{Code: `throw foo = new Error();`},                              // AssignmentExpression `=`
+			{Code: `throw foo.bar ||= 'literal'`},                           // logical-assign `||=` (left could be Error)
+			{Code: `throw foo[bar] ??= 'literal'`},                          // logical-assign `??=` (left could be Error)
+			{Code: `throw 1, 2, new Error();`},                              // SequenceExpression (last is Error)
+			{Code: `throw 'literal' && new Error();`},                       // LogicalExpression `&&` (right is Error)
+			{Code: `throw new Error() || 'literal';`},                       // LogicalExpression `||` (left is Error)
+			{Code: `throw foo ? new Error() : 'literal';`},                  // ConditionalExpression (consequent)
+			{Code: `throw foo ? 'literal' : new Error();`},                  // ConditionalExpression (alternate)
+			{Code: "throw tag `${foo}`;"},                                   // TaggedTemplateExpression
+			{Code: `function* foo() { var index = 0; throw yield index++; }`}, // YieldExpression
+			{Code: `async function foo() { throw await bar; }`},               // AwaitExpression
+			{Code: `throw obj?.foo`},                                          // optional chain (PropertyAccess)
+			{Code: `throw obj?.foo()`},                                        // optional chain (CallExpression)
+
+			// ---- tsgo-/TS-specific edge cases ----
+			// Parenthesized argument is unwrapped before the Identifier/`undefined` check.
+			{Code: `throw (foo);`},
+			// Nested parens around an Error-producing call.
+			{Code: `throw ((new Error()));`},
+			// Conditional with both branches Error-shaped.
+			{Code: `throw cond ? new Error() : foo();`},
+			// Sequence in parens — couldBeError sees the rightmost; the
+			// outer node is BinaryExpression, so IsUndefinedIdentifier returns
+			// false even when the rightmost is `undefined`.
+			{Code: `throw (1, new Error());`},
+			{Code: `throw (1, undefined);`},
+			// Compound logical assignment where the RHS is Error-shaped.
+			{Code: `throw foo &&= new Error();`},
+			// Nested logical: any operand could be Error.
+			{Code: `throw a || b || new Error();`},
+			{Code: `throw a ?? new Error();`},
+			{Code: `throw (cond ? new Error() : foo()) || 'literal';`},
+			// Optional element access.
+			{Code: `throw obj?.[key];`},
+			// Triple-wrapped Identifier `foo` is plainly valid.
+			{Code: `throw (((foo)));`},
+			// Yield inside a generator with await.
+			{Code: `async function* foo() { throw await (yield 1); }`},
+			// TS assertion wrappers are NOT transparent (matching upstream
+			// ESLint when run on a `.ts` file via @typescript-eslint/parser),
+			// but the OUTER access shape still drives the classification:
+			// `foo!.bar` is a PropertyAccessExpression at the top level →
+			// could-be-Error → valid. Same for `(foo as Error).bar`.
+			{Code: `throw foo!.bar;`},
+			{Code: `throw (foo as Error).bar;`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- ESLint upstream invalid cases ----
+			{
+				Code: `throw 'error';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Message: "Expected an error object to be thrown.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw 0;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Message: "Expected an error object to be thrown.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw false;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Message: "Expected an error object to be thrown.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw null;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Message: "Expected an error object to be thrown.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Message: "Expected an error object to be thrown.", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw undefined;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Message: "Do not throw undefined.", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- String concatenation ----
+			{
+				Code: `throw 'a' + 'b';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `var b = new Error(); throw 'a' + b;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 22},
+				},
+			},
+
+			// ---- AssignmentExpression ----
+			{
+				Code: `throw foo = 'error';`, // RHS is a literal
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw foo += new Error();`, // arithmetic compound-assign returns a primitive
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw foo &= new Error();`, // bitwise compound-assign returns a primitive
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw foo &&= 'literal'`, // either falsy `foo` or 'literal'; neither can be an Error
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- SequenceExpression ----
+			{
+				Code: `throw new Error(), 1, 2, 3;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- LogicalExpression ----
+			{
+				Code: `throw 'literal' && 'not an Error';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw foo && 'literal'`, // either falsy `foo` (not Error) or 'literal'
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- ConditionalExpression ----
+			{
+				Code: `throw foo ? 'not an Error' : 'literal';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- TemplateLiteral ----
+			{
+				Code: "throw `${err}`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Extra tsgo/TS edge cases ----
+			// Parenthesized literal still reported.
+			{
+				Code: `throw ('error');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// Parenthesized `undefined` still maps to undef.
+			{
+				Code: `throw (undefined);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 1},
+				},
+			},
+			// Sequence whose last element is a literal.
+			{
+				Code: `throw (foo(), 'error');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// Conditional with both branches non-Error.
+			{
+				Code: `throw cond ? 'a' : 'b';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// BigInt literal.
+			{
+				Code: `throw 1n;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// Regex literal.
+			{
+				Code: `throw /foo/;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// `void 0` evaluates to undefined at runtime, but is a UnaryExpression,
+			// not the Identifier `undefined`. ESLint reports "object" (not "undef")
+			// because it falls through couldBeError's default case.
+			{
+				Code: `throw void 0;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// ClassExpression / FunctionExpression / ArrowFunction / ArrayLiteral
+			// / ObjectLiteral / `this` / `new.target`: none are in couldBeError's
+			// node-type list, so they all report "object".
+			{
+				Code: `throw class {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw function() {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw () => {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw [];`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `class C { foo() { throw this; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 19},
+				},
+			},
+			{
+				Code: `function foo() { throw new.target; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 18},
+				},
+			},
+			// Nested logical short-circuit chain that cannot resolve to Error.
+			{
+				Code: `throw a && b && 'literal';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// ---- TS assertion wrappers: NOT transparent in upstream ESLint ----
+			// Verified empirically: ESLint core run on `.ts` via
+			// `@typescript-eslint/parser` reports "object" for all of these,
+			// because TSAsExpression / TSNonNullExpression / TSSatisfiesExpression
+			// / TSTypeAssertion are absent from `astUtils.couldBeError` and
+			// fall through its default branch.
+			{
+				Code: `throw foo as Error;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw foo!;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw foo satisfies unknown;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw <Error>foo;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// Non-null on optional chain: outer node is NonNullExpression, not
+			// PropertyAccessExpression → falls through → "object".
+			{
+				Code: `throw obj?.foo!;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// Underlying literal still reported.
+			{
+				Code: `throw 'foo' as Error;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw (5 as any);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			// `undefined` after parens IS detected as undef (parens transparent).
+			{
+				Code: `throw (((undefined)));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "undef", Line: 1, Column: 1},
+				},
+			},
+			// `undefined as any` / `undefined!` are TS assertion wrappers — not
+			// transparent — so they report "object", not "undef".
+			{
+				Code: `throw undefined as any;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `throw undefined!;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- JSX (TSX) ----
+			// JSXElement / JSXFragment / JsxSelfClosingElement are not in
+			// couldBeError → "object".
+			{
+				Code:   `const _ = () => { throw <div />; };`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "object", Line: 1, Column: 19}},
+			},
+			{
+				Code:   `const _ = () => { throw <></>; };`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "object", Line: 1, Column: 19}},
+			},
+			// Both branches of a conditional are JSX → couldBeError false on both.
+			{
+				Code:   `const _ = (c: boolean) => { throw c ? <div /> : <span />; };`,
+				Tsx:    true,
+				Errors: []rule_tester.InvalidTestCaseError{{MessageId: "object", Line: 1, Column: 29}},
+			},
+
+			// ---- Full Line/Column/EndLine/EndColumn assertions ----
+			// Single-line: report range spans the entire ThrowStatement
+			// (`throw 'error';` is 14 columns, so end is column 15).
+			{
+				Code: `throw 'error';`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1, EndLine: 1, EndColumn: 15},
+				},
+			},
+			// Multi-line throw expression — ASI does not fire because the
+			// next token after `throw` is `'a'` (no line break between them).
+			// Range must span both lines.
+			{
+				Code: "throw 'a' +\n  'b';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "object", Line: 1, Column: 1, EndLine: 2, EndColumn: 7},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -33,62 +33,6 @@ func parseOptions(options any) Options {
 	return opts
 }
 
-// couldBeError mirrors ESLint's astUtils.couldBeError, adapted to the tsgo AST
-// where AssignmentExpression / LogicalExpression / SequenceExpression are all
-// flattened into BinaryExpression and ChainExpression has no analog.
-func couldBeError(node *ast.Node) bool {
-	if node == nil {
-		return false
-	}
-	node = ast.SkipOuterExpressions(node, skipTransparent)
-	if node == nil {
-		return false
-	}
-	switch node.Kind {
-	case ast.KindIdentifier,
-		ast.KindCallExpression,
-		ast.KindNewExpression,
-		ast.KindPropertyAccessExpression,
-		ast.KindElementAccessExpression,
-		ast.KindTaggedTemplateExpression,
-		ast.KindYieldExpression,
-		ast.KindAwaitExpression:
-		return true
-	case ast.KindBinaryExpression:
-		bin := node.AsBinaryExpression()
-		if bin == nil || bin.OperatorToken == nil {
-			return false
-		}
-		switch bin.OperatorToken.Kind {
-		case ast.KindCommaToken:
-			return couldBeError(bin.Right)
-		case ast.KindEqualsToken, ast.KindAmpersandAmpersandEqualsToken:
-			return couldBeError(bin.Right)
-		case ast.KindBarBarEqualsToken, ast.KindQuestionQuestionEqualsToken:
-			return couldBeError(bin.Left) || couldBeError(bin.Right)
-		case ast.KindAmpersandAmpersandToken:
-			return couldBeError(bin.Right)
-		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
-			return couldBeError(bin.Left) || couldBeError(bin.Right)
-		default:
-			return false
-		}
-	case ast.KindConditionalExpression:
-		ce := node.AsConditionalExpression()
-		if ce == nil {
-			return false
-		}
-		return couldBeError(ce.WhenTrue) || couldBeError(ce.WhenFalse)
-	default:
-		return false
-	}
-}
-
-func isUndefinedIdentifier(node *ast.Node) bool {
-	node = ast.SkipOuterExpressions(node, skipTransparent)
-	return node != nil && ast.IsIdentifier(node) && node.AsIdentifier().Text == "undefined"
-}
-
 func checkRejectCall(ctx rule.RuleContext, callExpression *ast.Node, allowEmptyReject bool) {
 	args := callExpression.Arguments()
 	if len(args) == 0 {
@@ -99,7 +43,7 @@ func checkRejectCall(ctx rule.RuleContext, callExpression *ast.Node, allowEmptyR
 		return
 	}
 	first := args[0]
-	if !couldBeError(first) || isUndefinedIdentifier(first) {
+	if !utils.CouldBeError(first) || utils.IsUndefinedIdentifier(first) {
 		ctx.ReportNode(callExpression, buildRejectAnErrorMessage())
 	}
 }

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors.go
@@ -6,11 +6,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/utils"
 )
 
-// skipTransparent unwraps parentheses, type assertions, non-null assertions,
-// and `satisfies` so that TypeScript-only syntax does not perturb the
-// AST-based shape checks ESLint performs at the source level.
-const skipTransparent = ast.OEKParentheses | ast.OEKAssertions
-
 func buildRejectAnErrorMessage() rule.RuleMessage {
 	return rule.RuleMessage{
 		Id:          "rejectAnError",
@@ -59,10 +54,13 @@ var PreferPromiseRejectErrorsRule = rule.Rule{
 				}
 			},
 			ast.KindNewExpression: func(node *ast.Node) {
-				// ESTree drops parentheses, so ESLint's `node.callee.type === "Identifier"`
-				// already succeeds for `new (Promise)(...)`. tsgo retains parens (and TS
-				// assertions), so unwrap them here to keep behavior aligned.
-				callee := ast.SkipOuterExpressions(node.AsNewExpression().Expression, skipTransparent)
+				// ESTree drops parentheses at parse time, so ESLint's
+				// `node.callee.type === "Identifier"` succeeds for `new (Promise)(...)`.
+				// tsgo retains the ParenthesizedExpression wrapper — unwrap it here.
+				// TS assertion wrappers (`(Promise as any)`, `Promise!`, `<any>Promise`)
+				// are NOT unwrapped: ESLint's identifier check fails on them, so
+				// `new (Promise as any)(...)` is not recognized as a Promise constructor.
+				callee := ast.SkipParentheses(node.AsNewExpression().Expression)
 				if callee == nil || !ast.IsIdentifier(callee) || callee.AsIdentifier().Text != "Promise" {
 					return
 				}
@@ -70,7 +68,10 @@ var PreferPromiseRejectErrorsRule = rule.Rule{
 				if len(args) == 0 {
 					return
 				}
-				executor := ast.SkipOuterExpressions(args[0], skipTransparent)
+				// Same reasoning as the callee above: ESLint requires
+				// `executor.type === "FunctionExpression" || "ArrowFunctionExpression"`
+				// at the AST level — assertion-wrapped executors fail that check.
+				executor := ast.SkipParentheses(args[0])
 				if executor == nil || !ast.IsFunctionExpressionOrArrowFunction(executor) {
 					return
 				}
@@ -115,7 +116,11 @@ func findRejectReferences(ctx rule.RuleContext, executor *ast.Node, name string,
 			return
 		}
 		if ast.IsCallExpression(n) {
-			callee := ast.SkipOuterExpressions(n.AsCallExpression().Expression, skipTransparent)
+			// Parens are transparent in ESLint AST; TS assertions are not —
+			// `(reject as any)(5)` and `reject!(5)` are NOT flagged by upstream
+			// because their callee is TSAsExpression / TSNonNullExpression, not
+			// Identifier "reject".
+			callee := ast.SkipParentheses(n.AsCallExpression().Expression)
 			if callee != nil && ast.IsIdentifier(callee) && callee.AsIdentifier().Text == name {
 				if isExecutorParameterReference(ctx, callee, executor, name) {
 					visit(n)

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
@@ -54,12 +54,6 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
 			{Code: `class C { #reject; foo() { Promise.#reject(5); } }`},
 			{Code: `class C { #error; foo() { Promise.reject(this.#error); } }`},
 
-			// ---- TypeScript-only syntax should be transparent to couldBeError ----
-			{Code: `Promise.reject(foo as Error)`},
-			{Code: `Promise.reject(<Error>foo)`},
-			{Code: `Promise.reject(foo!)`},
-			{Code: `Promise.reject(foo satisfies Error)`},
-
 			// ---- ESLint requires params[1].type === "Identifier"; non-plain
 			// second-parameter shapes are not analyzed.
 			{Code: `new Promise((resolve, reject = foo) => reject(5))`},
@@ -86,6 +80,35 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{
+			// ---- TS assertion wrappers are NOT transparent in upstream ESLint ----
+			// Verified: ESLint core run on a `.ts` file via `@typescript-eslint/parser`
+			// reports each of these — TSAsExpression / TSTypeAssertion /
+			// TSNonNullExpression / TSSatisfiesExpression are absent from
+			// `astUtils.couldBeError` and fall through to its default branch.
+			{
+				Code: `Promise.reject(foo as Error)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(<Error>foo)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo!)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `Promise.reject(foo satisfies Error)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "rejectAnError", Line: 1, Column: 1},
+				},
+			},
 			{
 				Code: `Promise.reject(5)`,
 				Errors: []rule_tester.InvalidTestCaseError{

--- a/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
+++ b/internal/rules/prefer_promise_reject_errors/prefer_promise_reject_errors_test.go
@@ -77,6 +77,29 @@ func TestPreferPromiseRejectErrorsRule(t *testing.T) {
 			// ---- Reject method-like access (.call / .bind / .apply) is treated
 			// as a different operation by ESLint and is not flagged.
 			{Code: `new Promise((resolve, reject) => reject.call(null, new Error()))`},
+
+			// ---- TS assertion wrappers around the Promise constructor / executor
+			// / reject call are NOT recognized as "Promise constructor pattern" by
+			// upstream ESLint, because its identity / function-type checks all
+			// happen against the raw AST node. Verified empirically against
+			// ESLint core + @typescript-eslint/parser.
+			// (a) callee wrapped: not recognized as `new Promise(...)`.
+			{Code: `new (Promise as any)((resolve, reject) => reject(5))`},
+			{Code: `new (Promise!)((resolve, reject) => reject(5))`},
+			{Code: `new (<any>Promise)((resolve, reject) => reject(5))`},
+			// (b) executor wrapped: ESLint requires executor.type to be exactly
+			// FunctionExpression / ArrowFunctionExpression — assertion-wrapped fails.
+			{Code: `new Promise(((resolve: any, reject: any) => reject(5)) as any)`},
+			{Code: `new Promise(((resolve: any, reject: any) => reject(5))!)`},
+			// (c) reject call wrapped: callee identity check sees TSAsExpression /
+			// TSNonNullExpression instead of Identifier "reject".
+			{Code: `new Promise((resolve, reject) => (reject as any)(5))`},
+			{Code: `new Promise((resolve, reject) => reject!(5))`},
+			// (d) Member-access on `(Promise as any)` is not Promise.reject either.
+			{Code: `(Promise as any).reject(5)`},
+			// Parens-only controls: parens stay transparent, executor still analyzed.
+			{Code: `new Promise(((resolve, reject) => reject(new Error())))`},
+			{Code: `new Promise((resolve, reject) => (reject)(new Error()))`},
 		},
 		// Invalid cases
 		[]rule_tester.InvalidTestCase{

--- a/internal/utils/ast_helpers.go
+++ b/internal/utils/ast_helpers.go
@@ -114,6 +114,87 @@ func IsNonReferenceIdentifier(node *ast.Node) bool {
 	return false
 }
 
+// CouldBeError reports whether a node could plausibly evaluate to an Error
+// object at runtime. Mirrors ESLint's `astUtils.couldBeError`, adapted to the
+// tsgo AST where AssignmentExpression / LogicalExpression / SequenceExpression
+// are all flattened into BinaryExpression and ChainExpression has no analog.
+//
+// Only parentheses are unwrapped — TS-only assertion wrappers (`x as T`,
+// `<T>x`, `x satisfies T`, `x!`) are NOT unwrapped, because ESLint's
+// `astUtils.couldBeError` does not list them and falls through to `false`.
+// Verified against ESLint core run on a `.ts` file via `@typescript-eslint/parser`:
+// `throw foo as Error;` and `throw foo!;` are both reported as "object".
+//
+// Used by rules whose ESLint counterparts call `astUtils.couldBeError`:
+// `no-throw-literal`, `prefer-promise-reject-errors`, etc.
+func CouldBeError(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	node = ast.SkipParentheses(node)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier,
+		ast.KindCallExpression,
+		ast.KindNewExpression,
+		ast.KindPropertyAccessExpression,
+		ast.KindElementAccessExpression,
+		ast.KindTaggedTemplateExpression,
+		ast.KindYieldExpression,
+		ast.KindAwaitExpression:
+		return true
+
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin == nil || bin.OperatorToken == nil {
+			return false
+		}
+		switch bin.OperatorToken.Kind {
+		// `a, b, c` parses left-associatively in tsgo, so the rightmost
+		// expression is `bin.Right` of the outer BinaryExpression.
+		case ast.KindCommaToken:
+			return CouldBeError(bin.Right)
+		// `a = b` / `a &&= b` evaluate to the right operand.
+		case ast.KindEqualsToken, ast.KindAmpersandAmpersandEqualsToken:
+			return CouldBeError(bin.Right)
+		// `a ||= b` / `a ??= b` evaluate to either `a` or `b`.
+		case ast.KindBarBarEqualsToken, ast.KindQuestionQuestionEqualsToken:
+			return CouldBeError(bin.Left) || CouldBeError(bin.Right)
+		// `a && b` short-circuits to a falsy `a` (cannot be Error) or to `b`.
+		case ast.KindAmpersandAmpersandToken:
+			return CouldBeError(bin.Right)
+		// `a || b` / `a ?? b` evaluate to either operand.
+		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+			return CouldBeError(bin.Left) || CouldBeError(bin.Right)
+		default:
+			// Arithmetic / bitwise / comparison / compound-assign other than
+			// `=`, `&&=`, `||=`, `??=`: result is a primitive (or throws).
+			return false
+		}
+
+	case ast.KindConditionalExpression:
+		ce := node.AsConditionalExpression()
+		if ce == nil {
+			return false
+		}
+		return CouldBeError(ce.WhenTrue) || CouldBeError(ce.WhenFalse)
+	}
+
+	return false
+}
+
+// IsUndefinedIdentifier reports whether the node, after unwrapping parens, is
+// the literal identifier `undefined`. Purely lexical — does not detect `void 0`,
+// `undefined as any`, or a shadowed `undefined` binding, matching ESLint's
+// `node.argument.name === "undefined"` check (which only sees an Identifier
+// after parens are dropped at parse time, not after TS assertions).
+func IsUndefinedIdentifier(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	return node != nil && ast.IsIdentifier(node) && node.AsIdentifier().Text == "undefined"
+}
+
 // isReExportSpecifier checks if an ExportSpecifier is part of a re-export
 // declaration (export { ... } from 'mod').
 func isReExportSpecifier(exportSpec *ast.Node) bool {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -274,6 +274,7 @@ export default defineConfig({
     './tests/eslint/rules/no-unreachable.test.ts',
     './tests/eslint/rules/no-unsafe-finally.test.ts',
     './tests/eslint/rules/no-unsafe-negation.test.ts',
+    './tests/eslint/rules/no-throw-literal.test.ts',
     './tests/eslint/rules/no-unsafe-optional-chaining.test.ts',
     './tests/eslint/rules/no-useless-call.test.ts',
     './tests/eslint/rules/no-useless-catch.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-throw-literal.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-throw-literal.test.ts.snap
@@ -1,0 +1,1094 @@
+// Rstest Snapshot v1
+
+exports[`no-throw-literal > invalid 1`] = `
+{
+  "code": "throw 'error';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 2`] = `
+{
+  "code": "throw 0;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 3`] = `
+{
+  "code": "throw false;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 4`] = `
+{
+  "code": "throw null;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 5`] = `
+{
+  "code": "throw {};",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 6`] = `
+{
+  "code": "throw undefined;",
+  "diagnostics": [
+    {
+      "message": "Do not throw undefined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 7`] = `
+{
+  "code": "throw 'a' + 'b';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 8`] = `
+{
+  "code": "var b = new Error(); throw 'a' + b;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 9`] = `
+{
+  "code": "throw foo = 'error';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 10`] = `
+{
+  "code": "throw foo += new Error();",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 11`] = `
+{
+  "code": "throw foo &= new Error();",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 12`] = `
+{
+  "code": "throw foo &&= 'literal'",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 13`] = `
+{
+  "code": "throw new Error(), 1, 2, 3;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 14`] = `
+{
+  "code": "throw 'literal' && 'not an Error';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 15`] = `
+{
+  "code": "throw foo && 'literal'",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 16`] = `
+{
+  "code": "throw foo ? 'not an Error' : 'literal';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 17`] = `
+{
+  "code": "throw \`\${err}\`;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 18`] = `
+{
+  "code": "throw ('error');",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 19`] = `
+{
+  "code": "throw (undefined);",
+  "diagnostics": [
+    {
+      "message": "Do not throw undefined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 20`] = `
+{
+  "code": "throw (foo(), 'error');",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 21`] = `
+{
+  "code": "throw cond ? 'a' : 'b';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 22`] = `
+{
+  "code": "throw 1n;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 23`] = `
+{
+  "code": "throw /foo/;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 24`] = `
+{
+  "code": "throw void 0;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 25`] = `
+{
+  "code": "throw class {};",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 26`] = `
+{
+  "code": "throw function() {};",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 27`] = `
+{
+  "code": "throw () => {};",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 28`] = `
+{
+  "code": "throw [];",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 29`] = `
+{
+  "code": "class C { foo() { throw this; } }",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 30`] = `
+{
+  "code": "function foo() { throw new.target; }",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 31`] = `
+{
+  "code": "throw a && b && 'literal';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 32`] = `
+{
+  "code": "throw foo as Error;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 33`] = `
+{
+  "code": "throw foo!;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 34`] = `
+{
+  "code": "throw foo satisfies unknown;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 35`] = `
+{
+  "code": "throw <Error>foo;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 36`] = `
+{
+  "code": "throw obj?.foo!;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 37`] = `
+{
+  "code": "throw 'foo' as Error;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 38`] = `
+{
+  "code": "throw (5 as any);",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 39`] = `
+{
+  "code": "throw (((undefined)));",
+  "diagnostics": [
+    {
+      "message": "Do not throw undefined.",
+      "messageId": "undef",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 40`] = `
+{
+  "code": "throw undefined as any;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 41`] = `
+{
+  "code": "throw undefined!;",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-throw-literal > invalid 42`] = `
+{
+  "code": "throw 'a' +
+  'b';",
+  "diagnostics": [
+    {
+      "message": "Expected an error object to be thrown.",
+      "messageId": "object",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-throw-literal",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-promise-reject-errors.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/prefer-promise-reject-errors.test.ts.snap
@@ -2,6 +2,110 @@
 
 exports[`prefer-promise-reject-errors > invalid 1`] = `
 {
+  "code": "Promise.reject(foo as Error)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 2`] = `
+{
+  "code": "Promise.reject(<Error>foo)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 3`] = `
+{
+  "code": "Promise.reject(foo!)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 4`] = `
+{
+  "code": "Promise.reject(foo satisfies Error)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 5`] = `
+{
   "code": "Promise.reject(5)",
   "diagnostics": [
     {
@@ -26,7 +130,7 @@ exports[`prefer-promise-reject-errors > invalid 1`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 2`] = `
+exports[`prefer-promise-reject-errors > invalid 6`] = `
 {
   "code": "Promise.reject('foo')",
   "diagnostics": [
@@ -52,7 +156,7 @@ exports[`prefer-promise-reject-errors > invalid 2`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 3`] = `
+exports[`prefer-promise-reject-errors > invalid 7`] = `
 {
   "code": "Promise.reject(\`foo\`)",
   "diagnostics": [
@@ -78,7 +182,7 @@ exports[`prefer-promise-reject-errors > invalid 3`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 4`] = `
+exports[`prefer-promise-reject-errors > invalid 8`] = `
 {
   "code": "Promise.reject(!foo)",
   "diagnostics": [
@@ -104,7 +208,7 @@ exports[`prefer-promise-reject-errors > invalid 4`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 5`] = `
+exports[`prefer-promise-reject-errors > invalid 9`] = `
 {
   "code": "Promise.reject(void foo)",
   "diagnostics": [
@@ -114,110 +218,6 @@ exports[`prefer-promise-reject-errors > invalid 5`] = `
       "range": {
         "end": {
           "column": 25,
-          "line": 1,
-        },
-        "start": {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "ruleName": "prefer-promise-reject-errors",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`prefer-promise-reject-errors > invalid 6`] = `
-{
-  "code": "Promise.reject()",
-  "diagnostics": [
-    {
-      "message": "Expected the Promise rejection reason to be an Error.",
-      "messageId": "rejectAnError",
-      "range": {
-        "end": {
-          "column": 17,
-          "line": 1,
-        },
-        "start": {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "ruleName": "prefer-promise-reject-errors",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`prefer-promise-reject-errors > invalid 7`] = `
-{
-  "code": "Promise.reject(undefined)",
-  "diagnostics": [
-    {
-      "message": "Expected the Promise rejection reason to be an Error.",
-      "messageId": "rejectAnError",
-      "range": {
-        "end": {
-          "column": 26,
-          "line": 1,
-        },
-        "start": {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "ruleName": "prefer-promise-reject-errors",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`prefer-promise-reject-errors > invalid 8`] = `
-{
-  "code": "Promise.reject({ foo: 1 })",
-  "diagnostics": [
-    {
-      "message": "Expected the Promise rejection reason to be an Error.",
-      "messageId": "rejectAnError",
-      "range": {
-        "end": {
-          "column": 27,
-          "line": 1,
-        },
-        "start": {
-          "column": 1,
-          "line": 1,
-        },
-      },
-      "ruleName": "prefer-promise-reject-errors",
-    },
-  ],
-  "errorCount": 1,
-  "fileCount": 1,
-  "ruleCount": 1,
-}
-`;
-
-exports[`prefer-promise-reject-errors > invalid 9`] = `
-{
-  "code": "Promise.reject([1, 2, 3])",
-  "diagnostics": [
-    {
-      "message": "Expected the Promise rejection reason to be an Error.",
-      "messageId": "rejectAnError",
-      "range": {
-        "end": {
-          "column": 26,
           "line": 1,
         },
         "start": {
@@ -262,6 +262,110 @@ exports[`prefer-promise-reject-errors > invalid 10`] = `
 
 exports[`prefer-promise-reject-errors > invalid 11`] = `
 {
+  "code": "Promise.reject(undefined)",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 12`] = `
+{
+  "code": "Promise.reject({ foo: 1 })",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 13`] = `
+{
+  "code": "Promise.reject([1, 2, 3])",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 14`] = `
+{
+  "code": "Promise.reject()",
+  "diagnostics": [
+    {
+      "message": "Expected the Promise rejection reason to be an Error.",
+      "messageId": "rejectAnError",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "prefer-promise-reject-errors",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-promise-reject-errors > invalid 15`] = `
+{
   "code": "new Promise(function(resolve, reject) { reject() })",
   "diagnostics": [
     {
@@ -286,7 +390,7 @@ exports[`prefer-promise-reject-errors > invalid 11`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 12`] = `
+exports[`prefer-promise-reject-errors > invalid 16`] = `
 {
   "code": "Promise.reject(undefined)",
   "diagnostics": [
@@ -312,7 +416,7 @@ exports[`prefer-promise-reject-errors > invalid 12`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 13`] = `
+exports[`prefer-promise-reject-errors > invalid 17`] = `
 {
   "code": "Promise.reject('foo', somethingElse)",
   "diagnostics": [
@@ -338,7 +442,7 @@ exports[`prefer-promise-reject-errors > invalid 13`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 14`] = `
+exports[`prefer-promise-reject-errors > invalid 18`] = `
 {
   "code": "new Promise(function(resolve, reject) { reject(5) })",
   "diagnostics": [
@@ -364,7 +468,7 @@ exports[`prefer-promise-reject-errors > invalid 14`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 15`] = `
+exports[`prefer-promise-reject-errors > invalid 19`] = `
 {
   "code": "new Promise((resolve, reject) => { reject(5) })",
   "diagnostics": [
@@ -390,7 +494,7 @@ exports[`prefer-promise-reject-errors > invalid 15`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 16`] = `
+exports[`prefer-promise-reject-errors > invalid 20`] = `
 {
   "code": "new Promise((resolve, reject) => reject(5))",
   "diagnostics": [
@@ -416,7 +520,7 @@ exports[`prefer-promise-reject-errors > invalid 16`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 17`] = `
+exports[`prefer-promise-reject-errors > invalid 21`] = `
 {
   "code": "new Promise((resolve, reject) => reject())",
   "diagnostics": [
@@ -442,7 +546,7 @@ exports[`prefer-promise-reject-errors > invalid 17`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 18`] = `
+exports[`prefer-promise-reject-errors > invalid 22`] = `
 {
   "code": "new Promise(function(yes, no) { no(5) })",
   "diagnostics": [
@@ -468,7 +572,7 @@ exports[`prefer-promise-reject-errors > invalid 18`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 19`] = `
+exports[`prefer-promise-reject-errors > invalid 23`] = `
 {
   "code": "
           new Promise((resolve, reject) => {
@@ -501,7 +605,7 @@ exports[`prefer-promise-reject-errors > invalid 19`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 20`] = `
+exports[`prefer-promise-reject-errors > invalid 24`] = `
 {
   "code": "new Promise(({foo, bar, baz}, reject) => reject(5))",
   "diagnostics": [
@@ -527,7 +631,7 @@ exports[`prefer-promise-reject-errors > invalid 20`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 21`] = `
+exports[`prefer-promise-reject-errors > invalid 25`] = `
 {
   "code": "new Promise(function(reject, reject) { reject(5) })",
   "diagnostics": [
@@ -553,7 +657,7 @@ exports[`prefer-promise-reject-errors > invalid 21`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 22`] = `
+exports[`prefer-promise-reject-errors > invalid 26`] = `
 {
   "code": "new Promise(function(foo, arguments) { arguments(5) })",
   "diagnostics": [
@@ -579,7 +683,7 @@ exports[`prefer-promise-reject-errors > invalid 22`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 23`] = `
+exports[`prefer-promise-reject-errors > invalid 27`] = `
 {
   "code": "new Promise((foo, arguments) => arguments(5))",
   "diagnostics": [
@@ -605,7 +709,7 @@ exports[`prefer-promise-reject-errors > invalid 23`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 24`] = `
+exports[`prefer-promise-reject-errors > invalid 28`] = `
 {
   "code": "new Promise(function({}, reject) { reject(5) })",
   "diagnostics": [
@@ -631,7 +735,7 @@ exports[`prefer-promise-reject-errors > invalid 24`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 25`] = `
+exports[`prefer-promise-reject-errors > invalid 29`] = `
 {
   "code": "new Promise(({}, reject) => reject(5))",
   "diagnostics": [
@@ -657,7 +761,7 @@ exports[`prefer-promise-reject-errors > invalid 25`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 26`] = `
+exports[`prefer-promise-reject-errors > invalid 30`] = `
 {
   "code": "new Promise((resolve, reject, somethingElse = reject(5)) => {})",
   "diagnostics": [
@@ -683,7 +787,7 @@ exports[`prefer-promise-reject-errors > invalid 26`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 27`] = `
+exports[`prefer-promise-reject-errors > invalid 31`] = `
 {
   "code": "new Promise(function(resolve, reject) { var reject = somethingElse; reject(5) })",
   "diagnostics": [
@@ -709,7 +813,7 @@ exports[`prefer-promise-reject-errors > invalid 27`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 28`] = `
+exports[`prefer-promise-reject-errors > invalid 32`] = `
 {
   "code": "new Promise((resolve, reject) => setTimeout(() => reject(5), 0))",
   "diagnostics": [
@@ -735,7 +839,7 @@ exports[`prefer-promise-reject-errors > invalid 28`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 29`] = `
+exports[`prefer-promise-reject-errors > invalid 33`] = `
 {
   "code": "new Promise((resolve, reject) => arr.forEach(function () { reject('bad') }))",
   "diagnostics": [
@@ -761,7 +865,7 @@ exports[`prefer-promise-reject-errors > invalid 29`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 30`] = `
+exports[`prefer-promise-reject-errors > invalid 34`] = `
 {
   "code": "Promise.reject(...args)",
   "diagnostics": [
@@ -787,7 +891,7 @@ exports[`prefer-promise-reject-errors > invalid 30`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 31`] = `
+exports[`prefer-promise-reject-errors > invalid 35`] = `
 {
   "code": "Promise.reject(null)",
   "diagnostics": [
@@ -813,7 +917,7 @@ exports[`prefer-promise-reject-errors > invalid 31`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 32`] = `
+exports[`prefer-promise-reject-errors > invalid 36`] = `
 {
   "code": "Promise.reject(0)",
   "diagnostics": [
@@ -839,7 +943,7 @@ exports[`prefer-promise-reject-errors > invalid 32`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 33`] = `
+exports[`prefer-promise-reject-errors > invalid 37`] = `
 {
   "code": "Promise.reject(true)",
   "diagnostics": [
@@ -865,7 +969,7 @@ exports[`prefer-promise-reject-errors > invalid 33`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 34`] = `
+exports[`prefer-promise-reject-errors > invalid 38`] = `
 {
   "code": "Promise['reject'](5)",
   "diagnostics": [
@@ -891,7 +995,7 @@ exports[`prefer-promise-reject-errors > invalid 34`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 35`] = `
+exports[`prefer-promise-reject-errors > invalid 39`] = `
 {
   "code": "Promise[\`reject\`](5)",
   "diagnostics": [
@@ -917,7 +1021,7 @@ exports[`prefer-promise-reject-errors > invalid 35`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 36`] = `
+exports[`prefer-promise-reject-errors > invalid 40`] = `
 {
   "code": "new Promise(function fn(resolve, reject) { reject(5) })",
   "diagnostics": [
@@ -943,7 +1047,7 @@ exports[`prefer-promise-reject-errors > invalid 36`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 37`] = `
+exports[`prefer-promise-reject-errors > invalid 41`] = `
 {
   "code": "new Promise(async (resolve, reject) => reject(5))",
   "diagnostics": [
@@ -969,7 +1073,7 @@ exports[`prefer-promise-reject-errors > invalid 37`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 38`] = `
+exports[`prefer-promise-reject-errors > invalid 42`] = `
 {
   "code": "new Promise(function *(resolve, reject) { reject(5) })",
   "diagnostics": [
@@ -995,7 +1099,7 @@ exports[`prefer-promise-reject-errors > invalid 38`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 39`] = `
+exports[`prefer-promise-reject-errors > invalid 43`] = `
 {
   "code": "new Promise((resolve, reject) => { reject(1); reject('x'); reject(); })",
   "diagnostics": [
@@ -1051,7 +1155,7 @@ exports[`prefer-promise-reject-errors > invalid 39`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 40`] = `
+exports[`prefer-promise-reject-errors > invalid 44`] = `
 {
   "code": "new Promise((resolve, reject) => (reject)(5))",
   "diagnostics": [
@@ -1077,7 +1181,7 @@ exports[`prefer-promise-reject-errors > invalid 40`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 41`] = `
+exports[`prefer-promise-reject-errors > invalid 45`] = `
 {
   "code": "new Promise((resolve, reject) => reject?.(5))",
   "diagnostics": [
@@ -1103,7 +1207,7 @@ exports[`prefer-promise-reject-errors > invalid 41`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 42`] = `
+exports[`prefer-promise-reject-errors > invalid 46`] = `
 {
   "code": "new (Promise)((resolve, reject) => reject(5))",
   "diagnostics": [
@@ -1129,7 +1233,7 @@ exports[`prefer-promise-reject-errors > invalid 42`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 43`] = `
+exports[`prefer-promise-reject-errors > invalid 47`] = `
 {
   "code": "new Promise(((resolve, reject) => reject(5)))",
   "diagnostics": [
@@ -1155,7 +1259,7 @@ exports[`prefer-promise-reject-errors > invalid 43`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 44`] = `
+exports[`prefer-promise-reject-errors > invalid 48`] = `
 {
   "code": "Promise.reject?.(5)",
   "diagnostics": [
@@ -1181,7 +1285,7 @@ exports[`prefer-promise-reject-errors > invalid 44`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 45`] = `
+exports[`prefer-promise-reject-errors > invalid 49`] = `
 {
   "code": "Promise?.reject(5)",
   "diagnostics": [
@@ -1207,7 +1311,7 @@ exports[`prefer-promise-reject-errors > invalid 45`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 46`] = `
+exports[`prefer-promise-reject-errors > invalid 50`] = `
 {
   "code": "Promise?.reject?.(5)",
   "diagnostics": [
@@ -1233,7 +1337,7 @@ exports[`prefer-promise-reject-errors > invalid 46`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 47`] = `
+exports[`prefer-promise-reject-errors > invalid 51`] = `
 {
   "code": "(Promise?.reject)(5)",
   "diagnostics": [
@@ -1259,7 +1363,7 @@ exports[`prefer-promise-reject-errors > invalid 47`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 48`] = `
+exports[`prefer-promise-reject-errors > invalid 52`] = `
 {
   "code": "(Promise?.reject)?.(5)",
   "diagnostics": [
@@ -1285,7 +1389,7 @@ exports[`prefer-promise-reject-errors > invalid 48`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 49`] = `
+exports[`prefer-promise-reject-errors > invalid 53`] = `
 {
   "code": "Promise.reject(foo += new Error())",
   "diagnostics": [
@@ -1311,7 +1415,7 @@ exports[`prefer-promise-reject-errors > invalid 49`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 50`] = `
+exports[`prefer-promise-reject-errors > invalid 54`] = `
 {
   "code": "Promise.reject(foo -= new Error())",
   "diagnostics": [
@@ -1337,7 +1441,7 @@ exports[`prefer-promise-reject-errors > invalid 50`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 51`] = `
+exports[`prefer-promise-reject-errors > invalid 55`] = `
 {
   "code": "Promise.reject(foo **= new Error())",
   "diagnostics": [
@@ -1363,7 +1467,7 @@ exports[`prefer-promise-reject-errors > invalid 51`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 52`] = `
+exports[`prefer-promise-reject-errors > invalid 56`] = `
 {
   "code": "Promise.reject(foo <<= new Error())",
   "diagnostics": [
@@ -1389,7 +1493,7 @@ exports[`prefer-promise-reject-errors > invalid 52`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 53`] = `
+exports[`prefer-promise-reject-errors > invalid 57`] = `
 {
   "code": "Promise.reject(foo |= new Error())",
   "diagnostics": [
@@ -1415,7 +1519,7 @@ exports[`prefer-promise-reject-errors > invalid 53`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 54`] = `
+exports[`prefer-promise-reject-errors > invalid 58`] = `
 {
   "code": "Promise.reject(foo &= new Error())",
   "diagnostics": [
@@ -1441,7 +1545,7 @@ exports[`prefer-promise-reject-errors > invalid 54`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 55`] = `
+exports[`prefer-promise-reject-errors > invalid 59`] = `
 {
   "code": "Promise.reject(foo && 5)",
   "diagnostics": [
@@ -1467,7 +1571,7 @@ exports[`prefer-promise-reject-errors > invalid 55`] = `
 }
 `;
 
-exports[`prefer-promise-reject-errors > invalid 56`] = `
+exports[`prefer-promise-reject-errors > invalid 60`] = `
 {
   "code": "Promise.reject(foo &&= 5)",
   "diagnostics": [

--- a/packages/rslint-test-tools/tests/eslint/rules/no-throw-literal.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-throw-literal.test.ts
@@ -1,0 +1,240 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-throw-literal', {
+  valid: [
+    // ---- ESLint upstream valid cases ----
+    'throw new Error();',
+    "throw new Error('error');",
+    "throw Error('error');",
+    'var e = new Error(); throw e;',
+    'try {throw new Error();} catch (e) {throw e;};',
+    'throw a;', // Identifier
+    'throw foo();', // CallExpression
+    'throw new foo();', // NewExpression
+    'throw foo.bar;', // PropertyAccessExpression
+    'throw foo[bar];', // ElementAccessExpression
+    'class C { #field: any; foo() { throw foo.#field; } }', // private member
+    'throw foo = new Error();', // AssignmentExpression `=`
+    "throw foo.bar ||= 'literal'", // logical-assign `||=`
+    "throw foo[bar] ??= 'literal'", // logical-assign `??=`
+    'throw 1, 2, new Error();', // SequenceExpression
+    "throw 'literal' && new Error();", // LogicalExpression `&&`
+    "throw new Error() || 'literal';", // LogicalExpression `||`
+    "throw foo ? new Error() : 'literal';", // ConditionalExpression
+    "throw foo ? 'literal' : new Error();", // ConditionalExpression
+    'throw tag `${foo}`;', // TaggedTemplateExpression
+    'function* foo() { var index = 0; throw yield index++; }', // YieldExpression
+    'async function foo() { throw await bar; }', // AwaitExpression
+    'throw obj?.foo', // optional chain (PropertyAccess)
+    'throw obj?.foo()', // optional chain (CallExpression)
+
+    // ---- TS / paren wrappers ----
+    'throw (foo);',
+    'throw ((new Error()));',
+    'throw cond ? new Error() : foo();',
+    'throw (1, new Error());',
+    'throw (1, undefined);',
+    'throw foo &&= new Error();',
+    'throw a || b || new Error();',
+    'throw a ?? new Error();',
+    "throw (cond ? new Error() : foo()) || 'literal';",
+    'throw obj?.[key];',
+    'throw (((foo)));',
+    'async function* foo() { throw await (yield 1); }',
+    // OUTER access shape drives classification — `foo!.bar` is a top-level
+    // PropertyAccessExpression so it could be Error.
+    'throw foo!.bar;',
+    'throw (foo as Error).bar;',
+    // ---- JSX coverage lives in Go tests (no_throw_literal_test.go Tsx:true) ----
+  ],
+  invalid: [
+    // ---- ESLint upstream invalid cases ----
+    {
+      code: "throw 'error';",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw 0;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw false;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw null;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw {};',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw undefined;',
+      errors: [{ messageId: 'undef' }],
+    },
+
+    // ---- String concatenation ----
+    {
+      code: "throw 'a' + 'b';",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: "var b = new Error(); throw 'a' + b;",
+      errors: [{ messageId: 'object' }],
+    },
+
+    // ---- AssignmentExpression ----
+    {
+      code: "throw foo = 'error';",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw foo += new Error();',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw foo &= new Error();',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: "throw foo &&= 'literal'",
+      errors: [{ messageId: 'object' }],
+    },
+
+    // ---- SequenceExpression ----
+    {
+      code: 'throw new Error(), 1, 2, 3;',
+      errors: [{ messageId: 'object' }],
+    },
+
+    // ---- LogicalExpression ----
+    {
+      code: "throw 'literal' && 'not an Error';",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: "throw foo && 'literal'",
+      errors: [{ messageId: 'object' }],
+    },
+
+    // ---- ConditionalExpression ----
+    {
+      code: "throw foo ? 'not an Error' : 'literal';",
+      errors: [{ messageId: 'object' }],
+    },
+
+    // ---- TemplateLiteral ----
+    {
+      code: 'throw `${err}`;',
+      errors: [{ messageId: 'object' }],
+    },
+
+    // ---- Extra TS edge cases ----
+    {
+      code: "throw ('error');",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw (undefined);',
+      errors: [{ messageId: 'undef' }],
+    },
+    {
+      code: "throw (foo(), 'error');",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: "throw cond ? 'a' : 'b';",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw 1n;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw /foo/;',
+      errors: [{ messageId: 'object' }],
+    },
+    // `void 0` is a UnaryExpression, not Identifier `undefined` → "object".
+    {
+      code: 'throw void 0;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw class {};',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw function() {};',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw () => {};',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw [];',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'class C { foo() { throw this; } }',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'function foo() { throw new.target; }',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: "throw a && b && 'literal';",
+      errors: [{ messageId: 'object' }],
+    },
+    // ---- TS assertion wrappers — NOT transparent in upstream ESLint ----
+    {
+      code: 'throw foo as Error;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw foo!;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw foo satisfies unknown;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw <Error>foo;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw obj?.foo!;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: "throw 'foo' as Error;",
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw (5 as any);',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw (((undefined)));',
+      errors: [{ messageId: 'undef' }],
+    },
+    {
+      code: 'throw undefined as any;',
+      errors: [{ messageId: 'object' }],
+    },
+    {
+      code: 'throw undefined!;',
+      errors: [{ messageId: 'object' }],
+    },
+    // Multi-line throw expression — diagnostic range must span both lines.
+    {
+      code: "throw 'a' +\n  'b';",
+      errors: [{ messageId: 'object' }],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-promise-reject-errors.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-promise-reject-errors.test.ts
@@ -65,6 +65,21 @@ ruleTester.run('prefer-promise-reject-errors', {
     // ---- Reject method-like access (.call / .bind / .apply) is treated
     // as a different operation by ESLint and is not flagged.
     'new Promise((resolve, reject) => reject.call(null, new Error()))',
+
+    // ---- TS assertion wrappers around the Promise constructor / executor /
+    // reject call are NOT recognized as the Promise constructor pattern by
+    // upstream ESLint (verified empirically against ESLint + @typescript-eslint/parser).
+    'new (Promise as any)((resolve, reject) => reject(5))',
+    'new (Promise!)((resolve, reject) => reject(5))',
+    'new (<any>Promise)((resolve, reject) => reject(5))',
+    'new Promise(((resolve: any, reject: any) => reject(5)) as any)',
+    'new Promise(((resolve: any, reject: any) => reject(5))!)',
+    'new Promise((resolve, reject) => (reject as any)(5))',
+    'new Promise((resolve, reject) => reject!(5))',
+    '(Promise as any).reject(5)',
+    // Parens-only controls — still analyzed.
+    'new Promise(((resolve, reject) => reject(new Error())))',
+    'new Promise((resolve, reject) => (reject)(new Error()))',
   ],
   invalid: [
     // ---- TS assertion wrappers — NOT transparent in upstream ESLint ----

--- a/packages/rslint-test-tools/tests/eslint/rules/prefer-promise-reject-errors.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/prefer-promise-reject-errors.test.ts
@@ -43,12 +43,6 @@ ruleTester.run('prefer-promise-reject-errors', {
     'class C { #reject; foo() { Promise.#reject(5); } }',
     'class C { #error; foo() { Promise.reject(this.#error); } }',
 
-    // ---- TypeScript-only syntax should be transparent to couldBeError ----
-    'Promise.reject(foo as Error)',
-    'Promise.reject(<Error>foo)',
-    'Promise.reject(foo!)',
-    'Promise.reject(foo satisfies Error)',
-
     // ---- ESLint requires params[1].type === "Identifier"; non-plain
     // second-parameter shapes are not analyzed.
     'new Promise((resolve, reject = foo) => reject(5))',
@@ -73,6 +67,23 @@ ruleTester.run('prefer-promise-reject-errors', {
     'new Promise((resolve, reject) => reject.call(null, new Error()))',
   ],
   invalid: [
+    // ---- TS assertion wrappers — NOT transparent in upstream ESLint ----
+    {
+      code: 'Promise.reject(foo as Error)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(<Error>foo)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo!)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
+    {
+      code: 'Promise.reject(foo satisfies Error)',
+      errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],
+    },
     {
       code: 'Promise.reject(5)',
       errors: [{ messageId: 'rejectAnError', line: 1, column: 1 }],


### PR DESCRIPTION
## Summary

Port the [`no-throw-literal`](https://eslint.org/docs/latest/rules/no-throw-literal) rule from ESLint to rslint.

The rule disallows throwing values that cannot be `Error` objects (literals, plain objects, `undefined`, etc.). Implementation is a 1:1 port of ESLint's `astUtils.couldBeError`, adapted to the tsgo AST where `AssignmentExpression` / `LogicalExpression` / `SequenceExpression` collapse into `BinaryExpression` and `ChainExpression` has no analog (optional chains are flag-based).

This PR also extracts `couldBeError` / `isUndefinedIdentifier` from the existing `prefer-promise-reject-errors` rule into `internal/utils/ast_helpers.go` (`utils.CouldBeError` / `utils.IsUndefinedIdentifier`), so both core rules share one implementation.

### Real-world validation

Ran the built binary against two real codebases to confirm zero noise:

| Repo | Files | no-throw-literal hits |
|---|---|---|
| `web-infra-dev/rsbuild` | 1197 | 0 |
| `web-infra-dev/rspack` | 392 | 1 (a genuine `throw \`...\`` in `rspack-test-tools/src/test/creator.ts`, exact same diagnostic as ESLint upstream) |

### Upstream-alignment fix bundled in second commit

While extracting the helper I noticed `prefer-promise-reject-errors` also had three internal call sites that incorrectly unwrapped TS assertion wrappers (`as` / `!` / `satisfies` / `<T>x`) when identifying the Promise constructor / executor / `reject` call. Empirically verified against ESLint core run on a `.ts` file via `@typescript-eslint/parser`:

- `new (Promise as any)(...)` is **not** recognized as a Promise constructor by upstream
- `new Promise(((..., reject) => reject(5)) as any)` — assertion-wrapped executor not analyzed
- `(reject as any)(5)` / `reject!(5)` inside an executor not flagged

Second commit (`fix(prefer-promise-reject-errors): align TS assertion handling with upstream`) replaces the local `skipTransparent` (parens + assertions) with `ast.SkipParentheses` (parens only) at all three call sites, plus 11 Go tests + JS mirrors locking in the new behavior.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-throw-literal
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-throw-literal.js
- Test file: https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-throw-literal.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).