### PR TITLE
ci: bump golangci-lint timeout from 5m to 10m

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           version: v2.11.3
-          args: --timeout=5m ./cmd/... ./internal/...
+          args: --timeout=10m ./cmd/... ./internal/...
 
       - name: go vet
         run: npm run lint:go


### PR DESCRIPTION
## Summary

Bump the `golangci-lint` timeout in CI from `5m` to `10m` to avoid sporadic timeouts that have occasionally failed the Go lint job.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).