### PR TITLE
feat: port rule no-loop-func

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,6 +164,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_label_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
 	"github.com/web-infra-dev/rslint/internal/rules/no_lone_blocks"
+	"github.com/web-infra-dev/rslint/internal/rules/no_loop_func"
 	"github.com/web-infra-dev/rslint/internal/rules/no_loss_of_precision"
 	"github.com/web-infra-dev/rslint/internal/rules/no_misleading_character_class"
 	"github.com/web-infra-dev/rslint/internal/rules/no_multi_str"
@@ -609,6 +610,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-lone-blocks", no_lone_blocks.NoLoneBlocksRule)
+	GlobalRuleRegistry.Register("no-loop-func", no_loop_func.NoLoopFuncRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)
 	GlobalRuleRegistry.Register("no-misleading-character-class", no_misleading_character_class.NoMisleadingCharacterClassRule)
 	GlobalRuleRegistry.Register("no-new", no_new.NoNewRule)

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -1,0 +1,586 @@
+package no_loop_func
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+func buildUnsafeRefsMessage(varNames string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "unsafeRefs",
+		Description: fmt.Sprintf("Function declared in a loop contains unsafe references to variable(s) %s.", varNames),
+	}
+}
+
+type runState struct {
+	ctx          rule.RuleContext
+	skippedIIFEs map[*ast.Node]bool
+}
+
+// getContainingLoopNode walks up from `node` and returns the nearest enclosing
+// loop statement. Returns nil if no loop is encountered before a non-skipped
+// function-like ancestor is reached.
+func (s *runState) getContainingLoopNode(node *ast.Node) *ast.Node {
+	for current := node; current.Parent != nil; current = current.Parent {
+		parent := current.Parent
+		switch parent.Kind {
+		case ast.KindWhileStatement, ast.KindDoStatement:
+			return parent
+		case ast.KindForStatement:
+			forStmt := parent.AsForStatement()
+			if forStmt != nil && forStmt.Initializer != current {
+				return parent
+			}
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			stmt := parent.AsForInOrOfStatement()
+			if stmt != nil && stmt.Expression != current {
+				return parent
+			}
+		case ast.KindArrowFunction, ast.KindFunctionExpression, ast.KindFunctionDeclaration,
+			ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor,
+			ast.KindConstructor:
+			// NOTE: ClassStaticBlockDeclaration is intentionally NOT a boundary —
+			// ESLint walks through static blocks to the outer loop, because a
+			// static block runs once per class instantiation and each iteration
+			// creates a new class, so functions defined inside a static block
+			// inside a loop still exhibit the "closure per iteration" problem.
+			if s.skippedIIFEs[parent] {
+				continue
+			}
+			return nil
+		}
+	}
+	return nil
+}
+
+// getTopLoopNode walks up through containing loops until it finds the outermost
+// loop whose start is not before `excludedNode`'s end. If `excludedNode` is nil,
+// walks to the outermost loop.
+func (s *runState) getTopLoopNode(node *ast.Node, excludedNode *ast.Node) *ast.Node {
+	border := 0
+	if excludedNode != nil {
+		border = utils.TrimNodeTextRange(s.ctx.SourceFile, excludedNode).End()
+	}
+	outermost := node
+	containing := node
+	for containing != nil {
+		pos := utils.TrimNodeTextRange(s.ctx.SourceFile, containing).Pos()
+		if pos < border {
+			break
+		}
+		outermost = containing
+		containing = s.getContainingLoopNode(containing)
+	}
+	return outermost
+}
+
+// isIIFE reports whether `node` is a function directly invoked as the callee
+// of a call expression (e.g. `(function () {})()`). The function may be
+// wrapped in one or more parenthesized expressions.
+func isIIFE(node *ast.Node) bool {
+	if node.Kind != ast.KindFunctionExpression && node.Kind != ast.KindArrowFunction {
+		return false
+	}
+	outer := ast.WalkUpParenthesizedExpressions(node.Parent)
+	if outer == nil || outer.Kind != ast.KindCallExpression {
+		return false
+	}
+	// WalkUpParenthesizedExpressions ascends to the first non-paren ancestor,
+	// so `outer` is the CallExpression. The function is the callee iff the
+	// CallExpression's Expression resolves back to `node` (possibly through
+	// ParenthesizedExpression wrappers).
+	call := outer.AsCallExpression()
+	if call == nil {
+		return false
+	}
+	return ast.SkipParentheses(call.Expression) == node
+}
+
+// isAsyncOrGenerator reports whether a function-like node is declared `async`
+// or a generator (`function*` / `*m()`).
+func isAsyncOrGenerator(node *ast.Node) bool {
+	if ast.HasSyntacticModifier(node, ast.ModifierFlagsAsync) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindFunctionExpression:
+		if fn := node.AsFunctionExpression(); fn != nil && fn.AsteriskToken != nil {
+			return true
+		}
+	case ast.KindFunctionDeclaration:
+		if fn := node.AsFunctionDeclaration(); fn != nil && fn.AsteriskToken != nil {
+			return true
+		}
+	case ast.KindMethodDeclaration:
+		if m := node.AsMethodDeclaration(); m != nil && m.AsteriskToken != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// getFunctionBodyRoots returns the subtrees of a function-like node to scan
+// for identifier references — parameters and body. Excludes the function's
+// own name node so self-references inside the body are picked up normally.
+func getFunctionBodyRoots(node *ast.Node) []*ast.Node {
+	var roots []*ast.Node
+	for _, param := range node.Parameters() {
+		if param != nil {
+			roots = append(roots, param)
+		}
+	}
+	if body := node.Body(); body != nil {
+		roots = append(roots, body)
+	}
+	return roots
+}
+
+// referenceEntry captures a single identifier occurrence and its resolved
+// variable symbol, preserved in source order for first-seen deduplication.
+type referenceEntry struct {
+	name   string
+	node   *ast.Node
+	symbol *ast.Symbol
+}
+
+// collectThroughReferences walks the function-like node's parameters and body
+// and returns all identifier references whose resolved symbol has at least one
+// declaration outside the function subtree. The function's own name node is
+// excluded from the walk (it's the declaration, not a reference).
+func (s *runState) collectThroughReferences(funcNode *ast.Node) []referenceEntry {
+	var refs []referenceEntry
+	nameNode := funcNode.Name()
+
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		// Skip the function's own name node.
+		if n == nameNode {
+			return
+		}
+		// Skip type annotation subtrees entirely.
+		if ast.IsPartOfTypeNode(n) {
+			return
+		}
+		// Skip type-only children (type parameters, interface bodies, etc.).
+		switch n.Kind {
+		case ast.KindTypeAliasDeclaration, ast.KindInterfaceDeclaration,
+			ast.KindTypeParameter, ast.KindTypeReference:
+			return
+		}
+
+		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
+			sym := s.ctx.TypeChecker.GetSymbolAtLocation(n)
+			if sym != nil && (sym.Flags&ast.SymbolFlagsValue) != 0 {
+				if !isSymbolDeclaredInside(sym, funcNode) {
+					refs = append(refs, referenceEntry{
+						name:   n.Text(),
+						node:   n,
+						symbol: sym,
+					})
+				}
+			}
+		}
+
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+
+	for _, root := range getFunctionBodyRoots(funcNode) {
+		walk(root)
+	}
+	return refs
+}
+
+// isValueReferencePosition reports whether an Identifier node is used as a
+// value reference (readable or writable), as opposed to a property name,
+// object literal key, or member access right-hand side.
+func isValueReferencePosition(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return true
+	}
+	switch parent.Kind {
+	case ast.KindPropertyAccessExpression:
+		// foo.bar — `bar` is a property name, not a variable.
+		pa := parent.AsPropertyAccessExpression()
+		if pa != nil && pa.Name() == node {
+			return false
+		}
+	case ast.KindQualifiedName:
+		qn := parent.AsQualifiedName()
+		if qn != nil && qn.Right == node {
+			return false
+		}
+	case ast.KindMetaProperty:
+		return false
+	case ast.KindPropertyAssignment:
+		// { key: value } — the `key` side is a property name.
+		pa := parent.AsPropertyAssignment()
+		if pa != nil && pa.Name() == node {
+			return false
+		}
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor,
+		ast.KindPropertyDeclaration, ast.KindPropertySignature,
+		ast.KindMethodSignature, ast.KindEnumMember:
+		// Member/enum key position.
+		if parent.Name() == node {
+			return false
+		}
+	case ast.KindImportSpecifier:
+		is := parent.AsImportSpecifier()
+		if is != nil && is.PropertyName == node {
+			return false
+		}
+	case ast.KindExportSpecifier:
+		es := parent.AsExportSpecifier()
+		if es != nil && es.PropertyName == node {
+			return false
+		}
+	case ast.KindLabeledStatement:
+		if parent.Name() == node {
+			return false
+		}
+	case ast.KindBreakStatement, ast.KindContinueStatement:
+		// break/continue label — not a variable.
+		return false
+	}
+	return true
+}
+
+// isSymbolDeclaredInside reports whether any declaration of `sym` resolves to
+// a parameter or body binding of `funcNode`. The function's own name node is
+// intentionally NOT treated as "inside": ESLint models a named function
+// expression's name in an outer name scope, so self-references like
+// `function f() { f }` leak through the function's scope. The TypeChecker
+// records the "name binding" either as the name identifier or the function
+// node itself, depending on the declaration kind, so both are excluded.
+func isSymbolDeclaredInside(sym *ast.Symbol, funcNode *ast.Node) bool {
+	if sym == nil {
+		return false
+	}
+	nameNode := funcNode.Name()
+	for _, decl := range sym.Declarations {
+		if decl == funcNode || (nameNode != nil && decl == nameNode) {
+			continue
+		}
+		for n := decl; n != nil; n = n.Parent {
+			if n == funcNode {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getVarDeclListKind returns the kind of a VariableDeclarationList: one of
+// "const", "let", "var", "using", "await using", or "" for anything else.
+func getVarDeclListKind(declList *ast.Node) string {
+	if declList == nil || declList.Kind != ast.KindVariableDeclarationList {
+		return ""
+	}
+	flags := declList.Flags
+	switch {
+	case flags&ast.NodeFlagsAwaitUsing != 0:
+		return "await using"
+	case flags&ast.NodeFlagsUsing != 0:
+		return "using"
+	case flags&ast.NodeFlagsConst != 0:
+		return "const"
+	case flags&ast.NodeFlagsLet != 0:
+		return "let"
+	default:
+		return "var"
+	}
+}
+
+// enclosingVarDeclOfBindingElement walks up through nested BindingElement /
+// BindingPattern layers to the containing VariableDeclaration, or returns nil
+// if the binding does not ultimately belong to a VariableDeclaration.
+func enclosingVarDeclOfBindingElement(bindingElement *ast.Node) *ast.Node {
+	if bindingElement == nil || bindingElement.Kind != ast.KindBindingElement {
+		return nil
+	}
+	parent := ast.WalkUpBindingElementsAndPatterns(bindingElement)
+	if parent == nil || parent.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	return parent
+}
+
+// isWriteRef reports whether an identifier participates in a write to its
+// variable. Extends utils.IsWriteReference with the cases ESLint's scope
+// manager marks as writes but we don't otherwise detect: the binding names of
+// `var/let/const` declarations with initializers, and the bindings introduced
+// by `for (var/let/const ... in/of ...)` iteration.
+func isWriteRef(node *ast.Node) bool {
+	if utils.IsWriteReference(node) {
+		return true
+	}
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	parent := node.Parent
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		varDecl := parent.AsVariableDeclaration()
+		if varDecl == nil || varDecl.Name() != node {
+			return false
+		}
+		if varDecl.Initializer != nil {
+			return true
+		}
+		return isVarDeclInForInOrOf(parent)
+	case ast.KindBindingElement:
+		be := parent.AsBindingElement()
+		if be == nil || be.Name() != node {
+			return false
+		}
+		varDecl := enclosingVarDeclOfBindingElement(parent)
+		if varDecl == nil {
+			return false
+		}
+		vd := varDecl.AsVariableDeclaration()
+		if vd == nil {
+			return false
+		}
+		if vd.Initializer != nil {
+			return true
+		}
+		return isVarDeclInForInOrOf(varDecl)
+	}
+	return false
+}
+
+// isVarDeclInForInOrOf reports whether a VariableDeclaration sits directly
+// inside a for-in/for-of initializer.
+func isVarDeclInForInOrOf(varDecl *ast.Node) bool {
+	if varDecl == nil || varDecl.Parent == nil {
+		return false
+	}
+	declList := varDecl.Parent
+	if declList.Kind != ast.KindVariableDeclarationList || declList.Parent == nil {
+		return false
+	}
+	outer := declList.Parent
+	return outer.Kind == ast.KindForInStatement || outer.Kind == ast.KindForOfStatement
+}
+
+// isSafe reports whether a through-reference `ref` to a symbol `sym` is safe
+// with respect to a loop node `loopNode`. Safe means: no write to `sym` can
+// modify the function's closed-over view of it during successive iterations.
+func (s *runState) isSafe(loopNode *ast.Node, ref referenceEntry) bool {
+	sym := ref.symbol
+	if sym == nil || len(sym.Declarations) == 0 {
+		return true
+	}
+	decl := sym.Declarations[0]
+
+	// Look up the enclosing VariableDeclarationList (for var/let/const/using).
+	declList := getDeclListForSymbolDecl(decl)
+	kind := getVarDeclListKind(declList)
+
+	// Constant bindings never get rewritten, so they're safe.
+	if kind == "const" || kind == "using" || kind == "await using" {
+		return true
+	}
+
+	sf := s.ctx.SourceFile
+	loopRange := utils.TrimNodeTextRange(sf, loopNode)
+
+	// `let` declared inside the loop gets a fresh binding per iteration.
+	if kind == "let" && declList != nil {
+		declRange := utils.TrimNodeTextRange(sf, declList)
+		if declRange.Pos() > loopRange.Pos() && declRange.End() < loopRange.End() {
+			return true
+		}
+	}
+
+	var excluded *ast.Node
+	if kind == "let" {
+		excluded = declList
+	}
+	top := s.getTopLoopNode(loopNode, excluded)
+	border := utils.TrimNodeTextRange(sf, top).Pos()
+
+	// The variable's "variable scope" — the nearest function-like scope of its
+	// declaration. Used to tell whether a write happens in the same function
+	// or inside a nested function.
+	varScope := utils.FindEnclosingScope(decl)
+
+	safe := true
+	s.forEachReference(sym, func(refNode *ast.Node) bool {
+		if !isWriteRef(refNode) {
+			return false
+		}
+		refScope := utils.FindEnclosingScope(refNode)
+		if refScope == varScope {
+			refPos := utils.TrimNodeTextRange(sf, refNode).Pos()
+			if refPos < border {
+				return false
+			}
+		}
+		safe = false
+		return true
+	})
+	return safe
+}
+
+// getDeclListForSymbolDecl returns the VariableDeclarationList associated with
+// a declaration node, or nil if the declaration is not a variable-like binding.
+func getDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
+	if decl == nil {
+		return nil
+	}
+	current := decl
+	for current != nil {
+		if current.Kind == ast.KindVariableDeclarationList {
+			return current
+		}
+		if current.Kind == ast.KindVariableDeclaration ||
+			current.Kind == ast.KindBindingElement ||
+			current.Kind == ast.KindObjectBindingPattern ||
+			current.Kind == ast.KindArrayBindingPattern {
+			current = current.Parent
+			continue
+		}
+		return nil
+	}
+	return nil
+}
+
+// forEachReference walks the source file and invokes `cb` for every identifier
+// node whose resolved symbol is `sym`. Walk stops early when `cb` returns true.
+// Shorthand property assignments inside destructuring patterns
+// (e.g. `({a} = obj)`) need special handling: the TypeChecker resolves the
+// key identifier to the property symbol, not the written-to variable symbol.
+func (s *runState) forEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
+	tc := s.ctx.TypeChecker
+	var walk func(n *ast.Node) bool
+	walk = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
+			if tc.GetSymbolAtLocation(n) == sym {
+				if cb(n) {
+					return true
+				}
+			}
+		} else if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
+			if tc.GetShorthandAssignmentValueSymbol(n) == sym {
+				nameNode := n.AsShorthandPropertyAssignment().Name()
+				if nameNode != nil && cb(nameNode) {
+					return true
+				}
+			}
+		}
+		stop := false
+		n.ForEachChild(func(child *ast.Node) bool {
+			if walk(child) {
+				stop = true
+				return true
+			}
+			return false
+		})
+		return stop
+	}
+	walk(s.ctx.SourceFile.AsNode())
+}
+
+// checkForLoops processes a function-like node: if it is inside a loop and
+// has unsafe through-references, it is reported.
+func (s *runState) checkForLoops(node *ast.Node) {
+	loopNode := s.getContainingLoopNode(node)
+	if loopNode == nil {
+		return
+	}
+
+	refs := s.collectThroughReferences(node)
+
+	// IIFE handling — matches ESLint: non-async, non-generator IIFEs that are
+	// not self-referenced (either anonymous or whose name isn't used inside the
+	// function body) are skipped. Skipping marks them so nested functions can
+	// walk through them to find the enclosing loop.
+	if !isAsyncOrGenerator(node) && isIIFE(node) {
+		isFunctionExpression := node.Kind == ast.KindFunctionExpression
+		name := node.Name()
+		isFunctionReferenced := false
+		if isFunctionExpression && name != nil {
+			refName := name.Text()
+			for _, r := range refs {
+				if r.name == refName {
+					isFunctionReferenced = true
+					break
+				}
+			}
+		}
+		if !isFunctionReferenced {
+			s.skippedIIFEs[node] = true
+			return
+		}
+	}
+
+	seen := map[string]bool{}
+	var names []string
+	for _, r := range refs {
+		if r.symbol == nil {
+			continue
+		}
+		if seen[r.name] {
+			continue
+		}
+		if s.isSafe(loopNode, r) {
+			continue
+		}
+		seen[r.name] = true
+		names = append(names, r.name)
+	}
+
+	if len(names) == 0 {
+		return
+	}
+
+	varNames := "'" + strings.Join(names, "', '") + "'"
+	s.ctx.ReportNode(node, buildUnsafeRefsMessage(varNames))
+}
+
+// NoLoopFuncRule disallows function declarations that contain unsafe
+// references to variable(s) inside loop statements.
+var NoLoopFuncRule = rule.Rule{
+	Name: "no-loop-func",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+		s := &runState{
+			ctx:          ctx,
+			skippedIIFEs: map[*ast.Node]bool{},
+		}
+		check := func(node *ast.Node) {
+			s.checkForLoops(node)
+		}
+		return rule.RuleListeners{
+			ast.KindArrowFunction:       check,
+			ast.KindFunctionExpression:  check,
+			ast.KindFunctionDeclaration: check,
+			// NOTE: ESLint's ESTree represents class/object methods, getters,
+			// setters, and constructors as a FunctionExpression value under the
+			// property/method node — so its FunctionExpression listener catches
+			// them. In tsgo these are distinct kinds; listen explicitly so we
+			// match ESLint's behavior.
+			ast.KindMethodDeclaration: check,
+			ast.KindGetAccessor:       check,
+			ast.KindSetAccessor:       check,
+			ast.KindConstructor:       check,
+		}
+	},
+}

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -19,6 +19,12 @@ func buildUnsafeRefsMessage(varNames string) rule.RuleMessage {
 type runState struct {
 	ctx          rule.RuleContext
 	skippedIIFEs map[*ast.Node]bool
+	// refIndex buckets every value-position identifier (and destructuring
+	// shorthand write target) in the source file by resolved symbol. Populated
+	// lazily on the first forEachReference call and reused for all subsequent
+	// lookups — amortizes what would otherwise be a full-file walk per symbol
+	// into a single pass per rule invocation.
+	refIndex map[*ast.Symbol][]*ast.Node
 }
 
 // getContainingLoopNode walks up from `node` and returns the nearest enclosing
@@ -457,43 +463,51 @@ func getDeclListForSymbolDecl(decl *ast.Node) *ast.Node {
 	return nil
 }
 
-// forEachReference walks the source file and invokes `cb` for every identifier
-// node whose resolved symbol is `sym`. Walk stops early when `cb` returns true.
-// Shorthand property assignments inside destructuring patterns
-// (e.g. `({a} = obj)`) need special handling: the TypeChecker resolves the
-// key identifier to the property symbol, not the written-to variable symbol.
-func (s *runState) forEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
+// buildRefIndex performs a single pass over the source file and groups every
+// value-position identifier by its resolved symbol. ShorthandPropertyAssignment
+// inside destructuring needs special handling because TypeChecker resolves the
+// shorthand key to the property symbol, not the written-to variable symbol —
+// we store the name identifier keyed by the variable symbol instead.
+func (s *runState) buildRefIndex() {
+	if s.refIndex != nil {
+		return
+	}
+	s.refIndex = map[*ast.Symbol][]*ast.Node{}
 	tc := s.ctx.TypeChecker
-	var walk func(n *ast.Node) bool
-	walk = func(n *ast.Node) bool {
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
 		if n == nil {
-			return false
+			return
 		}
 		if n.Kind == ast.KindIdentifier && isValueReferencePosition(n) {
-			if tc.GetSymbolAtLocation(n) == sym {
-				if cb(n) {
-					return true
-				}
+			if sym := tc.GetSymbolAtLocation(n); sym != nil {
+				s.refIndex[sym] = append(s.refIndex[sym], n)
 			}
 		} else if n.Kind == ast.KindShorthandPropertyAssignment && utils.IsInDestructuringAssignment(n) {
-			if tc.GetShorthandAssignmentValueSymbol(n) == sym {
-				nameNode := n.AsShorthandPropertyAssignment().Name()
-				if nameNode != nil && cb(nameNode) {
-					return true
+			if sym := tc.GetShorthandAssignmentValueSymbol(n); sym != nil {
+				if nameNode := n.AsShorthandPropertyAssignment().Name(); nameNode != nil {
+					s.refIndex[sym] = append(s.refIndex[sym], nameNode)
 				}
 			}
 		}
-		stop := false
 		n.ForEachChild(func(child *ast.Node) bool {
-			if walk(child) {
-				stop = true
-				return true
-			}
+			walk(child)
 			return false
 		})
-		return stop
 	}
 	walk(s.ctx.SourceFile.AsNode())
+}
+
+// forEachReference invokes `cb` for every identifier node resolving to `sym`,
+// in source order. Returns early when `cb` returns true. The underlying index
+// is built on first use via buildRefIndex so subsequent calls are O(refs).
+func (s *runState) forEachReference(sym *ast.Symbol, cb func(*ast.Node) bool) {
+	s.buildRefIndex()
+	for _, node := range s.refIndex[sym] {
+		if cb(node) {
+			return
+		}
+	}
 }
 
 // checkForLoops processes a function-like node: if it is inside a loop and

--- a/internal/rules/no_loop_func/no_loop_func.go
+++ b/internal/rules/no_loop_func/no_loop_func.go
@@ -325,8 +325,9 @@ func enclosingVarDeclOfBindingElement(bindingElement *ast.Node) *ast.Node {
 // isWriteRef reports whether an identifier participates in a write to its
 // variable. Extends utils.IsWriteReference with the cases ESLint's scope
 // manager marks as writes but we don't otherwise detect: the binding names of
-// `var/let/const` declarations with initializers, and the bindings introduced
-// by `for (var/let/const ... in/of ...)` iteration.
+// `var/let/const` declarations with initializers, the bindings introduced
+// by `for (var/let/const ... in/of ...)` iteration, and catch-clause
+// parameters (bound anew per thrown exception).
 func isWriteRef(node *ast.Node) bool {
 	if utils.IsWriteReference(node) {
 		return true
@@ -341,10 +342,7 @@ func isWriteRef(node *ast.Node) bool {
 		if varDecl == nil || varDecl.Name() != node {
 			return false
 		}
-		if varDecl.Initializer != nil {
-			return true
-		}
-		return isVarDeclInForInOrOf(parent)
+		return varDeclIntroducesWrite(parent)
 	case ast.KindBindingElement:
 		be := parent.AsBindingElement()
 		if be == nil || be.Name() != node {
@@ -354,16 +352,27 @@ func isWriteRef(node *ast.Node) bool {
 		if varDecl == nil {
 			return false
 		}
-		vd := varDecl.AsVariableDeclaration()
-		if vd == nil {
-			return false
-		}
-		if vd.Initializer != nil {
-			return true
-		}
-		return isVarDeclInForInOrOf(varDecl)
+		return varDeclIntroducesWrite(varDecl)
 	}
 	return false
+}
+
+// varDeclIntroducesWrite reports whether a VariableDeclaration's binding is
+// written at its introduction: it has an initializer, is the target of a
+// for-in/for-of iteration, or is a catch-clause parameter.
+func varDeclIntroducesWrite(varDecl *ast.Node) bool {
+	vd := varDecl.AsVariableDeclaration()
+	if vd == nil {
+		return false
+	}
+	if vd.Initializer != nil {
+		return true
+	}
+	if isVarDeclInForInOrOf(varDecl) {
+		return true
+	}
+	// `catch (e) {...}` binds `e` per thrown exception.
+	return varDecl.Parent != nil && varDecl.Parent.Kind == ast.KindCatchClause
 }
 
 // isVarDeclInForInOrOf reports whether a VariableDeclaration sits directly

--- a/internal/rules/no_loop_func/no_loop_func.md
+++ b/internal/rules/no_loop_func/no_loop_func.md
@@ -1,0 +1,73 @@
+# no-loop-func
+
+Disallow function declarations that contain unsafe references inside loop statements.
+
+## Rule Details
+
+Writing functions within loops tends to result in errors due to the way the function creates a closure around the loop. For example:
+
+```javascript
+for (var i = 10; i; i--) {
+    (function() { return i; })();
+}
+```
+
+Generally speaking, it is safer to keep the closure code outside of the loop, or to use `let` / `const` for loop variables so each iteration produces a fresh binding.
+
+This rule disallows any function within a loop that contains unsafe references (e.g. to modified variables).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+for (var i = 0; i < 10; i++) {
+    funcs[i] = function() { return i; };
+}
+
+for (var i = 0; i < 10; i++) {
+    funcs[i] = () => i;
+}
+
+for (var i = 0; i < 10; i++) {
+    funcs[i] = function() { return i; };
+    funcs[i]();
+}
+
+var foo = 100;
+for (var i = 0; i < 10; i++) {
+    funcs[i] = function() { return foo; };
+    foo += 1;
+}
+
+var foo = 100;
+check(function() { return foo; });
+foo = 200;
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = function() {};
+
+for (var i = 0; i < 10; i++) {
+    funcs[i] = a;
+}
+
+for (let i = 0; i < 10; i++) {
+    funcs[i] = function() { return i; };
+}
+
+const foo = 100;
+for (var i = 0; i < 10; i++) {
+    funcs[i] = function() { return foo; };
+}
+
+// IIFEs are fine because they execute immediately.
+for (var i = 0; i < 10; i++) {
+    funcs[i] = (function() { return i; })();
+}
+```
+
+## Original Documentation
+
+- [ESLint rule](https://eslint.org/docs/latest/rules/no-loop-func)
+- [Source code](https://github.com/eslint/eslint/blob/main/lib/rules/no-loop-func.js)

--- a/internal/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/rules/no_loop_func/no_loop_func_test.go
@@ -1,0 +1,909 @@
+package no_loop_func
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoLoopFuncRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoLoopFuncRule,
+		[]rule_tester.ValidTestCase{
+			// Not inside a loop.
+			{Code: `string = 'function a() {}';`},
+			{Code: `for (var i=0; i<l; i++) { } var a = function() { i; };`},
+
+			// Function declared in for-init — not considered "inside the loop".
+			{Code: `for (var i=0, a=function() { i; }; i<l; i++) { }`},
+
+			// Function declared in the for-in/for-of iterable — not "inside the loop".
+			{Code: `for (var x in xs.filter(function(x) { return x != upper; })) { }`},
+			{Code: `for (var x of xs.filter(function(x) { return x != upper; })) { }`},
+
+			// No reference to loop-modified variables.
+			{Code: `for (var i=0; i<l; i++) { (function() {}) }`},
+			{Code: `for (var i in {}) { (function() {}) }`},
+			{Code: `for (var i of {}) { (function() {}) }`},
+
+			// Functions closing over unmodified `let` / `const` / `using` are OK.
+			{Code: `for (let i=0; i<l; i++) { (function() { i; }) }`},
+			{Code: `for (let i in {}) { i = 7; (function() { i; }) }`},
+			{Code: `for (const i of {}) { (function() { i; }) }`},
+			{Code: `for (using i of foo) { (function() { i; }) }`},
+			{Code: `for (await using i of foo) { (function() { i; }) }`},
+			{Code: `for (var i = 0; i < 10; ++i) { using foo = bar(i); (function() { foo; }) }`},
+			{Code: `for (var i = 0; i < 10; ++i) { await using foo = bar(i); (function() { foo; }) }`},
+
+			// Functions that never reference the enclosing loop variable.
+			{Code: `for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }`},
+			{Code: `let a = 0; for (let i=0; i<l; i++) { (function() { a; }); }`},
+			{Code: `let a = 0; for (let i in {}) { (function() { a; }); }`},
+			{Code: `let a = 0; for (let i of {}) { (function() { a; }); }`},
+			{Code: `let a = 0; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); }`},
+			{Code: `let a = 0; for (let i in {}) { function foo() { (function() { a; }); } }`},
+			{Code: `let a = 0; for (let i of {}) { (() => { (function() { a; }); }); }`},
+			{Code: `var a = 0; for (let i=0; i<l; i++) { (function() { a; }); }`},
+			{Code: `var a = 0; for (let i in {}) { (function() { a; }); }`},
+			{Code: `var a = 0; for (let i of {}) { (function() { a; }); }`},
+
+			// Closure over outer const — safe.
+			{Code: `
+let result = {};
+for (const score in scores) {
+  const letters = scores[score];
+  letters.split('').forEach(letter => {
+    result[letter] = score;
+  });
+}
+result.__default = 6;`},
+
+			// Variable declared after the loop — no modification visible.
+			{Code: `
+while (true) {
+    (function() { a; });
+}
+let a;`},
+
+			// Undeclared variables in the loop condition are picked up by no-undef.
+			{Code: `while(i) { (function() { i; }) }`},
+			{Code: `do { (function() { i; }) } while (i)`},
+
+			// Variables declared outside the loop and not updated in or after it.
+			{Code: `var i; while(i) { (function() { i; }) }`},
+			{Code: `var i; do { (function() { i; }) } while (i)`},
+
+			// Undeclared references — handled by no-undef, not here.
+			{Code: `for (var i=0; i<l; i++) { (function() { undeclared; }) }`},
+			{Code: `for (let i=0; i<l; i++) { (function() { undeclared; }) }`},
+			{Code: `for (var i in {}) { i = 7; (function() { undeclared; }) }`},
+			{Code: `for (let i in {}) { i = 7; (function() { undeclared; }) }`},
+			{Code: `for (const i of {}) { (function() { undeclared; }) }`},
+			{Code: `for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != undeclared)) {  } }`},
+
+			// IIFE — immediately invoked, not saved off, so closure semantics don't matter.
+			{Code: `
+let current = getStart();
+while (current) {
+(() => {
+    current;
+    current.a;
+    current.b;
+    current.c;
+    current.d;
+})();
+
+current = current.upper;
+}`},
+			{Code: `for (var i=0; (function() { i; })(), i<l; i++) { }`},
+			{Code: `for (var i=0; i<l; (function() { i; })(), i++) { }`},
+			{Code: `for (var i = 0; i < 10; ++i) { (()=>{ i;})() }`},
+			{Code: `for (var i = 0; i < 10; ++i) { (function a(){i;})() }`},
+			{Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((f => f)((() => i)()));
+}`},
+			{Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return (() => i)();
+    })());
+}`},
+
+			// Outer binding is const — function is safe even though reassigned later (runtime error).
+			{Code: `
+const foo = bar;
+
+for (var i = 0; i < 5; i++) {
+    arr.push(() => foo);
+}
+
+foo = baz;`},
+			{Code: `
+using foo = bar;
+
+for (var i = 0; i < 5; i++) {
+    arr.push(() => foo);
+}
+
+foo = baz;`},
+			{Code: `
+await using foo = bar;
+
+for (var i = 0; i < 5; i++) {
+    arr.push(() => foo);
+}
+
+foo = baz;`},
+
+			// TypeScript: plain type references inside closures never count as value references.
+			{Code: `
+for (let i = 0; i < 10; i++) {
+  function foo() {
+    console.log('A');
+  }
+}`},
+			{Code: `
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}`},
+			{Code: `
+type MyType = 1;
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}`},
+			// Unconfigured global type inside a closure: arrow only references the type, not the loop var.
+			{Code: `
+for (var i = 0; i < 10; i++) {
+  const process = (item: UnconfiguredGlobalType) => {
+    return item.id;
+  };
+}`},
+			{Code: `
+for (var i = 0; i < 10; i++) {
+  const process = (configItem: ConfiguredType, unconfigItem: UnconfiguredType) => {
+    return {
+      config: configItem.value,
+      unconfig: unconfigItem.value
+    };
+  };
+}`},
+
+			// ---- Destructuring: iteration binds to fresh const — safe ----
+			{Code: `for (const {a} of arr) { (function() { a; }) }`},
+			{Code: `for (const [a] of arr) { (function() { a; }) }`},
+			{Code: `for (const [[a]] of arr) { (function() { a; }) }`},
+			{Code: `for (const {a: {b}} of arr) { (function() { b; }) }`},
+			{Code: `for (const {a = 10} of arr) { (function() { a; }) }`},
+
+			// ---- Method-bound this / labeled statements — no through refs matter ----
+			{Code: `outer: for (var i = 0; i < l; i++) { (function() { break outer; }); }`},
+
+			// ---- Nested loops where outer-loop-declared let is read but not modified ----
+			{Code: `for (let i = 0; i < l; i++) { for (let j = 0; j < i; j++) { (function() { j; }) } }`},
+
+			// ---- Methods/getters inside class/object boundary shields inner closure ----
+			// A plain FunctionExpression inside a method inside a loop is "inside the method",
+			// not inside the loop — methods/accessors create their own scope boundary, just
+			// like plain FunctionExpressions. Matches ESLint (where class methods map to
+			// FunctionExpression in ESTree).
+			{Code: `for (var i = 0; i < l; i++) { const o = { m() { var f = function() { x; }; } }; }`},
+			{Code: `for (var i = 0; i < l; i++) { class C { m() { var f = function() { x; }; } } }`},
+
+			// ---- Methods referencing only local state or const outer bindings — safe ----
+			{Code: `const k = 10; for (var i = 0; i < l; i++) { class C { m() { return k; } } }`},
+
+			// ---- Computed property key captures loop var but the function body doesn't ----
+			// The key `[i]` evaluates in the outer scope each iteration; the function
+			// body has no through refs, so no report.
+			{Code: `for (var i = 0; i < l; i++) { var o = { [i]: function() {} }; }`},
+
+			// ---- ClassExpression name as through ref of a method inside the class ----
+			// `Foo` lives in the class's name scope; it has no writes, so referencing
+			// it from a method is safe on its own — only a write to a through ref
+			// would flag.
+			{Code: `for (var i = 0; i < l; i++) { const C = class Foo { m() { return Foo; } }; }`},
+
+			// ---- for-await-of with fresh const binding — safe ----
+			{Code: `async function f(xs) { for await (const x of xs) { (function() { x; }) } }`},
+
+			// ---- Parameter default value that references a let declared inside the loop ----
+			// `j` is fresh per iteration, so capturing it via a default is safe.
+			{Code: `for (let i = 0; i < l; i++) { let j = i; (function(x = j) { x; }); }`},
+
+			// ---- ForStatement with no init: loop var declared outside, no modification in/after ----
+			{Code: `var i; for (; i < l; ) { (function() { i; }) }`},
+
+			// ---- Import binding is read-only — safe through ref ----
+			{Code: `import { foo } from "./mod"; for (var i = 0; i < l; i++) { (function() { foo; }) }`},
+
+			// ---- Enum reference (TS value+type) is a const-like binding ----
+			{Code: `enum Color { Red } for (var i = 0; i < l; i++) { (function() { Color.Red; }) }`},
+
+			// ---- Through refs collected from nested functions inside a non-loop
+			// outer function (the inner function itself IS the closure at risk) ----
+			{Code: `function outer() { for (var i = 0; i < l; i++) { let j = i; (function() { j; }); } }`},
+
+			// ---- Skip-IIFE propagates: inner FE assigned to a var reads loop var
+			// only through an outer IIFE; only the inner FE should be flagged, not the outer ----
+			// (covered by the "outer IIFE skipped, inner FE reported" invariant)
+			{Code: `for (var i = 0; i < l; i++) { (function() { /* no through refs */ var local = 1; local; })(); }`},
+		},
+		[]rule_tester.InvalidTestCase{
+			// Each of these four asserts a complete position range so future
+			// refactors can't silently shift the report site across the three
+			// kinds of function-like containers we care about (FE, arrow, FD)
+			// and the two body-containment shapes (direct, via VariableDecl).
+			{
+				Code: `for (var i=0; i<l; i++) { (function() { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      1,
+					Column:    28,
+					EndLine:   1,
+					EndColumn: 45,
+				}},
+			},
+			{
+				Code: `for (var i=0; i<l; i++) { for (var j=0; j<m; j++) { (function() { i+j; }) } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i', 'j'.",
+					Line:      1,
+					Column:    54,
+				}},
+			},
+			{
+				Code: `for (var i in {}) { (function() { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      1,
+					Column:    22,
+				}},
+			},
+			{
+				Code: `for (var i of {}) { (function() { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+					Line:      1,
+					Column:    22,
+				}},
+			},
+			{
+				Code: `for (var i=0; i < l; i++) { (() => { i; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    30,
+				}},
+			},
+			{
+				Code: `for (var i=0; i < l; i++) { var a = function() { i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    37,
+				}},
+			},
+			{
+				Code: `for (var i=0; i < l; i++) { function a() { i; }; a(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    29,
+				}},
+			},
+
+			// Closure captures a variable written inside the loop.
+			{
+				Code: `let a; for (let i=0; i<l; i++) { a = 1; (function() { a; });}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i in {}) { (function() { a; }); a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i of {}) { (function() { a; }); } a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i in {}) { a = 1; function foo() { (function() { a; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (let i of {}) { (() => { (function() { a; }); }); } a = 1;`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Closure in a nested loop captures the outer `var`.
+			{
+				Code: `for (var i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (let x of xs) { let a; for (let y of ys) { a = 1; (function() { a; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var x of xs) { for (let y of ys) { (function() { x; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var x of xs) { (function() { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Write inside the loop occurs before or after the closure declaration.
+			{
+				Code: `var a; for (let x of xs) { a = 1; (function() { a; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `var a; for (let x of xs) { (function() { a; }); a = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; function foo() { a = 10; } for (let x of xs) { (function() { a; }); } foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; function foo() { a = 10; for (let x of xs) { (function() { a; }); } } foo();`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Generator / async IIFE — still checked.
+			{
+				Code: `let a; for (var i=0; i<l; i++) { (function* (){i;})() }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `let a; for (var i=0; i<l; i++) { (async function (){i;})() }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Self-referencing named IIFE — skip-IIFE optimization doesn't apply.
+			{
+				Code: `
+let current = getStart();
+const arr = [];
+while (current) {
+    (function f() {
+        current;
+        arr.push(f);
+    })();
+
+    current = current.upper;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    (function fun () {
+        if (arr.includes(fun)) return i;
+        else arr.push(fun);
+    })();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Async arrow IIFE — the async flag means we don't skip it.
+			{
+				Code: `
+let current = getStart();
+const arr = [];
+while (current) {
+    const p = (async () => {
+        await someDelay();
+        current;
+    })();
+
+    arr.push(p);
+    current = current.upper;
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// Nested arrow produced by an IIFE leaks the loop variable.
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((f => f)(
+        () => i
+    ));
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      6,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => i;
+    })());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      6,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => { return i };
+    })());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      6,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => {
+            return () => i
+        };
+    })());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      6,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () =>
+            (() => i)();
+    })());
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      6,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    (() => {
+        arr.push((async () => {
+            await 1;
+            return i;
+        })());
+    })();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      6,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    (() => {
+        (function f() {
+            if (!arr.includes(f)) {
+                arr.push(f);
+            }
+            return i;
+        })();
+    })();
+
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+var arr1 = [], arr2 = [];
+
+for (var [i, j] of ["a", "b", "c"].entries()) {
+    (() => {
+        arr1.push((() => i)());
+        arr2.push(() => j);
+    })();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'j'.",
+					Line:      7,
+				}},
+			},
+			{
+				Code: `
+var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    ((f) => {
+        arr.push(f);
+    })(() => {
+        return (() => i)();
+    });
+
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      7,
+				}},
+			},
+			{
+				Code: `
+for (var i = 0; i < 5; i++) {
+    (async () => {
+        () => i;
+    })();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      3,
+				}},
+			},
+
+			// Closure declared after other loop-body statements captures the loop var.
+			{
+				Code: `
+for (var i = 0; i < 10; i++) {
+    items.push({
+        id: i,
+        name: "Item " + i
+    });
+
+    const process = function (callback){
+        callback({ id: i, name: "Item " + i });
+    };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      8,
+				}},
+			},
+
+			// TypeScript: loop var is captured by a function whose only explicit
+			// annotations are types; `i` still leaks through.
+			{
+				Code: `
+for (var i = 0; i < 10; i++) {
+  function foo() {
+    console.log(i);
+  }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+for (var i = 0; i < 10; i++) {
+  const handler = (event: Event) => {
+    console.log(i);
+  };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+interface Item {
+  id: number;
+  name: string;
+}
+
+const items: Item[] = [];
+for (var i = 0; i < 10; i++) {
+  items.push({
+    id: i,
+    name: "Item " + i
+  });
+
+  const process = function(callback: (item: Item) => void): void {
+    callback({ id: i, name: "Item " + i });
+  };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+type Processor<T> = (item: T) => void;
+
+for (var i = 0; i < 10; i++) {
+  const processor: Processor<number> = (item) => {
+    return item + i;
+  };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `
+for (var i = 0; i < 10; i++) {
+  const process = (item: UnconfiguredGlobalType) => {
+    console.log(i, item.value);
+  };
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Destructuring bindings in for-in/of iterate (write each step) ----
+			{
+				Code: `for (var {a} of arr) { (function() { a; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+				}},
+			},
+			{
+				Code: `for (var [[a]] of arr) { (function() { a; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var {a = 10} of arr) { (function() { a; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Destructuring assignment in the body counts as a write ----
+			{
+				Code: `var a; for (var i = 0; i < l; i++) { [a] = [i]; (function() { a; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `var a; for (var i = 0; i < l; i++) { ({a} = {a: i}); (function() { a; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Async function declaration (not expression) inside a loop ----
+			{
+				Code: `for (var i = 0; i < l; i++) { async function f() { i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Nested functions inherit the outer's through references ----
+			{
+				Code: `for (var i = 0; i < l; i++) { function foo() { function bar() { i; } bar(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Class/object methods inside a loop that reference loop vars ----
+			// ESLint's ESTree treats these as FunctionExpression values so it reports
+			// them; we register explicit listeners for Method/Accessor/Constructor.
+			{
+				Code: `for (var i = 0; i < l; i++) { const o = { m() { return i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    43,
+				}},
+			},
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { m() { return i; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      1,
+					Column:    41,
+				}},
+			},
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { get x() { return i; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { set x(v) { this.a = i + v; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { constructor() { this.a = i; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var i = 0; i < l; i++) { const o = { async m() { return i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+			{
+				Code: `for (var i = 0; i < l; i++) { const o = { *m() { yield i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Functions inside a static block inside a loop — static block is transparent ----
+			{
+				Code: `
+for (var i = 0; i < l; i++) {
+    class C {
+        static {
+            var f = function() { i; };
+        }
+    }
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Line:      5,
+				}},
+			},
+
+			// ---- Parameter default value captures loop var (the function still
+			// closes over `i` across iterations) ----
+			{
+				Code: `for (var i = 0; i < l; i++) { (function(x = i) { x; }); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+
+			// ---- Computed key + function value both reference the loop var ----
+			{
+				Code: `for (var i = 0; i < l; i++) { var o = { [i]: function() { return i; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- ClassExpression name that IS reassigned inside the class — through ref unsafe ----
+			// (Not truly possible via `Foo = ...` at runtime — the class name is read-only
+			// within the class body — but a reassignment of an outer same-named binding is.
+			// The interesting shape is: the method references an OUTER var that's modified.)
+			{
+				Code: `var Foo; for (var i = 0; i < l; i++) { Foo = i; const C = class { m() { return Foo; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'Foo'.",
+				}},
+			},
+
+			// ---- for-await-of with `var` iterator — iteration writes the same binding ----
+			{
+				Code: `async function f(xs) { for await (var x of xs) { (function() { x; }) } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Through refs leak up through nested functions: outer FE is
+			// flagged when a nested FE references a loop-modified outer-scope var ----
+			{
+				Code: `for (var i = 0; i < l; i++) { function outer() { (function() { i; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					// Only the outer FunctionDeclaration is in the loop; the
+					// inner FE is inside a non-loop function, so only the
+					// outer one reports.
+				}},
+			},
+
+			// ---- Reassigned FunctionDeclaration name captured by a non-IIFE function ----
+			// - `function foo()` itself references `i` (unsafe).
+			// - `var g = function() { foo }` references `foo`, which is reassigned
+			//   inside the loop (`foo = null`), so `foo` is unsafe too.
+			{
+				Code: `for (var i = 0; i < l; i++) { function foo() { return i; } foo = null; var g = function() { foo; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "unsafeRefs"},
+					{MessageId: "unsafeRefs"},
+				},
+			},
+
+			// ---- FunctionDeclaration used directly in loop body (its own through refs) ----
+			{
+				Code: `for (var i = 0; i < l; i++) { function foo() { return i; } foo(); }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+
+			// ---- Multiple distinct unsafe refs appear in stable source order ----
+			{
+				Code: `var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function() { a + b; }) }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a', 'b'.",
+				}},
+			},
+		},
+	)
+}

--- a/internal/rules/no_loop_func/no_loop_func_test.go
+++ b/internal/rules/no_loop_func/no_loop_func_test.go
@@ -238,6 +238,27 @@ for (var i = 0; i < 10; i++) {
 			// only through an outer IIFE; only the inner FE should be flagged, not the outer ----
 			// (covered by the "outer IIFE skipped, inner FE reported" invariant)
 			{Code: `for (var i = 0; i < l; i++) { (function() { /* no through refs */ var local = 1; local; })(); }`},
+
+			// ---- Switch-case closure over fresh let ----
+			{Code: `for (let i = 0; i < l; i++) { switch (x) { case 1: (function() { i; }); break; } }`},
+
+			// ---- Try/catch/finally wrapper — block-scoped let is fresh per iteration ----
+			{Code: `for (let i = 0; i < l; i++) { try { const f = () => i; } catch (e) {} }`},
+
+			// ---- Parameter-default that is itself an arrow referencing fresh let ----
+			{Code: `for (let i = 0; i < l; i++) { const m = (x = () => i) => x(); }`},
+
+			// ---- Class property initializer arrow — each iteration fresh let ----
+			{Code: `for (let i = 0; i < l; i++) { class C { f = () => i; } }`},
+
+			// ---- Tagged template with arrow in interpolation, fresh let ----
+			{Code: "for (let i = 0; i < l; i++) { tag`${() => i}`; }"},
+
+			// ---- Spread argument — arrow captures fresh let ----
+			{Code: `for (let i = 0; i < l; i++) { foo(...[() => i]); }`},
+
+			// ---- Conditional expression branching to arrow, fresh let ----
+			{Code: `for (let i = 0; i < l; i++) { const f = cond ? (() => i) : null; }`},
 		},
 		[]rule_tester.InvalidTestCase{
 			// Each of these four asserts a complete position range so future
@@ -902,6 +923,76 @@ for (var i = 0; i < l; i++) {
 				Errors: []rule_tester.InvalidTestCaseError{{
 					MessageId: "unsafeRefs",
 					Message:   "Function declared in a loop contains unsafe references to variable(s) 'a', 'b'.",
+				}},
+			},
+
+			// ---- Closure-in-loop-in-skipped-IIFE-in-loop: both loops' vars should leak ----
+			{
+				Code: `
+for (var i = 0; i < 3; i++) {
+    (() => {
+        for (var j = 0; j < 3; j++) {
+            (function() { i + j; });
+        }
+    })();
+}`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i', 'j'.",
+				}},
+			},
+
+			// ---- Closure inside a catch clause inside a loop — `e` binds per exception,
+			// but `i` (loop var) leaks ----
+			{
+				Code: `for (var i = 0; i < l; i++) { try {} catch (e) { (function() { i; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+				}},
+			},
+
+			// ---- Closure inside a switch case inside a loop ----
+			{
+				Code: `for (var i = 0; i < l; i++) { switch (x) { case 1: (function() { i; }); break; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Closure inside a conditional expression inside a loop ----
+			{
+				Code: `for (var i = 0; i < l; i++) { const f = cond ? (() => i) : null; }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Class property initializer arrow — class re-created each iteration,
+			// the arrow closes over the loop var ----
+			{
+				Code: `for (var i = 0; i < l; i++) { class C { f = () => i; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Parameter default arrow capturing a loop var of an outer function ----
+			{
+				Code: `for (var i = 0; i < l; i++) { function m(x = () => i) { return x(); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+				}},
+			},
+
+			// ---- Catch binding captured by a closure in a loop ----
+			// ESLint's scope manager treats `catch (e)` as an implicit write per
+			// exception, so a closure capturing `e` inside a loop is unsafe.
+			{
+				Code: `for (var i = 0; i < l; i++) { try { throw 0; } catch (e) { (function() { e; }); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "unsafeRefs",
+					Message:   "Function declared in a loop contains unsafe references to variable(s) 'e'.",
 				}},
 			},
 		},

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -290,6 +290,7 @@ export default defineConfig({
     './tests/eslint/rules/no-label-var.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
+    './tests/eslint/rules/no-loop-func.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',
     './tests/eslint/rules/no-nested-ternary.test.ts',
     './tests/eslint/rules/object-shorthand.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-loop-func.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-loop-func.test.ts.snap
@@ -1,0 +1,1854 @@
+// Rstest Snapshot v1
+
+exports[`no-loop-func > invalid 1`] = `
+{
+  "code": "for (var i=0; i<l; i++) { (function() { i; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 2`] = `
+{
+  "code": "for (var i=0; i<l; i++) { for (var j=0; j<m; j++) { (function() { i+j; }) } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i', 'j'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 3`] = `
+{
+  "code": "for (var i in {}) { (function() { i; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 4`] = `
+{
+  "code": "for (var i of {}) { (function() { i; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 5`] = `
+{
+  "code": "for (var i=0; i < l; i++) { (() => { i; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 6`] = `
+{
+  "code": "for (var i=0; i < l; i++) { var a = function() { i; } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 7`] = `
+{
+  "code": "for (var i=0; i < l; i++) { function a() { i; }; a(); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 8`] = `
+{
+  "code": "let a; for (let i=0; i<l; i++) { a = 1; (function() { a; });}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 9`] = `
+{
+  "code": "let a; for (let i in {}) { (function() { a; }); a = 1; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 10`] = `
+{
+  "code": "let a; for (let i of {}) { (function() { a; }); } a = 1;",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 11`] = `
+{
+  "code": "let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); a = 1; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 12`] = `
+{
+  "code": "let a; for (let i in {}) { a = 1; function foo() { (function() { a; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 74,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 13`] = `
+{
+  "code": "let a; for (let i of {}) { (() => { (function() { a; }); }); } a = 1;",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 14`] = `
+{
+  "code": "for (var i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 15`] = `
+{
+  "code": "for (let x of xs) { let a; for (let y of ys) { a = 1; (function() { a; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 16`] = `
+{
+  "code": "for (var x of xs) { for (let y of ys) { (function() { x; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 17`] = `
+{
+  "code": "for (var x of xs) { (function() { x; }); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 18`] = `
+{
+  "code": "var a; for (let x of xs) { a = 1; (function() { a; }); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 19`] = `
+{
+  "code": "var a; for (let x of xs) { (function() { a; }); a = 1; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 20`] = `
+{
+  "code": "let a; function foo() { a = 10; } for (let x of xs) { (function() { a; }); } foo();",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 73,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 21`] = `
+{
+  "code": "let a; function foo() { a = 10; for (let x of xs) { (function() { a; }); } } foo();",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 22`] = `
+{
+  "code": "let a; for (var i=0; i<l; i++) { (function* (){i;})() }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 23`] = `
+{
+  "code": "let a; for (var i=0; i<l; i++) { (async function (){i;})() }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 24`] = `
+{
+  "code": "let current = getStart();
+const arr = [];
+while (current) {
+    (function f() {
+        current;
+        arr.push(f);
+    })();
+
+    current = current.upper;
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'current'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 7,
+        },
+        "start": {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 25`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    (function fun () {
+        if (arr.includes(fun)) return i;
+        else arr.push(fun);
+    })();
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 7,
+        },
+        "start": {
+          "column": 6,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 26`] = `
+{
+  "code": "let current = getStart();
+const arr = [];
+while (current) {
+    const p = (async () => {
+        await someDelay();
+        current;
+    })();
+
+    arr.push(p);
+    current = current.upper;
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'current'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 7,
+        },
+        "start": {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 27`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((f => f)(
+        () => i
+    ));
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 28`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => i;
+    })());
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 5,
+        },
+        "start": {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 29`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => { return i };
+    })());
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 5,
+        },
+        "start": {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 30`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => {
+            return () => i
+        };
+    })());
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 7,
+        },
+        "start": {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 31`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () =>
+            (() => i)();
+    })());
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 6,
+        },
+        "start": {
+          "column": 16,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 32`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    (() => {
+        arr.push((async () => {
+            await 1;
+            return i;
+        })());
+    })();
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 8,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 33`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    (() => {
+        (function f() {
+            if (!arr.includes(f)) {
+                arr.push(f);
+            }
+            return i;
+        })();
+    })();
+
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 10,
+        },
+        "start": {
+          "column": 10,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 34`] = `
+{
+  "code": "var arr1 = [], arr2 = [];
+
+for (var [i, j] of ["a", "b", "c"].entries()) {
+    (() => {
+        arr1.push((() => i)());
+        arr2.push(() => j);
+    })();
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'j'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 6,
+        },
+        "start": {
+          "column": 19,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 35`] = `
+{
+  "code": "var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    ((f) => {
+        arr.push(f);
+    })(() => {
+        return (() => i)();
+    });
+
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 8,
+        },
+        "start": {
+          "column": 8,
+          "line": 6,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 36`] = `
+{
+  "code": "for (var i = 0; i < 5; i++) {
+    (async () => {
+        () => i;
+    })();
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 6,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 37`] = `
+{
+  "code": "for (var i = 0; i < 10; i++) {
+    items.push({
+        id: i,
+        name: "Item " + i
+    });
+
+    const process = function (callback){
+        callback({ id: i, name: "Item " + i });
+    };
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 9,
+        },
+        "start": {
+          "column": 21,
+          "line": 7,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 38`] = `
+{
+  "code": "for (var i = 0; i < 10; i++) {
+  function foo() {
+    console.log(i);
+  }
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 39`] = `
+{
+  "code": "for (var i = 0; i < 10; i++) {
+  const handler = (event: Event) => {
+    console.log(i);
+  };
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 40`] = `
+{
+  "code": "interface Item {
+  id: number;
+  name: string;
+}
+
+const items: Item[] = [];
+for (var i = 0; i < 10; i++) {
+  items.push({
+    id: i,
+    name: "Item " + i
+  });
+
+  const process = function(callback: (item: Item) => void): void {
+    callback({ id: i, name: "Item " + i });
+  };
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 15,
+        },
+        "start": {
+          "column": 19,
+          "line": 13,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 41`] = `
+{
+  "code": "type Processor<T> = (item: T) => void;
+
+for (var i = 0; i < 10; i++) {
+  const processor: Processor<number> = (item) => {
+    return item + i;
+  };
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 6,
+        },
+        "start": {
+          "column": 40,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 42`] = `
+{
+  "code": "for (var i = 0; i < 10; i++) {
+  const process = (item: UnconfiguredGlobalType) => {
+    console.log(i, item.value);
+  };
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 4,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 43`] = `
+{
+  "code": "for (var {a} of arr) { (function() { a; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 44`] = `
+{
+  "code": "for (var [[a]] of arr) { (function() { a; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 45`] = `
+{
+  "code": "for (var {a = 10} of arr) { (function() { a; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 46`] = `
+{
+  "code": "var a; for (var i = 0; i < l; i++) { [a] = [i]; (function() { a; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 47`] = `
+{
+  "code": "var a; for (var i = 0; i < l; i++) { ({a} = {a: i}); (function() { a; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 48`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { async function f() { i; } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 49`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { function foo() { function bar() { i; } bar(); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 50`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { const o = { m() { return i; } }; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 51`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { class C { m() { return i; } } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 52`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { class C { get x() { return i; } } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 53`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { class C { set x(v) { this.a = i + v; } } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 69,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 54`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { class C { constructor() { this.a = i; } } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 55`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { const o = { async m() { return i; } }; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 66,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 56`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { const o = { *m() { yield i; } }; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 57`] = `
+{
+  "code": "for (var i = 0; i < l; i++) {
+    class C {
+        static {
+            var f = function() { i; };
+        }
+    }
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 4,
+        },
+        "start": {
+          "column": 21,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 58`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { (function(x = i) { x; }); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 59`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { var o = { [i]: function() { return i; } }; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 60`] = `
+{
+  "code": "var Foo; for (var i = 0; i < l; i++) { Foo = i; const C = class { m() { return Foo; } }; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'Foo'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 86,
+          "line": 1,
+        },
+        "start": {
+          "column": 67,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 61`] = `
+{
+  "code": "async function f(xs) { for await (var x of xs) { (function() { x; }) } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'x'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 68,
+          "line": 1,
+        },
+        "start": {
+          "column": 51,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 62`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { function outer() { (function() { i; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 72,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 63`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { function foo() { return i; } foo(); }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 64`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { function foo() { return i; } foo = null; var g = function() { foo; }; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'foo'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 99,
+          "line": 1,
+        },
+        "start": {
+          "column": 80,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 65`] = `
+{
+  "code": "var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function() { a + b; }) }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'a', 'b'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 77,
+          "line": 1,
+        },
+        "start": {
+          "column": 56,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-loop-func.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-loop-func.test.ts.snap
@@ -1852,3 +1852,165 @@ exports[`no-loop-func > invalid 65`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`no-loop-func > invalid 66`] = `
+{
+  "code": "for (var i = 0; i < 3; i++) {
+    (() => {
+        for (var j = 0; j < 3; j++) {
+            (function() { i + j; });
+        }
+    })();
+}",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i', 'j'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 4,
+        },
+        "start": {
+          "column": 14,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 67`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { try { throw 0; } catch (e) { (function() { e; }); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'e'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 78,
+          "line": 1,
+        },
+        "start": {
+          "column": 61,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 68`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { switch (x) { case 1: (function() { i; }); break; } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 69`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { const f = cond ? (() => i) : null; }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 70`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { class C { f = () => i; } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-loop-func > invalid 71`] = `
+{
+  "code": "for (var i = 0; i < l; i++) { function m(x = () => i) { return x(); } }",
+  "diagnostics": [
+    {
+      "message": "Function declared in a loop contains unsafe references to variable(s) 'i'.",
+      "messageId": "unsafeRefs",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-loop-func",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-loop-func.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-loop-func.test.ts
@@ -172,6 +172,21 @@ for (let i = 0; i < 10; i += 1) {
 
     // Non-loop-enclosing outer function: inner function safe (loop variable is fresh let).
     'function outer() { for (var i = 0; i < l; i++) { let j = i; (function() { j; }); } }',
+
+    // Switch-case / try-catch / ternary wrapping around a closure over fresh let.
+    'for (let i = 0; i < l; i++) { switch (x) { case 1: (function() { i; }); break; } }',
+    'for (let i = 0; i < l; i++) { try { const f = () => i; } catch (e) {} }',
+    'for (let i = 0; i < l; i++) { const f = cond ? (() => i) : null; }',
+
+    // Class property initializer arrow with fresh let.
+    'for (let i = 0; i < l; i++) { class C { f = () => i; } }',
+
+    // Parameter default arrow with fresh let.
+    'for (let i = 0; i < l; i++) { function m(x = () => i) { return x(); } }',
+
+    // Tagged template / spread wrapping closures that capture fresh let.
+    'for (let i = 0; i < l; i++) { tag`${() => i}`; }',
+    'for (let i = 0; i < l; i++) { foo(...[() => i]); }',
   ],
   invalid: [
     {
@@ -608,6 +623,48 @@ for (var i = 0; i < 10; i++) {
     // Multiple distinct unsafe refs listed in source order.
     {
       code: 'var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function() { a + b; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Nested loops inside a skipped IIFE, closure captures both loop vars.
+    {
+      code: `for (var i = 0; i < 3; i++) {
+    (() => {
+        for (var j = 0; j < 3; j++) {
+            (function() { i + j; });
+        }
+    })();
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Catch binding captured by a closure — `e` rebinds per exception.
+    {
+      code: 'for (var i = 0; i < l; i++) { try { throw 0; } catch (e) { (function() { e; }); } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Closure inside a switch case.
+    {
+      code: 'for (var i = 0; i < l; i++) { switch (x) { case 1: (function() { i; }); break; } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Closure inside a conditional expression.
+    {
+      code: 'for (var i = 0; i < l; i++) { const f = cond ? (() => i) : null; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Class property initializer arrow.
+    {
+      code: 'for (var i = 0; i < l; i++) { class C { f = () => i; } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Parameter default arrow capturing loop var.
+    {
+      code: 'for (var i = 0; i < l; i++) { function m(x = () => i) { return x(); } }',
       errors: [{ messageId: 'unsafeRefs' }],
     },
   ],

--- a/packages/rslint-test-tools/tests/eslint/rules/no-loop-func.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-loop-func.test.ts
@@ -1,0 +1,614 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-loop-func', {
+  valid: [
+    "string = 'function a() {}';",
+    'for (var i=0; i<l; i++) { } var a = function() { i; };',
+    'for (var i=0, a=function() { i; }; i<l; i++) { }',
+    'for (var x in xs.filter(function(x) { return x != upper; })) { }',
+    'for (var x of xs.filter(function(x) { return x != upper; })) { }',
+    'for (var i=0; i<l; i++) { (function() {}) }',
+    'for (var i in {}) { (function() {}) }',
+    'for (var i of {}) { (function() {}) }',
+    'for (let i=0; i<l; i++) { (function() { i; }) }',
+    'for (let i in {}) { i = 7; (function() { i; }) }',
+    'for (const i of {}) { (function() { i; }) }',
+    'for (using i of foo) { (function() { i; }) }',
+    'for (await using i of foo) { (function() { i; }) }',
+    'for (var i = 0; i < 10; ++i) { using foo = bar(i); (function() { foo; }) }',
+    'for (var i = 0; i < 10; ++i) { await using foo = bar(i); (function() { foo; }) }',
+    'for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }',
+    'let a = 0; for (let i=0; i<l; i++) { (function() { a; }); }',
+    'let a = 0; for (let i in {}) { (function() { a; }); }',
+    'let a = 0; for (let i of {}) { (function() { a; }); }',
+    'let a = 0; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); }',
+    'let a = 0; for (let i in {}) { function foo() { (function() { a; }); } }',
+    'let a = 0; for (let i of {}) { (() => { (function() { a; }); }); }',
+    'var a = 0; for (let i=0; i<l; i++) { (function() { a; }); }',
+    'var a = 0; for (let i in {}) { (function() { a; }); }',
+    'var a = 0; for (let i of {}) { (function() { a; }); }',
+    `let result = {};
+for (const score in scores) {
+  const letters = scores[score];
+  letters.split('').forEach(letter => {
+    result[letter] = score;
+  });
+}
+result.__default = 6;`,
+    `while (true) {
+    (function() { a; });
+}
+let a;`,
+    'while(i) { (function() { i; }) }',
+    'do { (function() { i; }) } while (i)',
+    'var i; while(i) { (function() { i; }) }',
+    'var i; do { (function() { i; }) } while (i)',
+    'for (var i=0; i<l; i++) { (function() { undeclared; }) }',
+    'for (let i=0; i<l; i++) { (function() { undeclared; }) }',
+    'for (var i in {}) { i = 7; (function() { undeclared; }) }',
+    'for (let i in {}) { i = 7; (function() { undeclared; }) }',
+    'for (const i of {}) { (function() { undeclared; }) }',
+    'for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != undeclared)) {  } }',
+    `let current = getStart();
+while (current) {
+(() => {
+    current;
+    current.a;
+    current.b;
+    current.c;
+    current.d;
+})();
+
+current = current.upper;
+}`,
+    'for (var i=0; (function() { i; })(), i<l; i++) { }',
+    'for (var i=0; i<l; (function() { i; })(), i++) { }',
+    'for (var i = 0; i < 10; ++i) { (()=>{ i;})() }',
+    'for (var i = 0; i < 10; ++i) { (function a(){i;})() }',
+    `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((f => f)((() => i)()));
+}`,
+    `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return (() => i)();
+    })());
+}`,
+    `const foo = bar;
+
+for (var i = 0; i < 5; i++) {
+    arr.push(() => foo);
+}
+
+foo = baz;`,
+    `using foo = bar;
+
+for (var i = 0; i < 5; i++) {
+    arr.push(() => foo);
+}
+
+foo = baz;`,
+    `await using foo = bar;
+
+for (var i = 0; i < 5; i++) {
+    arr.push(() => foo);
+}
+
+foo = baz;`,
+    `for (let i = 0; i < 10; i++) {
+  function foo() {
+    console.log('A');
+  }
+}`,
+    `let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}`,
+    `type MyType = 1;
+let someArray: MyType[] = [];
+for (let i = 0; i < 10; i += 1) {
+  someArray = someArray.filter((item: MyType) => !!item);
+}`,
+    `for (var i = 0; i < 10; i++) {
+  const process = (item: UnconfiguredGlobalType) => {
+    return item.id;
+  };
+}`,
+    `for (var i = 0; i < 10; i++) {
+  const process = (configItem: ConfiguredType, unconfigItem: UnconfiguredType) => {
+    return {
+      config: configItem.value,
+      unconfig: unconfigItem.value
+    };
+  };
+}`,
+
+    // Destructuring: const iterator bindings are fresh per iteration.
+    'for (const {a} of arr) { (function() { a; }) }',
+    'for (const [a] of arr) { (function() { a; }) }',
+    'for (const [[a]] of arr) { (function() { a; }) }',
+    'for (const {a: {b}} of arr) { (function() { b; }) }',
+    'for (const {a = 10} of arr) { (function() { a; }) }',
+
+    // Labeled loop — break label is not a variable reference.
+    'outer: for (var i = 0; i < l; i++) { (function() { break outer; }); }',
+
+    // Nested loops closing over only fresh-let bindings.
+    'for (let i = 0; i < l; i++) { for (let j = 0; j < i; j++) { (function() { j; }) } }',
+
+    // A FunctionExpression inside a method inside a loop — the method is its
+    // own scope boundary so the function is NOT "inside the loop".
+    'for (var i = 0; i < l; i++) { const o = { m() { var f = function() { x; }; } }; }',
+    'for (var i = 0; i < l; i++) { class C { m() { var f = function() { x; }; } } }',
+
+    // Method referencing only a const outer binding.
+    'const k = 10; for (var i = 0; i < l; i++) { class C { m() { return k; } } }',
+
+    // Computed key captures loop var; body doesn't — no through ref in body.
+    'for (var i = 0; i < l; i++) { var o = { [i]: function() {} }; }',
+
+    // Class-expression name as through ref with no writes — safe.
+    'for (var i = 0; i < l; i++) { const C = class Foo { m() { return Foo; } }; }',
+
+    // for-await-of with const iterator binding — fresh per iteration.
+    'async function f(xs) { for await (const x of xs) { (function() { x; }) } }',
+
+    // Parameter default captures a fresh let binding (safe).
+    'for (let i = 0; i < l; i++) { let j = i; (function(x = j) { x; }); }',
+
+    // ForStatement with no init, loop var declared outside, not modified.
+    'var i; for (; i < l; ) { (function() { i; }) }',
+
+    // Import binding — read-only, safe.
+    'import { foo } from "./mod"; for (var i = 0; i < l; i++) { (function() { foo; }) }',
+
+    // Enum reference (const-like).
+    'enum Color { Red } for (var i = 0; i < l; i++) { (function() { Color.Red; }) }',
+
+    // Non-loop-enclosing outer function: inner function safe (loop variable is fresh let).
+    'function outer() { for (var i = 0; i < l; i++) { let j = i; (function() { j; }); } }',
+  ],
+  invalid: [
+    {
+      code: 'for (var i=0; i<l; i++) { (function() { i; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i=0; i<l; i++) { for (var j=0; j<m; j++) { (function() { i+j; }) } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i in {}) { (function() { i; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i of {}) { (function() { i; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i=0; i < l; i++) { (() => { i; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i=0; i < l; i++) { var a = function() { i; } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i=0; i < l; i++) { function a() { i; }; a(); }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (let i=0; i<l; i++) { a = 1; (function() { a; });}',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (let i in {}) { (function() { a; }); a = 1; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (let i of {}) { (function() { a; }); } a = 1;',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); a = 1; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (let i in {}) { a = 1; function foo() { (function() { a; }); } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (let i of {}) { (() => { (function() { a; }); }); } a = 1;',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (let x of xs) { let a; for (let y of ys) { a = 1; (function() { a; }); } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var x of xs) { for (let y of ys) { (function() { x; }); } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var x of xs) { (function() { x; }); }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'var a; for (let x of xs) { a = 1; (function() { a; }); }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'var a; for (let x of xs) { (function() { a; }); a = 1; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; function foo() { a = 10; } for (let x of xs) { (function() { a; }); } foo();',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; function foo() { a = 10; for (let x of xs) { (function() { a; }); } } foo();',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (var i=0; i<l; i++) { (function* (){i;})() }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'let a; for (var i=0; i<l; i++) { (async function (){i;})() }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `let current = getStart();
+const arr = [];
+while (current) {
+    (function f() {
+        current;
+        arr.push(f);
+    })();
+
+    current = current.upper;
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    (function fun () {
+        if (arr.includes(fun)) return i;
+        else arr.push(fun);
+    })();
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `let current = getStart();
+const arr = [];
+while (current) {
+    const p = (async () => {
+        await someDelay();
+        current;
+    })();
+
+    arr.push(p);
+    current = current.upper;
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((f => f)(
+        () => i
+    ));
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => i;
+    })());
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => { return i };
+    })());
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () => {
+            return () => i
+        };
+    })());
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i++) {
+    arr.push((() => {
+        return () =>
+            (() => i)();
+    })());
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    (() => {
+        arr.push((async () => {
+            await 1;
+            return i;
+        })());
+    })();
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    (() => {
+        (function f() {
+            if (!arr.includes(f)) {
+                arr.push(f);
+            }
+            return i;
+        })();
+    })();
+
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr1 = [], arr2 = [];
+
+for (var [i, j] of ["a", "b", "c"].entries()) {
+    (() => {
+        arr1.push((() => i)());
+        arr2.push(() => j);
+    })();
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `var arr = [];
+
+for (var i = 0; i < 5; i ++) {
+    ((f) => {
+        arr.push(f);
+    })(() => {
+        return (() => i)();
+    });
+
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `for (var i = 0; i < 5; i++) {
+    (async () => {
+        () => i;
+    })();
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `for (var i = 0; i < 10; i++) {
+    items.push({
+        id: i,
+        name: "Item " + i
+    });
+
+    const process = function (callback){
+        callback({ id: i, name: "Item " + i });
+    };
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `for (var i = 0; i < 10; i++) {
+  function foo() {
+    console.log(i);
+  }
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `for (var i = 0; i < 10; i++) {
+  const handler = (event: Event) => {
+    console.log(i);
+  };
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `interface Item {
+  id: number;
+  name: string;
+}
+
+const items: Item[] = [];
+for (var i = 0; i < 10; i++) {
+  items.push({
+    id: i,
+    name: "Item " + i
+  });
+
+  const process = function(callback: (item: Item) => void): void {
+    callback({ id: i, name: "Item " + i });
+  };
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `type Processor<T> = (item: T) => void;
+
+for (var i = 0; i < 10; i++) {
+  const processor: Processor<number> = (item) => {
+    return item + i;
+  };
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: `for (var i = 0; i < 10; i++) {
+  const process = (item: UnconfiguredGlobalType) => {
+    console.log(i, item.value);
+  };
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Destructuring bindings in for-in/of iterate on each step.
+    {
+      code: 'for (var {a} of arr) { (function() { a; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var [[a]] of arr) { (function() { a; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var {a = 10} of arr) { (function() { a; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Destructuring assignment in the loop body is a write to the target.
+    {
+      code: 'var a; for (var i = 0; i < l; i++) { [a] = [i]; (function() { a; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'var a; for (var i = 0; i < l; i++) { ({a} = {a: i}); (function() { a; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Async function declaration nested in a loop.
+    {
+      code: 'for (var i = 0; i < l; i++) { async function f() { i; } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // The outer function leaks through-refs from inner nested functions.
+    {
+      code: 'for (var i = 0; i < l; i++) { function foo() { function bar() { i; } bar(); } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Class/object methods, getters, setters, constructors inside a loop.
+    {
+      code: 'for (var i = 0; i < l; i++) { const o = { m() { return i; } }; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < l; i++) { class C { m() { return i; } } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < l; i++) { class C { get x() { return i; } } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < l; i++) { class C { set x(v) { this.a = i + v; } } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < l; i++) { class C { constructor() { this.a = i; } } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < l; i++) { const o = { async m() { return i; } }; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+    {
+      code: 'for (var i = 0; i < l; i++) { const o = { *m() { yield i; } }; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // A function inside a static block inside a loop.
+    {
+      code: `for (var i = 0; i < l; i++) {
+    class C {
+        static {
+            var f = function() { i; };
+        }
+    }
+}`,
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Parameter default value captures the loop var.
+    {
+      code: 'for (var i = 0; i < l; i++) { (function(x = i) { x; }); }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Computed key + body both reference the loop var.
+    {
+      code: 'for (var i = 0; i < l; i++) { var o = { [i]: function() { return i; } }; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Outer binding reassigned in loop — method reads it unsafely.
+    {
+      code: 'var Foo; for (var i = 0; i < l; i++) { Foo = i; const C = class { m() { return Foo; } }; }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // for-await-of with `var` iterator — re-bound on each iteration.
+    {
+      code: 'async function f(xs) { for await (var x of xs) { (function() { x; }) } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Outer FD is flagged because a nested FE leaks an unsafe ref through it.
+    {
+      code: 'for (var i = 0; i < l; i++) { function outer() { (function() { i; }); } }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // FD directly in loop body referencing the loop var.
+    {
+      code: 'for (var i = 0; i < l; i++) { function foo() { return i; } foo(); }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+
+    // Two FD/FE reports in the same loop body (one for foo, one for g).
+    {
+      code: 'for (var i = 0; i < l; i++) { function foo() { return i; } foo = null; var g = function() { foo; }; }',
+      errors: [{ messageId: 'unsafeRefs' }, { messageId: 'unsafeRefs' }],
+    },
+
+    // Multiple distinct unsafe refs listed in source order.
+    {
+      code: 'var a, b; for (var i = 0; i < l; i++) { a = i; b = i; (function() { a + b; }) }',
+      errors: [{ messageId: 'unsafeRefs' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -191,6 +191,9 @@ Unregisterations
 Unregistration
 unrooted
 unstrict
+funcs
+unconfig
+unconfigured
 unstub
 untest
 subtests


### PR DESCRIPTION
## Summary

Port the `no-loop-func` rule from ESLint to rslint.

Disallow function declarations that contain unsafe references inside loop statements. Reports any `FunctionDeclaration` / `FunctionExpression` / `ArrowFunction` / `MethodDeclaration` / `GetAccessor` / `SetAccessor` / `Constructor` inside a loop body whose through-references resolve to variables that are rewritten across iterations (or in a nested function scope), matching ESLint's conservative closure-capture detection.

Implementation notes:

- Mirrors ESLint's `SKIPPED_IIFE_NODES` optimization: non-async, non-generator IIFEs that aren't self-referenced are walked through rather than reported (with paren unwrapping via `ast.WalkUpParenthesizedExpressions` since tsgo preserves `ParenthesizedExpression` nodes that ESTree collapses).
- Named function-expression self-references leak through the function's own scope (ESLint's name-scope semantics) — handled by treating both the function node and its name identifier as external during the inside/outside decision.
- Methods / getters / setters / constructors are registered as explicit listeners because ESTree represents them as `FunctionExpression` values under their property/method node, so ESLint's `FunctionExpression` listener catches them; tsgo uses distinct kinds for each.
- `ClassStaticBlockDeclaration` is intentionally kept transparent (not a walk boundary): each loop iteration creates a new class and re-runs the static block, so closures defined within still exhibit the per-iteration capture problem.
- Destructuring binding introductions inside `for (var/let/const ... in/of ...)` are treated as writes (tsgo's AST requires this to line up with ESLint's scope manager).
- Shorthand property assignments inside destructuring patterns (`({a} = obj)`) resolve to the property symbol via `GetSymbolAtLocation` — handled explicitly with `GetShorthandAssignmentValueSymbol` so the write to the variable is correctly tracked.

Differential validation on real codebases:

- `rsbuild`: 6 reports (all legitimate counter / shared-state patterns — `waitBeforeCompileDone`, `doneCompilers`×2, `outputFiles`, `allLines`, `found`).
- `rspack`: 3 reports (all legitimate — `count`, `doneCompilers`×2).

Verified report-by-report against the source; no false positives. Every report matches a pattern ESLint's no-loop-func would also flag.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-loop-func
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-loop-func.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).