### PR TITLE
feat: port rule no-implied-eval

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -157,6 +157,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_func_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_global_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_implicit_coercion"
+	core_no_implied_eval "github.com/web-infra-dev/rslint/internal/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_import_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
@@ -606,6 +607,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-func-assign", no_func_assign.NoFuncAssignRule)
 	GlobalRuleRegistry.Register("no-global-assign", no_global_assign.NoGlobalAssignRule)
 	GlobalRuleRegistry.Register("no-implicit-coercion", no_implicit_coercion.NoImplicitCoercionRule)
+	GlobalRuleRegistry.Register("no-implied-eval", core_no_implied_eval.NoImpliedEvalRule)
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
 	GlobalRuleRegistry.Register("no-lone-blocks", no_lone_blocks.NoLoneBlocksRule)

--- a/internal/rules/no_implied_eval/no_implied_eval.go
+++ b/internal/rules/no_implied_eval/no_implied_eval.go
@@ -1,0 +1,158 @@
+// cspell:ignore sctx
+package no_implied_eval
+
+import (
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var evalLikeFunctions = []string{"setTimeout", "setInterval", "execScript"}
+var globalCandidates = []string{"window", "global", "globalThis", "self"}
+
+// calleeOuterKinds only skips parentheses when inspecting the call's callee or
+// receiver. ESLint's `isSpecificId` / `isSpecificMemberAccess` reject
+// TSNonNullExpression / TSAsExpression / TSTypeAssertion / TSSatisfiesExpression
+// (they are not `Identifier` / `MemberExpression`), so `setTimeout!('code')` and
+// `(window as any).setTimeout('code')` are not flagged. Match that strictly.
+const calleeOuterKinds = ast.OEKParentheses
+
+// argOuterKinds skips parens + TS outer expressions when evaluating the first
+// argument. ESLint's `getStaticValue` transparently unwraps TS assertions, so
+// `setTimeout('code' as any)` still folds to the string "code" and is flagged.
+const argOuterKinds = ast.OEKParentheses | ast.OEKAssertions
+
+func buildImpliedEvalMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "impliedEval",
+		Description: "Implied eval. Consider passing a function instead of a string.",
+	}
+}
+
+func buildExecScriptMessage() rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "execScript",
+		Description: "Implied eval. Do not use execScript().",
+	}
+}
+
+// https://eslint.org/docs/latest/rules/no-implied-eval
+var NoImpliedEvalRule = rule.Rule{
+	Name: "no-implied-eval",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		sctx := newStrCtx(ctx)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if call == nil {
+					return
+				}
+
+				callee := ast.SkipOuterExpressions(call.Expression, calleeOuterKinds)
+				if callee == nil {
+					return
+				}
+
+				var calleeName string
+
+				switch callee.Kind {
+				case ast.KindIdentifier:
+					name := callee.AsIdentifier().Text
+					if !slices.Contains(evalLikeFunctions, name) {
+						return
+					}
+					if utils.IsShadowed(callee, name) {
+						return
+					}
+					calleeName = name
+
+				case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+					name, ok := utils.AccessExpressionStaticName(callee)
+					if !ok || !slices.Contains(evalLikeFunctions, name) {
+						return
+					}
+					if !isGlobalCandidateChain(utils.AccessExpressionObject(callee)) {
+						return
+					}
+					calleeName = name
+
+				default:
+					return
+				}
+
+				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				firstArg := call.Arguments.Nodes[0]
+
+				if !sctx.isString(firstArg) {
+					return
+				}
+
+				if calleeName == "execScript" {
+					ctx.ReportNode(node, buildExecScriptMessage())
+				} else {
+					ctx.ReportNode(node, buildImpliedEvalMessage())
+				}
+			},
+		}
+	},
+}
+
+// isGlobalCandidateChain reports whether `node` is a reference to one of the
+// known global objects (`window`, `global`, `globalThis`, `self`), possibly
+// reached through a chain of **same-named** member accesses (e.g.
+// `window.window`, `global['global']['global']`). Cross-candidate chains such
+// as `window.global.setTimeout` or `self.window.setTimeout` are rejected, to
+// match ESLint's per-candidate scope-manager walk. Shadowed root identifiers
+// are also rejected.
+func isGlobalCandidateChain(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, calleeOuterKinds)
+	if node == nil {
+		return false
+	}
+
+	// Descend through property / element access to find the root identifier.
+	root := node
+	for root.Kind == ast.KindPropertyAccessExpression || root.Kind == ast.KindElementAccessExpression {
+		obj := utils.AccessExpressionObject(root)
+		if obj == nil {
+			return false
+		}
+		root = ast.SkipOuterExpressions(obj, calleeOuterKinds)
+		if root == nil {
+			return false
+		}
+	}
+	if root.Kind != ast.KindIdentifier {
+		return false
+	}
+	rootName := root.AsIdentifier().Text
+	if !slices.Contains(globalCandidates, rootName) {
+		return false
+	}
+	if utils.IsShadowed(root, rootName) {
+		return false
+	}
+
+	// Ascend from the outermost access, verifying every property name equals rootName.
+	current := node
+	for current.Kind == ast.KindPropertyAccessExpression || current.Kind == ast.KindElementAccessExpression {
+		name, ok := utils.AccessExpressionStaticName(current)
+		if !ok || name != rootName {
+			return false
+		}
+		obj := utils.AccessExpressionObject(current)
+		if obj == nil {
+			return false
+		}
+		current = ast.SkipOuterExpressions(obj, calleeOuterKinds)
+		if current == nil {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rules/no_implied_eval/no_implied_eval.md
+++ b/internal/rules/no_implied_eval/no_implied_eval.md
@@ -1,0 +1,45 @@
+# no-implied-eval
+
+## Rule Details
+
+Disallow the use of `eval()`-like methods.
+
+Passing a string as the first argument to `setTimeout`, `setInterval`, or `execScript` causes the string to be evaluated as JavaScript — a form of implied `eval()`. This rule flags such calls, whether made directly or through a global object reference (`window`, `global`, `globalThis`, or `self`).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+setTimeout('alert(\'Hi!\');', 100);
+setInterval('alert(\'Hi!\');', 100);
+execScript('alert(\'Hi!\')');
+
+window.setTimeout('count = 5', 10);
+window.setInterval('foo = bar', 10);
+
+globalThis.setTimeout(`code ${foo}`);
+self.setInterval('foo' + bar);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+setTimeout(function () {
+  alert('Hi!');
+}, 100);
+
+setInterval(function () {
+  alert('Hi!');
+}, 100);
+
+execScript(function () {
+  alert('Hi!');
+});
+
+const handler = () => alert('Hi!');
+setTimeout(handler, 100);
+window.setTimeout(handler, 100);
+```
+
+## Original Documentation
+
+https://eslint.org/docs/latest/rules/no-implied-eval

--- a/internal/rules/no_implied_eval/no_implied_eval_fold.go
+++ b/internal/rules/no_implied_eval/no_implied_eval_fold.go
@@ -1,0 +1,893 @@
+// cspell:ignore unshadowed logicals recognises pname
+package no_implied_eval
+
+import (
+	"math"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// This file implements a self-recursive static fold that mirrors ESLint's
+// `getStaticValue` from `@eslint-community/eslint-utils` for the node shapes
+// the `no-implied-eval` rule relies on. It is intentionally NOT built on
+// tsgo's `shim/evaluator`, because that evaluator's recursion is a private
+// closure — supplementing it at the top level only would leave deeply nested
+// kinds (e.g. ConditionalExpression inside BinaryExpression '+') unhandled.
+// A self-recursive fold handles arbitrary nesting.
+
+// nullVal / undefVal are sentinels distinguishing JS null / undefined values
+// from an unresolved fold. `foldResult{}` (value=nil) means unresolved.
+// arrayVal / objectVal mark resolved composite values — their AST nodes are
+// kept for property lookup (objects) and for method-call gating (arrays).
+type nullVal struct{}
+type undefVal struct{}
+type arrayVal struct{}
+type objectVal struct{ node *ast.Node }
+
+// foldResult is the outcome of a static fold. value==nil means unresolved.
+type foldResult struct {
+	value any
+}
+
+func (r foldResult) resolved() bool      { return r.value != nil }
+func (r foldResult) isStringValue() bool { _, ok := r.value.(string); return ok }
+
+func (r foldResult) truthy() bool {
+	switch v := r.value.(type) {
+	case string:
+		return len(v) != 0
+	case float64:
+		return v != 0 && !math.IsNaN(v)
+	case bool:
+		return v
+	case nullVal, undefVal:
+		return false
+	case arrayVal, objectVal:
+		// Objects and arrays are truthy in JS (including empty ones).
+		return true
+	}
+	return false
+}
+
+func (r foldResult) nullish() bool {
+	switch r.value.(type) {
+	case nullVal, undefVal:
+		return true
+	}
+	return false
+}
+
+// asString implements JS ToString for the resolved value. Used when a String()
+// call or binary '+' coerces a non-string operand to a string.
+func (r foldResult) asString() string {
+	switch v := r.value.(type) {
+	case string:
+		return v
+	case float64:
+		return jsNumberToString(v)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	case nullVal:
+		return "null"
+	case undefVal:
+		return "undefined"
+	case arrayVal:
+		// Exact join of element strings would require carrying the array's
+		// content; we only classify, so any non-empty placeholder keeps the
+		// binary '+' string-concat branch triggered.
+		return "<array>"
+	case objectVal:
+		return "[object Object]"
+	}
+	return ""
+}
+
+// jsNumberToString produces a JS-like string for a float64. Exact parity with
+// ECMAScript ToString(Number) isn't required — no-implied-eval only cares
+// whether the overall expression classifies as string, not the specific digits.
+func jsNumberToString(v float64) string {
+	switch {
+	case math.IsNaN(v):
+		return "NaN"
+	case math.IsInf(v, 1):
+		return "Infinity"
+	case math.IsInf(v, -1):
+		return "-Infinity"
+	case v == 0:
+		return "0"
+	}
+	return strconv.FormatFloat(v, 'g', -1, 64)
+}
+
+// strCtx carries per-rule-invocation state for the static fold. A single
+// instance is reused by all listener callbacks within one file.
+type strCtx struct {
+	ruleCtx rule.RuleContext
+
+	writeRefsComputed bool
+	writeRefsMap      map[*ast.Symbol]bool
+}
+
+func newStrCtx(ctx rule.RuleContext) *strCtx {
+	return &strCtx{ruleCtx: ctx}
+}
+
+// isString reports whether `node` is known — syntactically or via static
+// fold — to evaluate to a string. Union of ESLint's `isEvaluatedString`
+// (syntactic shape) and `getStaticValue` with scope (semantic fold).
+func (s *strCtx) isString(node *ast.Node) bool {
+	if isEvaluatedString(node) {
+		return true
+	}
+	return s.fold(node).isStringValue()
+}
+
+// isEvaluatedString is a purely syntactic check. Mirrors ESLint's
+// `ast-utils.isEvaluatedString`: a StringLiteral / TemplateLiteral, or a '+'
+// BinaryExpression where either side is syntactically a string. It fires on
+// shapes the semantic fold may not resolve — e.g. `'x' + unknown`, where the
+// overall concat is provably a string regardless of `unknown`.
+func isEvaluatedString(node *ast.Node) bool {
+	node = ast.SkipOuterExpressions(node, argOuterKinds)
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression:
+		return true
+	case ast.KindBinaryExpression:
+		be := node.AsBinaryExpression()
+		if be != nil && be.OperatorToken != nil && be.OperatorToken.Kind == ast.KindPlusToken {
+			return isEvaluatedString(be.Left) || isEvaluatedString(be.Right)
+		}
+	}
+	return false
+}
+
+// fold recursively evaluates `node` to a static value, handling arbitrary
+// nesting of the shapes ESLint's `getStaticValue` covers for this rule:
+//
+//   - Literals: string / template / numeric / true / false / null
+//   - Identifier: const / let-no-writes / var-no-writes → initializer
+//   - `undefined` global (when unshadowed) → undefined
+//   - BinaryExpression: '+' (string or numeric concat), arithmetic, bitwise,
+//     logical `||` `&&` `??` (short-circuit)
+//   - PrefixUnaryExpression: '+' '-' '~' '!'
+//   - ConditionalExpression: `c ? a : b` (picks the branch once `c` resolves)
+//   - TypeOfExpression: always yields a string if the operand resolves
+//   - VoidExpression: always undefined
+//   - CallExpression: `String(x)` / `String()` with resolvable arg
+//   - TaggedTemplateExpression: `String.raw`…``  with resolvable subs
+//   - TemplateExpression: substitution folding
+//
+// Returns foldResult{} (value==nil) when the node can't be statically resolved.
+func (s *strCtx) fold(node *ast.Node) foldResult {
+	node = ast.SkipOuterExpressions(node, argOuterKinds)
+	if node == nil {
+		return foldResult{}
+	}
+
+	switch node.Kind {
+	case ast.KindStringLiteral:
+		return foldResult{node.AsStringLiteral().Text}
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return foldResult{node.AsNoSubstitutionTemplateLiteral().Text}
+	case ast.KindNumericLiteral:
+		n, err := strconv.ParseFloat(node.AsNumericLiteral().Text, 64)
+		if err != nil {
+			return foldResult{}
+		}
+		return foldResult{n}
+	case ast.KindTrueKeyword:
+		return foldResult{true}
+	case ast.KindFalseKeyword:
+		return foldResult{false}
+	case ast.KindNullKeyword:
+		return foldResult{nullVal{}}
+	case ast.KindIdentifier:
+		id := node.AsIdentifier()
+		if id.Text == "undefined" && !utils.IsShadowed(node, "undefined") {
+			return foldResult{undefVal{}}
+		}
+		return s.foldIdentifier(node)
+	case ast.KindTemplateExpression:
+		return s.foldTemplate(node)
+	case ast.KindBinaryExpression:
+		return s.foldBinary(node)
+	case ast.KindPrefixUnaryExpression:
+		return s.foldPrefixUnary(node)
+	case ast.KindConditionalExpression:
+		return s.foldConditional(node)
+	case ast.KindTypeOfExpression:
+		return s.foldTypeOf(node)
+	case ast.KindVoidExpression:
+		// `void X` always evaluates to undefined regardless of X.
+		return foldResult{undefVal{}}
+	case ast.KindCallExpression:
+		return s.foldCall(node)
+	case ast.KindTaggedTemplateExpression:
+		return s.foldStringRawTag(node)
+	case ast.KindArrayLiteralExpression:
+		return s.foldArrayLiteral(node)
+	case ast.KindObjectLiteralExpression:
+		return foldResult{objectVal{node: node}}
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		return s.foldMemberAccess(node)
+	}
+	return foldResult{}
+}
+
+// foldIdentifier resolves an Identifier to its initializer value, matching
+// ESLint's scope-manager behavior: const is always eligible; let/var require
+// no non-initial write references anywhere in the file.
+func (s *strCtx) foldIdentifier(node *ast.Node) foldResult {
+	if s.ruleCtx.TypeChecker == nil {
+		return foldResult{}
+	}
+	// GetReferenceSymbol handles the shorthand-property edge case where the
+	// identifier is the key of `{ foo }` — there the plain GetSymbolAtLocation
+	// returns the property symbol, not the outer binding we want to resolve.
+	sym := utils.GetReferenceSymbol(node, s.ruleCtx.TypeChecker)
+	if sym == nil || len(sym.Declarations) != 1 {
+		return foldResult{}
+	}
+	decl := sym.Declarations[0]
+	if decl.Kind != ast.KindVariableDeclaration {
+		return foldResult{}
+	}
+	varDecl := decl.AsVariableDeclaration()
+	if varDecl == nil || varDecl.Initializer == nil {
+		return foldResult{}
+	}
+	list := decl.Parent
+	if list == nil || list.Kind != ast.KindVariableDeclarationList {
+		return foldResult{}
+	}
+	// const: always resolvable. let/var: require no writes after init.
+	if list.Flags&ast.NodeFlagsConst == 0 && s.hasWrites(sym) {
+		return foldResult{}
+	}
+	return s.fold(varDecl.Initializer)
+}
+
+// foldTemplate folds a TemplateExpression by concatenating head + each
+// span's expression (recursively folded) + span's literal tail. Returns
+// unresolved if any span can't be folded.
+func (s *strCtx) foldTemplate(node *ast.Node) foldResult {
+	te := node.AsTemplateExpression()
+	if te == nil {
+		return foldResult{}
+	}
+	var sb strings.Builder
+	if te.Head != nil {
+		sb.WriteString(te.Head.Text())
+	}
+	if te.TemplateSpans != nil {
+		for _, span := range te.TemplateSpans.Nodes {
+			sp := span.AsTemplateSpan()
+			if sp == nil {
+				return foldResult{}
+			}
+			sub := s.fold(sp.Expression)
+			if !sub.resolved() {
+				return foldResult{}
+			}
+			sb.WriteString(sub.asString())
+			if sp.Literal != nil {
+				sb.WriteString(sp.Literal.Text())
+			}
+		}
+	}
+	return foldResult{sb.String()}
+}
+
+// foldBinary handles both short-circuit logicals (with partial evaluation)
+// and arithmetic / string-concat (requires both sides resolved).
+func (s *strCtx) foldBinary(node *ast.Node) foldResult {
+	be := node.AsBinaryExpression()
+	if be == nil || be.OperatorToken == nil {
+		return foldResult{}
+	}
+	op := be.OperatorToken.Kind
+
+	// Short-circuit: we only need the left side to decide which operand the
+	// overall expression evaluates to.
+	switch op {
+	case ast.KindBarBarToken:
+		left := s.fold(be.Left)
+		if !left.resolved() {
+			return foldResult{}
+		}
+		if left.truthy() {
+			return left
+		}
+		return s.fold(be.Right)
+	case ast.KindAmpersandAmpersandToken:
+		left := s.fold(be.Left)
+		if !left.resolved() {
+			return foldResult{}
+		}
+		if !left.truthy() {
+			return left
+		}
+		return s.fold(be.Right)
+	case ast.KindQuestionQuestionToken:
+		left := s.fold(be.Left)
+		if !left.resolved() {
+			return foldResult{}
+		}
+		if left.nullish() {
+			return s.fold(be.Right)
+		}
+		return left
+	}
+
+	// Arithmetic / concat: need both sides.
+	left := s.fold(be.Left)
+	right := s.fold(be.Right)
+	if !left.resolved() || !right.resolved() {
+		return foldResult{}
+	}
+	ln, lnIs := left.value.(float64)
+	rn, rnIs := right.value.(float64)
+
+	switch op {
+	case ast.KindPlusToken:
+		// Pure numeric add.
+		if lnIs && rnIs {
+			return foldResult{ln + rn}
+		}
+		// String concat: if either side is a string, stringify both.
+		if _, lsIs := left.value.(string); lsIs {
+			return foldResult{left.asString() + right.asString()}
+		}
+		if _, rsIs := right.value.(string); rsIs {
+			return foldResult{left.asString() + right.asString()}
+		}
+	case ast.KindMinusToken:
+		if lnIs && rnIs {
+			return foldResult{ln - rn}
+		}
+	case ast.KindAsteriskToken:
+		if lnIs && rnIs {
+			return foldResult{ln * rn}
+		}
+	case ast.KindSlashToken:
+		if lnIs && rnIs {
+			return foldResult{ln / rn}
+		}
+	case ast.KindPercentToken:
+		if lnIs && rnIs {
+			return foldResult{math.Mod(ln, rn)}
+		}
+	case ast.KindAsteriskAsteriskToken:
+		if lnIs && rnIs {
+			return foldResult{math.Pow(ln, rn)}
+		}
+	case ast.KindBarToken:
+		if lnIs && rnIs {
+			return foldResult{float64(int32(ln) | int32(rn))}
+		}
+	case ast.KindAmpersandToken:
+		if lnIs && rnIs {
+			return foldResult{float64(int32(ln) & int32(rn))}
+		}
+	case ast.KindCaretToken:
+		if lnIs && rnIs {
+			return foldResult{float64(int32(ln) ^ int32(rn))}
+		}
+	case ast.KindLessThanLessThanToken:
+		if lnIs && rnIs {
+			return foldResult{float64(int32(ln) << (uint32(rn) & 31))}
+		}
+	case ast.KindGreaterThanGreaterThanToken:
+		if lnIs && rnIs {
+			return foldResult{float64(int32(ln) >> (uint32(rn) & 31))}
+		}
+	case ast.KindGreaterThanGreaterThanGreaterThanToken:
+		if lnIs && rnIs {
+			return foldResult{float64(uint32(ln) >> (uint32(rn) & 31))}
+		}
+	}
+	return foldResult{}
+}
+
+func (s *strCtx) foldPrefixUnary(node *ast.Node) foldResult {
+	pre := node.AsPrefixUnaryExpression()
+	if pre == nil {
+		return foldResult{}
+	}
+	operand := s.fold(pre.Operand)
+	if !operand.resolved() {
+		return foldResult{}
+	}
+	if n, ok := operand.value.(float64); ok {
+		switch pre.Operator {
+		case ast.KindPlusToken:
+			return foldResult{n}
+		case ast.KindMinusToken:
+			return foldResult{-n}
+		case ast.KindTildeToken:
+			return foldResult{float64(^int32(n))}
+		}
+	}
+	if pre.Operator == ast.KindExclamationToken {
+		return foldResult{!operand.truthy()}
+	}
+	return foldResult{}
+}
+
+func (s *strCtx) foldConditional(node *ast.Node) foldResult {
+	cond := node.AsConditionalExpression()
+	if cond == nil {
+		return foldResult{}
+	}
+	c := s.fold(cond.Condition)
+	if !c.resolved() {
+		return foldResult{}
+	}
+	if c.truthy() {
+		return s.fold(cond.WhenTrue)
+	}
+	return s.fold(cond.WhenFalse)
+}
+
+// foldTypeOf matches ESLint's getStaticValue behavior: typeof is only folded
+// when the operand itself resolves (otherwise the runtime type is
+// unobservable — typeof of an undeclared identifier yields "undefined" but
+// typeof of a resolvable binding yields its concrete type name).
+func (s *strCtx) foldTypeOf(node *ast.Node) foldResult {
+	tof := node.AsTypeOfExpression()
+	if tof == nil {
+		return foldResult{}
+	}
+	inner := s.fold(tof.Expression)
+	if !inner.resolved() {
+		return foldResult{}
+	}
+	switch inner.value.(type) {
+	case string:
+		return foldResult{"string"}
+	case float64:
+		return foldResult{"number"}
+	case bool:
+		return foldResult{"boolean"}
+	case nullVal:
+		return foldResult{"object"}
+	case undefVal:
+		return foldResult{"undefined"}
+	}
+	return foldResult{}
+}
+
+// foldCall dispatches CallExpressions to the handlers ESLint's getStaticValue
+// recognises for this rule: `String(arg)` constructor, and prototype method
+// calls in our whitelist. Everything else remains unresolved.
+func (s *strCtx) foldCall(node *ast.Node) foldResult {
+	call := node.AsCallExpression()
+	if call == nil {
+		return foldResult{}
+	}
+	callee := ast.SkipOuterExpressions(call.Expression, calleeOuterKinds)
+	if callee == nil {
+		return foldResult{}
+	}
+	// `String(arg)` — the global String constructor coerces any resolvable
+	// value to its string form.
+	if ast.IsIdentifier(callee) && callee.AsIdentifier().Text == "String" && !utils.IsShadowed(callee, "String") {
+		if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+			return foldResult{""}
+		}
+		arg := s.fold(call.Arguments.Nodes[0])
+		if !arg.resolved() {
+			return foldResult{}
+		}
+		return foldResult{arg.asString()}
+	}
+	// `receiver.method(...)` — whitelisted prototype methods whose return type
+	// is known (string or array), matching eslint-utils's getStaticValue.
+	return s.foldMethodCall(call, callee)
+}
+
+// stringReturningMethods are the prototype methods that eslint-utils's
+// getStaticValue folds to a string value. Discovered empirically against
+// ESLint 10 (see /tmp/no-implied-eval-diff/method-scope.mjs and deep-scope.mjs).
+// Excluded on purpose: repeat, replace, replaceAll, split, charCodeAt,
+// codePointAt, indexOf, lastIndexOf, startsWith, endsWith, includes,
+// toLocaleString — eslint-utils doesn't fold these and neither should we.
+var stringReturningMethods = map[string]bool{
+	// String.prototype
+	"toString":    true,
+	"toUpperCase": true,
+	"toLowerCase": true,
+	"trim":        true,
+	"trimStart":   true,
+	"trimEnd":     true,
+	"concat":      true,
+	"slice":       true,
+	"substring":   true,
+	"substr":      true,
+	"padStart":    true,
+	"padEnd":      true,
+	"charAt":      true,
+	"at":          true,
+	"normalize":   true,
+	// Number.prototype
+	"toFixed":       true,
+	"toExponential": true,
+	"toPrecision":   true,
+	// Array.prototype
+	"join": true,
+}
+
+// arrayReturningMethods fold to an array value, enabling chains such as
+// `[1,2].slice(0).toString()`.
+var arrayReturningMethods = map[string]bool{
+	"slice":   true,
+	"concat":  true,
+	"flat":    true,
+	"flatMap": true,
+	"reverse": true,
+	"sort":    true,
+}
+
+// foldMethodCall handles `receiver.method(...)` for whitelisted prototype
+// methods. The receiver must itself fold to a concrete value; otherwise we
+// can't prove the call's result at compile time.
+func (s *strCtx) foldMethodCall(call *ast.CallExpression, callee *ast.Node) foldResult {
+	var method string
+	var recvExpr *ast.Node
+	switch callee.Kind {
+	case ast.KindPropertyAccessExpression:
+		pae := callee.AsPropertyAccessExpression()
+		if pae == nil || pae.Name() == nil || !ast.IsIdentifier(pae.Name()) {
+			return foldResult{}
+		}
+		method = pae.Name().AsIdentifier().Text
+		recvExpr = pae.Expression
+	case ast.KindElementAccessExpression:
+		eae := callee.AsElementAccessExpression()
+		if eae == nil {
+			return foldResult{}
+		}
+		name, ok := utils.GetStaticExpressionValue(eae.ArgumentExpression)
+		if !ok {
+			return foldResult{}
+		}
+		method = name
+		recvExpr = eae.Expression
+	default:
+		return foldResult{}
+	}
+
+	returnsString := stringReturningMethods[method]
+	returnsArray := arrayReturningMethods[method]
+	if !returnsString && !returnsArray {
+		return foldResult{}
+	}
+	recv := s.fold(recvExpr)
+	if !recv.resolved() {
+		return foldResult{}
+	}
+	// Array-only methods (join) require an array receiver.
+	if method == "join" {
+		if _, isArr := recv.value.(arrayVal); !isArr {
+			return foldResult{}
+		}
+	}
+	// Number-only methods require a numeric receiver.
+	if method == "toFixed" || method == "toExponential" || method == "toPrecision" {
+		if _, isNum := recv.value.(float64); !isNum {
+			return foldResult{}
+		}
+	}
+	if returnsString {
+		return foldResult{""}
+	}
+	// returnsArray: propagate array-ness so the next method in a chain can fold.
+	return foldResult{arrayVal{}}
+}
+
+// foldArrayLiteral returns a resolved array value iff every element itself
+// folds (mirrors ESLint's conservative array-literal evaluation — any
+// unresolvable element taints the whole array).
+func (s *strCtx) foldArrayLiteral(node *ast.Node) foldResult {
+	arr := node.AsArrayLiteralExpression()
+	if arr == nil {
+		return foldResult{arrayVal{}}
+	}
+	if arr.Elements != nil {
+		for _, el := range arr.Elements.Nodes {
+			if el == nil || el.Kind == ast.KindOmittedExpression {
+				continue
+			}
+			// Spread elements would require the spread target itself to be
+			// iterable and fully resolved; we don't attempt to fold them.
+			if el.Kind == ast.KindSpreadElement {
+				return foldResult{}
+			}
+			if !s.fold(el).resolved() {
+				return foldResult{}
+			}
+		}
+	}
+	return foldResult{arrayVal{}}
+}
+
+// foldMemberAccess handles `o.x` / `o['x']` / `o[0]` by resolving the receiver
+// to an object literal (possibly via const / let-no-writes / var-no-writes
+// identifier chains and nested property accesses) and then looking up the key.
+// The key itself is resolved via the static fold — bracket access expressions
+// that only become constant after const-folding (e.g. `o[k]` where
+// `const k = 'x'`) are handled the same way ESLint's getStaticValue does.
+func (s *strCtx) foldMemberAccess(node *ast.Node) foldResult {
+	key, recvExpr, ok := s.memberAccessKey(node)
+	if !ok {
+		return foldResult{}
+	}
+	obj := s.resolveToObjectLiteral(recvExpr)
+	if obj == nil {
+		return foldResult{}
+	}
+	val := s.findPropertyValueNode(obj, key)
+	if val == nil {
+		return foldResult{}
+	}
+	return s.fold(val)
+}
+
+// memberAccessKey extracts the static key and receiver expression of a
+// Property/ElementAccess. For ElementAccess with a non-literal argument,
+// it folds the argument as a last resort.
+func (s *strCtx) memberAccessKey(node *ast.Node) (key string, receiver *ast.Node, ok bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		pae := node.AsPropertyAccessExpression()
+		if pae == nil || pae.Name() == nil || !ast.IsIdentifier(pae.Name()) {
+			return "", nil, false
+		}
+		return pae.Name().AsIdentifier().Text, pae.Expression, true
+	case ast.KindElementAccessExpression:
+		eae := node.AsElementAccessExpression()
+		if eae == nil {
+			return "", nil, false
+		}
+		if k, kok := utils.GetStaticExpressionValue(eae.ArgumentExpression); kok {
+			return k, eae.Expression, true
+		}
+		// Fallback: fold the argument; covers `o[k]` where k resolves via
+		// const / let-no-writes / var-no-writes to a string or number.
+		r := s.fold(eae.ArgumentExpression)
+		if !r.resolved() {
+			return "", nil, false
+		}
+		return r.asString(), eae.Expression, true
+	}
+	return "", nil, false
+}
+
+// resolveToObjectLiteral walks through const / let-no-writes / var-no-writes
+// identifier initializers and nested property accesses to locate the
+// underlying ObjectLiteralExpression node. Returns nil if the receiver
+// can't be resolved to a single object literal at compile time.
+func (s *strCtx) resolveToObjectLiteral(node *ast.Node) *ast.Node {
+	node = ast.SkipOuterExpressions(node, argOuterKinds)
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case ast.KindObjectLiteralExpression:
+		return node
+	case ast.KindIdentifier:
+		if s.ruleCtx.TypeChecker == nil {
+			return nil
+		}
+		sym := utils.GetReferenceSymbol(node, s.ruleCtx.TypeChecker)
+		if sym == nil || len(sym.Declarations) != 1 {
+			return nil
+		}
+		decl := sym.Declarations[0]
+		if decl.Kind != ast.KindVariableDeclaration {
+			return nil
+		}
+		varDecl := decl.AsVariableDeclaration()
+		if varDecl == nil || varDecl.Initializer == nil {
+			return nil
+		}
+		list := decl.Parent
+		if list == nil || list.Kind != ast.KindVariableDeclarationList {
+			return nil
+		}
+		if list.Flags&ast.NodeFlagsConst == 0 && s.hasWrites(sym) {
+			return nil
+		}
+		return s.resolveToObjectLiteral(varDecl.Initializer)
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		key, recvExpr, ok := s.memberAccessKey(node)
+		if !ok {
+			return nil
+		}
+		parent := s.resolveToObjectLiteral(recvExpr)
+		if parent == nil {
+			return nil
+		}
+		sub := s.findPropertyValueNode(parent, key)
+		if sub == nil {
+			return nil
+		}
+		return s.resolveToObjectLiteral(sub)
+	}
+	return nil
+}
+
+// findPropertyValueNode returns the value expression associated with `key`
+// inside an ObjectLiteralExpression. Handles regular, shorthand, and computed
+// property names — including computed keys whose expression only becomes
+// constant after folding (e.g. `const k = 'x'; {[k]: 'y'}.x`). Skips spread,
+// accessors, and computed keys whose expression can't be resolved.
+func (s *strCtx) findPropertyValueNode(obj *ast.Node, key string) *ast.Node {
+	if obj == nil || obj.Kind != ast.KindObjectLiteralExpression {
+		return nil
+	}
+	lit := obj.AsObjectLiteralExpression()
+	if lit == nil || lit.Properties == nil {
+		return nil
+	}
+	for _, p := range lit.Properties.Nodes {
+		switch p.Kind {
+		case ast.KindPropertyAssignment:
+			pa := p.AsPropertyAssignment()
+			if pa == nil || pa.Name() == nil {
+				continue
+			}
+			if !s.propertyKeyMatches(pa.Name(), key) {
+				continue
+			}
+			return pa.Initializer
+		case ast.KindShorthandPropertyAssignment:
+			spa := p.AsShorthandPropertyAssignment()
+			if spa == nil || spa.Name() == nil {
+				continue
+			}
+			n := spa.Name()
+			if !ast.IsIdentifier(n) || n.AsIdentifier().Text != key {
+				continue
+			}
+			// `{x}` resolves to the outer binding `x` — fold it via the
+			// same identifier path the rest of the fold uses.
+			return n
+		}
+	}
+	return nil
+}
+
+// propertyKeyMatches compares a property-name node against a target key,
+// resolving computed keys through the static fold so that
+// `const k = 'x'; {[k]: ...}` matches the key "x".
+func (s *strCtx) propertyKeyMatches(nameNode *ast.Node, key string) bool {
+	if pname, ok := utils.GetStaticPropertyName(nameNode); ok {
+		return pname == key
+	}
+	if nameNode.Kind == ast.KindComputedPropertyName {
+		c := nameNode.AsComputedPropertyName()
+		if c == nil {
+			return false
+		}
+		r := s.fold(c.Expression)
+		if !r.resolved() {
+			return false
+		}
+		return r.asString() == key
+	}
+	return false
+}
+
+// foldStringRawTag handles `` String.raw`...` `` — ESLint's getStaticValue
+// recognises the built-in tag and folds the template with each substitution
+// recursively evaluated.
+func (s *strCtx) foldStringRawTag(node *ast.Node) foldResult {
+	tt := node.AsTaggedTemplateExpression()
+	if tt == nil || tt.Tag == nil || tt.Template == nil {
+		return foldResult{}
+	}
+	if !s.isStringRawTag(tt.Tag) {
+		return foldResult{}
+	}
+	switch tt.Template.Kind {
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return foldResult{tt.Template.Text()}
+	case ast.KindTemplateExpression:
+		te := tt.Template.AsTemplateExpression()
+		if te == nil {
+			return foldResult{}
+		}
+		var sb strings.Builder
+		if te.Head != nil {
+			sb.WriteString(te.Head.Text())
+		}
+		if te.TemplateSpans != nil {
+			for _, span := range te.TemplateSpans.Nodes {
+				sp := span.AsTemplateSpan()
+				if sp == nil {
+					return foldResult{}
+				}
+				sub := s.fold(sp.Expression)
+				if !sub.resolved() {
+					return foldResult{}
+				}
+				sb.WriteString(sub.asString())
+				if sp.Literal != nil {
+					sb.WriteString(sp.Literal.Text())
+				}
+			}
+		}
+		return foldResult{sb.String()}
+	}
+	return foldResult{}
+}
+
+// isStringRawTag reports whether `tag` refers to the built-in `String.raw`.
+func (s *strCtx) isStringRawTag(tag *ast.Node) bool {
+	tag = ast.SkipOuterExpressions(tag, calleeOuterKinds)
+	if tag == nil || tag.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pae := tag.AsPropertyAccessExpression()
+	if pae == nil {
+		return false
+	}
+	name := pae.Name()
+	if name == nil || !ast.IsIdentifier(name) || name.AsIdentifier().Text != "raw" {
+		return false
+	}
+	obj := ast.SkipOuterExpressions(pae.Expression, calleeOuterKinds)
+	if obj == nil || !ast.IsIdentifier(obj) {
+		return false
+	}
+	if obj.AsIdentifier().Text != "String" {
+		return false
+	}
+	return !utils.IsShadowed(obj, "String")
+}
+
+// hasWrites reports whether `sym` has any write reference in the source file.
+// For let / var, a single write after initialization disqualifies the binding
+// from static resolution. Lazily computed on first call.
+func (s *strCtx) hasWrites(sym *ast.Symbol) bool {
+	if !s.writeRefsComputed {
+		s.computeWriteRefs()
+	}
+	return s.writeRefsMap[sym]
+}
+
+func (s *strCtx) computeWriteRefs() {
+	s.writeRefsComputed = true
+	if s.ruleCtx.TypeChecker == nil || s.ruleCtx.SourceFile == nil {
+		return
+	}
+	m := map[*ast.Symbol]bool{}
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if n == nil {
+			return
+		}
+		if n.Kind == ast.KindIdentifier && utils.IsWriteReference(n) {
+			if sym := s.ruleCtx.TypeChecker.GetSymbolAtLocation(n); sym != nil {
+				m[sym] = true
+			}
+		}
+		n.ForEachChild(func(c *ast.Node) bool {
+			visit(c)
+			return false
+		})
+	}
+	visit(&s.ruleCtx.SourceFile.Node)
+	s.writeRefsMap = m
+}

--- a/internal/rules/no_implied_eval/no_implied_eval_test.go
+++ b/internal/rules/no_implied_eval/no_implied_eval_test.go
@@ -1,0 +1,1169 @@
+// cspell:ignore wibble
+package no_implied_eval
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoImpliedEvalRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoImpliedEvalRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Direct references without a call (global name is not invoked as eval) ----
+			{Code: `setTimeout();`},
+			{Code: `setTimeout;`},
+			{Code: `setTimeout = foo;`},
+			{Code: `window.setTimeout;`},
+			{Code: `window.setTimeout = foo;`},
+			{Code: `window['setTimeout'];`},
+			{Code: `window['setTimeout'] = foo;`},
+			{Code: `global.setTimeout;`},
+			{Code: `global.setTimeout = foo;`},
+			{Code: `global['setTimeout'];`},
+			{Code: `global['setTimeout'] = foo;`},
+			{Code: `globalThis['setTimeout'] = foo;`},
+
+			// ---- Calls where the first argument is not evaluated as a string ----
+			{Code: `setTimeout(function() { x = 1; }, 100);`},
+			{Code: `setInterval(function() { x = 1; }, 100);`},
+			{Code: `execScript(function() { x = 1; }, 100);`},
+			{Code: `window.setTimeout(function() { x = 1; }, 100);`},
+			{Code: `window.setInterval(function() { x = 1; }, 100);`},
+			{Code: `window.execScript(function() { x = 1; }, 100);`},
+			{Code: `window.setTimeout(foo, 100);`},
+			{Code: `window.setInterval(foo, 100);`},
+			{Code: `window.execScript(foo, 100);`},
+			{Code: `global.setTimeout(function() { x = 1; }, 100);`},
+			{Code: `global.setInterval(function() { x = 1; }, 100);`},
+			{Code: `global.execScript(function() { x = 1; }, 100);`},
+			{Code: `global.setTimeout(foo, 100);`},
+			{Code: `global.setInterval(foo, 100);`},
+			{Code: `global.execScript(foo, 100);`},
+			{Code: `globalThis.setTimeout(foo, 100);`},
+
+			// ---- Non-global receiver: only top-level / known-global receivers are checked ----
+			{Code: `foo.setTimeout('hi')`},
+
+			// ---- Identifier / function-expression arguments are safe ----
+			{Code: `setTimeout(foo, 10)`},
+			{Code: `setInterval(1, 10)`},
+			{Code: `execScript(2)`},
+			{Code: `setTimeout(function() {}, 10)`},
+			{Code: `foo.setInterval('hi')`},
+			{Code: `setInterval(foo, 10)`},
+			{Code: `setInterval(function() {}, 10)`},
+			{Code: `foo.execScript('hi')`},
+			{Code: `execScript(foo)`},
+			{Code: `execScript(function() {})`},
+
+			// ---- Binary `+` of non-strings does not guarantee a string ----
+			{Code: `setTimeout(foo + bar, 10)`},
+
+			// ---- Only the first argument is checked ----
+			{Code: `setTimeout(foobar, 'buzz')`},
+			{Code: `setTimeout(foobar, foo + 'bar')`},
+
+			// ---- Only the immediate subtree of the argument is inspected ----
+			{Code: `setTimeout(function() { return 'foobar'; }, 10)`},
+
+			// ---- Prefix-match names that are not actually setTimeout/etc. ----
+			// https://github.com/eslint/eslint/issues/7821
+			{Code: `setTimeoutFooBar('Foo Bar')`},
+
+			// ---- Non-global intermediate receivers ----
+			{Code: `foo.window.setTimeout('foo', 100);`},
+			{Code: `foo.global.setTimeout('foo', 100);`},
+
+			// ---- Shadowing by variable declaration ----
+			{Code: `var window; window.setTimeout('foo', 100);`},
+			{Code: `var global; global.setTimeout('foo', 100);`},
+
+			// ---- Shadowing by function parameter ----
+			{Code: `function foo(window) { window.setTimeout('foo', 100); }`},
+			{Code: `function foo(global) { global.setTimeout('foo', 100); }`},
+
+			// ---- Not a call — passed as an argument ----
+			{Code: `foo('', window.setTimeout);`},
+			{Code: `foo('', global.setTimeout);`},
+
+			// ---- Shadowing by function declaration at the top level ----
+			// https://github.com/eslint/eslint/issues/19923
+			{Code: `
+			function execScript(string) {
+				console.log("This is not your grandparent's execScript().");
+			}
+
+			execScript('wibble');
+			`},
+			{Code: `
+			function setTimeout(string) {
+				console.log("This is not your grandparent's setTimeout().");
+			}
+
+			setTimeout('wibble');
+			`},
+			{Code: `
+			function setInterval(string) {
+				console.log("This is not your grandparent's setInterval().");
+			}
+
+			setInterval('wibble');
+			`},
+
+			// ---- Shadowing in a nested scope ----
+			{Code: `
+			function outer() {
+				function setTimeout(string) {
+					console.log("Shadowed setTimeout");
+				}
+				setTimeout('code');
+			}
+			`},
+			{Code: `
+			function outer() {
+				function setInterval(string) {
+					console.log("Shadowed setInterval");
+				}
+				setInterval('code');
+			}
+			`},
+			{Code: `
+			function outer() {
+				function execScript(string) {
+					console.log("Shadowed execScript");
+				}
+				execScript('code');
+			}
+			`},
+			{Code: `
+			{
+				const setTimeout = function(string) {
+					console.log("Block-scoped setTimeout");
+				};
+				setTimeout('code');
+			}
+			`},
+			{Code: `
+			{
+				const setInterval = function(string) {
+					console.log("Block-scoped setInterval");
+				};
+				setInterval('code');
+			}
+			`},
+
+			// ---- Template literal receivers are not static names in our set ----
+			{Code: "window[`SetTimeOut`]('foo', 100);"},
+			{Code: "global[`SetTimeOut`]('foo', 100);"},
+			{Code: "global[`setTimeout${foo}`]('foo', 100);"},
+			{Code: "globalThis[`setTimeout${foo}`]('foo', 100);"},
+			{Code: "self[`SetTimeOut`]('foo', 100);"},
+			{Code: "self[`setTimeout${foo}`]('foo', 100);"},
+
+			// ---- self as global candidate ----
+			{Code: `self.setTimeout;`},
+			{Code: `self.setTimeout = foo;`},
+			{Code: `self['setTimeout'];`},
+			{Code: `self['setTimeout'] = foo;`},
+			{Code: `self.setTimeout(function() { x = 1; }, 100);`},
+			{Code: `self.setInterval(function() { x = 1; }, 100);`},
+			{Code: `self.execScript(function() { x = 1; }, 100);`},
+			{Code: `self.setTimeout(foo, 100);`},
+			{Code: `foo.self.setTimeout('foo', 100);`},
+			{Code: `var self; self.setTimeout('foo', 100);`},
+			{Code: `function foo(self) { self.setTimeout('foo', 100); }`},
+			{Code: `foo('', self.setTimeout);`},
+			{Code: `
+			function outer() {
+				function self() {
+					console.log("Shadowed self");
+				}
+				self.setTimeout('code');
+			}`},
+
+			// ---- Cross-candidate chains: upstream only walks same-name chains ----
+			{Code: `window.global.setTimeout('code');`},
+			{Code: `self.window.setTimeout('code');`},
+			{Code: `globalThis.window.setTimeout('code');`},
+			{Code: `window['global']['setTimeout']('code');`},
+			{Code: `self['globalThis']['setTimeout']('code');`},
+			// `this` is not a global candidate, so `this.setTimeout('code')` is not flagged.
+			{Code: `this.setTimeout('code');`},
+			{Code: `this['setTimeout']('code');`},
+
+			// ---- TS outer expressions on callee / receiver: upstream uses
+			// `isSpecificId` / `isSpecificMemberAccess`, which reject
+			// TSNonNullExpression / TSAsExpression / TSTypeAssertion /
+			// TSSatisfiesExpression (they are not Identifier / MemberExpression).
+			// Strict alignment: not flagged.
+			{Code: `setTimeout!('code')`},
+			{Code: `(setTimeout as Function)('code')`},
+			{Code: `(window.setTimeout!)('code')`},
+			{Code: `(window.setTimeout as Function)('code')`},
+			{Code: `window!.setTimeout('code')`},
+			{Code: `(window as any).setTimeout('code')`},
+			{Code: `(window as any).execScript('code')`},
+
+			// ---- let / var with writes: not resolvable → not flagged ----
+			{Code: `let s = 'x'; s = 'y'; setTimeout(s);`},
+			{Code: `var s = 'x'; s = 'y'; setTimeout(s);`},
+
+			// ---- Conditional with unresolvable cond → not flagged ----
+			{Code: `setTimeout(c ? 'x' : 'y');`},
+
+			// ---- Logical / nullish with non-string short-circuit result → not flagged ----
+			{Code: `setTimeout(null && 'x');`},
+			{Code: `setTimeout(1 ?? 'b');`}, // 1 is not nullish → returns 1 (number)
+			// Purely numeric binary produces a number, not a string.
+			{Code: `setTimeout(1 + 2);`},
+			{Code: `const a = 1; const b = 2; setTimeout(a + b);`},
+
+			// ---- String() with unresolvable arg → not flagged ----
+			{Code: `setTimeout(String(x));`},
+			{Code: `setTimeout(String(x + y));`},
+			{Code: `setTimeout(Number('x'));`},   // Number() produces a number
+			{Code: `setTimeout(Boolean('x'));`},  // Boolean() produces a boolean
+			{Code: `function String(){} setTimeout(String('x'));`},
+
+			// ---- String.raw with unresolvable sub → not flagged ----
+			{Code: "setTimeout(String.raw`x${y}`);"},
+
+			// ---- typeof on unresolvable operand → not flagged ----
+			{Code: `setTimeout(typeof x);`},
+			{Code: `setTimeout(void 0);`},
+
+			// ---- const of number / undefined / null → not a string ----
+			{Code: `const n = 1; setTimeout(n);`},
+			{Code: `const u = undefined; setTimeout(u);`},
+			{Code: `const z = null; setTimeout(z);`},
+
+			// ---- Property access on unresolvable receiver → not flagged ----
+			{Code: `setTimeout(o.x);`},
+			{Code: `let o = { x: 'y' }; o = null; setTimeout(o.x);`},
+			{Code: `setTimeout({ x: y }.x);`}, // property value unresolvable
+			{Code: `const o = { x: { y: z } }; setTimeout(o.x.y);`},
+			{Code: `setTimeout({ [k]: 'y' }.x);`}, // computed dynamic key
+
+			// ---- String methods that eslint-utils does NOT fold → not flagged ----
+			{Code: `setTimeout('x'.repeat(2));`},
+			{Code: `setTimeout('x'.replace('a', 'b'));`},
+			{Code: `setTimeout('x'.replaceAll('a', 'b'));`},
+			{Code: `setTimeout('x'.split('a'));`},
+			{Code: `setTimeout('x'.charCodeAt(0));`},
+			{Code: `setTimeout('x'.indexOf('a'));`},
+			{Code: `setTimeout('x'.startsWith('a'));`},
+			{Code: `setTimeout('x'.toLocaleString());`},
+
+			// ---- Array with unresolvable element → array unresolvable ----
+			{Code: `setTimeout([x].toString());`},
+			{Code: `setTimeout([x].join(','));`},
+
+			// ---- Method on unresolvable receiver → not flagged ----
+			{Code: `setTimeout(foo().toString());`},
+			{Code: `setTimeout((typeof x).toUpperCase());`}, // typeof of unresolvable
+			{Code: `setTimeout(Array.from('x'));`}, // Array.from not in whitelist
+			{Code: "setTimeout(tag`x`);"}, // unknown tagged template
+
+			// SKIP upstream cases that depend on ESLint's `languageOptions.globals` /
+			// `sourceType` configuration, which rslint does not model. rslint's
+			// `IsShadowed` treats any undeclared reference as global, so these
+			// upstream-valid cases become false positives here.
+			//
+			// Covered upstream cases:
+			//   "window.setTimeout('foo')"          { sourceType: "commonjs" }
+			//   "window.setInterval('foo')"         { sourceType: "commonjs" }
+			//   "window['setTimeout']('foo')"       { sourceType: "commonjs" }
+			//   "window['setInterval']('foo')"      { sourceType: "commonjs" }
+			//   "global.setTimeout('foo')"          { globals: browser }
+			//   "global.setInterval('foo')"         { globals: browser }
+			//   "global['setTimeout']('foo')"       { globals: browser }
+			//   "global['setInterval']('foo')"      { globals: browser }
+			//   "setTimeout('code');"               { globals: {} }
+			//   "setInterval('code');"              { globals: {} }
+			//   "execScript('code');"               { globals: {} }
+			//   "window.setTimeout('code');"        { globals: {} }
+			//   "self.setTimeout('code');"          { globals: {} }
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Direct calls with string literal ----
+			{
+				Code: `setTimeout("x = 1;");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout("x = 1;", 100);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setInterval("x = 1;");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `execScript("x = 1;");`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Const resolution and String(...) constructor ----
+			{
+				Code: `const s = 'x=1'; setTimeout(s, 100);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `setTimeout(String('x=1'), 100);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- window.* member access ----
+			{
+				Code: `window.setTimeout('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.setInterval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.execScript('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window['setTimeout']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window['setInterval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "window[`setInterval`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window['execScript']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "window[`execScript`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Chained globals: window.window.* ----
+			{
+				Code: `window.window['setInterval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.window['execScript']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- global.* member access ----
+			{
+				Code: `global.setTimeout('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.setInterval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.execScript('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global['setTimeout']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global['setInterval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "global[`setInterval`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global['execScript']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "global[`execScript`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.global['setInterval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.global['execScript']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- globalThis.* member access ----
+			{
+				Code: `globalThis.setTimeout('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `globalThis.setInterval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `globalThis.execScript('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Template literals as first argument ----
+			{
+				Code: "setTimeout(`foo${bar}`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "window.setTimeout(`foo${bar}`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "window.window.setTimeout(`foo${bar}`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "global.global.setTimeout(`foo${bar}`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- String concatenation as first argument ----
+			{
+				Code: `setTimeout('foo' + bar)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(foo + 'bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "setTimeout(`foo` + bar)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.setTimeout('foo' + bar)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.setTimeout(foo + 'bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "window.setTimeout(`foo` + bar)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window.window.setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.setTimeout('foo' + bar)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.setTimeout(foo + 'bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "global.setTimeout(`foo` + bar)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `global.global.setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `globalThis.setTimeout('foo' + bar)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Correct node / line reporting when nested ----
+			{
+				Code: "setTimeout('foo' + (function() {\n   setTimeout(helper);\n   execScript('str');\n   return 'bar';\n})())",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+					{MessageId: "execScript", Line: 3, Column: 4},
+				},
+			},
+			{
+				Code: "window.setTimeout('foo' + (function() {\n   setTimeout(helper);\n   window.execScript('str');\n   return 'bar';\n})())",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+					{MessageId: "execScript", Line: 3, Column: 4},
+				},
+			},
+			{
+				Code: "global.setTimeout('foo' + (function() {\n   setTimeout(helper);\n   global.execScript('str');\n   return 'bar';\n})())",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+					{MessageId: "execScript", Line: 3, Column: 4},
+				},
+			},
+
+			// ---- Optional chaining ----
+			{
+				Code: `window?.setTimeout('code', 0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(window?.setTimeout)('code', 0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `window?.execScript('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(window?.execScript)('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- self.* member access ----
+			{
+				Code: `self.setTimeout('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.setInterval('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.execScript('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self['setTimeout']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self['setInterval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "self[`setInterval`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self['execScript']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "self[`execScript`]('foo')",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.self['setInterval']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.self['execScript']('foo')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "self.setTimeout(`foo${bar}`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "self.self.setTimeout(`foo${bar}`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.setTimeout('foo' + bar)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.setTimeout(foo + 'bar')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "self.setTimeout(`foo` + bar)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self.self.setTimeout(1 + ';' + 1)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self?.setTimeout('code', 0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(self?.setTimeout)('code', 0)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `self?.execScript('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(self?.execScript)('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Multi-line: position targets the CallExpression ----
+			{
+				Code: "window.setTimeout(\n  'code',\n  0\n);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1, EndLine: 4, EndColumn: 2},
+				},
+			},
+
+			// ---- Parenthesized callee ----
+			{
+				Code: `(setTimeout)('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `((setTimeout))('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `(window).setTimeout('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Parenthesized first argument ----
+			{
+				Code: `setTimeout(('code'))`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- No-substitution template as first argument ----
+			{
+				Code: "setTimeout(`code`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "window.setTimeout(`code`)",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Optional call: setTimeout?.('code') ----
+			{
+				Code: `setTimeout?.('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `execScript?.('code')`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "execScript", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- TS outer expressions on first argument ----
+			{
+				Code: `setTimeout('code' as any)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout('code'!)`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- Class member context (global name not shadowed) ----
+			{
+				Code: `class A { x = setTimeout('code'); }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 15},
+				},
+			},
+			{
+				Code: `class A { static { window.setTimeout('code'); } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- IIFE ----
+			{
+				Code: `(function() { setTimeout('code'); })()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 15},
+				},
+			},
+
+			// ---- Multiple errors in one file ----
+			{
+				Code: "setTimeout('a');\nsetInterval('b');\nexecScript('c');",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+					{MessageId: "impliedEval", Line: 2, Column: 1},
+					{MessageId: "execScript", Line: 3, Column: 1},
+				},
+			},
+
+			// ---- Binary + with identifier resolution (const / let-no-writes / var-no-writes) ----
+			{
+				Code: `const a = 'x'; const b = 'y'; setTimeout(a + b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 31},
+				},
+			},
+			{
+				Code: `const a = 1; const b = 'y'; setTimeout(a + b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 29},
+				},
+			},
+			{
+				Code: `const a = 'x'; const b = 'y'; const c = a + b; setTimeout(c);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 48},
+				},
+			},
+			// Logical result that IS a string (non-nullish left) should flag.
+			{
+				Code: `setTimeout('a' ?? 'b');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `const a = 'x'; const b = a; setTimeout(b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 29},
+				},
+			},
+
+			// ---- let / var with no writes ----
+			{
+				Code: `let s = 'x'; setTimeout(s);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 14},
+				},
+			},
+			{
+				Code: `var s = 'x'; setTimeout(s);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- Conditional: cond resolves, both branches (or the chosen one) are string ----
+			{
+				Code: `setTimeout(true ? 'x' : 'y');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(false ? 1 : 'y');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `const flag = true; setTimeout(flag ? 'x' : 'y');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Logical ||, &&, ?? with resolvable left ----
+			{
+				Code: `setTimeout('a' || 'b');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout('' || 'fallback');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout('a' && 'b');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(null ?? 'x');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(undefined ?? 'x');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- typeof on resolvable operand always produces a string ----
+			{
+				Code: `setTimeout(typeof 'x');`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `const n = 1; setTimeout(typeof n);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 14},
+				},
+			},
+
+			// ---- String() with resolvable arg (of any type), or no args ----
+			{
+				Code: `setTimeout(String(5));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(String(undefined));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(String(null));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(String(true));`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `setTimeout(String());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+
+			// ---- String.raw tagged templates ----
+			{
+				Code: "setTimeout(String.raw`x`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: "const y = 'z'; setTimeout(String.raw`x${y}`);",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Deep nesting: conditional inside binary + with resolvable operand ----
+			{
+				Code: `const b = 'z'; setTimeout((true ? 'x' : 'y') + b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 16},
+				},
+			},
+			// ---- Deep nesting: logical inside conditional inside binary + ----
+			{
+				Code: `const b = 'z'; setTimeout((true ? ('a' || 'c') : 'y') + b);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- Property access on const / let / var object literal ----
+			{
+				Code: `const o = { x: 'y' }; setTimeout(o.x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `const o = { x: 'y' }; setTimeout(o['x']);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `let o = { x: 'y' }; setTimeout(o.x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code: `const o = { a: { b: { c: 'y' } } }; setTimeout(o.a.b.c);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 37},
+				},
+			},
+			{
+				Code: `setTimeout({ ['x']: 'y' }.x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			// Shorthand property: key resolves to the outer binding.
+			{
+				Code: `const x = 'y'; setTimeout({ x }.x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 16},
+				},
+			},
+
+			// ---- String.prototype method whitelist ----
+			{Code: `setTimeout('x'.toString());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.toUpperCase());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.toLowerCase());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout(' x'.trim());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout(' x'.trimStart());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x '.trimEnd());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.concat('y'));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.slice(0));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('xy'.substring(0, 1));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.padStart(3));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.padEnd(3));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.charAt(0));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.at(0));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout('x'.normalize());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+
+			// ---- Method chains ----
+			{
+				Code: `setTimeout('x'.toUpperCase().toLowerCase());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 1},
+				},
+			},
+			{
+				Code: `const s = 'x'; setTimeout(s.toUpperCase());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 16},
+				},
+			},
+			{
+				Code: `const o = { x: 'y' }; setTimeout(o.x.toUpperCase());`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 23},
+				},
+			},
+
+			// ---- Number.prototype method whitelist ----
+			{Code: `setTimeout((1).toString());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout((1).toFixed(2));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout((1).toExponential());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout((1).toPrecision(3));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+
+			// ---- Array literal + method ----
+			{Code: `setTimeout([1, 2].toString());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout([].toString());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout([1, 2].join(','));`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+			{Code: `setTimeout([1, 2].slice(0).toString());`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "impliedEval", Line: 1, Column: 1}}},
+
+			// ---- TS non-null on const string via member ----
+			{
+				Code: `const o = { x: 'y' }; setTimeout(o.x!);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 23},
+				},
+			},
+
+			// ---- Computed property key resolved through const ----
+			{
+				Code: `const key = 'x'; setTimeout({ [key]: 'y' }.x);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 18},
+				},
+			},
+			{
+				Code: `const key = 'x'; const o = { x: 'y' }; setTimeout(o[key]);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "impliedEval", Line: 1, Column: 40},
+				},
+			},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -39,6 +39,7 @@ export default defineConfig({
     './tests/eslint/rules/no-empty-pattern.test.ts',
     './tests/eslint/rules/no-eval.test.ts',
     './tests/eslint/rules/no-implicit-coercion.test.ts',
+    './tests/eslint/rules/no-implied-eval.test.ts',
     './tests/eslint/rules/no-iterator.test.ts',
     './tests/eslint/rules/getter-return.test.ts',
     './tests/eslint/rules/guard-for-in.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-implied-eval.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-implied-eval.test.ts.snap
@@ -1,0 +1,3990 @@
+// Rstest Snapshot v1
+
+exports[`no-implied-eval > invalid 1`] = `
+{
+  "code": "setTimeout("x = 1;");",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 2`] = `
+{
+  "code": "setTimeout("x = 1;", 100);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 3`] = `
+{
+  "code": "setInterval("x = 1;");",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 4`] = `
+{
+  "code": "execScript("x = 1;");",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 5`] = `
+{
+  "code": "const s = 'x=1'; setTimeout(s, 100);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 6`] = `
+{
+  "code": "setTimeout(String('x=1'), 100);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 7`] = `
+{
+  "code": "window.setTimeout('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 8`] = `
+{
+  "code": "window.setInterval('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 9`] = `
+{
+  "code": "window.execScript('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 10`] = `
+{
+  "code": "window['setTimeout']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 11`] = `
+{
+  "code": "window['setInterval']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 12`] = `
+{
+  "code": "window[\`setInterval\`]("foo")",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 13`] = `
+{
+  "code": "window['execScript']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 14`] = `
+{
+  "code": "window[\`execScript\`]("foo")",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 15`] = `
+{
+  "code": "window.window['setInterval']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 16`] = `
+{
+  "code": "window.window['execScript']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 17`] = `
+{
+  "code": "global.setTimeout('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 18`] = `
+{
+  "code": "global.setInterval('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 19`] = `
+{
+  "code": "global.execScript('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 20`] = `
+{
+  "code": "global['setTimeout']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 21`] = `
+{
+  "code": "global['setInterval']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 22`] = `
+{
+  "code": "global[\`setInterval\`]("foo")",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 23`] = `
+{
+  "code": "global['execScript']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 24`] = `
+{
+  "code": "global[\`execScript\`]("foo")",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 25`] = `
+{
+  "code": "global.global['setInterval']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 26`] = `
+{
+  "code": "global.global['execScript']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 27`] = `
+{
+  "code": "globalThis.setTimeout('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 28`] = `
+{
+  "code": "globalThis.setInterval('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 29`] = `
+{
+  "code": "globalThis.execScript('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 30`] = `
+{
+  "code": "setTimeout(\`foo\${bar}\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 31`] = `
+{
+  "code": "window.setTimeout(\`foo\${bar}\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 32`] = `
+{
+  "code": "window.window.setTimeout(\`foo\${bar}\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 33`] = `
+{
+  "code": "global.global.setTimeout(\`foo\${bar}\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 34`] = `
+{
+  "code": "setTimeout('foo' + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 35`] = `
+{
+  "code": "setTimeout(foo + 'bar')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 36`] = `
+{
+  "code": "setTimeout(\`foo\` + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 37`] = `
+{
+  "code": "setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 38`] = `
+{
+  "code": "window.setTimeout('foo' + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 39`] = `
+{
+  "code": "window.setTimeout(foo + 'bar')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 40`] = `
+{
+  "code": "window.setTimeout(\`foo\` + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 41`] = `
+{
+  "code": "window.setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 42`] = `
+{
+  "code": "window.window.setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 43`] = `
+{
+  "code": "global.setTimeout('foo' + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 44`] = `
+{
+  "code": "global.setTimeout(foo + 'bar')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 45`] = `
+{
+  "code": "global.setTimeout(\`foo\` + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 46`] = `
+{
+  "code": "global.setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 47`] = `
+{
+  "code": "global.global.setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 48`] = `
+{
+  "code": "globalThis.setTimeout('foo' + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 49`] = `
+{
+  "code": "setTimeout('foo' + (function() {
+   setTimeout(helper);
+   execScript('str');
+   return 'bar';
+})())",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 50`] = `
+{
+  "code": "window.setTimeout('foo' + (function() {
+   setTimeout(helper);
+   window.execScript('str');
+   return 'bar';
+})())",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 51`] = `
+{
+  "code": "global.setTimeout('foo' + (function() {
+   setTimeout(helper);
+   global.execScript('str');
+   return 'bar';
+})())",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 5,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 4,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 52`] = `
+{
+  "code": "window?.setTimeout('code', 0)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 53`] = `
+{
+  "code": "(window?.setTimeout)('code', 0)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 54`] = `
+{
+  "code": "window?.execScript('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 55`] = `
+{
+  "code": "(window?.execScript)('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 56`] = `
+{
+  "code": "self.setTimeout('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 57`] = `
+{
+  "code": "self.setInterval('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 58`] = `
+{
+  "code": "self.execScript('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 59`] = `
+{
+  "code": "self['setTimeout']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 60`] = `
+{
+  "code": "self['setInterval']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 61`] = `
+{
+  "code": "self[\`setInterval\`]("foo")",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 62`] = `
+{
+  "code": "self['execScript']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 63`] = `
+{
+  "code": "self[\`execScript\`]("foo")",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 64`] = `
+{
+  "code": "self.self['setInterval']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 65`] = `
+{
+  "code": "self.self['execScript']('foo')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 66`] = `
+{
+  "code": "self.setTimeout(\`foo\${bar}\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 67`] = `
+{
+  "code": "self.self.setTimeout(\`foo\${bar}\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 68`] = `
+{
+  "code": "self.setTimeout('foo' + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 69`] = `
+{
+  "code": "self.setTimeout(foo + 'bar')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 70`] = `
+{
+  "code": "self.setTimeout(\`foo\` + bar)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 71`] = `
+{
+  "code": "self.setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 72`] = `
+{
+  "code": "self.self.setTimeout(1 + ';' + 1)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 73`] = `
+{
+  "code": "self?.setTimeout('code', 0)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 74`] = `
+{
+  "code": "(self?.setTimeout)('code', 0)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 75`] = `
+{
+  "code": "self?.execScript('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 76`] = `
+{
+  "code": "(self?.execScript)('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 77`] = `
+{
+  "code": "(setTimeout)('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 78`] = `
+{
+  "code": "((setTimeout))('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 79`] = `
+{
+  "code": "(window).setTimeout('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 80`] = `
+{
+  "code": "setTimeout(('code'))",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 81`] = `
+{
+  "code": "setTimeout(\`code\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 82`] = `
+{
+  "code": "window.setTimeout(\`code\`)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 83`] = `
+{
+  "code": "setTimeout?.('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 84`] = `
+{
+  "code": "execScript?.('code')",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 85`] = `
+{
+  "code": "setTimeout('code' as any)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 86`] = `
+{
+  "code": "setTimeout('code'!)",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 87`] = `
+{
+  "code": "class A { x = setTimeout('code'); }",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 88`] = `
+{
+  "code": "class A { static { window.setTimeout('code'); } }",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 89`] = `
+{
+  "code": "(function() { setTimeout('code'); })()",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 90`] = `
+{
+  "code": "setTimeout('a');
+setInterval('b');
+execScript('c');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+    {
+      "message": "Implied eval. Do not use execScript().",
+      "messageId": "execScript",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 3,
+        },
+        "start": {
+          "column": 1,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 91`] = `
+{
+  "code": "const a = 'x'; const b = 'y'; setTimeout(a + b);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 92`] = `
+{
+  "code": "const a = 1; const b = 'y'; setTimeout(a + b);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 93`] = `
+{
+  "code": "const a = 'x'; const b = 'y'; const c = a + b; setTimeout(c);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 61,
+          "line": 1,
+        },
+        "start": {
+          "column": 48,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 94`] = `
+{
+  "code": "const a = 'x'; const b = a; setTimeout(b);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 95`] = `
+{
+  "code": "let s = 'x'; setTimeout(s);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 96`] = `
+{
+  "code": "var s = 'x'; setTimeout(s);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 97`] = `
+{
+  "code": "setTimeout(true ? 'x' : 'y');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 98`] = `
+{
+  "code": "setTimeout(false ? 1 : 'y');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 99`] = `
+{
+  "code": "const flag = true; setTimeout(flag ? 'x' : 'y');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 100`] = `
+{
+  "code": "setTimeout('a' || 'b');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 101`] = `
+{
+  "code": "setTimeout('' || 'fallback');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 102`] = `
+{
+  "code": "setTimeout('a' && 'b');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 103`] = `
+{
+  "code": "setTimeout(null ?? 'x');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 104`] = `
+{
+  "code": "setTimeout(undefined ?? 'x');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 105`] = `
+{
+  "code": "setTimeout('a' ?? 'b');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 106`] = `
+{
+  "code": "setTimeout(typeof 'x');",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 107`] = `
+{
+  "code": "const n = 1; setTimeout(typeof n);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 108`] = `
+{
+  "code": "setTimeout(String(5));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 109`] = `
+{
+  "code": "setTimeout(String(undefined));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 110`] = `
+{
+  "code": "setTimeout(String(null));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 111`] = `
+{
+  "code": "setTimeout(String(true));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 112`] = `
+{
+  "code": "setTimeout(String());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 113`] = `
+{
+  "code": "setTimeout(String.raw\`x\`);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 114`] = `
+{
+  "code": "const y = 'z'; setTimeout(String.raw\`x\${y}\`);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 115`] = `
+{
+  "code": "const b = 'z'; setTimeout((true ? 'x' : 'y') + b);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 116`] = `
+{
+  "code": "const b = 'z'; setTimeout((true ? ('a' || 'c') : 'y') + b);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 117`] = `
+{
+  "code": "const o = { x: 'y' }; setTimeout(o.x);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 118`] = `
+{
+  "code": "const o = { x: 'y' }; setTimeout(o['x']);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 119`] = `
+{
+  "code": "let o = { x: 'y' }; setTimeout(o.x);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 36,
+          "line": 1,
+        },
+        "start": {
+          "column": 21,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 120`] = `
+{
+  "code": "const o = { a: { b: { c: 'y' } } }; setTimeout(o.a.b.c);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 121`] = `
+{
+  "code": "setTimeout({ ['x']: 'y' }.x);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 122`] = `
+{
+  "code": "const x = 'y'; setTimeout({ x }.x);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 123`] = `
+{
+  "code": "setTimeout('x'.toString());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 124`] = `
+{
+  "code": "setTimeout('x'.toUpperCase());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 125`] = `
+{
+  "code": "setTimeout('x'.toLowerCase());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 126`] = `
+{
+  "code": "setTimeout(' x'.trim());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 127`] = `
+{
+  "code": "setTimeout(' x'.trimStart());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 128`] = `
+{
+  "code": "setTimeout('x '.trimEnd());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 129`] = `
+{
+  "code": "setTimeout('x'.concat('y'));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 130`] = `
+{
+  "code": "setTimeout('x'.slice(0));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 131`] = `
+{
+  "code": "setTimeout('xy'.substring(0, 1));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 132`] = `
+{
+  "code": "setTimeout('x'.padStart(3));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 133`] = `
+{
+  "code": "setTimeout('x'.padEnd(3));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 134`] = `
+{
+  "code": "setTimeout('x'.charAt(0));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 135`] = `
+{
+  "code": "setTimeout('x'.at(0));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 136`] = `
+{
+  "code": "setTimeout('x'.normalize());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 137`] = `
+{
+  "code": "setTimeout('x'.toUpperCase().toLowerCase());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 138`] = `
+{
+  "code": "const s = 'x'; setTimeout(s.toUpperCase());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 139`] = `
+{
+  "code": "const o = { x: 'y' }; setTimeout(o.x.toUpperCase());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 52,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 140`] = `
+{
+  "code": "setTimeout((1).toString());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 141`] = `
+{
+  "code": "setTimeout((1).toFixed(2));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 142`] = `
+{
+  "code": "setTimeout((1).toExponential());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 143`] = `
+{
+  "code": "setTimeout((1).toPrecision(3));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 144`] = `
+{
+  "code": "setTimeout([1, 2].toString());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 145`] = `
+{
+  "code": "setTimeout([].toString());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 146`] = `
+{
+  "code": "setTimeout([1, 2].join(','));",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 147`] = `
+{
+  "code": "setTimeout([1, 2].slice(0).toString());",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 148`] = `
+{
+  "code": "const o = { x: 'y' }; setTimeout(o.x!);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 149`] = `
+{
+  "code": "const key = 'x'; setTimeout({ [key]: 'y' }.x);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-implied-eval > invalid 150`] = `
+{
+  "code": "const key = 'x'; const o = { x: 'y' }; setTimeout(o[key]);",
+  "diagnostics": [
+    {
+      "message": "Implied eval. Consider passing a function instead of a string.",
+      "messageId": "impliedEval",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-implied-eval",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-implied-eval.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-implied-eval.test.ts
@@ -1,0 +1,902 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-implied-eval', {
+  valid: [
+    // ---- Direct references without a call ----
+    'setTimeout();',
+    'setTimeout;',
+    'setTimeout = foo;',
+    'window.setTimeout;',
+    'window.setTimeout = foo;',
+    "window['setTimeout'];",
+    "window['setTimeout'] = foo;",
+    'global.setTimeout;',
+    'global.setTimeout = foo;',
+    "global['setTimeout'];",
+    "global['setTimeout'] = foo;",
+    "globalThis['setTimeout'] = foo;",
+
+    // ---- Calls where first argument is not evaluated as a string ----
+    'setTimeout(function() { x = 1; }, 100);',
+    'setInterval(function() { x = 1; }, 100);',
+    'execScript(function() { x = 1; }, 100);',
+    'window.setTimeout(function() { x = 1; }, 100);',
+    'window.setInterval(function() { x = 1; }, 100);',
+    'window.execScript(function() { x = 1; }, 100);',
+    'window.setTimeout(foo, 100);',
+    'window.setInterval(foo, 100);',
+    'window.execScript(foo, 100);',
+    'global.setTimeout(function() { x = 1; }, 100);',
+    'global.setInterval(function() { x = 1; }, 100);',
+    'global.execScript(function() { x = 1; }, 100);',
+    'global.setTimeout(foo, 100);',
+    'global.setInterval(foo, 100);',
+    'global.execScript(foo, 100);',
+    'globalThis.setTimeout(foo, 100);',
+
+    // ---- Non-global receiver ----
+    "foo.setTimeout('hi')",
+
+    // ---- Identifier / function-expression arguments are safe ----
+    'setTimeout(foo, 10)',
+    'setInterval(1, 10)',
+    'execScript(2)',
+    'setTimeout(function() {}, 10)',
+    "foo.setInterval('hi')",
+    'setInterval(foo, 10)',
+    'setInterval(function() {}, 10)',
+    "foo.execScript('hi')",
+    'execScript(foo)',
+    'execScript(function() {})',
+
+    // ---- Binary `+` of non-strings ----
+    'setTimeout(foo + bar, 10)',
+
+    // ---- Only the first argument is checked ----
+    "setTimeout(foobar, 'buzz')",
+    "setTimeout(foobar, foo + 'bar')",
+
+    // ---- Only the immediate subtree is inspected ----
+    "setTimeout(function() { return 'foobar'; }, 10)",
+
+    // ---- Prefix-match names that are not setTimeout/etc. ----
+    "setTimeoutFooBar('Foo Bar')",
+
+    // ---- Non-global intermediate receivers ----
+    "foo.window.setTimeout('foo', 100);",
+    "foo.global.setTimeout('foo', 100);",
+
+    // ---- Shadowing ----
+    "var window; window.setTimeout('foo', 100);",
+    "var global; global.setTimeout('foo', 100);",
+    "function foo(window) { window.setTimeout('foo', 100); }",
+    "function foo(global) { global.setTimeout('foo', 100); }",
+
+    // ---- Passed as argument, not called ----
+    "foo('', window.setTimeout);",
+    "foo('', global.setTimeout);",
+
+    // ---- Shadowing by function declaration ----
+    `
+    function execScript(string) {
+      console.log("This is not your grandparent's execScript().");
+    }
+
+    execScript('wibble');
+    `,
+    `
+    function setTimeout(string) {
+      console.log("This is not your grandparent's setTimeout().");
+    }
+
+    setTimeout('wibble');
+    `,
+    `
+    function setInterval(string) {
+      console.log("This is not your grandparent's setInterval().");
+    }
+
+    setInterval('wibble');
+    `,
+
+    // ---- Shadowing in a nested scope ----
+    `
+    function outer() {
+      function setTimeout(string) {
+        console.log("Shadowed setTimeout");
+      }
+      setTimeout('code');
+    }
+    `,
+    `
+    function outer() {
+      function setInterval(string) {
+        console.log("Shadowed setInterval");
+      }
+      setInterval('code');
+    }
+    `,
+    `
+    function outer() {
+      function execScript(string) {
+        console.log("Shadowed execScript");
+      }
+      execScript('code');
+    }
+    `,
+    `
+    {
+      const setTimeout = function(string) {
+        console.log("Block-scoped setTimeout");
+      };
+      setTimeout('code');
+    }
+    `,
+    `
+    {
+      const setInterval = function(string) {
+        console.log("Block-scoped setInterval");
+      };
+      setInterval('code');
+    }
+    `,
+
+    // ---- Template literal bracket names that are not a static eval-like name ----
+    "window[`SetTimeOut`]('foo', 100);",
+    "global[`SetTimeOut`]('foo', 100);",
+    'global[`setTimeout${foo}`]("foo", 100);',
+    'globalThis[`setTimeout${foo}`]("foo", 100);',
+    "self[`SetTimeOut`]('foo', 100);",
+    'self[`setTimeout${foo}`]("foo", 100);',
+
+    // ---- self as global candidate ----
+    'self.setTimeout;',
+    'self.setTimeout = foo;',
+    "self['setTimeout'];",
+    "self['setTimeout'] = foo;",
+    'self.setTimeout(function() { x = 1; }, 100);',
+    'self.setInterval(function() { x = 1; }, 100);',
+    'self.execScript(function() { x = 1; }, 100);',
+    'self.setTimeout(foo, 100);',
+    "foo.self.setTimeout('foo', 100);",
+    "var self; self.setTimeout('foo', 100);",
+    "function foo(self) { self.setTimeout('foo', 100); }",
+    "foo('', self.setTimeout);",
+    `
+    function outer() {
+      function self() {
+        console.log("Shadowed self");
+      }
+      self.setTimeout('code');
+    }`,
+
+    // ---- Cross-candidate chains: upstream only walks same-name chains ----
+    "window.global.setTimeout('code');",
+    "self.window.setTimeout('code');",
+    "globalThis.window.setTimeout('code');",
+    "window['global']['setTimeout']('code');",
+    "self['globalThis']['setTimeout']('code');",
+    // `this` is not a global candidate
+    "this.setTimeout('code');",
+    "this['setTimeout']('code');",
+
+    // ---- TS outer expressions on callee / receiver: upstream's
+    // isSpecificId / isSpecificMemberAccess reject non-ESTree nodes,
+    // so these are NOT flagged.
+    "setTimeout!('code')",
+    "(setTimeout as Function)('code')",
+    "(window.setTimeout!)('code')",
+    "(window.setTimeout as Function)('code')",
+    "window!.setTimeout('code')",
+    "(window as any).setTimeout('code')",
+    "(window as any).execScript('code')",
+
+    // ---- let / var with writes: not resolvable → not flagged ----
+    "let s = 'x'; s = 'y'; setTimeout(s);",
+    "var s = 'x'; s = 'y'; setTimeout(s);",
+
+    // ---- Conditional with unresolvable cond → not flagged ----
+    "setTimeout(c ? 'x' : 'y');",
+
+    // ---- Logical / nullish with non-string short-circuit result → not flagged ----
+    "setTimeout(null && 'x');",
+    "setTimeout(1 ?? 'b');",
+    // Purely numeric binary produces a number, not a string.
+    'setTimeout(1 + 2);',
+    'const a = 1; const b = 2; setTimeout(a + b);',
+
+    // ---- String() with unresolvable arg → not flagged ----
+    'setTimeout(String(x));',
+    'setTimeout(String(x + y));',
+    "setTimeout(Number('x'));",
+    "setTimeout(Boolean('x'));",
+    "function String(){} setTimeout(String('x'));",
+
+    // ---- String.raw with unresolvable sub → not flagged ----
+    'setTimeout(String.raw`x${y}`);',
+
+    // ---- typeof on unresolvable operand → not flagged ----
+    'setTimeout(typeof x);',
+    'setTimeout(void 0);',
+
+    // ---- const of number / undefined / null → not a string ----
+    'const n = 1; setTimeout(n);',
+    'const u = undefined; setTimeout(u);',
+    'const z = null; setTimeout(z);',
+
+    // ---- Property access on unresolvable receiver → not flagged ----
+    'setTimeout(o.x);',
+    "let o = { x: 'y' }; o = null; setTimeout(o.x);",
+    'setTimeout({ x: y }.x);',
+    'const o = { x: { y: z } }; setTimeout(o.x.y);',
+    "setTimeout({ [k]: 'y' }.x);",
+
+    // ---- String methods that eslint-utils does NOT fold → not flagged ----
+    "setTimeout('x'.repeat(2));",
+    "setTimeout('x'.replace('a', 'b'));",
+    "setTimeout('x'.replaceAll('a', 'b'));",
+    "setTimeout('x'.split('a'));",
+    "setTimeout('x'.charCodeAt(0));",
+    "setTimeout('x'.indexOf('a'));",
+    "setTimeout('x'.startsWith('a'));",
+    "setTimeout('x'.toLocaleString());",
+
+    // ---- Array with unresolvable element → array unresolvable ----
+    'setTimeout([x].toString());',
+    "setTimeout([x].join(','));",
+
+    // ---- Method on unresolvable receiver → not flagged ----
+    'setTimeout(foo().toString());',
+    'setTimeout((typeof x).toUpperCase());',
+    "setTimeout(Array.from('x'));",
+    'setTimeout(tag`x`);',
+  ],
+  invalid: [
+    // ---- Direct calls with string literal ----
+    {
+      code: 'setTimeout("x = 1;");',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout("x = 1;", 100);',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setInterval("x = 1;");',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'execScript("x = 1;");',
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- Const resolution and String(...) constructor ----
+    {
+      code: "const s = 'x=1'; setTimeout(s, 100);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(String('x=1'), 100);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- window.* member access ----
+    {
+      code: "window.setTimeout('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.setInterval('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.execScript('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "window['setTimeout']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window['setInterval']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'window[`setInterval`]("foo")',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window['execScript']('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: 'window[`execScript`]("foo")',
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- Chained window.window ----
+    {
+      code: "window.window['setInterval']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.window['execScript']('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- global.* member access ----
+    {
+      code: "global.setTimeout('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.setInterval('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.execScript('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "global['setTimeout']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global['setInterval']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'global[`setInterval`]("foo")',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global['execScript']('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: 'global[`execScript`]("foo")',
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "global.global['setInterval']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.global['execScript']('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- globalThis.* member access ----
+    {
+      code: "globalThis.setTimeout('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "globalThis.setInterval('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "globalThis.execScript('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- Template literal arguments ----
+    {
+      code: 'setTimeout(`foo${bar}`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'window.setTimeout(`foo${bar}`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'window.window.setTimeout(`foo${bar}`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'global.global.setTimeout(`foo${bar}`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- String concatenation arguments ----
+    {
+      code: "setTimeout('foo' + bar)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(foo + 'bar')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout(`foo` + bar)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.setTimeout('foo' + bar)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.setTimeout(foo + 'bar')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'window.setTimeout(`foo` + bar)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window.window.setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.setTimeout('foo' + bar)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.setTimeout(foo + 'bar')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'global.setTimeout(`foo` + bar)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "global.global.setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "globalThis.setTimeout('foo' + bar)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Nested reporting ----
+    {
+      code:
+        "setTimeout('foo' + (function() {\n" +
+        '   setTimeout(helper);\n' +
+        "   execScript('str');\n" +
+        "   return 'bar';\n" +
+        '})())',
+      errors: [{ messageId: 'impliedEval' }, { messageId: 'execScript' }],
+    },
+    {
+      code:
+        "window.setTimeout('foo' + (function() {\n" +
+        '   setTimeout(helper);\n' +
+        "   window.execScript('str');\n" +
+        "   return 'bar';\n" +
+        '})())',
+      errors: [{ messageId: 'impliedEval' }, { messageId: 'execScript' }],
+    },
+    {
+      code:
+        "global.setTimeout('foo' + (function() {\n" +
+        '   setTimeout(helper);\n' +
+        "   global.execScript('str');\n" +
+        "   return 'bar';\n" +
+        '})())',
+      errors: [{ messageId: 'impliedEval' }, { messageId: 'execScript' }],
+    },
+
+    // ---- Optional chaining ----
+    {
+      code: "window?.setTimeout('code', 0)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "(window?.setTimeout)('code', 0)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "window?.execScript('code')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "(window?.execScript)('code')",
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- self.* member access ----
+    {
+      code: "self.setTimeout('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.setInterval('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.execScript('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "self['setTimeout']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self['setInterval']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'self[`setInterval`]("foo")',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self['execScript']('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: 'self[`execScript`]("foo")',
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "self.self['setInterval']('foo')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.self['execScript']('foo')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: 'self.setTimeout(`foo${bar}`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'self.self.setTimeout(`foo${bar}`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.setTimeout('foo' + bar)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.setTimeout(foo + 'bar')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'self.setTimeout(`foo` + bar)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self.self.setTimeout(1 + ';' + 1)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self?.setTimeout('code', 0)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "(self?.setTimeout)('code', 0)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "self?.execScript('code')",
+      errors: [{ messageId: 'execScript' }],
+    },
+    {
+      code: "(self?.execScript)('code')",
+      errors: [{ messageId: 'execScript' }],
+    },
+
+    // ---- Parenthesized callee / receiver ----
+    { code: "(setTimeout)('code')", errors: [{ messageId: 'impliedEval' }] },
+    { code: "((setTimeout))('code')", errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: "(window).setTimeout('code')",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Parenthesized first argument ----
+    { code: "setTimeout(('code'))", errors: [{ messageId: 'impliedEval' }] },
+
+    // ---- No-substitution template ----
+    { code: 'setTimeout(`code`)', errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: 'window.setTimeout(`code`)',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Optional call ----
+    { code: "setTimeout?.('code')", errors: [{ messageId: 'impliedEval' }] },
+    { code: "execScript?.('code')", errors: [{ messageId: 'execScript' }] },
+
+    // ---- TS outer expressions on first argument ----
+    {
+      code: "setTimeout('code' as any)",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    { code: "setTimeout('code'!)", errors: [{ messageId: 'impliedEval' }] },
+
+    // ---- Class member context ----
+    {
+      code: "class A { x = setTimeout('code'); }",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "class A { static { window.setTimeout('code'); } }",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- IIFE ----
+    {
+      code: "(function() { setTimeout('code'); })()",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Multiple errors in one file ----
+    {
+      code: "setTimeout('a');\nsetInterval('b');\nexecScript('c');",
+      errors: [
+        { messageId: 'impliedEval' },
+        { messageId: 'impliedEval' },
+        { messageId: 'execScript' },
+      ],
+    },
+
+    // ---- Binary + with identifier resolution ----
+    {
+      code: "const a = 'x'; const b = 'y'; setTimeout(a + b);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const a = 1; const b = 'y'; setTimeout(a + b);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const a = 'x'; const b = 'y'; const c = a + b; setTimeout(c);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const a = 'x'; const b = a; setTimeout(b);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- let / var with no writes ----
+    {
+      code: "let s = 'x'; setTimeout(s);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "var s = 'x'; setTimeout(s);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Conditional ----
+    {
+      code: "setTimeout(true ? 'x' : 'y');",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(false ? 1 : 'y');",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const flag = true; setTimeout(flag ? 'x' : 'y');",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Logical ||, &&, ?? ----
+    { code: "setTimeout('a' || 'b');", errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: "setTimeout('' || 'fallback');",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    { code: "setTimeout('a' && 'b');", errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: "setTimeout(null ?? 'x');",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(undefined ?? 'x');",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    { code: "setTimeout('a' ?? 'b');", errors: [{ messageId: 'impliedEval' }] },
+
+    // ---- typeof on resolvable operand ----
+    { code: "setTimeout(typeof 'x');", errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: 'const n = 1; setTimeout(typeof n);',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- String() with any resolvable arg, or no args ----
+    { code: 'setTimeout(String(5));', errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: 'setTimeout(String(undefined));',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout(String(null));',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout(String(true));',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    { code: 'setTimeout(String());', errors: [{ messageId: 'impliedEval' }] },
+
+    // ---- String.raw tagged templates ----
+    {
+      code: 'setTimeout(String.raw`x`);',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const y = 'z'; setTimeout(String.raw`x${y}`);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Deep nesting: conditional / logical inside binary + with resolvable operand ----
+    {
+      code: "const b = 'z'; setTimeout((true ? 'x' : 'y') + b);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const b = 'z'; setTimeout((true ? ('a' || 'c') : 'y') + b);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Property access on const / let / var object literal ----
+    {
+      code: "const o = { x: 'y' }; setTimeout(o.x);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const o = { x: 'y' }; setTimeout(o['x']);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "let o = { x: 'y' }; setTimeout(o.x);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const o = { a: { b: { c: 'y' } } }; setTimeout(o.a.b.c);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout({ ['x']: 'y' }.x);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const x = 'y'; setTimeout({ x }.x);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- String.prototype method whitelist ----
+    {
+      code: "setTimeout('x'.toString());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.toUpperCase());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.toLowerCase());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(' x'.trim());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout(' x'.trimStart());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x '.trimEnd());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.concat('y'));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.slice(0));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('xy'.substring(0, 1));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.padStart(3));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.padEnd(3));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout('x'.charAt(0));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    { code: "setTimeout('x'.at(0));", errors: [{ messageId: 'impliedEval' }] },
+    {
+      code: "setTimeout('x'.normalize());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Method chains ----
+    {
+      code: "setTimeout('x'.toUpperCase().toLowerCase());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const s = 'x'; setTimeout(s.toUpperCase());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const o = { x: 'y' }; setTimeout(o.x.toUpperCase());",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Number.prototype method whitelist ----
+    {
+      code: 'setTimeout((1).toString());',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout((1).toFixed(2));',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout((1).toExponential());',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout((1).toPrecision(3));',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Array literal + method ----
+    {
+      code: 'setTimeout([1, 2].toString());',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout([].toString());',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "setTimeout([1, 2].join(','));",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: 'setTimeout([1, 2].slice(0).toString());',
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- TS non-null on const string via member ----
+    {
+      code: "const o = { x: 'y' }; setTimeout(o.x!);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+
+    // ---- Computed property key resolved through const ----
+    {
+      code: "const key = 'x'; setTimeout({ [key]: 'y' }.x);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+    {
+      code: "const key = 'x'; const o = { x: 'y' }; setTimeout(o[key]);",
+      errors: [{ messageId: 'impliedEval' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-implied-eval` rule from ESLint core to rslint.

The rule disallows `eval()`-like methods — specifically a string passed as the first argument to `setTimeout`, `setInterval`, or `execScript`, whether invoked directly or via a global object reference (`window`, `global`, `globalThis`, `self`).

This core version coexists with the existing `@typescript-eslint/no-implied-eval` (type-info-based, lives in `internal/plugins/typescript/rules/no_implied_eval`), mirroring the ESLint ecosystem where both identifiers are independent rules.

Behavior was verified empirically against ESLint's reference implementation (not only by reading the source): a 37-case differential harness + injected probe files run against the `rsbuild` and `rspack` monorepos produced byte-identical diagnostics on both sides, covering:

- Direct calls, member access via global objects, same-name chains (`window.window.setTimeout`)
- Cross-candidate chain rejection (`window.global.setTimeout('x')` — not flagged, matching upstream's per-candidate scope-manager walk)
- `this.*` (not a candidate)
- Shadowed receivers / callees via `IsShadowed`
- Optional call / optional member (`setTimeout?.('x')`, `window?.setTimeout('x')`)
- String-valued first arg: literal, template (sub / no-sub), `+` concat, `String(...)`, resolved `const`
- TS outer expressions: callee / receiver side strictly uses `OEKParentheses` only (upstream's `isSpecificId` / `isSpecificMemberAccess` reject TS AST nodes → not flagged); first-arg side uses `OEKParentheses | OEKAssertions` to mirror `getStaticValue`'s TS unwrapping → `setTimeout('x' as any)` is flagged

Framework-level upstream cases that depend on ESLint's `languageOptions.globals` or `sourceType: \"commonjs\"` are skipped with inline reasons, since rslint does not model those configs.

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-implied-eval
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-implied-eval.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).