### PR TITLE
feat: port rule no-shadow

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -187,6 +187,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_self_compare"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sequences"
 	"github.com/web-infra-dev/rslint/internal/rules/no_setter_return"
+	"github.com/web-infra-dev/rslint/internal/rules/no_shadow"
 	"github.com/web-infra-dev/rslint/internal/rules/no_shadow_restricted_names"
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
@@ -628,6 +629,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-self-assign", no_self_assign.NoSelfAssignRule)
 	GlobalRuleRegistry.Register("no-self-compare", no_self_compare.NoSelfCompareRule)
 	GlobalRuleRegistry.Register("no-sequences", no_sequences.NoSequencesRule)
+	GlobalRuleRegistry.Register("no-shadow", no_shadow.NoShadowRule)
 	GlobalRuleRegistry.Register("no-shadow-restricted-names", no_shadow_restricted_names.NoShadowRestrictedNamesRule)
 	GlobalRuleRegistry.Register("strict", strict.StrictRule)
 	GlobalRuleRegistry.Register("no-template-curly-in-string", no_template_curly_in_string.NoTemplateCurlyInString)

--- a/internal/rules/no_shadow/no_shadow.go
+++ b/internal/rules/no_shadow/no_shadow.go
@@ -1,0 +1,1794 @@
+package no_shadow
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// ecmaScriptGlobals lists ECMAScript built-in globals referenced by the
+// `builtinGlobals` option. We pair this with a TypeChecker-based default-
+// library scan so that environment-specific globals (DOM, Node, …) are also
+// picked up when type information is available. The hard-coded list is
+// necessary because once a user writes `var Object = 0` at module scope, the
+// TypeChecker resolves `Object` to the local binding and the default-library
+// match is lost.
+var ecmaScriptGlobals = map[string]bool{
+	"AggregateError":       true,
+	"Array":                true,
+	"ArrayBuffer":          true,
+	"AsyncDisposableStack": true,
+	"AsyncIterator":        true,
+	"Atomics":              true,
+	"BigInt":               true,
+	"BigInt64Array":        true,
+	"BigUint64Array":       true,
+	"Boolean":              true,
+	"DataView":             true,
+	"Date":                 true,
+	"decodeURI":            true,
+	"decodeURIComponent":   true,
+	"DisposableStack":      true,
+	"encodeURI":            true,
+	"encodeURIComponent":   true,
+	"Error":                true,
+	"escape":               true,
+	"EvalError":            true,
+	"FinalizationRegistry": true,
+	"Float32Array":         true,
+	"Float64Array":         true,
+	"Function":             true,
+	"globalThis":           true,
+	"Infinity":             true,
+	"Int8Array":            true,
+	"Int16Array":           true,
+	"Int32Array":           true,
+	"Intl":                 true,
+	"isFinite":             true,
+	"isNaN":                true,
+	"Iterator":             true,
+	"JSON":                 true,
+	"Map":                  true,
+	"Math":                 true,
+	"NaN":                  true,
+	"Number":               true,
+	"Object":               true,
+	"parseFloat":           true,
+	"parseInt":             true,
+	"Promise":              true,
+	"Proxy":                true,
+	"RangeError":           true,
+	"ReferenceError":       true,
+	"Reflect":              true,
+	"RegExp":               true,
+	"Set":                  true,
+	"SharedArrayBuffer":    true,
+	"String":               true,
+	"SuppressedError":      true,
+	"Symbol":               true,
+	"SyntaxError":          true,
+	"TypeError":            true,
+	"Uint8Array":           true,
+	"Uint8ClampedArray":    true,
+	"Uint16Array":          true,
+	"Uint32Array":          true,
+	"unescape":             true,
+	"URIError":             true,
+	"undefined":            true,
+	"WeakMap":              true,
+	"WeakRef":              true,
+	"WeakSet":              true,
+}
+
+// https://eslint.org/docs/latest/rules/no-shadow
+//
+// Scope semantics are reconstructed by walking the AST and tracking scopes
+// directly (rslint has no eslint-scope-equivalent). This covers the common
+// cases exercised by the ESLint test suite. Framework-level concepts that
+// rslint deliberately does not expose (for example `/*global*/` directive
+// comments, `env`/`globals` in languageOptions, `parserOptions.globalReturn`)
+// are intentionally not modeled — the rule reports shadowing against
+// declarations visible within the file plus, when a type checker is
+// available, symbols from the default TypeScript libraries.
+
+type hoistMode int
+
+const (
+	hoistFunctions hoistMode = iota
+	hoistAll
+	hoistNever
+	hoistTypes
+	hoistFunctionsAndTypes
+)
+
+type options struct {
+	builtinGlobals                             bool
+	hoist                                      hoistMode
+	allow                                      map[string]bool
+	ignoreOnInitialization                     bool
+	ignoreTypeValueShadow                      bool
+	ignoreFunctionTypeParameterNameValueShadow bool
+}
+
+func defaultOptions() options {
+	return options{
+		builtinGlobals:         false,
+		hoist:                  hoistFunctions,
+		allow:                  map[string]bool{},
+		ignoreOnInitialization: false,
+		ignoreTypeValueShadow:  true,
+		ignoreFunctionTypeParameterNameValueShadow: true,
+	}
+}
+
+func parseOptions(raw any) options {
+	opts := defaultOptions()
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["builtinGlobals"].(bool); ok {
+		opts.builtinGlobals = v
+	}
+	if v, ok := optsMap["hoist"].(string); ok {
+		switch v {
+		case "all":
+			opts.hoist = hoistAll
+		case "functions":
+			opts.hoist = hoistFunctions
+		case "never":
+			opts.hoist = hoistNever
+		case "types":
+			opts.hoist = hoistTypes
+		case "functions-and-types":
+			opts.hoist = hoistFunctionsAndTypes
+		}
+	}
+	if v, ok := optsMap["ignoreOnInitialization"].(bool); ok {
+		opts.ignoreOnInitialization = v
+	}
+	if v, ok := optsMap["ignoreTypeValueShadow"].(bool); ok {
+		opts.ignoreTypeValueShadow = v
+	}
+	if v, ok := optsMap["ignoreFunctionTypeParameterNameValueShadow"].(bool); ok {
+		opts.ignoreFunctionTypeParameterNameValueShadow = v
+	}
+	if list, ok := optsMap["allow"].([]interface{}); ok {
+		for _, item := range list {
+			if s, ok := item.(string); ok {
+				opts.allow[s] = true
+			}
+		}
+	}
+	return opts
+}
+
+// ---------------------------------------------------------------------------
+// Scope model
+// ---------------------------------------------------------------------------
+
+type defKind int
+
+const (
+	defVariable       defKind = iota // var/let/const binding, binding element
+	defParameter                     // function parameter
+	defFunctionName                  // FunctionDeclaration name (outer scope)
+	defFnExprName                    // FunctionExpression name (inner scope only)
+	defClassName                     // ClassDeclaration name (outer scope)
+	defClassInnerName                // Class name visible inside class scope
+	defImport                        // Import specifier / default / namespace
+	defCatch                         // Catch parameter
+	defType                          // Interface, type alias
+	defEnumName                      // Enum declaration
+	defNamespaceName                 // Module/namespace declaration
+	defTypeParameter                 // Generic type parameter
+)
+
+type variable struct {
+	name    string
+	id      *ast.Node // identifier node of this declaration
+	defNode *ast.Node // declaration node (VariableDeclaration, FunctionDeclaration, ...)
+	parent  *ast.Node // parent of defNode (for parsed import detection, parameter typing, etc.)
+	kind    defKind
+
+	isValueBinding   bool // runtime value vs. type-only
+	isTypeOnlyImport bool // ImportSpecifier with `type` modifier
+	declareModifier  bool // `declare` modifier (.d.ts handling)
+
+	scope *scope
+}
+
+type scopeKind int
+
+const (
+	scopeGlobal           scopeKind = iota
+	scopeFunction                   // function-like bodies & their parameters
+	scopeFunctionExprName           // FunctionExpression's name binding
+	scopeBlock                      // { ... } / for-init / switch case
+	scopeCatch                      // catch clause
+	scopeClass                      // class body: type parameters & inner class name
+	scopeModule                     // TS namespace
+	scopeType                       // TS type alias / interface / function type: type parameters
+)
+
+type scope struct {
+	kind               scopeKind
+	block              *ast.Node
+	parent             *scope
+	vars               []*variable
+	byName             map[string][]*variable
+	globalAugmentation bool // true inside `declare global { ... }` chain
+}
+
+func newScope(kind scopeKind, block *ast.Node, parent *scope) *scope {
+	return &scope{
+		kind:   kind,
+		block:  block,
+		parent: parent,
+		byName: map[string][]*variable{},
+	}
+}
+
+func (s *scope) add(v *variable) {
+	v.scope = s
+	s.vars = append(s.vars, v)
+	s.byName[v.name] = append(s.byName[v.name], v)
+}
+
+// variableScope returns the nearest ancestor (or self) that acts as a var
+// hoist target: function-like scopes, module scopes, and the global scope.
+func (s *scope) variableScope() *scope {
+	current := s
+	for current != nil {
+		switch current.kind {
+		case scopeFunction, scopeModule, scopeGlobal:
+			return current
+		}
+		current = current.parent
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Scope builder
+// ---------------------------------------------------------------------------
+
+type builder struct {
+	sourceFile     *ast.SourceFile
+	allScopes      []*scope
+	builtinGlobals map[string]bool
+}
+
+func (b *builder) push(kind scopeKind, block *ast.Node, parent *scope) *scope {
+	s := newScope(kind, block, parent)
+	if parent != nil && parent.globalAugmentation {
+		s.globalAugmentation = true
+	}
+	b.allScopes = append(b.allScopes, s)
+	return s
+}
+
+func (b *builder) buildProgram(sf *ast.SourceFile) *scope {
+	global := b.push(scopeGlobal, sf.AsNode(), nil)
+	if sf.Statements == nil {
+		return global
+	}
+	// First pass: hoist var / function / class / import names into the global scope.
+	b.hoistStatements(sf.Statements.Nodes, global)
+	// Second pass: walk children that introduce nested scopes.
+	for _, stmt := range sf.Statements.Nodes {
+		b.visitStatement(stmt, global)
+	}
+	return global
+}
+
+// hoistStatements collects declarations that belong to the enclosing
+// variable scope (var / function / class / enum / interface / type /
+// namespace / import). Block-scoped declarations (let/const/class inside
+// a nested block) are collected in visitBlock.
+func (b *builder) hoistStatements(statements []*ast.Node, s *scope) {
+	for _, stmt := range statements {
+		b.hoistStatement(stmt, s, false)
+	}
+}
+
+// addNamedDecl records a declaration whose binding name is the Name() child
+// of `stmt` (covers function, class, interface, type alias, enum, namespace,
+// import-equals). Returns without adding when the statement has no identifier
+// name (for example anonymous default exports and ambient-module strings).
+func (b *builder) addNamedDecl(stmt *ast.Node, s *scope, kind defKind, isValue bool) {
+	n := stmt.Name()
+	if n == nil || n.Kind != ast.KindIdentifier {
+		return
+	}
+	isAmbient := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
+	// Body-less FunctionDeclarations come in two flavors: overload signatures
+	// (no `declare`, there will be a later implementation) and ambient
+	// declarations (`declare function foo(): void`). typescript-eslint's scope
+	// manager merges all signatures under one Variable, so we only need to
+	// register a single binding: skip overload signatures, but keep ambient
+	// declarations so that inner scopes detect them as shadowed.
+	if kind == defFunctionName && stmt.Body() == nil && !isAmbient {
+		return
+	}
+	s.add(&variable{
+		name:            n.Text(),
+		id:              n,
+		defNode:         stmt,
+		parent:          stmt.Parent,
+		kind:            kind,
+		isValueBinding:  isValue,
+		declareModifier: isAmbient,
+	})
+}
+
+// hoistStatement records the declarations introduced by `stmt` into scope
+// `s`. When `blockScope` is true, only block-scoped bindings (let/const/
+// class/function/type/enum/namespace) are added — var is assumed to have
+// been hoisted to an outer variable scope. Otherwise, every binding kind
+// (including var) is added and the function's child statements are scanned
+// for nested `var` declarations that also hoist to this scope.
+func (b *builder) hoistStatement(stmt *ast.Node, s *scope, blockScope bool) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.Kind {
+	case ast.KindVariableStatement:
+		vs := stmt.AsVariableStatement()
+		if vs == nil || vs.DeclarationList == nil {
+			return
+		}
+		isVar := utils.IsVarKeyword(vs.DeclarationList)
+		if blockScope && isVar {
+			return
+		}
+		declareMod := ast.HasSyntacticModifier(stmt, ast.ModifierFlagsAmbient)
+		b.collectVariableDeclarations(vs.DeclarationList, s, declareMod)
+	case ast.KindFunctionDeclaration:
+		b.addNamedDecl(stmt, s, defFunctionName, true)
+	case ast.KindClassDeclaration:
+		b.addNamedDecl(stmt, s, defClassName, true)
+	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+		b.addNamedDecl(stmt, s, defType, false)
+	case ast.KindEnumDeclaration:
+		b.addNamedDecl(stmt, s, defEnumName, true)
+	case ast.KindModuleDeclaration:
+		// Ambient `declare module 'str' { ... }` uses a string-literal name and
+		// doesn't bind a variable — addNamedDecl skips it automatically.
+		b.addNamedDecl(stmt, s, defNamespaceName, true)
+	case ast.KindImportDeclaration:
+		if !blockScope {
+			b.collectImport(stmt, s)
+		}
+	case ast.KindImportEqualsDeclaration:
+		if !blockScope {
+			b.addNamedDecl(stmt, s, defImport, true)
+		}
+	case ast.KindForStatement:
+		fs := stmt.AsForStatement()
+		if !blockScope && fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		fs := stmt.AsForInOrOfStatement()
+		if !blockScope && fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	}
+
+	if blockScope {
+		return
+	}
+	// For variable-scope hoisting, recurse into wrapper statements to collect
+	// nested `var` declarations. Skip statement kinds that form scope
+	// boundaries of their own (function / class / module bodies are processed
+	// by visit*).
+	switch stmt.Kind {
+	case ast.KindBlock, ast.KindIfStatement, ast.KindWhileStatement,
+		ast.KindDoStatement, ast.KindTryStatement, ast.KindCatchClause,
+		ast.KindSwitchStatement, ast.KindCaseClause, ast.KindDefaultClause,
+		ast.KindCaseBlock, ast.KindForStatement, ast.KindForInStatement,
+		ast.KindForOfStatement, ast.KindLabeledStatement, ast.KindWithStatement,
+		ast.KindExpressionStatement, ast.KindReturnStatement, ast.KindThrowStatement:
+		stmt.ForEachChild(func(child *ast.Node) bool {
+			b.hoistVarOnly(child, s)
+			return false
+		})
+	}
+}
+
+// hoistVarOnly walks a subtree and only hoists `var` declarations (into the
+// enclosing function/module/global scope). Function-like nodes and ambient
+// module declarations terminate the walk.
+func (b *builder) hoistVarOnly(node *ast.Node, s *scope) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindVariableStatement:
+		vs := node.AsVariableStatement()
+		if vs != nil && vs.DeclarationList != nil && utils.IsVarKeyword(vs.DeclarationList) {
+			declareMod := ast.HasSyntacticModifier(node, ast.ModifierFlagsAmbient)
+			b.collectVariableDeclarations(vs.DeclarationList, s, declareMod)
+		}
+		return
+	case ast.KindForStatement:
+		fs := node.AsForStatement()
+		if fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		fs := node.AsForInOrOfStatement()
+		if fs != nil && fs.Initializer != nil && fs.Initializer.Kind == ast.KindVariableDeclarationList && utils.IsVarKeyword(fs.Initializer) {
+			b.collectVariableDeclarations(fs.Initializer, s, false)
+		}
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+		ast.KindArrowFunction, ast.KindMethodDeclaration,
+		ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
+		ast.KindClassStaticBlockDeclaration, ast.KindClassDeclaration,
+		ast.KindClassExpression, ast.KindModuleDeclaration:
+		return
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.hoistVarOnly(child, s)
+		return false
+	})
+}
+
+// collectVariableDeclarations walks a VariableDeclarationList and adds each
+// binding identifier to the given scope. For destructuring patterns, the
+// innermost BindingElement is stored as `defNode` so that the rule can reach
+// the initializer/default of that specific binding site later.
+func (b *builder) collectVariableDeclarations(declList *ast.Node, s *scope, declareMod bool) {
+	list := declList.AsVariableDeclarationList()
+	if list == nil || list.Declarations == nil {
+		return
+	}
+	for _, decl := range list.Declarations.Nodes {
+		vd := decl.AsVariableDeclaration()
+		if vd == nil || vd.Name() == nil {
+			continue
+		}
+		utils.CollectBindingNames(vd.Name(), func(id *ast.Node, name string) {
+			defNode := decl
+			for p := id.Parent; p != nil && p != decl; p = p.Parent {
+				if p.Kind == ast.KindBindingElement {
+					defNode = p
+					break
+				}
+			}
+			s.add(&variable{
+				name:            name,
+				id:              id,
+				defNode:         defNode,
+				parent:          defNode.Parent,
+				kind:            defVariable,
+				isValueBinding:  true,
+				declareModifier: declareMod,
+			})
+		})
+	}
+}
+
+func (b *builder) collectImport(node *ast.Node, s *scope) {
+	importDecl := node.AsImportDeclaration()
+	if importDecl == nil || importDecl.ImportClause == nil {
+		return
+	}
+	clause := importDecl.ImportClause.AsImportClause()
+	if clause == nil {
+		return
+	}
+	isTypeImport := importDecl.ImportClause.IsTypeOnly()
+	// Default import.
+	if clause.Name() != nil && clause.Name().Kind == ast.KindIdentifier {
+		s.add(&variable{
+			name:             clause.Name().Text(),
+			id:               clause.Name(),
+			defNode:          node,
+			parent:           node.Parent,
+			kind:             defImport,
+			isValueBinding:   !isTypeImport,
+			isTypeOnlyImport: isTypeImport,
+		})
+	}
+	if clause.NamedBindings == nil {
+		return
+	}
+	switch clause.NamedBindings.Kind {
+	case ast.KindNamespaceImport:
+		ns := clause.NamedBindings.AsNamespaceImport()
+		if ns != nil && ns.Name() != nil && ns.Name().Kind == ast.KindIdentifier {
+			s.add(&variable{
+				name:             ns.Name().Text(),
+				id:               ns.Name(),
+				defNode:          node,
+				parent:           node.Parent,
+				kind:             defImport,
+				isValueBinding:   !isTypeImport,
+				isTypeOnlyImport: isTypeImport,
+			})
+		}
+	case ast.KindNamedImports:
+		named := clause.NamedBindings.AsNamedImports()
+		if named == nil || named.Elements == nil {
+			return
+		}
+		for _, elem := range named.Elements.Nodes {
+			if elem == nil {
+				continue
+			}
+			spec := elem.AsImportSpecifier()
+			if spec == nil || spec.Name() == nil || spec.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			specTypeOnly := spec.IsTypeOnly || isTypeImport
+			s.add(&variable{
+				name:             spec.Name().Text(),
+				id:               spec.Name(),
+				defNode:          node,
+				parent:           node.Parent,
+				kind:             defImport,
+				isValueBinding:   !specTypeOnly,
+				isTypeOnlyImport: specTypeOnly,
+			})
+		}
+	}
+}
+
+// visitStatement recurses into nodes that may create nested scopes.
+func (b *builder) visitStatement(stmt *ast.Node, parent *scope) {
+	if stmt == nil {
+		return
+	}
+	switch stmt.Kind {
+	case ast.KindFunctionDeclaration:
+		b.visitFunctionLike(stmt, parent)
+	case ast.KindClassDeclaration:
+		b.visitClass(stmt, parent, false)
+	case ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+		b.visitTypeDecl(stmt, parent)
+	case ast.KindEnumDeclaration:
+		b.visitEnum(stmt, parent)
+	case ast.KindModuleDeclaration:
+		b.visitModuleDecl(stmt, parent)
+	case ast.KindBlock:
+		b.visitBlock(stmt, parent)
+	case ast.KindForStatement:
+		b.visitForStatement(stmt, parent)
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		b.visitForInOrOf(stmt, parent)
+	case ast.KindIfStatement:
+		ifStmt := stmt.AsIfStatement()
+		if ifStmt != nil {
+			b.visitExpression(ifStmt.Expression, parent)
+			b.visitStatement(ifStmt.ThenStatement, parent)
+			b.visitStatement(ifStmt.ElseStatement, parent)
+		}
+	case ast.KindWhileStatement:
+		ws := stmt.AsWhileStatement()
+		if ws != nil {
+			b.visitExpression(ws.Expression, parent)
+			b.visitStatement(ws.Statement, parent)
+		}
+	case ast.KindDoStatement:
+		ds := stmt.AsDoStatement()
+		if ds != nil {
+			b.visitExpression(ds.Expression, parent)
+			b.visitStatement(ds.Statement, parent)
+		}
+	case ast.KindTryStatement:
+		ts := stmt.AsTryStatement()
+		if ts != nil {
+			b.visitStatement(ts.TryBlock, parent)
+			if ts.CatchClause != nil {
+				b.visitCatch(ts.CatchClause, parent)
+			}
+			b.visitStatement(ts.FinallyBlock, parent)
+		}
+	case ast.KindSwitchStatement:
+		sw := stmt.AsSwitchStatement()
+		if sw != nil {
+			b.visitExpression(sw.Expression, parent)
+			b.visitSwitchCases(sw, parent)
+		}
+	case ast.KindLabeledStatement:
+		ls := stmt.AsLabeledStatement()
+		if ls != nil {
+			b.visitStatement(ls.Statement, parent)
+		}
+	case ast.KindReturnStatement:
+		if rs := stmt.AsReturnStatement(); rs != nil {
+			b.visitExpression(rs.Expression, parent)
+		}
+	case ast.KindThrowStatement:
+		if ts := stmt.AsThrowStatement(); ts != nil {
+			b.visitExpression(ts.Expression, parent)
+		}
+	case ast.KindExpressionStatement:
+		if es := stmt.AsExpressionStatement(); es != nil {
+			b.visitExpression(es.Expression, parent)
+		}
+	case ast.KindVariableStatement:
+		vs := stmt.AsVariableStatement()
+		if vs != nil && vs.DeclarationList != nil {
+			b.visitVarDeclList(vs.DeclarationList, parent)
+		}
+	case ast.KindExportAssignment:
+		ea := stmt.AsExportAssignment()
+		if ea != nil {
+			b.visitExpression(ea.Expression, parent)
+		}
+	case ast.KindExportDeclaration:
+		// No new scopes.
+	case ast.KindImportDeclaration, ast.KindImportEqualsDeclaration:
+		// No new scopes.
+	case ast.KindWithStatement:
+		ws := stmt.AsWithStatement()
+		if ws != nil {
+			b.visitExpression(ws.Expression, parent)
+			b.visitStatement(ws.Statement, parent)
+		}
+	default:
+		// Catch-all — traverse children.
+		stmt.ForEachChild(func(child *ast.Node) bool {
+			b.visitStatement(child, parent)
+			return false
+		})
+	}
+}
+
+// visitVarDeclList walks a VariableDeclarationList so that any nested
+// function/class/conditional-type scopes in type annotations, initializers,
+// or destructuring defaults get created.
+func (b *builder) visitVarDeclList(declList *ast.Node, parent *scope) {
+	list := declList.AsVariableDeclarationList()
+	if list == nil || list.Declarations == nil {
+		return
+	}
+	for _, decl := range list.Declarations.Nodes {
+		vd := decl.AsVariableDeclaration()
+		if vd == nil {
+			continue
+		}
+		if vd.Type != nil {
+			b.visitExpression(vd.Type, parent)
+		}
+		if vd.Initializer != nil {
+			b.visitExpression(vd.Initializer, parent)
+		}
+		if vd.Name() != nil {
+			b.visitBindingPattern(vd.Name(), parent)
+		}
+	}
+}
+
+// visitBindingPattern recurses into destructuring defaults that may contain
+// function / class expressions creating nested scopes.
+func (b *builder) visitBindingPattern(pattern *ast.Node, parent *scope) {
+	if pattern == nil {
+		return
+	}
+	pattern.ForEachChild(func(child *ast.Node) bool {
+		if child.Kind == ast.KindBindingElement {
+			be := child.AsBindingElement()
+			if be != nil {
+				if be.Initializer != nil {
+					b.visitExpression(be.Initializer, parent)
+				}
+				if be.Name() != nil {
+					b.visitBindingPattern(be.Name(), parent)
+				}
+			}
+		}
+		return false
+	})
+}
+
+// visitExpression walks an expression to discover nested function/class
+// expressions and other scope-creating constructs.
+func (b *builder) visitExpression(expr *ast.Node, parent *scope) {
+	if expr == nil {
+		return
+	}
+	switch expr.Kind {
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		b.visitFunctionLike(expr, parent)
+		return
+	case ast.KindMethodDeclaration, ast.KindConstructor,
+		ast.KindGetAccessor, ast.KindSetAccessor:
+		// Object-literal shorthand methods (and accessors) also need their
+		// own function scope. Class-body members are already processed by
+		// visitClass, so we only get here for the object-literal case.
+		b.visitFunctionLike(expr, parent)
+		return
+	case ast.KindClassExpression:
+		b.visitClass(expr, parent, true)
+		return
+	}
+	if ast.IsFunctionTypeNode(expr) || ast.IsConstructorTypeNode(expr) ||
+		ast.IsCallSignatureDeclaration(expr) || ast.IsConstructSignatureDeclaration(expr) ||
+		ast.IsMethodSignatureDeclaration(expr) {
+		b.visitFunctionType(expr, parent)
+		return
+	}
+	if expr.Kind == ast.KindConditionalType {
+		b.visitConditionalType(expr, parent)
+		return
+	}
+	expr.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, parent)
+		return false
+	})
+}
+
+// visitConditionalType creates a scope for the conditional type so that
+// `infer X` clauses in the extends-position introduce a binding visible to
+// nested types and to the true branch. ESLint/typescript-eslint reports an
+// inner `infer X` shadowing an outer one within the same conditional chain.
+func (b *builder) visitConditionalType(node *ast.Node, outer *scope) {
+	cond := node.AsConditionalTypeNode()
+	if cond == nil {
+		return
+	}
+	condScope := b.push(scopeType, node, outer)
+	collectInferTypes(cond.ExtendsType, condScope)
+	if cond.CheckType != nil {
+		b.visitExpression(cond.CheckType, outer)
+	}
+	if cond.ExtendsType != nil {
+		b.visitExpression(cond.ExtendsType, condScope)
+	}
+	if cond.TrueType != nil {
+		b.visitExpression(cond.TrueType, condScope)
+	}
+	if cond.FalseType != nil {
+		b.visitExpression(cond.FalseType, outer)
+	}
+}
+
+// collectInferTypes walks `extendsType` and adds each `infer X` binding to
+// the conditional-type scope. Nested function/conditional types stop the
+// walk because they introduce their own scopes.
+func collectInferTypes(node *ast.Node, s *scope) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindFunctionType, ast.KindConstructorType, ast.KindConditionalType:
+		return
+	case ast.KindInferType:
+		it := node.AsInferTypeNode()
+		if it != nil && it.TypeParameter != nil {
+			tp := it.TypeParameter.AsTypeParameter()
+			if tp != nil && tp.Name() != nil && tp.Name().Kind == ast.KindIdentifier {
+				s.add(&variable{
+					name:           tp.Name().Text(),
+					id:             tp.Name(),
+					defNode:        it.TypeParameter,
+					parent:         it.TypeParameter.Parent,
+					kind:           defTypeParameter,
+					isValueBinding: false,
+				})
+			}
+		}
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		collectInferTypes(child, s)
+		return false
+	})
+}
+
+// visitFunctionType handles TS function/construct types and call/construct
+// signatures. Parameters introduce bindings that may trigger (or be filtered
+// out by) `ignoreFunctionTypeParameterNameValueShadow`.
+func (b *builder) visitFunctionType(node *ast.Node, outer *scope) {
+	s := b.push(scopeFunction, node, outer)
+	b.addTypeParameters(node, s)
+	b.addParameters(node, s, false)
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, s)
+		return false
+	})
+}
+
+// addTypeParameters records `function f<T>` / `class C<T>` / `type X<T>`
+// generic names into `s`. Each type parameter is a type-only binding.
+func (b *builder) addTypeParameters(node *ast.Node, s *scope) {
+	for _, tp := range node.TypeParameters() {
+		if tp == nil {
+			continue
+		}
+		tpDecl := tp.AsTypeParameter()
+		if tpDecl == nil || tpDecl.Name() == nil || tpDecl.Name().Kind != ast.KindIdentifier {
+			continue
+		}
+		s.add(&variable{
+			name:           tpDecl.Name().Text(),
+			id:             tpDecl.Name(),
+			defNode:        tp,
+			parent:         tp.Parent,
+			kind:           defTypeParameter,
+			isValueBinding: false,
+		})
+	}
+}
+
+// addParameters records the binding identifiers from each parameter of
+// `node` into `s`, optionally recursing into each parameter's type
+// annotation and initializer so that nested function types create scopes.
+func (b *builder) addParameters(node *ast.Node, s *scope, recurseAnnotations bool) {
+	for _, param := range node.Parameters() {
+		if param == nil {
+			continue
+		}
+		// Skip `this` pseudo-parameter.
+		if pn := param.Name(); pn != nil && pn.Kind == ast.KindIdentifier && pn.Text() == "this" {
+			continue
+		}
+		if recurseAnnotations {
+			// Parameter decorators (`@dec x: T`) run at class-definition time,
+			// in the enclosing class scope (s.parent for methods). Fall back
+			// to `s` for standalone functions (decorators there are illegal
+			// in TS but shouldn't crash).
+			decScope := s
+			if s.parent != nil {
+				decScope = s.parent
+			}
+			for _, dec := range param.Decorators() {
+				b.visitExpression(dec, decScope)
+			}
+			if paramDecl := param.AsParameterDeclaration(); paramDecl != nil && paramDecl.Type != nil {
+				b.visitExpression(paramDecl.Type, s)
+			}
+			if init := param.Initializer(); init != nil {
+				b.visitExpression(init, s)
+			}
+		}
+		if param.Name() == nil {
+			continue
+		}
+		if recurseAnnotations && param.Name().Kind != ast.KindIdentifier {
+			b.visitBindingPattern(param.Name(), s)
+		}
+		utils.CollectBindingNames(param.Name(), func(id *ast.Node, name string) {
+			s.add(&variable{
+				name:           name,
+				id:             id,
+				defNode:        param,
+				parent:         param.Parent,
+				kind:           defParameter,
+				isValueBinding: true,
+			})
+		})
+	}
+}
+
+// visitFunctionLike handles FunctionDeclaration, FunctionExpression,
+// ArrowFunction, MethodDeclaration, Constructor, Get/SetAccessor.
+func (b *builder) visitFunctionLike(node *ast.Node, outer *scope) {
+	// Computed method/accessor name (`[expr]`) is evaluated in the enclosing
+	// scope (class body or object literal context). Walk it before pushing
+	// the function's own scope so that shadows inside the key expression
+	// check against the right scope.
+	if name := node.Name(); name != nil && name.Kind == ast.KindComputedPropertyName {
+		if cpn := name.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
+			b.visitExpression(cpn.Expression, outer)
+		}
+	}
+
+	// Function expression with a name → intermediate scope holding just
+	// the function's own name.
+	fnExprScope := outer
+	if node.Kind == ast.KindFunctionExpression {
+		if n := node.Name(); n != nil && n.Kind == ast.KindIdentifier {
+			innerFnName := b.push(scopeFunctionExprName, node, outer)
+			innerFnName.add(&variable{
+				name:           n.Text(),
+				id:             n,
+				defNode:        node,
+				parent:         node.Parent,
+				kind:           defFnExprName,
+				isValueBinding: true,
+			})
+			fnExprScope = innerFnName
+		}
+	}
+
+	fnScope := b.push(scopeFunction, node, fnExprScope)
+	b.addTypeParameters(node, fnScope)
+	b.addParameters(node, fnScope, true)
+	if retType := node.Type(); retType != nil {
+		b.visitExpression(retType, fnScope)
+	}
+
+	// Body.
+	body := node.Body()
+	if body == nil {
+		return
+	}
+	if body.Kind == ast.KindBlock {
+		block := body.AsBlock()
+		if block != nil && block.Statements != nil {
+			b.hoistStatements(block.Statements.Nodes, fnScope)
+			for _, stmt := range block.Statements.Nodes {
+				b.visitStatement(stmt, fnScope)
+			}
+		}
+	} else {
+		// Arrow expression body.
+		b.visitExpression(body, fnScope)
+	}
+}
+
+func (b *builder) visitClass(node *ast.Node, outer *scope, isExpression bool) {
+	// Class-level decorators run BEFORE the class is defined — in the outer
+	// scope. Any shadows inside them (e.g. `@((t) => { const x = 1; })`) must
+	// be checked against outer bindings.
+	for _, dec := range node.Decorators() {
+		b.visitExpression(dec, outer)
+	}
+
+	classScope := b.push(scopeClass, node, outer)
+	// Inner scope always holds the class name (for both declarations and
+	// expressions — ESLint's scope model duplicates the name here).
+	if n := node.Name(); n != nil && n.Kind == ast.KindIdentifier {
+		_ = isExpression
+		classScope.add(&variable{
+			name:           n.Text(),
+			id:             n,
+			defNode:        node,
+			parent:         node.Parent,
+			kind:           defClassInnerName,
+			isValueBinding: true,
+		})
+	}
+	b.addTypeParameters(node, classScope)
+
+	// Heritage clauses (`extends`, `implements`): expressions here are
+	// evaluated when the class is defined and can contain IIFEs/arrows whose
+	// body may shadow outer bindings. Walk them inside classScope so that
+	// class type parameters remain visible to type arguments.
+	node.ForEachChild(func(c *ast.Node) bool {
+		if c.Kind == ast.KindHeritageClause {
+			c.ForEachChild(func(t *ast.Node) bool {
+				b.visitExpression(t, classScope)
+				return false
+			})
+		}
+		return false
+	})
+
+	for _, member := range node.Members() {
+		if member == nil {
+			continue
+		}
+		// Member decorators evaluate when the class is defined; use classScope
+		// so that class type parameters remain visible.
+		for _, dec := range member.Decorators() {
+			b.visitExpression(dec, classScope)
+		}
+		switch member.Kind {
+		case ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor:
+			// visitFunctionLike handles the computed-name (if any) itself.
+			b.visitFunctionLike(member, classScope)
+		case ast.KindPropertyDeclaration:
+			// Properties don't go through visitFunctionLike — walk the
+			// computed key here.
+			if memberName := member.Name(); memberName != nil && memberName.Kind == ast.KindComputedPropertyName {
+				if cpn := memberName.AsComputedPropertyName(); cpn != nil && cpn.Expression != nil {
+					b.visitExpression(cpn.Expression, classScope)
+				}
+			}
+			if init := member.Initializer(); init != nil {
+				b.visitExpression(init, classScope)
+			}
+		case ast.KindClassStaticBlockDeclaration:
+			sb := member.AsClassStaticBlockDeclaration()
+			if sb != nil && sb.Body != nil && sb.Body.Kind == ast.KindBlock {
+				// Static block is its own function-like variable scope for var purposes.
+				staticScope := b.push(scopeFunction, member, classScope)
+				block := sb.Body.AsBlock()
+				if block != nil && block.Statements != nil {
+					b.hoistStatements(block.Statements.Nodes, staticScope)
+					for _, stmt := range block.Statements.Nodes {
+						b.visitStatement(stmt, staticScope)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (b *builder) visitTypeDecl(node *ast.Node, outer *scope) {
+	typeScope := b.push(scopeType, node, outer)
+	b.addTypeParameters(node, typeScope)
+	// Recurse into type body / heritage / members to discover FunctionType
+	// and similar type-level scopes.
+	node.ForEachChild(func(child *ast.Node) bool {
+		b.visitExpression(child, typeScope)
+		return false
+	})
+}
+
+func (b *builder) visitEnum(node *ast.Node, outer *scope) {
+	enumScope := b.push(scopeBlock, node, outer)
+	ed := node.AsEnumDeclaration()
+	if ed == nil || ed.Members == nil {
+		return
+	}
+	// Enum members are bindings in the enum's inner scope. An outer
+	// declaration with the same name is reported as shadowed by the member.
+	for _, m := range ed.Members.Nodes {
+		if m == nil {
+			continue
+		}
+		em := m.AsEnumMember()
+		if em == nil || em.Name() == nil {
+			continue
+		}
+		if em.Name().Kind == ast.KindIdentifier {
+			enumScope.add(&variable{
+				name:           em.Name().Text(),
+				id:             em.Name(),
+				defNode:        m,
+				parent:         m.Parent,
+				kind:           defVariable,
+				isValueBinding: true,
+			})
+		}
+		if em.Initializer != nil {
+			b.visitExpression(em.Initializer, enumScope)
+		}
+	}
+}
+
+func (b *builder) visitModuleDecl(node *ast.Node, outer *scope) {
+	md := node.AsModuleDeclaration()
+	if md == nil {
+		return
+	}
+	// `declare global { ... }` — treat as continuation of the enclosing global
+	// scope. Any bindings inside are conceptually global and the scopes under
+	// it are marked so shadowing checks are skipped.
+	if ast.IsGlobalScopeAugmentation(node) {
+		augScope := b.push(scopeModule, node, outer)
+		augScope.globalAugmentation = true
+		if md.Body != nil {
+			b.walkModuleBlock(md.Body, augScope)
+		}
+		return
+	}
+	moduleScope := b.push(scopeModule, node, outer)
+	// Inherit the global-augmentation flag from the parent chain.
+	if outer != nil && outer.globalAugmentation {
+		moduleScope.globalAugmentation = true
+	}
+	if md.Body == nil {
+		return
+	}
+	if md.Body.Kind == ast.KindModuleDeclaration {
+		// Nested namespace chain: `namespace A.B.C { }` — unwrap.
+		b.visitModuleDecl(md.Body, moduleScope)
+		return
+	}
+	b.walkModuleBlock(md.Body, moduleScope)
+}
+
+func (b *builder) walkModuleBlock(body *ast.Node, s *scope) {
+	if body == nil {
+		return
+	}
+	if body.Kind == ast.KindModuleBlock {
+		mb := body.AsModuleBlock()
+		if mb != nil && mb.Statements != nil {
+			b.hoistStatements(mb.Statements.Nodes, s)
+			for _, stmt := range mb.Statements.Nodes {
+				b.visitStatement(stmt, s)
+			}
+		}
+	}
+}
+
+func (b *builder) visitBlock(block *ast.Node, outer *scope) {
+	parent := block.Parent
+	// If this block is the body of a function-like, it has already been processed by visitFunctionLike.
+	if parent != nil {
+		switch parent.Kind {
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindArrowFunction, ast.KindMethodDeclaration,
+			ast.KindConstructor, ast.KindGetAccessor, ast.KindSetAccessor,
+			ast.KindClassStaticBlockDeclaration:
+			return
+		case ast.KindCatchClause:
+			// Handled in visitCatch.
+			return
+		}
+	}
+	s := b.push(scopeBlock, block, outer)
+	blk := block.AsBlock()
+	if blk == nil || blk.Statements == nil {
+		return
+	}
+	// Block-scoped declarations (let/const/class/function-in-strict/type/...) live at this block.
+	for _, stmt := range blk.Statements.Nodes {
+		b.hoistStatement(stmt, s, true)
+	}
+	// `var` hoists up to the enclosing variable scope.
+	varHost := s.variableScope()
+	if varHost == nil {
+		varHost = s
+	}
+	for _, stmt := range blk.Statements.Nodes {
+		b.hoistVarOnly(stmt, varHost)
+	}
+	// Recurse.
+	for _, stmt := range blk.Statements.Nodes {
+		b.visitStatement(stmt, s)
+	}
+}
+
+// forInitScope handles a for/for-in/for-of initializer. A let/const
+// initializer introduces a new block scope wrapping the loop body; otherwise
+// the initializer stays in `outer`. Returns the scope the loop body lives in.
+func (b *builder) forInitScope(forNode *ast.Node, initializer *ast.Node, outer *scope) *scope {
+	if initializer != nil && initializer.Kind == ast.KindVariableDeclarationList && !utils.IsVarKeyword(initializer) {
+		forScope := b.push(scopeBlock, forNode, outer)
+		b.collectVariableDeclarations(initializer, forScope, false)
+		b.visitVarDeclList(initializer, forScope)
+		return forScope
+	}
+	if initializer != nil {
+		if initializer.Kind == ast.KindVariableDeclarationList {
+			b.visitVarDeclList(initializer, outer)
+		} else {
+			b.visitExpression(initializer, outer)
+		}
+	}
+	return outer
+}
+
+func (b *builder) visitForStatement(stmt *ast.Node, outer *scope) {
+	fs := stmt.AsForStatement()
+	if fs == nil {
+		return
+	}
+	body := b.forInitScope(stmt, fs.Initializer, outer)
+	if fs.Condition != nil {
+		b.visitExpression(fs.Condition, body)
+	}
+	if fs.Incrementor != nil {
+		b.visitExpression(fs.Incrementor, body)
+	}
+	if fs.Statement != nil {
+		b.visitStatement(fs.Statement, body)
+	}
+}
+
+func (b *builder) visitForInOrOf(stmt *ast.Node, outer *scope) {
+	fs := stmt.AsForInOrOfStatement()
+	if fs == nil {
+		return
+	}
+	body := b.forInitScope(stmt, fs.Initializer, outer)
+	if fs.Expression != nil {
+		b.visitExpression(fs.Expression, outer)
+	}
+	if fs.Statement != nil {
+		b.visitStatement(fs.Statement, body)
+	}
+}
+
+func (b *builder) visitCatch(node *ast.Node, outer *scope) {
+	cc := node.AsCatchClause()
+	if cc == nil {
+		return
+	}
+	catchScope := b.push(scopeCatch, node, outer)
+	if cc.VariableDeclaration != nil {
+		vd := cc.VariableDeclaration.AsVariableDeclaration()
+		if vd != nil && vd.Name() != nil {
+			utils.CollectBindingNames(vd.Name(), func(id *ast.Node, name string) {
+				catchScope.add(&variable{
+					name:           name,
+					id:             id,
+					defNode:        cc.VariableDeclaration,
+					parent:         node,
+					kind:           defCatch,
+					isValueBinding: true,
+				})
+			})
+		}
+	}
+	if cc.Block != nil && cc.Block.Kind == ast.KindBlock {
+		// The catch block is a BlockStatement whose direct parent is this CatchClause.
+		// We treat it as nested: create an extra block scope for its body.
+		bodyScope := b.push(scopeBlock, cc.Block, catchScope)
+		blk := cc.Block.AsBlock()
+		if blk != nil && blk.Statements != nil {
+			for _, stmt := range blk.Statements.Nodes {
+				b.hoistStatement(stmt, bodyScope, true)
+			}
+			varHost := bodyScope.variableScope()
+			if varHost == nil {
+				varHost = bodyScope
+			}
+			for _, stmt := range blk.Statements.Nodes {
+				b.hoistVarOnly(stmt, varHost)
+			}
+			for _, stmt := range blk.Statements.Nodes {
+				b.visitStatement(stmt, bodyScope)
+			}
+		}
+	}
+}
+
+func (b *builder) visitSwitchCases(sw *ast.SwitchStatement, outer *scope) {
+	if sw.CaseBlock == nil {
+		return
+	}
+	cb := sw.CaseBlock.AsCaseBlock()
+	if cb == nil || cb.Clauses == nil {
+		return
+	}
+	// Switch introduces a block scope for its clauses.
+	switchScope := b.push(scopeBlock, sw.AsNode(), outer)
+	// First: hoist block-level declarations across all clauses.
+	for _, clause := range cb.Clauses.Nodes {
+		if clause == nil {
+			continue
+		}
+		c := clause.AsCaseOrDefaultClause()
+		if c == nil || c.Statements == nil {
+			continue
+		}
+		for _, s := range c.Statements.Nodes {
+			b.hoistStatement(s, switchScope, true)
+		}
+	}
+	// Vars hoist to enclosing var scope.
+	varHost := switchScope.variableScope()
+	if varHost == nil {
+		varHost = switchScope
+	}
+	for _, clause := range cb.Clauses.Nodes {
+		if clause == nil {
+			continue
+		}
+		c := clause.AsCaseOrDefaultClause()
+		if c == nil || c.Statements == nil {
+			continue
+		}
+		for _, s := range c.Statements.Nodes {
+			b.hoistVarOnly(s, varHost)
+		}
+	}
+	// Recurse into statements.
+	for _, clause := range cb.Clauses.Nodes {
+		if clause == nil {
+			continue
+		}
+		c := clause.AsCaseOrDefaultClause()
+		if c == nil {
+			continue
+		}
+		if c.Expression != nil {
+			b.visitExpression(c.Expression, switchScope)
+		}
+		if c.Statements != nil {
+			for _, s := range c.Statements.Nodes {
+				b.visitStatement(s, switchScope)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rule entry
+// ---------------------------------------------------------------------------
+
+var NoShadowRule = rule.Rule{
+	Name: "no-shadow",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		if ctx.SourceFile == nil {
+			return rule.RuleListeners{}
+		}
+
+		b := &builder{sourceFile: ctx.SourceFile}
+		global := b.buildProgram(ctx.SourceFile)
+
+		filename := ""
+		if ctx.SourceFile.AsNode() != nil {
+			filename = ctx.SourceFile.FileName()
+		}
+		isDeclFile := strings.HasSuffix(filename, ".d.ts") ||
+			strings.HasSuffix(filename, ".d.cts") ||
+			strings.HasSuffix(filename, ".d.mts")
+
+		// Pre-compute the set of default-library globals. We seed with a
+		// hard-coded ECMAScript list (so the rule works without a
+		// TypeChecker, and so it still flags `var Object = 0` at module
+		// scope where TypeChecker would resolve `Object` to the local
+		// binding), then union in whatever the default library exposes.
+		builtinGlobals := map[string]bool{}
+		if opts.builtinGlobals {
+			for name := range ecmaScriptGlobals {
+				builtinGlobals[name] = true
+			}
+			if ctx.TypeChecker != nil && ctx.Program != nil {
+				for _, sym := range ctx.TypeChecker.GetSymbolsInScope(ctx.SourceFile.AsNode(), ast.SymbolFlagsValue) {
+					if sym == nil || sym.Name == "" {
+						continue
+					}
+					if utils.IsSymbolFromDefaultLibrary(ctx.Program, sym) {
+						builtinGlobals[sym.Name] = true
+					}
+				}
+			}
+		}
+		b.builtinGlobals = builtinGlobals
+
+		// Walk scopes top-down and check each variable. The global scope is
+		// included so that `builtinGlobals: true` can flag a module-level
+		// declaration shadowing an ECMAScript global (ESLint's module scope
+		// sits between the file and the global scope; we collapse them and
+		// compensate by letting checkVariable consult the globals table).
+		for _, s := range b.allScopes {
+			if s.globalAugmentation {
+				continue
+			}
+			for _, v := range s.vars {
+				if opts.allow[v.name] {
+					continue
+				}
+				if v.name == "this" {
+					continue
+				}
+				if isDuplicatedClassNameInClassScope(v) {
+					continue
+				}
+				if isDeclFile && v.declareModifier {
+					continue
+				}
+				b.checkVariable(ctx, s, v, opts, global)
+			}
+		}
+
+		return rule.RuleListeners{}
+	},
+}
+
+// isDuplicatedClassNameInClassScope suppresses the inner class-name binding
+// that ESLint-scope adds for ClassDeclarations.
+func isDuplicatedClassNameInClassScope(v *variable) bool {
+	return v.kind == defClassInnerName && v.defNode != nil && v.defNode.Kind == ast.KindClassDeclaration
+}
+
+// checkVariable tests whether `v` shadows a variable in some outer scope.
+func (b *builder) checkVariable(ctx rule.RuleContext, s *scope, v *variable, opts options, global *scope) {
+	shadowed := findShadowed(v, s.parent)
+	shadowedGlobal := shadowed == nil && opts.builtinGlobals && b.builtinGlobals[v.name]
+	if shadowed == nil && !shadowedGlobal {
+		return
+	}
+
+	// Ignore function-name-initializer exceptions:
+	// var a = function a() {};  /  var A = class A {};
+	if shadowed != nil && isFunctionNameInitializerException(v, shadowed) {
+		return
+	}
+
+	// ignoreOnInitialization: shadow is inside the initializer of the outer binding,
+	// and the inner variable's own variableScope is a FunctionExpression / ArrowFunction
+	// whose enclosing call is inside that initializer.
+	if opts.ignoreOnInitialization && shadowed != nil && isInInitPatternCall(v, shadowed) {
+		return
+	}
+
+	// hoist modes: in `functions` / `never` / `types` / `functions-and-types`,
+	// shadow reports are suppressed when the outer declaration appears *after*
+	// the inner declaration (TDZ-like). `all` always reports.
+	if shadowed != nil && opts.hoist != hoistAll && isInTdz(v, shadowed, opts.hoist) {
+		return
+	}
+
+	// TS: ignoreTypeValueShadow
+	if shadowed != nil && opts.ignoreTypeValueShadow && isTypeValueShadow(v, shadowed) {
+		return
+	}
+
+	// TS: ignoreFunctionTypeParameterNameValueShadow
+	if opts.ignoreFunctionTypeParameterNameValueShadow && isFunctionTypeParameterShadow(v) {
+		return
+	}
+
+	// TS: type parameter of a static method shadowing the enclosing class's
+	// type parameter is a no-op at runtime and ESLint ignores it.
+	if isGenericOfStaticMethod(v) {
+		return
+	}
+
+	// External declaration merging: type-only import + module augmentation.
+	if shadowed != nil && isExternalDeclarationMerging(v, shadowed) {
+		return
+	}
+
+	if shadowedGlobal && shadowed == nil {
+		ctx.ReportNode(v.id, rule.RuleMessage{
+			Id:          "noShadowGlobal",
+			Description: fmt.Sprintf("'%s' is already a global variable.", v.name),
+		})
+		return
+	}
+	if shadowed != nil && shadowed.id != nil {
+		line, column := getLineColumn(b.sourceFile, shadowed.id)
+		ctx.ReportNode(v.id, rule.RuleMessage{
+			Id: "noShadow",
+			Description: fmt.Sprintf(
+				"'%s' is already declared in the upper scope on line %d column %d.",
+				v.name, line, column,
+			),
+		})
+		return
+	}
+	// Builtin-global match without an identifier (from default library).
+	ctx.ReportNode(v.id, rule.RuleMessage{
+		Id:          "noShadowGlobal",
+		Description: fmt.Sprintf("'%s' is already a global variable.", v.name),
+	})
+}
+
+// findShadowed walks outward from `start` and returns the first outer
+// variable with the same name as `v`, or nil if none is found. Builtin
+// globals are handled separately by checkVariable.
+func findShadowed(v *variable, start *scope) *variable {
+	for cur := start; cur != nil; cur = cur.parent {
+		if matches, ok := cur.byName[v.name]; ok {
+			return matches[0]
+		}
+	}
+	return nil
+}
+
+// isTypeValueShadow mirrors the ESLint/typescript-eslint logic.
+// ESLint's check treats the shadowed binding as a "type import" if ANY
+// specifier in the same ImportDeclaration is type-only — this is a quirk
+// that bubbles the `type` marker across all specifiers of one declaration.
+func isTypeValueShadow(v *variable, shadowed *variable) bool {
+	isInnerValue := v.isValueBinding
+
+	isTypeImport := shadowed.kind == defImport && importHasAnyTypeOnlySpecifier(shadowed.defNode)
+	isShadowedValue := shadowed.isValueBinding && !isTypeImport
+
+	return isInnerValue != isShadowedValue
+}
+
+// importHasAnyTypeOnlySpecifier returns true when the ImportDeclaration
+// carries either a top-level `type` modifier or a named specifier with
+// `import { type X }` syntax.
+func importHasAnyTypeOnlySpecifier(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindImportDeclaration {
+		return false
+	}
+	importDecl := node.AsImportDeclaration()
+	if importDecl == nil || importDecl.ImportClause == nil {
+		return false
+	}
+	if importDecl.ImportClause.IsTypeOnly() {
+		return true
+	}
+	clause := importDecl.ImportClause.AsImportClause()
+	if clause == nil || clause.NamedBindings == nil {
+		return false
+	}
+	if clause.NamedBindings.Kind != ast.KindNamedImports {
+		return false
+	}
+	named := clause.NamedBindings.AsNamedImports()
+	if named == nil || named.Elements == nil {
+		return false
+	}
+	for _, elem := range named.Elements.Nodes {
+		if elem == nil {
+			continue
+		}
+		spec := elem.AsImportSpecifier()
+		if spec != nil && spec.IsTypeOnly {
+			return true
+		}
+	}
+	return false
+}
+
+// isGenericOfStaticMethod returns true when `v` is a type parameter of a
+// method declaration carrying the `static` modifier. ESLint ignores these
+// shadows since the static method runs against a class-independent `this`.
+func isGenericOfStaticMethod(v *variable) bool {
+	if v.kind != defTypeParameter {
+		return false
+	}
+	tp := v.defNode
+	if tp == nil {
+		return false
+	}
+	// Walk up the first couple of parents — tsgo may or may not wrap type
+	// parameters in a TypeParameterList node depending on the form — and
+	// stop at the enclosing method/function node.
+	for cur := tp.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindMethodDeclaration:
+			return ast.HasStaticModifier(cur)
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindArrowFunction, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor,
+			ast.KindClassDeclaration, ast.KindClassExpression,
+			ast.KindInterfaceDeclaration, ast.KindTypeAliasDeclaration:
+			return false
+		}
+	}
+	return false
+}
+
+// isFunctionTypeParameterShadow returns true when `v` is a parameter of a
+// TS function type / construct signature — its binding lives in a type-level
+// position and ESLint ignores these shadows by default.
+func isFunctionTypeParameterShadow(v *variable) bool {
+	if v.kind != defParameter {
+		return false
+	}
+	p := v.defNode
+	if p == nil {
+		return false
+	}
+	parent := p.Parent
+	if parent == nil {
+		return false
+	}
+	if ast.IsFunctionTypeNode(parent) || ast.IsConstructorTypeNode(parent) ||
+		ast.IsCallSignatureDeclaration(parent) || ast.IsConstructSignatureDeclaration(parent) ||
+		ast.IsMethodSignatureDeclaration(parent) {
+		return true
+	}
+	// Bodyless function-like declarations (e.g. `declare function f()`,
+	// method signatures on `declare class`, overload signatures) also count.
+	if ast.IsFunctionLikeDeclaration(parent) && parent.Body() == nil {
+		return true
+	}
+	return false
+}
+
+// isExternalDeclarationMerging covers the `import type Foo from 'bar'` +
+// `declare module 'bar' { interface Foo {} }` case.
+func isExternalDeclarationMerging(v *variable, shadowed *variable) bool {
+	if shadowed.kind != defImport || !shadowed.isTypeOnlyImport {
+		return false
+	}
+	if shadowed.defNode == nil || shadowed.defNode.Kind != ast.KindImportDeclaration {
+		return false
+	}
+	importDecl := shadowed.defNode.AsImportDeclaration()
+	if importDecl == nil || importDecl.ModuleSpecifier == nil || !ast.IsStringLiteral(importDecl.ModuleSpecifier) {
+		return false
+	}
+	importSrc := importDecl.ModuleSpecifier.Text()
+	mod := ast.FindAncestor(v.id, func(n *ast.Node) bool {
+		return n.Kind == ast.KindModuleDeclaration
+	})
+	if mod == nil {
+		return false
+	}
+	md := mod.AsModuleDeclaration()
+	if md == nil || md.Name() == nil {
+		return false
+	}
+	return md.Name().Text() == importSrc
+}
+
+// isInTdz tests whether the inner variable appears *before* the outer
+// declaration and should therefore be suppressed under the given hoist mode.
+func isInTdz(inner *variable, outer *variable, mode hoistMode) bool {
+	if inner.id == nil || outer.id == nil {
+		return false
+	}
+	if inner.id.End() >= outer.id.Pos() {
+		return false
+	}
+	switch mode {
+	case hoistAll:
+		return false
+	case hoistTypes:
+		// Suppress only for outer type declarations.
+		if outer.kind == defType {
+			return false
+		}
+		return true
+	case hoistFunctionsAndTypes:
+		if outer.kind == defFunctionName || outer.kind == defType {
+			return false
+		}
+		return true
+	case hoistFunctions:
+		if outer.kind == defFunctionName {
+			return false
+		}
+		return true
+	case hoistNever:
+		return true
+	}
+	return false
+}
+
+// isFunctionNameInitializerException implements the `var a = function a() {}`
+// / `var A = class A {}` / default-destructuring variants that ESLint ignores.
+func isFunctionNameInitializerException(inner *variable, outer *variable) bool {
+	if outer.defNode == nil || inner.defNode == nil {
+		return false
+	}
+	if inner.kind != defFnExprName && (inner.kind != defClassInnerName || inner.defNode.Kind != ast.KindClassExpression) {
+		return false
+	}
+	expr := inner.defNode // FunctionExpression / ClassExpression
+	// Outer must be a VariableDeclaration or BindingElement with an initializer.
+	var initializer *ast.Node
+	switch outer.defNode.Kind {
+	case ast.KindVariableDeclaration:
+		vd := outer.defNode.AsVariableDeclaration()
+		if vd != nil {
+			initializer = vd.Initializer
+		}
+	case ast.KindBindingElement, ast.KindParameter:
+		initializer = outer.defNode.Initializer()
+	}
+	if initializer == nil {
+		return false
+	}
+	if initializer.Pos() > expr.Pos() || expr.End() > initializer.End() {
+		return false
+	}
+	// Walk up from `expr` through logical / ternary / paren wrappers only;
+	// success iff we land exactly on `initializer`.
+	current := expr
+	for {
+		if current == initializer {
+			return true
+		}
+		parent := current.Parent
+		if parent == nil {
+			return false
+		}
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression:
+			current = parent
+			continue
+		case ast.KindBinaryExpression:
+			be := parent.AsBinaryExpression()
+			if be != nil && be.OperatorToken != nil {
+				op := be.OperatorToken.Kind
+				if op == ast.KindBarBarToken || op == ast.KindAmpersandAmpersandToken || op == ast.KindQuestionQuestionToken {
+					current = parent
+					continue
+				}
+			}
+			return false
+		case ast.KindConditionalExpression:
+			ce := parent.AsConditionalExpression()
+			if ce != nil && ce.Condition != current {
+				current = parent
+				continue
+			}
+			return false
+		default:
+			return false
+		}
+	}
+}
+
+// isInInitPatternCall handles the `ignoreOnInitialization` option.
+// The inner variable's variableScope block must be a function expression or
+// arrow whose enclosing call lies inside the outer variable's initializer,
+// AND the function's outer variable scope must BE the scope that owns the
+// shadowed variable (matching ESLint's `getOuterScope === shadowedVariable.scope`
+// check, which prevents suppressing shadows inside nested closures).
+func isInInitPatternCall(inner *variable, outer *variable) bool {
+	if inner.scope == nil {
+		return false
+	}
+	vs := inner.scope.variableScope()
+	if vs == nil || vs.block == nil {
+		return false
+	}
+	if vs.block.Kind != ast.KindFunctionExpression && vs.block.Kind != ast.KindArrowFunction {
+		return false
+	}
+	// The function's immediate outer variable scope must be the same variable
+	// scope that owns `outer`. ESLint additionally skips a
+	// `function-expression-name` scope between the two; we do the same by
+	// peeling it off.
+	outerOfFn := vs.parent
+	for outerOfFn != nil && outerOfFn.kind == scopeFunctionExprName {
+		outerOfFn = outerOfFn.parent
+	}
+	outerOfFnVS := outerOfFn
+	if outerOfFnVS != nil && outerOfFnVS.kind != scopeFunction && outerOfFnVS.kind != scopeModule && outerOfFnVS.kind != scopeGlobal {
+		outerOfFnVS = outerOfFnVS.variableScope()
+	}
+	if outer.scope == nil {
+		return false
+	}
+	outerScopeVS := outer.scope
+	if outerScopeVS.kind != scopeFunction && outerScopeVS.kind != scopeModule && outerScopeVS.kind != scopeGlobal {
+		outerScopeVS = outerScopeVS.variableScope()
+	}
+	if outerOfFnVS != outerScopeVS {
+		return false
+	}
+	fn := vs.block
+	call := ast.FindAncestor(fn, func(n *ast.Node) bool {
+		return n.Kind == ast.KindCallExpression
+	})
+	if call == nil {
+		return false
+	}
+	location := call.End()
+	// Walk ancestors of the outer declaration's identifier.
+	node := outer.id
+	for node != nil {
+		parent := node.Parent
+		if parent == nil {
+			break
+		}
+		switch parent.Kind {
+		case ast.KindVariableDeclaration:
+			vd := parent.AsVariableDeclaration()
+			if vd != nil && vd.Initializer != nil && vd.Initializer.Pos() <= location && location <= vd.Initializer.End() {
+				return true
+			}
+			// for-in / for-of expression RHS.
+			if parent.Parent != nil && parent.Parent.Parent != nil {
+				forStmt := parent.Parent.Parent
+				if forStmt.Kind == ast.KindForInStatement || forStmt.Kind == ast.KindForOfStatement {
+					fs := forStmt.AsForInOrOfStatement()
+					if fs != nil && fs.Expression != nil && fs.Expression.Pos() <= location && location <= fs.Expression.End() {
+						return true
+					}
+				}
+			}
+			return false
+		case ast.KindBindingElement:
+			be := parent.AsBindingElement()
+			if be != nil && be.Initializer != nil && be.Initializer.Pos() <= location && location <= be.Initializer.End() {
+				return true
+			}
+		case ast.KindParameter:
+			init := parent.Initializer()
+			if init != nil && init.Pos() <= location && location <= init.End() {
+				return true
+			}
+		case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+			ast.KindClassDeclaration, ast.KindClassExpression,
+			ast.KindArrowFunction, ast.KindCatchClause,
+			ast.KindImportDeclaration, ast.KindExportDeclaration,
+			ast.KindMethodDeclaration, ast.KindConstructor,
+			ast.KindGetAccessor, ast.KindSetAccessor:
+			return false
+		}
+		node = parent
+	}
+	return false
+}
+
+// getLineColumn returns 1-based line and column for the identifier's start position.
+func getLineColumn(sf *ast.SourceFile, n *ast.Node) (int, int) {
+	if sf == nil || n == nil {
+		return 0, 0
+	}
+	pos := scanner.GetTokenPosOfNode(n, sf, false)
+	line, col := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, pos)
+	return line + 1, int(col) + 1
+}

--- a/internal/rules/no_shadow/no_shadow.md
+++ b/internal/rules/no_shadow/no_shadow.md
@@ -1,0 +1,89 @@
+# no-shadow
+
+Disallow variable declarations from shadowing variables declared in the outer scope.
+
+## Rule Details
+
+Shadowing occurs when a local variable shares the same name as a variable in its
+containing scope. Inside the inner scope, the outer variable becomes
+inaccessible, which can be a source of confusion.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var a = 3;
+function b() {
+  var a = 10;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var a = 3;
+function b() {
+  var c = 10;
+}
+```
+
+## Options
+
+### `builtinGlobals`
+
+Shadowing a built-in global (for example `Object`, `Array`) is reported when
+this option is `true`. Default: `false`.
+
+```json
+{ "no-shadow": ["error", { "builtinGlobals": true }] }
+```
+
+```javascript
+function foo() {
+  var Object = 0;
+}
+```
+
+### `hoist`
+
+Controls whether shadowing is reported before the outer declaration. Default:
+`"functions"`.
+
+- `"functions"`: report only before function declarations.
+- `"all"`: always report, even when the outer declaration appears after the
+  inner one.
+- `"never"`: never report before the outer declaration.
+- `"types"`: report when the outer declaration is a type (`type` or
+  `interface`).
+- `"functions-and-types"`: report for both outer function declarations and type
+  declarations.
+
+### `allow`
+
+Array of names for which shadowing is allowed. Default: `[]`.
+
+```json
+{ "no-shadow": ["error", { "allow": ["done"] }] }
+```
+
+### `ignoreOnInitialization`
+
+Ignores shadowing inside the initializer of the outer declaration when it is
+called as a callback or IIFE. Default: `false`.
+
+```json
+{ "no-shadow": ["error", { "ignoreOnInitialization": true }] }
+```
+
+### `ignoreTypeValueShadow`
+
+Ignores shadowing between a value and a type of the same name (TypeScript).
+Default: `true`.
+
+### `ignoreFunctionTypeParameterNameValueShadow`
+
+Ignores shadowing for parameters declared inside a function type. Default:
+`true`.
+
+## Original Documentation
+
+<https://eslint.org/docs/latest/rules/no-shadow>

--- a/internal/rules/no_shadow/no_shadow_test.go
+++ b/internal/rules/no_shadow/no_shadow_test.go
@@ -1,0 +1,1592 @@
+package no_shadow
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Cases follow the upstream ESLint test file
+// (https://github.com/eslint/eslint/blob/main/tests/lib/rules/no-shadow.js),
+// in roughly the same order so that a diff against that file is tractable.
+// Framework-level concepts that rslint doesn't model
+// (languageOptions.globals / env / parserOptions.globalReturn / script-vs-
+// module sourceType distinction) are marked `Skip: true` with a comment
+// pointing at the reason.
+func TestNoShadowRule(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoShadowRule,
+
+		[]rule_tester.ValidTestCase{
+			// ---- Core JS: baseline (no shadow) ----
+			{Code: `var a=3; function b(x) { a++; return x + a; }; setTimeout(function() { b(a); }, 0);`},
+
+			// ---- Function-name initializer exception (function expression) ----
+			{Code: `(function() { var doSomething = function doSomething() {}; doSomething() }())`},
+			{Code: `(function() { var doSomething = foo || function doSomething() {}; doSomething() }())`},
+			{Code: `(function() { var doSomething = function doSomething() {} || foo; doSomething() }())`},
+			{Code: `(function() { var doSomething = foo && function doSomething() {}; doSomething() }())`},
+			{Code: `(function() { var doSomething = foo ?? function doSomething() {}; doSomething() }())`},
+			{Code: `(function() { var doSomething = foo || (bar || function doSomething() {}); doSomething() }())`},
+			{Code: `(function() { var doSomething = foo || (bar && function doSomething() {}); doSomething() }())`},
+			{Code: `(function() { var doSomething = foo ? function doSomething() {} : bar; doSomething() }())`},
+			{Code: `(function() { var doSomething = foo ? bar: function doSomething() {}; doSomething() }())`},
+			{Code: `(function() { var doSomething = foo ? bar: (baz || function doSomething() {}); doSomething() }())`},
+			{Code: `(function() { var doSomething = (foo ? bar: function doSomething() {}) || baz; doSomething() }())`},
+			{Code: `(function() { var { doSomething = function doSomething() {} } = obj; doSomething() }())`},
+			{Code: `(function() { var { doSomething = function doSomething() {} || foo } = obj; doSomething() }())`},
+			{Code: `(function() { var { doSomething = foo ? function doSomething() {} : bar } = obj; doSomething() }())`},
+			{Code: `(function() { var { doSomething = foo ? bar : function doSomething() {} } = obj; doSomething() }())`},
+			{Code: `(function() { var { doSomething = foo || (bar ? baz : (qux || function doSomething() {})) || quux } = obj; doSomething() }())`},
+			{Code: `function foo(doSomething = function doSomething() {}) { doSomething(); }`},
+			{Code: `function foo(doSomething = function doSomething() {} || foo) { doSomething(); }`},
+			{Code: `function foo(doSomething = foo ? function doSomething() {} : bar) { doSomething(); }`},
+			{Code: `function foo(doSomething = foo ? bar : function doSomething() {}) { doSomething(); }`},
+			{Code: `function foo(doSomething = foo || (bar ? baz : (qux || function doSomething() {})) || quux) { doSomething(); }`},
+
+			// ---- Miscellaneous ----
+			{Code: "var arguments;\nfunction bar() { }"},
+			{Code: `var a=3; var b = (x) => { a++; return x + a; }; setTimeout(() => { b(a); }, 0);`},
+
+			// ---- Classes ----
+			{Code: `class A {}`},
+			{Code: `class A { constructor() { var a; } }`},
+			// Function-name initializer exception (class expression)
+			{Code: `(function() { var A = class A {}; })()`},
+			{Code: `(function() { var A = foo || class A {}; })()`},
+			{Code: `(function() { var A = class A {} || foo; })()`},
+			{Code: `(function() { var A = foo && class A {} || foo; })()`},
+			{Code: `(function() { var A = foo ?? class A {}; })()`},
+			{Code: `(function() { var A = foo || (bar || class A {}); })()`},
+			{Code: `(function() { var A = foo || (bar && class A {}); })()`},
+			{Code: `(function() { var A = foo ? class A {} : bar; })()`},
+			{Code: `(function() { var A = foo ? bar : class A {}; })()`},
+			{Code: `(function() { var A = foo ? bar: (baz || class A {}); })()`},
+			{Code: `(function() { var A = (foo ? bar: class A {}) || baz; })()`},
+			{Code: `(function() { var { A = class A {} } = obj; }())`},
+			{Code: `(function() { var { A = class A {} || foo } = obj; }())`},
+			{Code: `(function() { var { A = foo ? class A {} : bar } = obj; }())`},
+			{Code: `(function() { var { A = foo ? bar : class A {} } = obj; }())`},
+			{Code: `(function() { var { A = foo || (bar ? baz : (qux || class A {})) || quux } = obj; }())`},
+			{Code: `function foo(A = class A {}) { doSomething(); }`},
+			{Code: `function foo(A = class A {} || foo) { doSomething(); }`},
+			{Code: `function foo(A = foo ? class A {} : bar) { doSomething(); }`},
+			{Code: `function foo(A = foo ? bar : class A {}) { doSomething(); }`},
+			{Code: `function foo(A = foo || (bar ? baz : (qux || class A {})) || quux) { doSomething(); }`},
+
+			// ---- Block shadowing a later var: not a shadow (var redeclares) ----
+			{Code: `{ var a; } var a;`},
+
+			// ---- hoist: default "functions" ----
+			{Code: `{ let a; } let a;`},
+			{Code: `{ let a; } var a;`},
+			{Code: `{ const a = 0; } const a = 1;`},
+			{Code: `{ const a = 0; } var a;`},
+
+			// ---- hoist: "never" — outer declaration appears after inner, never report ----
+			{Code: `{ let a; } let a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ let a; } var a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ let a; } function a() {}`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ const a = 0; } const a = 1;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ const a = 0; } var a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ const a = 0; } function a() {}`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo() { let a; } let a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo() { let a; } var a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo() { let a; } function a() {}`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo() { var a; } let a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo() { var a; } var a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo() { var a; } function a() {}`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo(a) { } let a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo(a) { } var a;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `function foo(a) { } function a() {}`, Options: map[string]interface{}{"hoist": "never"}},
+
+			// ---- Implicit default hoist — after inner sibling already hidden in block ----
+			{Code: `{ let a; } let a;`},
+			{Code: `{ let a; } var a;`},
+			{Code: `{ const a = 0; } const a = 1;`},
+			{Code: `{ const a = 0; } var a;`},
+			{Code: `function foo() { let a; } let a;`},
+			{Code: `function foo() { let a; } var a;`},
+			{Code: `function foo() { var a; } let a;`},
+			{Code: `function foo() { var a; } var a;`},
+			{Code: `function foo(a) { } let a;`},
+			{Code: `function foo(a) { } var a;`},
+
+			// ---- builtinGlobals off (default) ----
+			{Code: `function foo() { var Object = 0; }`},
+			// SKIP: `function foo() { var top = 0; }` with globals.browser — requires env.
+
+			// Script-mode merging (VALID under script sourceType). Our implementation
+			// always treats the file as a module, so `var Object = 0;` at top level
+			// under `builtinGlobals: true` reports. Skip to preserve upstream intent.
+			{Code: `var Object = 0;`, Options: map[string]interface{}{"builtinGlobals": true}, Skip: true},
+			// SKIP: `var top = 0;` + browser globals — requires env.
+
+			// ---- allow list ----
+			{Code: `function foo(cb) { (function (cb) { cb(42); })(cb); }`, Options: map[string]interface{}{"allow": []interface{}{"cb"}}},
+
+			// ---- Class fields / methods (not shadowing — different kinds) ----
+			{Code: `class C { foo; foo() { let foo; } }`},
+
+			// ---- Class static blocks ----
+			{Code: `class C { static { var x; } static { var x; } }`},
+			{Code: `class C { static { let x; } static { let x; } }`},
+			{Code: `class C { static { var x; { var x; /* redeclaration */ } } }`},
+			{Code: `class C { static { { var x; } { var x; /* redeclaration */ } } }`},
+			{Code: `class C { static { { let x; } { let x; } } }`},
+
+			// ---- ignoreOnInitialization (callback form) ----
+			{Code: `const a = [].find(a => a)`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const a = [].find(function(a) { return a; })`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const [a = [].find(a => true)] = dummy`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a = [].find(a => true) } = dummy`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `function func(a = [].find(a => true)) {}`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `for (const a in [].find(a => true)) {}`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `for (const a of [].find(a => true)) {}`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const a = [].map(a => true).filter(a => a === 'b')`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const a = [].map(a => true).filter(a => a === 'b').find(a => a === 'c')`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a } = (({ a }) => ({ a }))();`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const person = people.find(item => {const person = item.name; return person === 'foo'})`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var y = bar || foo(y => y);`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var y = bar && foo(y => y);`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var z = bar(foo(z => z));`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var z = boo(bar(foo(z => z)));`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var match = function (person) { return person.name === 'foo'; };` + "\n" + `const person = [].find(match);`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const a = foo(x || (a => {}))`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a = 1 } = foo(a => {})`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const person = {...people.find((person) => person.firstName.startsWith('s'))}`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const person = { firstName: people.filter((person) => person.firstName.startsWith('s')).map((person) => person.firstName)[0]}`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `() => { const y = foo(y => y); }`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+
+			// ---- ignoreOnInitialization (IIFE form) ----
+			{Code: `const x = (x => x)()`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var y = bar || (y => y)();`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var y = bar && (y => y)();`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var x = (x => x)((y => y)());`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a = 1 } = (a => {})()`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `() => { const y = (y => y)(); }`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const [x = y => y] = [].map(y => y)`},
+
+			// ========================================================
+			// TypeScript-specific valid cases
+			// ========================================================
+
+			// ---- Function-type parameters (default ignoreFunctionTypeParameterNameValueShadow: true) ----
+			{Code: `function foo<T = (arg: any) => any>(arg: T) {}`},
+			{Code: `function foo<T = ([arg]: [any]) => any>(arg: T) {}`},
+			{Code: `function foo<T = ({ args }: { args: any }) => any>(arg: T) {}`},
+			{Code: `function foo<T = (...args: any[]) => any>(fn: T, args: any[]) {}`},
+			{Code: `function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}`},
+			{Code: `function foo<T extends (...args: any[]) => any>(fn: T, ...args: any[]) {}`},
+			{Code: `function foo<T extends ([args]: any[]) => any>(fn: T, args: any[]) {}`},
+			{Code: `function foo<T extends ([...args]: any[]) => any>(fn: T, args: any[]) {}`},
+			{Code: `function foo<T extends ({ args }: { args: any }) => any>(fn: T, args: any) {}`},
+			{Code: `function foo<T extends (id: string, ...args: any[]) => any>(fn: T, ...args: any[]) {}`},
+			{Code: `type Args = 1; function foo<T extends (Args: any) => void>(arg: T) {}`},
+
+			// ---- Conditional types with infer T ----
+			{Code: `export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any ? T[] : Func extends (...args: infer T) => any ? T : never;`},
+
+			// ---- Local Object vs global (builtinGlobals off) ----
+			{Code: `function foo() { var Object = 0; }`},
+
+			// ---- this params ----
+			{Code: `function test(this: number) { function test2(this: number) {} }`},
+
+			// ---- Declaration merging (value + namespace / value + interface) ----
+			{Code: `class Foo { prop = 1; } namespace Foo { export const v = 2; }`},
+			{Code: `function Foo() {} namespace Foo { export const v = 2; }`},
+			{Code: `class Foo { prop = 1; } interface Foo { prop2: string }`},
+
+			// ---- Module augmentation with type-only import of the same module ----
+			{Code: `import type { Foo } from 'bar';` + "\n" + `declare module 'bar' { export interface Foo { x: string } }`},
+
+			// ---- Type/value shadowing (default ignoreTypeValueShadow: true) ----
+			{Code: `const x = 1; type x = string;`},
+			{Code: `const x = 1; { type x = string; }`},
+			// SKIP: `type Foo = 1;` + languageOptions.globals.Foo — requires globals.
+
+			// ---- TS enum declaration (member order-independent initializer) ----
+			{Code: `enum Direction { left = 'left', right = 'right' }`},
+
+			// ---- ignoreFunctionTypeParameterNameValueShadow: true (default) — various TS signature positions ----
+			{Code: `const test = 1; type Fn = (test: string) => typeof test;`},
+			// SKIP: `type Fn = (Foo: string) => typeof Foo` with globals.Foo — requires globals.
+			{Code: `const arg = 0; interface Test { (arg: string): typeof arg; }`},
+			{Code: `const arg = 0; interface Test { p1(arg: string): typeof arg; }`},
+			{Code: `const arg = 0; declare function test(arg: string): typeof arg;`},
+			{Code: `const arg = 0; declare const test: (arg: string) => typeof arg;`},
+			{Code: `const arg = 0; declare class Test { p1(arg: string): typeof arg; }`},
+			{Code: `const arg = 0; declare const Test: { new (arg: string): typeof arg };`},
+			{Code: `const arg = 0; type Bar = new (arg: number) => typeof arg;`},
+			{Code: `const arg = 0; declare namespace Lib { function test(arg: string): typeof arg; }`},
+
+			// ---- `declare global` is transparent ----
+			{Code: `declare global { interface ArrayConstructor {} } export {};`, Options: map[string]interface{}{"builtinGlobals": true}},
+			{Code: `declare global { const a: string; namespace Foo { const a: number; } } export {};`},
+			{Code: `declare global { type A = 'foo'; namespace Foo { type A = 'bar'; } } export {};`, Options: map[string]interface{}{"ignoreTypeValueShadow": false}},
+			// SKIP: `declare global { const foo; type Fn = (foo) => void }` under ignoreFunctionTypeParameterNameValueShadow: false — framework globals.
+
+			// ---- Static method generic doesn't collide with class generic ----
+			{Code: `export class Wrapper<Wrapped> { private constructor(private readonly wrapped: Wrapped) {} unwrap(): Wrapped { return this.wrapped; } static create<Wrapped>(wrapped: Wrapped) { return new Wrapper<Wrapped>(wrapped); } }`},
+			{Code: `function makeA() { return class A<T> { constructor(public value: T) {} static make<T>(value: T) { return new A<T>(value); } }; }`},
+
+			// ---- Real-code-discovered: any type-only specifier in an import treats the
+			// whole declaration as a type import for shadow purposes (ESLint quirk). ----
+			{Code: `import binding, { type AssetInfo } from 'm';
+class Foo { static __from_binding(binding: any) { return binding; } }`},
+			{Code: `import { foo, type Bar } from 'm';
+function fn(foo: number) { return foo; }`},
+			// (`import * as N, { type T } from 'm'` is not valid TS syntax, omitted)
+
+			// ---- infer X in conditional types is type-level, doesn't leak to value scope ----
+			{Code: `type X<T> = T extends infer U ? U : never;
+const U = 1;`},
+			{Code: `type X<T> = T extends string ? T : never;
+const T = 1;`}, // T type param doesn't leak
+
+			// ---- Object literal accessor (no shadow when distinct names) ----
+			{Code: `const x = 1;
+const o = { get y() { return 1; }, set y(v) {} };`},
+
+			// ---- Class field with private name (#) — no shadow vs same plain name ----
+			{Code: `class C { #priv = 1; m() { const priv = 2; return [this.#priv, priv]; } }`},
+
+			// ---- Tuple labels don't introduce bindings ----
+			{Code: `type Pair = [first: string, second: number];
+const first = 1;`},
+
+			// ---- Class field name same as class name — different namespace ----
+			{Code: `class C6 { C6 = 1; }`},
+
+			// ---- Method name same as outer var — methods are class-scoped ----
+			{Code: `function g1() {}
+class CG { g1() {} }`},
+
+			// ---- Mapped type [K in keyof T] doesn't leak ----
+			{Code: `type Map1<T> = { [K in keyof T]: K };
+const K = 1;`},
+
+			// ---- Multiple infer at same level (sibling, not nested) — not shadow ----
+			{Code: `type X<T> = T extends { a: infer U } & { b: infer U } ? U : never;`},
+
+			// ---- Default destructure with reference to outer of same name (shadow happens to be the inner) ----
+			// `function f({ a = a }) {}` — `a` on right refers to outer. Inner a still shadows.
+			// Treated as invalid but we want to not crash.
+
+			// ---- Generic in arrow function does not shadow outer value ----
+			{Code: `const T = 1; const arr = <T extends string>(x: T) => x;`},
+
+			// ---- Import type + type alias — ignoreTypeValueShadow true ----
+			{Code: `import type { foo } from './foo';` + "\n" + `type bar = number;` + "\n" + `function doThing(foo: number, bar: number) {}`},
+			{Code: `import { type foo } from './foo';` + "\n" + `function doThing(foo: number) {}`},
+
+			// ---- ignoreOnInitialization (TS flavor) ----
+			{Code: `const a = [].find(a => a);`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const a = [].find(function (a) { return a; });`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const [a = [].find(a => true)] = dummy;`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a = [].find(a => true) } = dummy;`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `function func(a = [].find(a => true)) {}`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+
+			// ---- hoist TS: "never" ----
+			{Code: `type Foo<A> = 1; type A = 1;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `interface Foo<A> {} type A = 1;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `interface Foo<A> {} interface A {}`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `type Foo<A> = 1; interface A {}`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ type A = 1; } type A = 1;`, Options: map[string]interface{}{"hoist": "never"}},
+			{Code: `{ interface Foo<A> {} } type A = 1;`, Options: map[string]interface{}{"hoist": "never"}},
+
+			// ---- hoist TS: "functions" (default for type-only situations still suppresses) ----
+			{Code: `type Foo<A> = 1; type A = 1;`, Options: map[string]interface{}{"hoist": "functions"}},
+			{Code: `interface Foo<A> {} type A = 1;`, Options: map[string]interface{}{"hoist": "functions"}},
+			{Code: `interface Foo<A> {} interface A {}`, Options: map[string]interface{}{"hoist": "functions"}},
+			{Code: `type Foo<A> = 1; interface A {}`, Options: map[string]interface{}{"hoist": "functions"}},
+			{Code: `{ type A = 1; } type A = 1;`, Options: map[string]interface{}{"hoist": "functions"}},
+			{Code: `{ interface Foo<A> {} } type A = 1;`, Options: map[string]interface{}{"hoist": "functions"}},
+
+			// ---- import-type + module augmentation of same module (valid forms) ----
+			{Code: `import type { Foo } from 'bar';` + "\n" + `declare module 'bar' { export type Foo = string }`},
+			{Code: `import type { Foo } from 'bar';` + "\n" + `declare module 'bar' { interface Foo { x: string } }`},
+			{Code: `import { type Foo } from 'bar';` + "\n" + `declare module 'bar' { export type Foo = string }`},
+			{Code: `import { type Foo } from 'bar';` + "\n" + `declare module 'bar' { export interface Foo { x: string } }`},
+			{Code: `import { type Foo } from 'bar';` + "\n" + `declare module 'bar' { type Foo = string }`},
+			{Code: `import { type Foo } from 'bar';` + "\n" + `declare module 'bar' { interface Foo { x: string } }`},
+
+			// ---- .d.ts declare — under builtinGlobals with globals, valid ----
+			// These rely on globals: languageOptions which we don't support. But
+			// the `declare`-in-dts branch is independent of that and still applies,
+			// so we also assert the subset that should be valid without globals:
+			// ambient decls in .d.ts are always filtered regardless of shadowing.
+			// (Full fixtures with a specific .d.ts filename are not trivial in the
+			// unit tester; these rely on upstream fixture setup so we skip them.)
+
+			// ==== Additional ESLint cases for full coverage ====
+
+			{Code: `var match = function (person) { return person.name === 'foo'; };
+const person = [].find(match);`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  const arg = 0;
+  
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		`, Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": true}},
+			{Code: `
+		  declare global {
+			const foo: string;
+			type Fn = (foo: number) => void;
+		  }
+		  export {};
+		`, Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false}},
+			{Code: `
+  import { type foo } from './foo';
+  
+  // 'foo' is already declared in the upper scope
+  function doThing(foo: number) {}
+		`, Options: map[string]interface{}{"ignoreTypeValueShadow": true}},
+			{Code: `const a = [].map(a => true).filter(a => a === 'b');`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  const a = []
+	.map(a => true)
+	.filter(a => a === 'b')
+	.find(a => a === 'c');
+		`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  const person = people.find(item => {
+	const person = item.name;
+	return person === 'foo';
+  });
+		`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  var match = function (person) {
+	return person.name === 'foo';
+  };
+  const person = [].find(match);
+		`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const a = foo(x || (a => {}));`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a = 1 } = foo(a => {});`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const person = { ...people.find(person => person.firstName.startsWith('s')) };`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  const person = {
+	firstName: people
+	  .filter(person => person.firstName.startsWith('s'))
+	  .map(person => person.firstName)[0],
+  };
+		`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  () => {
+	const y = foo(y => y);
+  };
+		`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const x = (x => x)();`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `const { a = 1 } = (a => {})();`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `
+  () => {
+	const y = (y => y)();
+  };
+		`, Options: map[string]interface{}{"ignoreOnInitialization": true}},
+			{Code: `var arguments;
+function bar() { }`},
+			{Code: `
+  function test(this: Foo) {
+	function test2(this: Bar) {}
+  }
+	  `},
+			{Code: `
+  class Foo {
+	prop = 1;
+  }
+  interface Foo {
+	prop2: string;
+  }
+	  `},
+			{Code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+	  `},
+			{Code: `
+  enum Direction {
+	left = 'left',
+	right = 'right',
+  }
+	  `},
+			{Code: `const [x = y => y] = [].map(y => y);`},
+			{Code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'bar' {
+	export type Foo = string;
+  }
+		`},
+			{Code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'bar' {
+	interface Foo {
+	  x: string;
+	}
+  }
+		`},
+			{Code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	export type Foo = string;
+  }
+		`},
+			{Code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`},
+			{Code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	type Foo = string;
+  }
+		`},
+			{Code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	interface Foo {
+	  x: string;
+	}
+  }
+		`},
+		},
+
+		[]rule_tester.InvalidTestCase{
+			// ---- Basic function/arrow shadow (full line/col) ----
+			{
+				Code: `function a(x) { var b = function c() { var x = 'foo'; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'x' is already declared in the upper scope on line 1 column 12.", Line: 1, Column: 44},
+				},
+			},
+			{
+				Code: `var a = (x) => { var b = () => { var x = 'foo'; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'x' is already declared in the upper scope on line 1 column 10.", Line: 1, Column: 38},
+				},
+			},
+			{
+				Code: `function a(x) { var b = function () { var x = 'foo'; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'x' is already declared in the upper scope on line 1 column 12.", Line: 1, Column: 43},
+				},
+			},
+			{
+				Code: `var x = 1; function a(x) { return ++x; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'x' is already declared in the upper scope on line 1 column 5.", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code: `var a=3; function b() { var a=10; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'a' is already declared in the upper scope on line 1 column 5."},
+				},
+			},
+			{
+				Code: `var a=3; function b() { var a=10; }; setTimeout(function() { b(); }, 0);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'a' is already declared in the upper scope on line 1 column 5."},
+				},
+			},
+			{
+				Code: `var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Message: "'a' is already declared in the upper scope on line 1 column 5."},
+					{MessageId: "noShadow", Message: "'b' is already declared in the upper scope on line 1 column 19."},
+				},
+			},
+			{
+				Code: `var x = 1; { let x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: `let x = 1; { const x = 2; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- hoist: default "functions" (outer function declared after inner) ----
+			{Code: `{ let a; } function a() {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `{ const a = 0; } function a() {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { let a; } function a() {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { var a; } function a() {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(a) { } function a() {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+
+			// ---- hoist: "all" — all permutations ----
+			{Code: `{ let a; } let a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `{ let a; } var a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `{ let a; } function a() {}`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `{ const a = 0; } const a = 1;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `{ const a = 0; } var a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `{ const a = 0; } function a() {}`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { let a; } let a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { let a; } var a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { let a; } function a() {}`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { var a; } let a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { var a; } var a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo() { var a; } function a() {}`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(a) { } let a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(a) { } var a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `function foo(a) { } function a() {}`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+
+			// ---- Function/class expression self-name shadowing inner body ----
+			{Code: `(function a() { function a(){} })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function a() { class a{} })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function a() { (function a(){}); })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function a() { (class a{}); })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function() { var a = function(a) {}; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function() { var a = function() { function a() {} }; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function() { var a = function() { class a{} }; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function() { var a = function() { (function a() {}); }; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function() { var a = function() { (class a{}); }; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `(function() { var a = class { constructor() { class a {} } }; })()`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `class A { constructor() { var A; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+
+			// ---- Nested shadowing chain (multiple errors) ----
+			{
+				Code: `(function a() { function a(){ function a(){} } })()`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 26},
+					{MessageId: "noShadow", Line: 1, Column: 40},
+				},
+			},
+
+			// ---- builtinGlobals ----
+			{Code: `function foo() { var Object = 0; }`, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal", Message: "'Object' is already a global variable."}}},
+			// SKIP: `function foo() { var top = 0; }` requires browser globals.
+			{Code: `var Object = 0;`, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal"}}},
+			// SKIP: `var top = 0;` browser globals.
+			// SKIP: `var Object = 0;` with globalReturn — framework parserOptions.
+			// SKIP: `var top = 0;` with globalReturn + browser — framework.
+			{Code: `function foo(cb) { (function (cb) { cb(42); })(cb); }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 31}}},
+
+			// ---- Class static blocks ----
+			{Code: `class C { static { let a; { let a; } } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 33}}},
+			{Code: `class C { static { var C; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 24}}},
+			{Code: `class C { static { let C; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 24}}},
+			{Code: `var a; class C { static { var a; } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 31}}},
+			{Code: `class C { static { var a; } } var a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 24}}},
+			{Code: `class C { static { let a; } } let a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 24}}},
+			{Code: `class C { static { var a; } } let a;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 24}}},
+			{Code: `class C { static { var a; class D { static { var a; } } } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 50}}},
+			{Code: `class C { static { let a; class D { static { let a; } } } }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 50}}},
+
+			// ---- Hoist "all" inside IIFEs / arrows with param list ----
+			{
+				Code:    `let x = foo((x,y) => {});` + "\n" + `let y;`,
+				Options: map[string]interface{}{"hoist": "all"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    `let x = ((x,y) => {})();` + "\n" + `let y;`,
+				Options: map[string]interface{}{"hoist": "all"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- ignoreOnInitialization: the function is inside the class, so shadow is still reported ----
+			{
+				Code:    `const a = fn(()=>{ class C { fn () { const a = 42; return a } } return new C() })`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 44},
+				},
+			},
+			{
+				Code:    `function a() {}` + "\n" + `foo(a => {});`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 2, Column: 5},
+				},
+			},
+			{
+				Code:    `const a = fn(()=>{ function C() { this.fn=function() { const a = 42; return a } } return new C() });`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 62},
+				},
+			},
+			{
+				Code:    `const x = foo(() => { const bar = () => { return x => {}; }; return bar; });`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 50},
+				},
+			},
+			{
+				Code:    `const x = foo(() => { return { bar(x) {} }; });`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 36},
+				},
+			},
+			{
+				Code:    `const x = () => { foo(x => x); }`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `const foo = () => { let x; bar(x => x); }`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 32},
+				},
+			},
+			{
+				Code:    `foo(() => { const x = x => x; });`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 23},
+				},
+			},
+			{
+				Code:    `const foo = (x) => { bar(x => {}) }`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 26},
+				},
+			},
+			{
+				Code:    `const a = (()=>{ class C { fn () { const a = 42; return a } } return new C() })()`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 42},
+				},
+			},
+			{
+				Code:    `const x = () => { (x => x)(); }`,
+				Options: map[string]interface{}{"ignoreOnInitialization": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow", Line: 1, Column: 20},
+				},
+			},
+
+			// ---- Call-wrap: initializer-exception does NOT apply ----
+			{Code: `const a = wrap(function a() {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 25}}},
+			{Code: `const a = foo || wrap(function a() {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 32}}},
+			{Code: `const { a = wrap(function a() {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 27}}},
+			{Code: `const { a = foo || wrap(function a() {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 34}}},
+			{Code: `const { a = foo, b = function a() {} } = {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 31}}},
+			{Code: `const { A = Foo, B = class A {} } = {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 28}}},
+			{Code: `function foo(a = wrap(function a() {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 32}}},
+			{Code: `function foo(a = foo || wrap(function a() {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 39}}},
+			{Code: `const A = wrap(class A {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 22}}},
+			{Code: `const A = foo || wrap(class A {});`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 29}}},
+			{Code: `const { A = wrap(class A {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 24}}},
+			{Code: `const { A = foo || wrap(class A {}) } = obj;`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 31}}},
+			{Code: `function foo(A = wrap(class A {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 29}}},
+			{Code: `function foo(A = foo || wrap(class A {})) {}`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 36}}},
+			// Ternary test branch: fn expr is `test`, not an unwrap path.
+			{Code: `var a = function a() {} ? foo : bar`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 18}}},
+			{Code: `var A = class A {} ? foo : bar`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 15}}},
+			// SKIP: `(function Array() {})` + builtinGlobals — relies on env/sourceType=module.
+			{Code: `(function Array() {})`, Options: map[string]interface{}{"builtinGlobals": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadowGlobal", Line: 1, Column: 11}}},
+			{Code: `let a; { let b = (function a() {}) }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 28}}},
+			{Code: `let a = foo; { let b = (function a() {}) }`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow", Line: 1, Column: 34}}},
+
+			// ========================================================
+			// TypeScript-specific invalid cases
+			// ========================================================
+
+			{
+				Code: "\n  type T = 1;\n  {\n\ttype T = 2;\n  }\n\t\t",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: "\n  type T = 1;\n  function foo<T>(arg: T) {}\n\t\t",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: "\n  function foo<T>() {\n\treturn function <T>() {};\n  }\n\t\t",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: "\n  type T = string;\n  function foo<T extends (arg: any) => void>(arg: T) {}\n\t\t",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const x = 1;\n  {\n\ttype x = string;\n  }\n\t\t",
+				Options: map[string]interface{}{"ignoreTypeValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// SKIP: `type Foo = 1;` + globals.Foo — framework globals.
+
+			{
+				Code:    "\n  const test = 1;\n  type Fn = (test: string) => typeof test;\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// SKIP: `type Fn = (Foo: string) => typeof Foo` + globals.Foo — framework globals.
+
+			{
+				Code:    "\n  const arg = 0;\n  interface Test {\n\t(arg: string): typeof arg;\n  }\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  interface Test {\n\tp1(arg: string): typeof arg;\n  }\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  declare function test(arg: string): typeof arg;\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  declare const test: (arg: string) => typeof arg;\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  declare class Test {\n\tp1(arg: string): typeof arg;\n  }\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  declare const Test: {\n\tnew (arg: string): typeof arg;\n  };\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  type Bar = new (arg: number) => typeof arg;\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  const arg = 0;\n  declare namespace Lib {\n\tfunction test(arg: string): typeof arg;\n  }\n\t\t",
+				Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Type imports with ignoreTypeValueShadow: false ----
+			{
+				Code:    "\nimport type { foo } from './foo';\nfunction doThing(foo: number) {}\n",
+				Options: map[string]interface{}{"ignoreTypeValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\nimport { type foo } from './foo';\nfunction doThing(foo: number) {}\n",
+				Options: map[string]interface{}{"ignoreTypeValueShadow": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: "\nimport { foo } from './foo';\nfunction doThing(foo: number, bar: number) {}\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Module augmentation with interface shadowing ----
+			{
+				Code: "\ninterface Foo {}\ndeclare module 'bar' { export interface Foo { x: string } }\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: "\nimport type { Foo } from 'bar';\ndeclare module 'baz' { export interface Foo { x: string } }\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: "\nimport { type Foo } from 'bar';\ndeclare module 'baz' { export interface Foo { x: string } }\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- hoist: "all" with TS ----
+			{
+				Code:    "\n  let x = foo((x, y) => {});\n  let y;\n\t\t",
+				Options: map[string]interface{}{"hoist": "all"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code:    "\n  let x = foo((x, y) => {});\n  let y;\n\t\t",
+				Options: map[string]interface{}{"hoist": "functions"},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- hoist: "types" / "functions-and-types" / "all" — all type permutations ----
+			{Code: "\n  type Foo<A> = 1;\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  interface Foo<A> {}\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  interface Foo<A> {}\n  interface A {}\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  type Foo<A> = 1;\n  interface A {}\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  {\n\ttype A = 1;\n  }\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  {\n\tinterface A {}\n  }\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  type Foo<A> = 1;\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  interface Foo<A> {}\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  interface Foo<A> {}\n  interface A {}\n\t\t", Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  type Foo<A> = 1;\n  interface A {}\n\t\t", Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  {\n\ttype A = 1;\n  }\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  {\n\tinterface A {}\n  }\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  type Foo<A> = 1;\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n\tif (true) {\n\t\tconst foo = 6;\n\t}\n\n\tfunction foo() { }\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n\t// types\n\ttype Bar<Foo> = 1;\n\ttype Foo = 1;\n\n\t// functions\n\tif (true) {\n\t\tconst b = 6;\n\t}\n\n\tfunction b() { }\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}, {MessageId: "noShadow"}}},
+			{Code: "\n\t// types\n\ttype Bar<Foo> = 1;\n\ttype Foo = 1;\n\n\t// functions\n\tif (true) {\n\t\tconst b = 6;\n\t}\n\n\tfunction b() { }\n\t\t", Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  interface Foo<A> {}\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  interface Foo<A> {}\n  interface A {}\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  type Foo<A> = 1;\n  interface A {}\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  {\n\ttype A = 1;\n  }\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: "\n  {\n\tinterface A {}\n  }\n  type A = 1;\n\t\t", Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+
+			// SKIP: TS cases relying on languageOptions.globals (args/has/Foo).
+
+			// ---- Enum member shadowing outer const ----
+			{
+				Code: "\n\t\tconst A = 2;\n\t\tenum Test {\n\t\t\tA = 1,\n\t\t\tB = A,\n\t\t}\n\t",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- infer T shadowing infer T (nested in same conditional chain) ----
+			{
+				Code: `type X<T> = T extends (infer U) ? (U extends (infer U) ? U : never) : never;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Object literal getter/setter/method param shadow ----
+			{
+				Code: `const x = 1; const o = { foo(x: number) { return x; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: `const x = 1; const o = { get foo() { const x = 2; return x; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: `const x = 1; const o = { async foo(x: number) { return x; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			{
+				Code: `const x = 1; const o = { *foo(x: number) { yield x; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- using declarations ----
+			{
+				Code: `using u = { [Symbol.dispose]() {} }; { using u = { [Symbol.dispose]() {} }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Class generic shadowed by instance method generic ----
+			{
+				Code: `class C<T> { static s<T>(): T { return null as any; } i<T>(): T { return null as any; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Object pattern rename shadow ----
+			{
+				Code: `const a = 1; function f({ x: a }: any) { return a; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Function expression name shadowed by its own parameter ----
+			{
+				Code: `const fn = function f(f: number) { return f; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Decorator: shadowing inside decorated method body ----
+			{
+				Code: `function dec(x: any) { return x; }
+@dec class CD { method() { const dec = 1; return dec; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Computed property name with class member shadow ----
+			{
+				Code: `const k = 'x'; class C { foo() { const k = 1; return k; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Default parameter referencing outer var of same name (still reported) ----
+			{
+				Code: `const a = 1; function f({ a = a }: any) { return a; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Optional catch binding does NOT introduce binding (but declared var inside still checked) ----
+			{
+				Code: `const e = 1; try {} catch ({ message: e }) { return e; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Async generator with for-of ----
+			{
+				Code: `async function* g() { const v = 1; for await (const v of [Promise.resolve(1)]) yield v; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Multi-decl in single statement ----
+			{
+				Code: `const a = 1, b = 2; function f() { const a = 3, b = 4; return a + b; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Switch case lexical scope shadow ----
+			{
+				Code: `function f() { const z = 1; switch (z) { case 1: { const z = 2; break; } case 2: { const z = 3; break; } } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Namespace import param shadow ----
+			{
+				Code: `import * as Mods from 'fs'; function f(Mods: number) { return Mods; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Re-declared inside arrow returning class with the same name ----
+			{
+				Code: `const Z = 1; const make = () => class Z {};`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- typeof reference + parameter shadow ----
+			{
+				Code: `const t = 1; type T = typeof t; function f(t: number) { return t; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Default parameter with type reference ----
+			{
+				Code: `const opts = { x: 1 }; function f(opts: typeof opts = opts) { return opts; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Anonymous function expression with same name inside ----
+			{
+				Code: `const a = 1; const fn = function() { const a = 2; return a; };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Nested class with shadowed name ----
+			{
+				Code: `const A = 1; class A_outer { x = class A {}; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Rest pattern shadow inner destructure ----
+			{
+				Code: `function f(...args: number[]) { function g({ args }: any) { return args; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Generator with for-of shadow ----
+			{
+				Code: `function* g() { const v = 1; for (const v of [1,2,3]) { yield v; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Real-code-discovered: function type inside parameter type
+			// annotation carries its own generics that shadow outer generics ----
+			{
+				Code: `function f<A>(fn: <A>(x: A) => A): A { return fn as any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Function type in return position with shadowing generic ----
+			{
+				Code: `function f<T>(): <T>(x: T) => T { return null as any; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Nested catch clause shadow ----
+			{
+				Code: `try {} catch (e) { try {} catch (e) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Method with same generic name as class generic ----
+			{
+				Code: `class C<T> { m<T>(x: T): T { return x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Double shadow chain ----
+			{
+				Code: `const x = 1; function f(x: number) { function g(x: number) { return x; } return g; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Array pattern with elision shadow ----
+			{
+				Code: `const a = 1; function f([, a]: any[]) { return a; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Optional-chain call with arrow param shadow ----
+			{
+				Code: `const a = 1; const fn = { call: (cb: any) => cb }; fn.call?.(a => a);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Parameter property with same name as outer ----
+			{
+				Code: `const x = 1; class C { constructor(public x: number) {} m() { const x = 1; return x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Dynamic import callback shadow ----
+			{
+				Code: `const mod = 1; import('m').then((mod) => mod);`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- TS 4.7+: infer T extends U ----
+			{
+				Code: `type X<T> = T extends Array<infer U> ? (U extends Array<infer U> ? U : never) : never;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- TS 4.7 generic instantiation expression + builtinGlobals ----
+			{
+				Code:    `const g = Array<number>; function f(Array: any) { return Array; }`,
+				Options: map[string]interface{}{"builtinGlobals": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadowGlobal"},
+				},
+			},
+
+			// ---- TS 4.9 `accessor` field ----
+			{
+				Code: `const x = 1; class C { accessor x = 1; m() { const x = 2; return x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Async iteration with destructure ----
+			{
+				Code: `async function f() { const x = 1; for await (const { v: x } of [Promise.resolve({ v: 1 })]) { return x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- using + for-of ----
+			{
+				Code: `async function f() { using u = { [Symbol.dispose]() {} }; for (const u of [] as any[]) { void u; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Destructure with computed key + inner rebind ----
+			{
+				Code: `const k = 'a'; function f({ [k]: v }: any) { const k = 1; return [v, k]; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- HOC pattern: component param shadowed by inner ----
+			{
+				Code: `function withTheme<P>(Component: any) { return function ThemedComponent(props: P) { const Component = 1; return Component; }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Reducer pattern with case block ----
+			{
+				Code: `type A = { type: 'inc' } | { type: 'set'; value: number }; function reducer(state: number, action: A) { switch (action.type) { case 'inc': { const state = 1; return state + 1; } case 'set': return action.value; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Array chain with same callback name (3 separate shadows) ----
+			{
+				Code: `function chain() { const item = { id: 1 }; [1, 2, 3].map(item => item + 1).filter(item => item > 1).forEach(item => void item); void item; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Triply nested try/catch ----
+			{
+				Code: `const e = 1; try { try { throw new Error(); } catch (e) { try { throw e; } catch (e) {} } } catch (e) {} void e;`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Computed method name + param shadow ----
+			{
+				Code: `const methodName = 'foo'; const obj = { [methodName](methodName: string) { return methodName; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Nested for loops with same loop var ----
+			{
+				Code: `function f() { for (let i = 0; i < 1; i++) { for (let i = 0; i < 1; i++) {} } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Method overload: impl-signature param shadow ----
+			{
+				Code: `const a = 1; class C { m(x: string): void; m(x: number): void; m(a: any): void { void a; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Factory returning object method with generic shadow ----
+			{
+				Code: `function mk<T>(x: T) { return { get<T>(): T { return null as any; } }; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Empty block doesn't prevent later shadow ----
+			{
+				Code: `const c = 1; { /* empty */ } { const c = 2; void c; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- const enum + param shadow ----
+			{
+				Code: `const enum E { A, B } function f(E: number) { return E; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Abstract class with generic + abstract method generic shadow ----
+			{
+				Code: `abstract class C<T extends object> { abstract m<T>(): T; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Symbol.iterator method with shadowed param ----
+			{
+				Code: `const iter = 1; class C { [Symbol.iterator](iter: number) { return iter; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Constructor with optional param shadow ----
+			{
+				Code: `const x = 1; class C { constructor(x?: number) { void x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- typeof type query + same-name parameter ----
+			{
+				Code: `const val = { x: 1 }; function f(val: typeof val) { return val; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Async method param shadow ----
+			{
+				Code: `const x = 1; class C { async m(x: number) { return x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Generator method param shadow ----
+			{
+				Code: `const x = 1; class C { *m(x: number) { yield x; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Ambient function shadowed by inner const (bot #1 / #3) ----
+			{
+				Code: `declare function foo(): void; function bar() { const foo = 1; return foo; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Heritage clause IIFE shadow (bot #2) ----
+			{
+				Code: `const h = 1; class C extends (function() { const h = 2; return class {}; })() {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Heritage clause comma-expression arrow shadow ----
+			{
+				Code: `const h = 1; class C extends ((h => h)(1), Object) {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Class decorator factory body shadow (bot #2) ----
+			{
+				Code: `function dec(x: any) { return x; }
+@((target: any) => { const dec = 1; return dec && target; })
+class D {}`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Method decorator body shadow ----
+			{
+				Code: `const md = 1; class C { @((t: any, k: string) => { const md = 1; void md; }) method() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Parameter decorator body shadow ----
+			{
+				Code: `const pd = 1; class C { method(@((t: any, k: any, i: number) => { const pd = 1; void pd; }) x: number) {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Computed key on class method (self-discovered during audit) ----
+			{
+				Code: `const k = 1; class C { [((k) => k)(2)]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Computed key on class property ----
+			{
+				Code: `const k = 1; class C { [((k) => k)(2)] = 1; }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Computed key on getter ----
+			{
+				Code: `const g = 1; class C { get [((g) => g)(1)]() { return 1; } }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Computed key on async generator method ----
+			{
+				Code: `const m = 1; class C { async *[((m) => m)(1)]() {} }`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ---- Object-literal method with shadow inside computed key ----
+			{
+				Code: `const k = 1; const o = { [((k) => k)(2)]() {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Object-literal getter with shadow inside computed key ----
+			{
+				Code: `const k = 1; const o = { get [((k) => k)(1)]() { return 1; } };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+			// ---- Object-literal setter with shadow inside computed key ----
+			{
+				Code: `const k = 1; const o = { set [((k) => k)(1)](v: number) {} };`,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noShadow"},
+				},
+			},
+
+			// ==== Additional ESLint invalid cases for full coverage ====
+
+			{Code: `let x = foo((x,y) => {});
+let y;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}, {MessageId: "noShadow"}}},
+			{Code: `function a() {}
+foo(a => {});`, Options: map[string]interface{}{"ignoreOnInitialization": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `let x = ((x,y) => {})();
+let y;`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}, {MessageId: "noShadow"}}},
+			{Code: `let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  type T = 1;
+  {
+	type T = 2;
+  }
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  type T = 1;
+  function foo<T>(arg: T) {}
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  function foo<T>() {
+	return function <T>() {};
+  }
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  type T = string;
+  function foo<T extends (arg: any) => void>(arg: T) {}
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  const arg = 0;
+  
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		`, Options: map[string]interface{}{"ignoreFunctionTypeParameterNameValueShadow": false}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  import type { foo } from './foo';
+  function doThing(foo: number) {}
+		`, Options: map[string]interface{}{"ignoreTypeValueShadow": false}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  import { type foo } from './foo';
+  function doThing(foo: number) {}
+		`, Options: map[string]interface{}{"ignoreTypeValueShadow": false}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  import { foo } from './foo';
+  function doThing(foo: number, bar: number) {}
+		`, Options: map[string]interface{}{"ignoreTypeValueShadow": true}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  interface Foo {}
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  let x = foo((x, y) => {});
+  let y;
+		`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}, {MessageId: "noShadow"}}},
+			{Code: `
+  let x = foo((x, y) => {});
+  let y;
+		`, Options: map[string]interface{}{"hoist": "functions"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`, Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`, Options: map[string]interface{}{"hoist": "all"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+	if (true) {
+		const foo = 6;
+	}
+
+	function foo() { }
+		`, Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		`, Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}, {MessageId: "noShadow"}}},
+			{Code: `
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		`, Options: map[string]interface{}{"hoist": "types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`, Options: map[string]interface{}{"hoist": "functions-and-types"}, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+			{Code: `
+			const A = 2;
+			enum Test {
+				A = 1,
+				B = A,
+			}
+		`, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noShadow"}}},
+		},
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -288,6 +288,7 @@ export default defineConfig({
     './tests/eslint/rules/no-bitwise.test.ts',
     './tests/eslint/rules/max-lines.test.ts',
     './tests/eslint/rules/no-label-var.test.ts',
+    './tests/eslint/rules/no-shadow.test.ts',
     './tests/eslint/rules/no-labels.test.ts',
     './tests/eslint/rules/no-lone-blocks.test.ts',
     './tests/eslint/rules/no-multi-str.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-shadow.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-shadow.test.ts.snap
@@ -1,0 +1,6478 @@
+// Rstest Snapshot v1
+
+exports[`no-shadow > invalid 1`] = `
+{
+  "code": "function a(x) { var b = function c() { var x = 'foo'; }; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 2`] = `
+{
+  "code": "var a = (x) => { var b = () => { var x = 'foo'; }; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 3`] = `
+{
+  "code": "function a(x) { var b = function () { var x = 'foo'; }; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 4`] = `
+{
+  "code": "var x = 1; function a(x) { return ++x; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 5`] = `
+{
+  "code": "var a=3; function b() { var a=10; }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 6`] = `
+{
+  "code": "var a=3; function b() { var a=10; }; setTimeout(function() { b(); }, 0);",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 7`] = `
+{
+  "code": "var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'b' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 8`] = `
+{
+  "code": "var x = 1; { let x = 2; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 9`] = `
+{
+  "code": "let x = 1; { const x = 2; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 10`] = `
+{
+  "code": "{ let a; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 21.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 11`] = `
+{
+  "code": "{ const a = 0; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 27.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 12`] = `
+{
+  "code": "function foo() { let a; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 36.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 13`] = `
+{
+  "code": "function foo() { var a; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 36.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 14`] = `
+{
+  "code": "function foo(a) { } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 30.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 15`] = `
+{
+  "code": "{ let a; } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 16.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 16`] = `
+{
+  "code": "{ let a; } var a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 16.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 17`] = `
+{
+  "code": "{ let a; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 21.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 18`] = `
+{
+  "code": "{ const a = 0; } const a = 1;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 24.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 19`] = `
+{
+  "code": "{ const a = 0; } var a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 22.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 20`] = `
+{
+  "code": "{ const a = 0; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 27.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 21`] = `
+{
+  "code": "function foo() { let a; } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 31.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 22`] = `
+{
+  "code": "function foo() { let a; } var a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 31.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 23`] = `
+{
+  "code": "function foo() { let a; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 36.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 24`] = `
+{
+  "code": "function foo() { var a; } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 31.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 25`] = `
+{
+  "code": "function foo() { var a; } var a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 31.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 26`] = `
+{
+  "code": "function foo() { var a; } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 36.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 27`] = `
+{
+  "code": "function foo(a) { } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 25.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 28`] = `
+{
+  "code": "function foo(a) { } var a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 25.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 29`] = `
+{
+  "code": "function foo(a) { } function a() {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 30.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 30`] = `
+{
+  "code": "(function a() { function a(){} })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 31`] = `
+{
+  "code": "(function a() { class a{} })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 32`] = `
+{
+  "code": "(function a() { (function a(){}); })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 33`] = `
+{
+  "code": "(function a() { (class a{}); })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 34`] = `
+{
+  "code": "(function() { var a = function(a) {}; })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 35`] = `
+{
+  "code": "(function() { var a = function() { function a() {} }; })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 36`] = `
+{
+  "code": "(function() { var a = function() { class a{} }; })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 37`] = `
+{
+  "code": "(function() { var a = function() { (function a() {}); }; })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 38`] = `
+{
+  "code": "(function() { var a = function() { (class a{}); }; })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 39`] = `
+{
+  "code": "(function() { var a = class { constructor() { class a {} } }; })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 40`] = `
+{
+  "code": "class A { constructor() { var A; } }",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 41`] = `
+{
+  "code": "(function a() { function a(){ function a(){} } })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 26.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 42`] = `
+{
+  "code": "function foo() { var Object = 0; }",
+  "diagnostics": [
+    {
+      "message": "'Object' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 43`] = `
+{
+  "code": "var Object = 0;",
+  "diagnostics": [
+    {
+      "message": "'Object' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 44`] = `
+{
+  "code": "(function Array() {})",
+  "diagnostics": [
+    {
+      "message": "'Array' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 45`] = `
+{
+  "code": "function foo(cb) { (function (cb) { cb(42); })(cb); }",
+  "diagnostics": [
+    {
+      "message": "'cb' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 46`] = `
+{
+  "code": "class C { static { let a; { let a; } } }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 24.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 34,
+          "line": 1,
+        },
+        "start": {
+          "column": 33,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 47`] = `
+{
+  "code": "class C { static { var C; } }",
+  "diagnostics": [
+    {
+      "message": "'C' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 48`] = `
+{
+  "code": "class C { static { let C; } }",
+  "diagnostics": [
+    {
+      "message": "'C' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 49`] = `
+{
+  "code": "var a; class C { static { var a; } }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 50`] = `
+{
+  "code": "class C { static { var a; } } var a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 35.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 51`] = `
+{
+  "code": "class C { static { let a; } } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 35.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 52`] = `
+{
+  "code": "class C { static { var a; } } let a;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 35.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 53`] = `
+{
+  "code": "class C { static { var a; class D { static { var a; } } } }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 24.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 54`] = `
+{
+  "code": "class C { static { let a; class D { static { let a; } } } }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 24.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 55`] = `
+{
+  "code": "let x = foo((x,y) => {});
+let y;",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 2 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 56`] = `
+{
+  "code": "let x = ((x,y) => {})();
+let y;",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 2 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 57`] = `
+{
+  "code": "const a = fn(()=>{ class C { fn () { const a = 42; return a } } return new C() })",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 58`] = `
+{
+  "code": "function a() {}
+foo(a => {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 59`] = `
+{
+  "code": "const a = fn(()=>{ function C() { this.fn=function() { const a = 42; return a } } return new C() });",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 60`] = `
+{
+  "code": "const x = foo(() => { const bar = () => { return x => {}; }; return bar; });",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 61`] = `
+{
+  "code": "const x = foo(() => { return { bar(x) {} }; });",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 62`] = `
+{
+  "code": "const x = () => { foo(x => x); }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 63`] = `
+{
+  "code": "const foo = () => { let x; bar(x => x); }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 25.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 64`] = `
+{
+  "code": "foo(() => { const x = x => x; });",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 19.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 65`] = `
+{
+  "code": "const foo = (x) => { bar(x => {}) }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 26,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 66`] = `
+{
+  "code": "const a = (()=>{ class C { fn () { const a = 42; return a } } return new C() })()",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 67`] = `
+{
+  "code": "const x = () => { (x => x)(); }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 68`] = `
+{
+  "code": "const a = wrap(function a() {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 69`] = `
+{
+  "code": "const a = foo || wrap(function a() {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 70`] = `
+{
+  "code": "const { a = wrap(function a() {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 71`] = `
+{
+  "code": "const { a = foo || wrap(function a() {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 72`] = `
+{
+  "code": "const { a = foo, b = function a() {} } = {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 73`] = `
+{
+  "code": "const { A = Foo, B = class A {} } = {}",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 74`] = `
+{
+  "code": "function foo(a = wrap(function a() {})) {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 75`] = `
+{
+  "code": "function foo(a = foo || wrap(function a() {})) {}",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 76`] = `
+{
+  "code": "const A = wrap(class A {});",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 1,
+        },
+        "start": {
+          "column": 22,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 77`] = `
+{
+  "code": "const A = foo || wrap(class A {});",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 78`] = `
+{
+  "code": "const { A = wrap(class A {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 1,
+        },
+        "start": {
+          "column": 24,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 79`] = `
+{
+  "code": "const { A = foo || wrap(class A {}) } = obj;",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 80`] = `
+{
+  "code": "function foo(A = wrap(class A {})) {}",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 29,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 81`] = `
+{
+  "code": "function foo(A = foo || wrap(class A {})) {}",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 82`] = `
+{
+  "code": "var a = function a() {} ? foo : bar",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 1,
+        },
+        "start": {
+          "column": 18,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 83`] = `
+{
+  "code": "var A = class A {} ? foo : bar",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 15,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 84`] = `
+{
+  "code": "(function Array() {})",
+  "diagnostics": [
+    {
+      "message": "'Array' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 16,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 85`] = `
+{
+  "code": "let a; { let b = (function a() {}) }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 86`] = `
+{
+  "code": "let a = foo; { let b = (function a() {}) }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 87`] = `
+{
+  "code": "
+  type T = 1;
+  {
+	type T = 2;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 88`] = `
+{
+  "code": "
+  type T = 1;
+  function foo<T>(arg: T) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 89`] = `
+{
+  "code": "
+  function foo<T>() {
+	return function <T>() {};
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 16.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 90`] = `
+{
+  "code": "
+  type T = string;
+  function foo<T extends (arg: any) => void>(arg: T) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 91`] = `
+{
+  "code": "
+  const x = 1;
+  {
+	type x = string;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 92`] = `
+{
+  "code": "
+  const test = 1;
+  type Fn = (test: string) => typeof test;
+		",
+  "diagnostics": [
+    {
+      "message": "'test' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 3,
+        },
+        "start": {
+          "column": 14,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 93`] = `
+{
+  "code": "
+  const arg = 0;
+  interface Test {
+	(arg: string): typeof arg;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 94`] = `
+{
+  "code": "
+  const arg = 0;
+  interface Test {
+	p1(arg: string): typeof arg;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 95`] = `
+{
+  "code": "
+  const arg = 0;
+  declare function test(arg: string): typeof arg;
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 25,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 96`] = `
+{
+  "code": "
+  const arg = 0;
+  declare const test: (arg: string) => typeof arg;
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 3,
+        },
+        "start": {
+          "column": 24,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 97`] = `
+{
+  "code": "
+  const arg = 0;
+  declare class Test {
+	p1(arg: string): typeof arg;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 98`] = `
+{
+  "code": "
+  const arg = 0;
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 99`] = `
+{
+  "code": "
+  const arg = 0;
+  type Bar = new (arg: number) => typeof arg;
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 100`] = `
+{
+  "code": "
+  const arg = 0;
+  declare namespace Lib {
+	function test(arg: string): typeof arg;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 4,
+        },
+        "start": {
+          "column": 16,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 101`] = `
+{
+  "code": "
+import type { foo } from './foo';
+function doThing(foo: number) {}
+",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 15.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 102`] = `
+{
+  "code": "
+import { type foo } from './foo';
+function doThing(foo: number) {}
+",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 15.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 103`] = `
+{
+  "code": "
+import { foo } from './foo';
+function doThing(foo: number, bar: number) {}
+",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 18,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 104`] = `
+{
+  "code": "
+interface Foo {}
+declare module 'bar' { export interface Foo { x: string } }
+",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 41,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 105`] = `
+{
+  "code": "
+import type { Foo } from 'bar';
+declare module 'baz' { export interface Foo { x: string } }
+",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 15.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 41,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 106`] = `
+{
+  "code": "
+import { type Foo } from 'bar';
+declare module 'baz' { export interface Foo { x: string } }
+",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 15.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 3,
+        },
+        "start": {
+          "column": 41,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 107`] = `
+{
+  "code": "
+  let x = foo((x, y) => {});
+  let y;
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 3 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 108`] = `
+{
+  "code": "
+  let x = foo((x, y) => {});
+  let y;
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 109`] = `
+{
+  "code": "
+  type Foo<A> = 1;
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 110`] = `
+{
+  "code": "
+  interface Foo<A> {}
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 111`] = `
+{
+  "code": "
+  interface Foo<A> {}
+  interface A {}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 112`] = `
+{
+  "code": "
+  type Foo<A> = 1;
+  interface A {}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 113`] = `
+{
+  "code": "
+  {
+	type A = 1;
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 114`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 115`] = `
+{
+  "code": "
+  type Foo<A> = 1;
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 116`] = `
+{
+  "code": "
+  interface Foo<A> {}
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 117`] = `
+{
+  "code": "
+  interface Foo<A> {}
+  interface A {}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 118`] = `
+{
+  "code": "
+  type Foo<A> = 1;
+  interface A {}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 119`] = `
+{
+  "code": "
+  {
+	type A = 1;
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 120`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 121`] = `
+{
+  "code": "
+  type Foo<A> = 1;
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 122`] = `
+{
+  "code": "
+	if (true) {
+		const foo = 6;
+	}
+
+	function foo() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 6 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 123`] = `
+{
+  "code": "
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 4 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'b' is already declared in the upper scope on line 11 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 8,
+        },
+        "start": {
+          "column": 9,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 124`] = `
+{
+  "code": "
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 4 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 125`] = `
+{
+  "code": "
+  interface Foo<A> {}
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 126`] = `
+{
+  "code": "
+  interface Foo<A> {}
+  interface A {}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 18,
+          "line": 2,
+        },
+        "start": {
+          "column": 17,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 127`] = `
+{
+  "code": "
+  type Foo<A> = 1;
+  interface A {}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 3 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 2,
+        },
+        "start": {
+          "column": 12,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 128`] = `
+{
+  "code": "
+  {
+	type A = 1;
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 7,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 129`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 130`] = `
+{
+  "code": "
+		const A = 2;
+		enum Test {
+			A = 1,
+			B = A,
+		}
+	",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 4,
+        },
+        "start": {
+          "column": 4,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 131`] = `
+{
+  "code": "type X<T> = T extends (infer U) ? (U extends (infer U) ? U : never) : never;",
+  "diagnostics": [
+    {
+      "message": "'U' is already declared in the upper scope on line 1 column 30.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 132`] = `
+{
+  "code": "const x = 1; const o = { foo(x: number) { return x; } };",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 133`] = `
+{
+  "code": "const x = 1; const o = { get foo() { const x = 2; return x; } };",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 134`] = `
+{
+  "code": "const x = 1; const o = { async foo(x: number) { return x; } };",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 135`] = `
+{
+  "code": "const x = 1; const o = { *foo(x: number) { yield x; } };",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 136`] = `
+{
+  "code": "using u = { [Symbol.dispose]() {} }; { using u = { [Symbol.dispose]() {} }; }",
+  "diagnostics": [
+    {
+      "message": "'u' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 47,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 137`] = `
+{
+  "code": "class C<T> { static s<T>(): T { return null as any; } i<T>(): T { return null as any; } }",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 138`] = `
+{
+  "code": "const a = 1; function f({ x: a }: any) { return a; }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 30,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 139`] = `
+{
+  "code": "const fn = function f(f: number) { return f; };",
+  "diagnostics": [
+    {
+      "message": "'f' is already declared in the upper scope on line 1 column 21.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 1,
+        },
+        "start": {
+          "column": 23,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 140`] = `
+{
+  "code": "function dec(x: any) { return x; }
+@dec class CD { method() { const dec = 1; return dec; } }",
+  "diagnostics": [
+    {
+      "message": "'dec' is already declared in the upper scope on line 1 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 2,
+        },
+        "start": {
+          "column": 34,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 141`] = `
+{
+  "code": "const k = 'x'; class C { foo() { const k = 1; return k; } }",
+  "diagnostics": [
+    {
+      "message": "'k' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 142`] = `
+{
+  "code": "const a = 1; function f({ a = a }: any) { return a; }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 143`] = `
+{
+  "code": "const e = 1; try {} catch ({ message: e }) { return e; }",
+  "diagnostics": [
+    {
+      "message": "'e' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 144`] = `
+{
+  "code": "async function* g() { const v = 1; for await (const v of [Promise.resolve(1)]) yield v; }",
+  "diagnostics": [
+    {
+      "message": "'v' is already declared in the upper scope on line 1 column 29.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 54,
+          "line": 1,
+        },
+        "start": {
+          "column": 53,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 145`] = `
+{
+  "code": "const a = 1, b = 2; function f() { const a = 3, b = 4; return a + b; }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 1,
+        },
+        "start": {
+          "column": 42,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'b' is already declared in the upper scope on line 1 column 14.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 146`] = `
+{
+  "code": "function f() { const z = 1; switch (z) { case 1: { const z = 2; break; } case 2: { const z = 3; break; } } }",
+  "diagnostics": [
+    {
+      "message": "'z' is already declared in the upper scope on line 1 column 22.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'z' is already declared in the upper scope on line 1 column 22.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 91,
+          "line": 1,
+        },
+        "start": {
+          "column": 90,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 147`] = `
+{
+  "code": "import * as Mods from 'fs'; function f(Mods: number) { return Mods; }",
+  "diagnostics": [
+    {
+      "message": "'Mods' is already declared in the upper scope on line 1 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 148`] = `
+{
+  "code": "const Z = 1; const make = () => class Z {};",
+  "diagnostics": [
+    {
+      "message": "'Z' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 1,
+        },
+        "start": {
+          "column": 39,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 149`] = `
+{
+  "code": "const t = 1; type T = typeof t; function f(t: number) { return t; }",
+  "diagnostics": [
+    {
+      "message": "'t' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 150`] = `
+{
+  "code": "const opts = { x: 1 }; function f(opts: typeof opts = opts) { return opts; }",
+  "diagnostics": [
+    {
+      "message": "'opts' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 35,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 151`] = `
+{
+  "code": "const a = 1; const fn = function() { const a = 2; return a; };",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 45,
+          "line": 1,
+        },
+        "start": {
+          "column": 44,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 152`] = `
+{
+  "code": "const A = 1; class A_outer { x = class A {}; }",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 41,
+          "line": 1,
+        },
+        "start": {
+          "column": 40,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 153`] = `
+{
+  "code": "function f(...args: number[]) { function g({ args }: any) { return args; } }",
+  "diagnostics": [
+    {
+      "message": "'args' is already declared in the upper scope on line 1 column 15.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 46,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 154`] = `
+{
+  "code": "function* g() { const v = 1; for (const v of [1,2,3]) { yield v; } }",
+  "diagnostics": [
+    {
+      "message": "'v' is already declared in the upper scope on line 1 column 23.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 41,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 155`] = `
+{
+  "code": "function f<A>(fn: <A>(x: A) => A): A { return fn as any; }",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 1 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 1,
+        },
+        "start": {
+          "column": 20,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 156`] = `
+{
+  "code": "function f<T>(): <T>(x: T) => T { return null as any; }",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 1 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 1,
+        },
+        "start": {
+          "column": 19,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 157`] = `
+{
+  "code": "try {} catch (e) { try {} catch (e) {} }",
+  "diagnostics": [
+    {
+      "message": "'e' is already declared in the upper scope on line 1 column 15.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 158`] = `
+{
+  "code": "class C<T> { m<T>(x: T): T { return x; } }",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 1 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 159`] = `
+{
+  "code": "const x = 1; function f(x: number) { function g(x: number) { return x; } return g; }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 25.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 160`] = `
+{
+  "code": "const a = 1; function f([, a]: any[]) { return a; }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 161`] = `
+{
+  "code": "const a = 1; const fn = { call: (cb: any) => cb }; fn.call?.(a => a);",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 63,
+          "line": 1,
+        },
+        "start": {
+          "column": 62,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 162`] = `
+{
+  "code": "const x = 1; class C { constructor(public x: number) {} m() { const x = 1; return x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 44,
+          "line": 1,
+        },
+        "start": {
+          "column": 43,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 70,
+          "line": 1,
+        },
+        "start": {
+          "column": 69,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 163`] = `
+{
+  "code": "const mod = 1; import('m').then((mod) => mod);",
+  "diagnostics": [
+    {
+      "message": "'mod' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 164`] = `
+{
+  "code": "type X<T> = T extends Array<infer U> ? (U extends Array<infer U> ? U : never) : never;",
+  "diagnostics": [
+    {
+      "message": "'U' is already declared in the upper scope on line 1 column 35.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 63,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 165`] = `
+{
+  "code": "const g = Array<number>; function f(Array: any) { return Array; }",
+  "diagnostics": [
+    {
+      "message": "'Array' is already a global variable.",
+      "messageId": "noShadowGlobal",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 166`] = `
+{
+  "code": "const x = 1; class C { accessor x = 1; m() { const x = 2; return x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 167`] = `
+{
+  "code": "async function f() { const x = 1; for await (const { v: x } of [Promise.resolve({ v: 1 })]) { return x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 28.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 1,
+        },
+        "start": {
+          "column": 57,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 168`] = `
+{
+  "code": "async function f() { using u = { [Symbol.dispose]() {} }; for (const u of [] as any[]) { void u; } }",
+  "diagnostics": [
+    {
+      "message": "'u' is already declared in the upper scope on line 1 column 28.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 71,
+          "line": 1,
+        },
+        "start": {
+          "column": 70,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 169`] = `
+{
+  "code": "const k = 'a'; function f({ [k]: v }: any) { const k = 1; return [v, k]; }",
+  "diagnostics": [
+    {
+      "message": "'k' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 53,
+          "line": 1,
+        },
+        "start": {
+          "column": 52,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 170`] = `
+{
+  "code": "function withTheme<P>(Component: any) { return function ThemedComponent(props: P) { const Component = 1; return Component; }; }",
+  "diagnostics": [
+    {
+      "message": "'Component' is already declared in the upper scope on line 1 column 23.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 100,
+          "line": 1,
+        },
+        "start": {
+          "column": 91,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 171`] = `
+{
+  "code": "type A = { type: 'inc' } | { type: 'set'; value: number }; function reducer(state: number, action: A) { switch (action.type) { case 'inc': { const state = 1; return state + 1; } case 'set': return action.value; } }",
+  "diagnostics": [
+    {
+      "message": "'state' is already declared in the upper scope on line 1 column 77.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 153,
+          "line": 1,
+        },
+        "start": {
+          "column": 148,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 172`] = `
+{
+  "code": "function chain() { const item = { id: 1 }; [1, 2, 3].map(item => item + 1).filter(item => item > 1).forEach(item => void item); void item; }",
+  "diagnostics": [
+    {
+      "message": "'item' is already declared in the upper scope on line 1 column 26.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 62,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'item' is already declared in the upper scope on line 1 column 26.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 87,
+          "line": 1,
+        },
+        "start": {
+          "column": 83,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'item' is already declared in the upper scope on line 1 column 26.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 113,
+          "line": 1,
+        },
+        "start": {
+          "column": 109,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 173`] = `
+{
+  "code": "const e = 1; try { try { throw new Error(); } catch (e) { try { throw e; } catch (e) {} } } catch (e) {} void e;",
+  "diagnostics": [
+    {
+      "message": "'e' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 55,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'e' is already declared in the upper scope on line 1 column 54.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 84,
+          "line": 1,
+        },
+        "start": {
+          "column": 83,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'e' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 101,
+          "line": 1,
+        },
+        "start": {
+          "column": 100,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 174`] = `
+{
+  "code": "const methodName = 'foo'; const obj = { [methodName](methodName: string) { return methodName; } };",
+  "diagnostics": [
+    {
+      "message": "'methodName' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 64,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 175`] = `
+{
+  "code": "function f() { for (let i = 0; i < 1; i++) { for (let i = 0; i < 1; i++) {} } }",
+  "diagnostics": [
+    {
+      "message": "'i' is already declared in the upper scope on line 1 column 25.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 56,
+          "line": 1,
+        },
+        "start": {
+          "column": 55,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 176`] = `
+{
+  "code": "const a = 1; class C { m(x: string): void; m(x: number): void; m(a: any): void { void a; } }",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 67,
+          "line": 1,
+        },
+        "start": {
+          "column": 66,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 177`] = `
+{
+  "code": "function mk<T>(x: T) { return { get<T>(): T { return null as any; } }; }",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 1 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 38,
+          "line": 1,
+        },
+        "start": {
+          "column": 37,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 178`] = `
+{
+  "code": "const c = 1; { /* empty */ } { const c = 2; void c; }",
+  "diagnostics": [
+    {
+      "message": "'c' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 39,
+          "line": 1,
+        },
+        "start": {
+          "column": 38,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 179`] = `
+{
+  "code": "const enum E { A, B } function f(E: number) { return E; }",
+  "diagnostics": [
+    {
+      "message": "'E' is already declared in the upper scope on line 1 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 180`] = `
+{
+  "code": "abstract class C<T extends object> { abstract m<T>(): T; }",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 1 column 18.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 50,
+          "line": 1,
+        },
+        "start": {
+          "column": 49,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 181`] = `
+{
+  "code": "const iter = 1; class C { [Symbol.iterator](iter: number) { return iter; } }",
+  "diagnostics": [
+    {
+      "message": "'iter' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 49,
+          "line": 1,
+        },
+        "start": {
+          "column": 45,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 182`] = `
+{
+  "code": "const x = 1; class C { constructor(x?: number) { void x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 36,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 183`] = `
+{
+  "code": "const val = { x: 1 }; function f(val: typeof val) { return val; }",
+  "diagnostics": [
+    {
+      "message": "'val' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 37,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 184`] = `
+{
+  "code": "const x = 1; class C { async m(x: number) { return x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 185`] = `
+{
+  "code": "const x = 1; class C { *m(x: number) { yield x; } }",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 186`] = `
+{
+  "code": "declare function foo(): void; function bar() { const foo = 1; return foo; }",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 1 column 18.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 1,
+        },
+        "start": {
+          "column": 54,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 187`] = `
+{
+  "code": "const h = 1; class C extends (function() { const h = 2; return class {}; })() {}",
+  "diagnostics": [
+    {
+      "message": "'h' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 51,
+          "line": 1,
+        },
+        "start": {
+          "column": 50,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 188`] = `
+{
+  "code": "const h = 1; class C extends ((h => h)(1), Object) {}",
+  "diagnostics": [
+    {
+      "message": "'h' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 1,
+        },
+        "start": {
+          "column": 32,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 189`] = `
+{
+  "code": "function dec(x: any) { return x; }
+@((target: any) => { const dec = 1; return dec && target; })
+class D {}",
+  "diagnostics": [
+    {
+      "message": "'dec' is already declared in the upper scope on line 1 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 28,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 190`] = `
+{
+  "code": "const md = 1; class C { @((t: any, k: string) => { const md = 1; void md; }) method() {} }",
+  "diagnostics": [
+    {
+      "message": "'md' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 60,
+          "line": 1,
+        },
+        "start": {
+          "column": 58,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 191`] = `
+{
+  "code": "const pd = 1; class C { method(@((t: any, k: any, i: number) => { const pd = 1; void pd; }) x: number) {} }",
+  "diagnostics": [
+    {
+      "message": "'pd' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 75,
+          "line": 1,
+        },
+        "start": {
+          "column": 73,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 192`] = `
+{
+  "code": "const k = 1; class C { [((k) => k)(2)]() {} }",
+  "diagnostics": [
+    {
+      "message": "'k' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 193`] = `
+{
+  "code": "const k = 1; class C { [((k) => k)(2)] = 1; }",
+  "diagnostics": [
+    {
+      "message": "'k' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 1,
+        },
+        "start": {
+          "column": 27,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 194`] = `
+{
+  "code": "const g = 1; class C { get [((g) => g)(1)]() { return 1; } }",
+  "diagnostics": [
+    {
+      "message": "'g' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 1,
+        },
+        "start": {
+          "column": 31,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 195`] = `
+{
+  "code": "const m = 1; class C { async *[((m) => m)(1)]() {} }",
+  "diagnostics": [
+    {
+      "message": "'m' is already declared in the upper scope on line 1 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 1,
+        },
+        "start": {
+          "column": 34,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 196`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 197`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 198`] = `
+{
+  "code": "
+	if (true) {
+		const foo = 6;
+	}
+
+	function foo() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 6 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 199`] = `
+{
+  "code": "
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 4 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'b' is already declared in the upper scope on line 11 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 8,
+        },
+        "start": {
+          "column": 9,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 200`] = `
+{
+  "code": "
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 4 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 201`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 202`] = `
+{
+  "code": "let x = foo((x,y) => {});
+let y;",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 2 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 1,
+        },
+        "start": {
+          "column": 16,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 203`] = `
+{
+  "code": "function a() {}
+foo(a => {});",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 2,
+        },
+        "start": {
+          "column": 5,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 204`] = `
+{
+  "code": "let x = ((x,y) => {})();
+let y;",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 1 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 2 column 5.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 13,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 205`] = `
+{
+  "code": "let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });",
+  "diagnostics": [
+    {
+      "message": "'a' is already declared in the upper scope on line 1 column 29.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 48,
+          "line": 1,
+        },
+        "start": {
+          "column": 47,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 206`] = `
+{
+  "code": "
+  type T = 1;
+  {
+	type T = 2;
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 7,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 207`] = `
+{
+  "code": "
+  type T = 1;
+  function foo<T>(arg: T) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 208`] = `
+{
+  "code": "
+  function foo<T>() {
+	return function <T>() {};
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 16.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 3,
+        },
+        "start": {
+          "column": 19,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 209`] = `
+{
+  "code": "
+  type T = string;
+  function foo<T extends (arg: any) => void>(arg: T) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'T' is already declared in the upper scope on line 2 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 16,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 210`] = `
+{
+  "code": "
+  const arg = 0;
+  
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		",
+  "diagnostics": [
+    {
+      "message": "'arg' is already declared in the upper scope on line 2 column 9.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 5,
+        },
+        "start": {
+          "column": 7,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 211`] = `
+{
+  "code": "
+  import type { foo } from './foo';
+  function doThing(foo: number) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 212`] = `
+{
+  "code": "
+  import { type foo } from './foo';
+  function doThing(foo: number) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 213`] = `
+{
+  "code": "
+  import { foo } from './foo';
+  function doThing(foo: number, bar: number) {}
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 2 column 12.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 23,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 214`] = `
+{
+  "code": "
+  interface Foo {}
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 13.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 215`] = `
+{
+  "code": "
+  import type { Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 216`] = `
+{
+  "code": "
+  import { type Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 2 column 17.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 22,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 217`] = `
+{
+  "code": "
+  let x = foo((x, y) => {});
+  let y;
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'y' is already declared in the upper scope on line 3 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 218`] = `
+{
+  "code": "
+  let x = foo((x, y) => {});
+  let y;
+		",
+  "diagnostics": [
+    {
+      "message": "'x' is already declared in the upper scope on line 2 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 2,
+        },
+        "start": {
+          "column": 16,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 219`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 220`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 221`] = `
+{
+  "code": "
+	if (true) {
+		const foo = 6;
+	}
+
+	function foo() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'foo' is already declared in the upper scope on line 6 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 222`] = `
+{
+  "code": "
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 4 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+    {
+      "message": "'b' is already declared in the upper scope on line 11 column 11.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 8,
+        },
+        "start": {
+          "column": 9,
+          "line": 8,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 223`] = `
+{
+  "code": "
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		",
+  "diagnostics": [
+    {
+      "message": "'Foo' is already declared in the upper scope on line 4 column 7.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 224`] = `
+{
+  "code": "
+  {
+	interface A {}
+  }
+  type A = 1;
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 5 column 8.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 3,
+        },
+        "start": {
+          "column": 12,
+          "line": 3,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-shadow > invalid 225`] = `
+{
+  "code": "
+			const A = 2;
+			enum Test {
+				A = 1,
+				B = A,
+			}
+		",
+  "diagnostics": [
+    {
+      "message": "'A' is already declared in the upper scope on line 2 column 10.",
+      "messageId": "noShadow",
+      "range": {
+        "end": {
+          "column": 6,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "no-shadow",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-shadow.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-shadow.test.ts
@@ -1,0 +1,2009 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Mirrors the Go test file 1:1. Framework-level ESLint concepts
+// (languageOptions.globals, parserOptions.ecmaFeatures.globalReturn, env,
+// sourceType: "script" vs "module" distinction) are not exercised here; see
+// the `SKIP` comments in the Go file for the full list.
+ruleTester.run('no-shadow', {
+  valid: [
+    // ---- Baseline (no shadow) ----
+    'var a=3; function b(x) { a++; return x + a; }; setTimeout(function() { b(a); }, 0);',
+
+    // ---- Function-name initializer exception (function expression) ----
+    '(function() { var doSomething = function doSomething() {}; doSomething() }())',
+    '(function() { var doSomething = foo || function doSomething() {}; doSomething() }())',
+    '(function() { var doSomething = function doSomething() {} || foo; doSomething() }())',
+    '(function() { var doSomething = foo && function doSomething() {}; doSomething() }())',
+    '(function() { var doSomething = foo ?? function doSomething() {}; doSomething() }())',
+    '(function() { var doSomething = foo || (bar || function doSomething() {}); doSomething() }())',
+    '(function() { var doSomething = foo || (bar && function doSomething() {}); doSomething() }())',
+    '(function() { var doSomething = foo ? function doSomething() {} : bar; doSomething() }())',
+    '(function() { var doSomething = foo ? bar: function doSomething() {}; doSomething() }())',
+    '(function() { var doSomething = foo ? bar: (baz || function doSomething() {}); doSomething() }())',
+    '(function() { var doSomething = (foo ? bar: function doSomething() {}) || baz; doSomething() }())',
+    '(function() { var { doSomething = function doSomething() {} } = obj; doSomething() }())',
+    '(function() { var { doSomething = function doSomething() {} || foo } = obj; doSomething() }())',
+    '(function() { var { doSomething = foo ? function doSomething() {} : bar } = obj; doSomething() }())',
+    '(function() { var { doSomething = foo ? bar : function doSomething() {} } = obj; doSomething() }())',
+    '(function() { var { doSomething = foo || (bar ? baz : (qux || function doSomething() {})) || quux } = obj; doSomething() }())',
+    'function foo(doSomething = function doSomething() {}) { doSomething(); }',
+    'function foo(doSomething = function doSomething() {} || foo) { doSomething(); }',
+    'function foo(doSomething = foo ? function doSomething() {} : bar) { doSomething(); }',
+    'function foo(doSomething = foo ? bar : function doSomething() {}) { doSomething(); }',
+    'function foo(doSomething = foo || (bar ? baz : (qux || function doSomething() {})) || quux) { doSomething(); }',
+
+    // ---- Miscellaneous ----
+    'var arguments;\nfunction bar() { }',
+    'var a=3; var b = (x) => { a++; return x + a; }; setTimeout(() => { b(a); }, 0);',
+
+    // ---- Class (no shadow) and class-expression initializer exceptions ----
+    'class A {}',
+    'class A { constructor() { var a; } }',
+    '(function() { var A = class A {}; })()',
+    '(function() { var A = foo || class A {}; })()',
+    '(function() { var A = class A {} || foo; })()',
+    '(function() { var A = foo && class A {} || foo; })()',
+    '(function() { var A = foo ?? class A {}; })()',
+    '(function() { var A = foo || (bar || class A {}); })()',
+    '(function() { var A = foo || (bar && class A {}); })()',
+    '(function() { var A = foo ? class A {} : bar; })()',
+    '(function() { var A = foo ? bar : class A {}; })()',
+    '(function() { var A = foo ? bar: (baz || class A {}); })()',
+    '(function() { var A = (foo ? bar: class A {}) || baz; })()',
+    '(function() { var { A = class A {} } = obj; }())',
+    '(function() { var { A = class A {} || foo } = obj; }())',
+    '(function() { var { A = foo ? class A {} : bar } = obj; }())',
+    '(function() { var { A = foo ? bar : class A {} } = obj; }())',
+    '(function() { var { A = foo || (bar ? baz : (qux || class A {})) || quux } = obj; }())',
+    'function foo(A = class A {}) { doSomething(); }',
+    'function foo(A = class A {} || foo) { doSomething(); }',
+    'function foo(A = foo ? class A {} : bar) { doSomething(); }',
+    'function foo(A = foo ? bar : class A {}) { doSomething(); }',
+    'function foo(A = foo || (bar ? baz : (qux || class A {})) || quux) { doSomething(); }',
+
+    // ---- Block redecl (not shadow) ----
+    '{ var a; } var a;',
+
+    // ---- hoist default ("functions") ----
+    '{ let a; } let a;',
+    '{ let a; } var a;',
+    '{ const a = 0; } const a = 1;',
+    '{ const a = 0; } var a;',
+
+    // ---- hoist: never ----
+    { code: '{ let a; } let a;', options: [{ hoist: 'never' }] as any },
+    { code: '{ let a; } var a;', options: [{ hoist: 'never' }] as any },
+    {
+      code: '{ let a; } function a() {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: '{ const a = 0; } const a = 1;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    { code: '{ const a = 0; } var a;', options: [{ hoist: 'never' }] as any },
+    {
+      code: '{ const a = 0; } function a() {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo() { let a; } let a;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo() { let a; } var a;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo() { let a; } function a() {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo() { var a; } let a;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo() { var a; } var a;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo() { var a; } function a() {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo(a) { } let a;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo(a) { } var a;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'function foo(a) { } function a() {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+
+    // ---- builtinGlobals default: off ----
+    'function foo() { var Object = 0; }',
+
+    // ---- allow list ----
+    {
+      code: 'function foo(cb) { (function (cb) { cb(42); })(cb); }',
+      options: [{ allow: ['cb'] }] as any,
+    },
+
+    // ---- Class (property vs method same name) ----
+    'class C { foo; foo() { let foo; } }',
+
+    // ---- Class static blocks ----
+    'class C { static { var x; } static { var x; } }',
+    'class C { static { let x; } static { let x; } }',
+    'class C { static { var x; { var x; /* redeclaration */ } } }',
+    'class C { static { { var x; } { var x; /* redeclaration */ } } }',
+    'class C { static { { let x; } { let x; } } }',
+
+    // ---- ignoreOnInitialization (callback) ----
+    {
+      code: 'const a = [].find(a => a)',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const a = [].find(function(a) { return a; })',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const [a = [].find(a => true)] = dummy',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const { a = [].find(a => true) } = dummy',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'function func(a = [].find(a => true)) {}',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'for (const a in [].find(a => true)) {}',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'for (const a of [].find(a => true)) {}',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: "const a = [].map(a => true).filter(a => a === 'b')",
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: "const a = [].map(a => true).filter(a => a === 'b').find(a => a === 'c')",
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const { a } = (({ a }) => ({ a }))();',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: "const person = people.find(item => {const person = item.name; return person === 'foo'})",
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var y = bar || foo(y => y);',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var y = bar && foo(y => y);',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var z = bar(foo(z => z));',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var z = boo(bar(foo(z => z)));',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: "var match = function (person) { return person.name === 'foo'; };\nconst person = [].find(match);",
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const a = foo(x || (a => {}))',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const { a = 1 } = foo(a => {})',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: "const person = {...people.find((person) => person.firstName.startsWith('s'))}",
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: "const person = { firstName: people.filter((person) => person.firstName.startsWith('s')).map((person) => person.firstName)[0]}",
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: '() => { const y = foo(y => y); }',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+
+    // ---- ignoreOnInitialization (IIFE) ----
+    {
+      code: 'const x = (x => x)()',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var y = bar || (y => y)();',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var y = bar && (y => y)();',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'var x = (x => x)((y => y)());',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: 'const { a = 1 } = (a => {})()',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: '() => { const y = (y => y)(); }',
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    'const [x = y => y] = [].map(y => y)',
+
+    // ---- TS function-type parameters (default ignoreFunctionTypeParameterNameValueShadow: true) ----
+    'function foo<T = (arg: any) => any>(arg: T) {}',
+    'function foo<T = ([arg]: [any]) => any>(arg: T) {}',
+    'function foo<T = ({ args }: { args: any }) => any>(arg: T) {}',
+    'function foo<T = (...args: any[]) => any>(fn: T, args: any[]) {}',
+    'function foo<T extends (...args: any[]) => any>(fn: T, args: any[]) {}',
+    'function foo<T extends (...args: any[]) => any>(fn: T, ...args: any[]) {}',
+    'function foo<T extends ([args]: any[]) => any>(fn: T, args: any[]) {}',
+    'function foo<T extends ([...args]: any[]) => any>(fn: T, args: any[]) {}',
+    'function foo<T extends ({ args }: { args: any }) => any>(fn: T, args: any) {}',
+    'function foo<T extends (id: string, ...args: any[]) => any>(fn: T, ...args: any[]) {}',
+    'type Args = 1; function foo<T extends (Args: any) => void>(arg: T) {}',
+
+    // ---- Conditional types with infer T ----
+    'export type ArrayInput<Func> = Func extends (arg0: Array<infer T>) => any ? T[] : Func extends (...args: infer T) => any ? T : never;',
+
+    // ---- Declaration merging ----
+    'class Foo { prop = 1; } namespace Foo { export const v = 2; }',
+    'function Foo() {} namespace Foo { export const v = 2; }',
+    'class Foo { prop = 1; } interface Foo { prop2: string }',
+
+    // ---- this param ----
+    'function test(this: number) { function test2(this: number) {} }',
+
+    // ---- Type-only import + module augmentation of same module ----
+    "import type { Foo } from 'bar';\ndeclare module 'bar' { export interface Foo { x: string } }",
+
+    // ---- TS type/value shadow (default ignoreTypeValueShadow: true) ----
+    'const x = 1; type x = string;',
+    'const x = 1; { type x = string; }',
+
+    // ---- TS enum constant initializers ----
+    "enum Direction { left = 'left', right = 'right' }",
+
+    // ---- ignoreFunctionTypeParameterNameValueShadow: true (default) — various TS signature positions ----
+    'const test = 1; type Fn = (test: string) => typeof test;',
+    'const arg = 0; interface Test { (arg: string): typeof arg; }',
+    'const arg = 0; interface Test { p1(arg: string): typeof arg; }',
+    'const arg = 0; declare function test(arg: string): typeof arg;',
+    'const arg = 0; declare const test: (arg: string) => typeof arg;',
+    'const arg = 0; declare class Test { p1(arg: string): typeof arg; }',
+    'const arg = 0; declare const Test: { new (arg: string): typeof arg };',
+    'const arg = 0; type Bar = new (arg: number) => typeof arg;',
+    'const arg = 0; declare namespace Lib { function test(arg: string): typeof arg; }',
+
+    // ---- declare global is transparent ----
+    {
+      code: 'declare global { interface ArrayConstructor {} } export {};',
+      options: [{ builtinGlobals: true }] as any,
+    },
+    'declare global { const a: string; namespace Foo { const a: number; } } export {};',
+    {
+      code: "declare global { type A = 'foo'; namespace Foo { type A = 'bar'; } } export {};",
+      options: [{ ignoreTypeValueShadow: false }] as any,
+    },
+
+    // ---- Static vs instance class generic ----
+    'export class Wrapper<Wrapped> { private constructor(private readonly wrapped: Wrapped) {} unwrap(): Wrapped { return this.wrapped; } static create<Wrapped>(wrapped: Wrapped) { return new Wrapper<Wrapped>(wrapped); } }',
+    'function makeA() { return class A<T> { constructor(public value: T) {} static make<T>(value: T) { return new A<T>(value); } }; }',
+
+    // ---- Import type + type alias — value shadow allowed under default ----
+    "import type { foo } from './foo';\ntype bar = number;\nfunction doThing(foo: number, bar: number) {}",
+    "import { type foo } from './foo';\nfunction doThing(foo: number) {}",
+
+    // ---- TS hoist: never ----
+    {
+      code: 'type Foo<A> = 1; type A = 1;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'interface Foo<A> {} type A = 1;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'interface Foo<A> {} interface A {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: 'type Foo<A> = 1; interface A {}',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: '{ type A = 1; } type A = 1;',
+      options: [{ hoist: 'never' }] as any,
+    },
+    {
+      code: '{ interface Foo<A> {} } type A = 1;',
+      options: [{ hoist: 'never' }] as any,
+    },
+
+    // ---- TS hoist: functions (type not reported under this mode) ----
+    {
+      code: 'type Foo<A> = 1; type A = 1;',
+      options: [{ hoist: 'functions' }] as any,
+    },
+    {
+      code: 'interface Foo<A> {} type A = 1;',
+      options: [{ hoist: 'functions' }] as any,
+    },
+    {
+      code: 'interface Foo<A> {} interface A {}',
+      options: [{ hoist: 'functions' }] as any,
+    },
+    {
+      code: 'type Foo<A> = 1; interface A {}',
+      options: [{ hoist: 'functions' }] as any,
+    },
+    {
+      code: '{ type A = 1; } type A = 1;',
+      options: [{ hoist: 'functions' }] as any,
+    },
+    {
+      code: '{ interface Foo<A> {} } type A = 1;',
+      options: [{ hoist: 'functions' }] as any,
+    },
+
+    // ---- Real-code-discovered: cross-specifier import-type quirk ----
+    "import binding, { type AssetInfo } from 'm';\nclass Foo { static __from_binding(binding: any) { return binding; } }",
+    "import { foo, type Bar } from 'm';\nfunction fn(foo: number) { return foo; }",
+
+    // ---- infer X is type-level only ----
+    'type X<T> = T extends infer U ? U : never;\nconst U = 1;',
+    'type X<T> = T extends string ? T : never;\nconst T = 1;',
+
+    // ---- Object literal accessor distinct names ----
+    'const x = 1; const o = { get y() { return 1; }, set y(v) {} };',
+
+    // ---- Class private field name ----
+    'class C { #priv = 1; m() { const priv = 2; return [this.#priv, priv]; } }',
+
+    // ---- Tuple labels not bindings ----
+    'type Pair = [first: string, second: number];\nconst first = 1;',
+
+    // ---- Class field name same as class ----
+    'class C6 { C6 = 1; }',
+
+    // ---- Method name same as outer ----
+    'function g1() {}\nclass CG { g1() {} }',
+
+    // ---- Mapped type binding doesn't leak ----
+    'type Map1<T> = { [K in keyof T]: K };\nconst K = 1;',
+
+    // ---- Generic in arrow ----
+    'const T = 1; const arr = <T extends string>(x: T) => x;',
+
+    // ---- Multiple sibling `infer U` at same level ----
+    'type X<T> = T extends { a: infer U } & { b: infer U } ? U : never;',
+
+    // ---- Module augmentation (valid forms) ----
+    "import type { Foo } from 'bar';\ndeclare module 'bar' { export type Foo = string }",
+    "import type { Foo } from 'bar';\ndeclare module 'bar' { interface Foo { x: string } }",
+    "import { type Foo } from 'bar';\ndeclare module 'bar' { export type Foo = string }",
+    "import { type Foo } from 'bar';\ndeclare module 'bar' { export interface Foo { x: string } }",
+    "import { type Foo } from 'bar';\ndeclare module 'bar' { type Foo = string }",
+    "import { type Foo } from 'bar';\ndeclare module 'bar' { interface Foo { x: string } }",
+
+    // ==== Additional cases mirroring Go test additions ====
+    {
+      code: `var arguments;
+function bar() { }`,
+    },
+    {
+      code: `var match = function (person) { return person.name === 'foo'; };
+const person = [].find(match);`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `import type { Foo } from 'bar';
+declare module 'bar' { export interface Foo { x: string } }`,
+    },
+    {
+      code: `import binding, { type AssetInfo } from 'm';
+class Foo { static __from_binding(binding: any) { return binding; } }`,
+    },
+    {
+      code: `import { foo, type Bar } from 'm';
+function fn(foo: number) { return foo; }`,
+    },
+    {
+      code: `type X<T> = T extends infer U ? U : never;
+const U = 1;`,
+    },
+    {
+      code: `type X<T> = T extends string ? T : never;
+const T = 1;`,
+    },
+    {
+      code: `type Pair = [first: string, second: number];
+const first = 1;`,
+    },
+    {
+      code: `function g1() {}
+class CG { g1() {} }`,
+    },
+    {
+      code: `type Map1<T> = { [K in keyof T]: K };
+const K = 1;`,
+    },
+    {
+      code: `import type { foo } from './foo';
+type bar = number;
+function doThing(foo: number, bar: number) {}`,
+    },
+    {
+      code: `import { type foo } from './foo';
+function doThing(foo: number) {}`,
+    },
+    {
+      code: `const a = [].find(a => a);`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const a = [].find(function (a) { return a; });`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const [a = [].find(a => true)] = dummy;`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const { a = [].find(a => true) } = dummy;`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `import type { Foo } from 'bar';
+declare module 'bar' { export type Foo = string }`,
+    },
+    {
+      code: `import type { Foo } from 'bar';
+declare module 'bar' { interface Foo { x: string } }`,
+    },
+    {
+      code: `import { type Foo } from 'bar';
+declare module 'bar' { export type Foo = string }`,
+    },
+    {
+      code: `import { type Foo } from 'bar';
+declare module 'bar' { export interface Foo { x: string } }`,
+    },
+    {
+      code: `import { type Foo } from 'bar';
+declare module 'bar' { type Foo = string }`,
+    },
+    {
+      code: `import { type Foo } from 'bar';
+declare module 'bar' { interface Foo { x: string } }`,
+    },
+    {
+      code: `var match = function (person) { return person.name === 'foo'; };
+const person = [].find(match);`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  const arg = 0;
+  
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		`,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: true }] as any,
+    },
+    {
+      code: `
+		  declare global {
+			const foo: string;
+			type Fn = (foo: number) => void;
+		  }
+		  export {};
+		`,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+    },
+    {
+      code: `
+  import { type foo } from './foo';
+  
+  // 'foo' is already declared in the upper scope
+  function doThing(foo: number) {}
+		`,
+      options: [{ ignoreTypeValueShadow: true }] as any,
+    },
+    {
+      code: `const a = [].map(a => true).filter(a => a === 'b');`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  const a = []
+	.map(a => true)
+	.filter(a => a === 'b')
+	.find(a => a === 'c');
+		`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  const person = people.find(item => {
+	const person = item.name;
+	return person === 'foo';
+  });
+		`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  var match = function (person) {
+	return person.name === 'foo';
+  };
+  const person = [].find(match);
+		`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const a = foo(x || (a => {}));`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const { a = 1 } = foo(a => {});`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const person = { ...people.find(person => person.firstName.startsWith('s')) };`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  const person = {
+	firstName: people
+	  .filter(person => person.firstName.startsWith('s'))
+	  .map(person => person.firstName)[0],
+  };
+		`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  () => {
+	const y = foo(y => y);
+  };
+		`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const x = (x => x)();`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `const { a = 1 } = (a => {})();`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `
+  () => {
+	const y = (y => y)();
+  };
+		`,
+      options: [{ ignoreOnInitialization: true }] as any,
+    },
+    {
+      code: `var arguments;
+function bar() { }`,
+    },
+    {
+      code: `
+  function test(this: Foo) {
+	function test2(this: Bar) {}
+  }
+	  `,
+    },
+    {
+      code: `
+  class Foo {
+	prop = 1;
+  }
+  interface Foo {
+	prop2: string;
+  }
+	  `,
+    },
+    {
+      code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+	  `,
+    },
+    {
+      code: `
+  enum Direction {
+	left = 'left',
+	right = 'right',
+  }
+	  `,
+    },
+    {
+      code: `const [x = y => y] = [].map(y => y);`,
+    },
+    {
+      code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'bar' {
+	export type Foo = string;
+  }
+		`,
+    },
+    {
+      code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'bar' {
+	interface Foo {
+	  x: string;
+	}
+  }
+		`,
+    },
+    {
+      code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	export type Foo = string;
+  }
+		`,
+    },
+    {
+      code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`,
+    },
+    {
+      code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	type Foo = string;
+  }
+		`,
+    },
+    {
+      code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'bar' {
+	interface Foo {
+	  x: string;
+	}
+  }
+		`,
+    },
+  ],
+  invalid: [
+    // ---- Core JS shadow with line/column ----
+    {
+      code: `function a(x) { var b = function c() { var x = 'foo'; }; }`,
+      errors: [{ messageId: 'noShadow', line: 1, column: 44 }],
+    },
+    {
+      code: `var a = (x) => { var b = () => { var x = 'foo'; }; }`,
+      errors: [{ messageId: 'noShadow', line: 1, column: 38 }],
+    },
+    {
+      code: `function a(x) { var b = function () { var x = 'foo'; }; }`,
+      errors: [{ messageId: 'noShadow', line: 1, column: 43 }],
+    },
+    {
+      code: `var x = 1; function a(x) { return ++x; }`,
+      errors: [{ messageId: 'noShadow', line: 1, column: 23 }],
+    },
+    {
+      code: 'var a=3; function b() { var a=10; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'var a=3; function b() { var a=10; }; setTimeout(function() { b(); }, 0);',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);',
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+
+    { code: 'var x = 1; { let x = 2; }', errors: [{ messageId: 'noShadow' }] },
+    {
+      code: 'let x = 1; { const x = 2; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Default hoist ("functions") ----
+    { code: '{ let a; } function a() {}', errors: [{ messageId: 'noShadow' }] },
+    {
+      code: '{ const a = 0; } function a() {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { let a; } function a() {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { var a; } function a() {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(a) { } function a() {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- hoist: "all" — all permutations ----
+    {
+      code: '{ let a; } let a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '{ let a; } var a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '{ let a; } function a() {}',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '{ const a = 0; } const a = 1;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '{ const a = 0; } var a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '{ const a = 0; } function a() {}',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { let a; } let a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { let a; } var a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { let a; } function a() {}',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { var a; } let a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { var a; } var a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo() { var a; } function a() {}',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(a) { } let a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(a) { } var a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function foo(a) { } function a() {}',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- fn/class expression self-name ----
+    {
+      code: '(function a() { function a(){} })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function a() { class a{} })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function a() { (function a(){}); })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function a() { (class a{}); })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function() { var a = function(a) {}; })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function() { var a = function() { function a() {} }; })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function() { var a = function() { class a{} }; })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function() { var a = function() { (function a() {}); }; })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function() { var a = function() { (class a{}); }; })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '(function() { var a = class { constructor() { class a {} } }; })()',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'class A { constructor() { var A; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Nested multi-error ----
+    {
+      code: '(function a() { function a(){ function a(){} } })()',
+      errors: [
+        { messageId: 'noShadow', line: 1, column: 26 },
+        { messageId: 'noShadow', line: 1, column: 40 },
+      ],
+    },
+
+    // ---- builtinGlobals ----
+    {
+      code: 'function foo() { var Object = 0; }',
+      options: [{ builtinGlobals: true }] as any,
+      errors: [{ messageId: 'noShadowGlobal' }],
+    },
+    {
+      code: 'var Object = 0;',
+      options: [{ builtinGlobals: true }] as any,
+      errors: [{ messageId: 'noShadowGlobal' }],
+    },
+    {
+      code: '(function Array() {})',
+      options: [{ builtinGlobals: true }] as any,
+      errors: [{ messageId: 'noShadowGlobal', line: 1, column: 11 }],
+    },
+
+    // ---- allow mismatch ----
+    {
+      code: 'function foo(cb) { (function (cb) { cb(42); })(cb); }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 31 }],
+    },
+
+    // ---- Class static blocks ----
+    {
+      code: 'class C { static { let a; { let a; } } }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 33 }],
+    },
+    {
+      code: 'class C { static { var C; } }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 24 }],
+    },
+    {
+      code: 'class C { static { let C; } }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 24 }],
+    },
+    {
+      code: 'var a; class C { static { var a; } }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 31 }],
+    },
+    {
+      code: 'class C { static { var a; } } var a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 24 }],
+    },
+    {
+      code: 'class C { static { let a; } } let a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 24 }],
+    },
+    {
+      code: 'class C { static { var a; } } let a;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 24 }],
+    },
+    {
+      code: 'class C { static { var a; class D { static { var a; } } } }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 50 }],
+    },
+    {
+      code: 'class C { static { let a; class D { static { let a; } } } }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 50 }],
+    },
+
+    // ---- Hoist "all" with param list ----
+    {
+      code: 'let x = foo((x,y) => {});\nlet y;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: 'let x = ((x,y) => {})();\nlet y;',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+
+    // ---- ignoreOnInitialization mismatches (still reported) ----
+    {
+      code: 'const a = fn(()=>{ class C { fn () { const a = 42; return a } } return new C() })',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 44 }],
+    },
+    {
+      code: 'function a() {}\nfoo(a => {});',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 2, column: 5 }],
+    },
+    {
+      code: 'const a = fn(()=>{ function C() { this.fn=function() { const a = 42; return a } } return new C() });',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 62 }],
+    },
+    {
+      code: 'const x = foo(() => { const bar = () => { return x => {}; }; return bar; });',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 50 }],
+    },
+    {
+      code: 'const x = foo(() => { return { bar(x) {} }; });',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 36 }],
+    },
+    {
+      code: 'const x = () => { foo(x => x); }',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 23 }],
+    },
+    {
+      code: 'const foo = () => { let x; bar(x => x); }',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 32 }],
+    },
+    {
+      code: 'foo(() => { const x = x => x; });',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 23 }],
+    },
+    {
+      code: 'const foo = (x) => { bar(x => {}) }',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 26 }],
+    },
+    {
+      code: 'const a = (()=>{ class C { fn () { const a = 42; return a } } return new C() })()',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 42 }],
+    },
+    {
+      code: 'const x = () => { (x => x)(); }',
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow', line: 1, column: 20 }],
+    },
+
+    // ---- Call-wrap does NOT trigger the initializer exception ----
+    {
+      code: 'const a = wrap(function a() {});',
+      errors: [{ messageId: 'noShadow', line: 1, column: 25 }],
+    },
+    {
+      code: 'const a = foo || wrap(function a() {});',
+      errors: [{ messageId: 'noShadow', line: 1, column: 32 }],
+    },
+    {
+      code: 'const { a = wrap(function a() {}) } = obj;',
+      errors: [{ messageId: 'noShadow', line: 1, column: 27 }],
+    },
+    {
+      code: 'const { a = foo || wrap(function a() {}) } = obj;',
+      errors: [{ messageId: 'noShadow', line: 1, column: 34 }],
+    },
+    {
+      code: 'const { a = foo, b = function a() {} } = {}',
+      errors: [{ messageId: 'noShadow', line: 1, column: 31 }],
+    },
+    {
+      code: 'const { A = Foo, B = class A {} } = {}',
+      errors: [{ messageId: 'noShadow', line: 1, column: 28 }],
+    },
+    {
+      code: 'function foo(a = wrap(function a() {})) {}',
+      errors: [{ messageId: 'noShadow', line: 1, column: 32 }],
+    },
+    {
+      code: 'function foo(a = foo || wrap(function a() {})) {}',
+      errors: [{ messageId: 'noShadow', line: 1, column: 39 }],
+    },
+    {
+      code: 'const A = wrap(class A {});',
+      errors: [{ messageId: 'noShadow', line: 1, column: 22 }],
+    },
+    {
+      code: 'const A = foo || wrap(class A {});',
+      errors: [{ messageId: 'noShadow', line: 1, column: 29 }],
+    },
+    {
+      code: 'const { A = wrap(class A {}) } = obj;',
+      errors: [{ messageId: 'noShadow', line: 1, column: 24 }],
+    },
+    {
+      code: 'const { A = foo || wrap(class A {}) } = obj;',
+      errors: [{ messageId: 'noShadow', line: 1, column: 31 }],
+    },
+    {
+      code: 'function foo(A = wrap(class A {})) {}',
+      errors: [{ messageId: 'noShadow', line: 1, column: 29 }],
+    },
+    {
+      code: 'function foo(A = foo || wrap(class A {})) {}',
+      errors: [{ messageId: 'noShadow', line: 1, column: 36 }],
+    },
+    {
+      code: 'var a = function a() {} ? foo : bar',
+      errors: [{ messageId: 'noShadow', line: 1, column: 18 }],
+    },
+    {
+      code: 'var A = class A {} ? foo : bar',
+      errors: [{ messageId: 'noShadow', line: 1, column: 15 }],
+    },
+    {
+      code: '(function Array() {})',
+      options: [{ builtinGlobals: true }] as any,
+      errors: [{ messageId: 'noShadowGlobal', line: 1, column: 11 }],
+    },
+    {
+      code: 'let a; { let b = (function a() {}) }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 28 }],
+    },
+    {
+      code: 'let a = foo; { let b = (function a() {}) }',
+      errors: [{ messageId: 'noShadow', line: 1, column: 34 }],
+    },
+
+    // ==============================================================
+    // TypeScript invalid
+    // ==============================================================
+
+    {
+      code: '\n  type T = 1;\n  {\n\ttype T = 2;\n  }\n\t\t',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type T = 1;\n  function foo<T>(arg: T) {}\n\t\t',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  function foo<T>() {\n\treturn function <T>() {};\n  }\n\t\t',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type T = string;\n  function foo<T extends (arg: any) => void>(arg: T) {}\n\t\t',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const x = 1;\n  {\n\ttype x = string;\n  }\n\t\t',
+      options: [{ ignoreTypeValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- ignoreFunctionTypeParameterNameValueShadow: false ----
+    {
+      code: '\n  const test = 1;\n  type Fn = (test: string) => typeof test;\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  interface Test {\n\t(arg: string): typeof arg;\n  }\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  interface Test {\n\tp1(arg: string): typeof arg;\n  }\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  declare function test(arg: string): typeof arg;\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  declare const test: (arg: string) => typeof arg;\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  declare class Test {\n\tp1(arg: string): typeof arg;\n  }\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  declare const Test: {\n\tnew (arg: string): typeof arg;\n  };\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  type Bar = new (arg: number) => typeof arg;\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  const arg = 0;\n  declare namespace Lib {\n\tfunction test(arg: string): typeof arg;\n  }\n\t\t',
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Type import with ignoreTypeValueShadow: false ----
+    {
+      code: "\nimport type { foo } from './foo';\nfunction doThing(foo: number) {}\n",
+      options: [{ ignoreTypeValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: "\nimport { type foo } from './foo';\nfunction doThing(foo: number) {}\n",
+      options: [{ ignoreTypeValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: "\nimport { foo } from './foo';\nfunction doThing(foo: number, bar: number) {}\n",
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Module augmentation interface shadow ----
+    {
+      code: "\ninterface Foo {}\ndeclare module 'bar' { export interface Foo { x: string } }\n",
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: "\nimport type { Foo } from 'bar';\ndeclare module 'baz' { export interface Foo { x: string } }\n",
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: "\nimport { type Foo } from 'bar';\ndeclare module 'baz' { export interface Foo { x: string } }\n",
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- hoist: all with TS ----
+    {
+      code: '\n  let x = foo((x, y) => {});\n  let y;\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  let x = foo((x, y) => {});\n  let y;\n\t\t',
+      options: [{ hoist: 'functions' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- TS hoist: types / functions-and-types / all ----
+    {
+      code: '\n  type Foo<A> = 1;\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  interface Foo<A> {}\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  interface Foo<A> {}\n  interface A {}\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type Foo<A> = 1;\n  interface A {}\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  {\n\ttype A = 1;\n  }\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  {\n\tinterface A {}\n  }\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type Foo<A> = 1;\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  interface Foo<A> {}\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  interface Foo<A> {}\n  interface A {}\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type Foo<A> = 1;\n  interface A {}\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  {\n\ttype A = 1;\n  }\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  {\n\tinterface A {}\n  }\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type Foo<A> = 1;\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n\tif (true) {\n\t\tconst foo = 6;\n\t}\n\n\tfunction foo() { }\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n\t// types\n\ttype Bar<Foo> = 1;\n\ttype Foo = 1;\n\n\t// functions\n\tif (true) {\n\t\tconst b = 6;\n\t}\n\n\tfunction b() { }\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: '\n\t// types\n\ttype Bar<Foo> = 1;\n\ttype Foo = 1;\n\n\t// functions\n\tif (true) {\n\t\tconst b = 6;\n\t}\n\n\tfunction b() { }\n\t\t',
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  interface Foo<A> {}\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  interface Foo<A> {}\n  interface A {}\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  type Foo<A> = 1;\n  interface A {}\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  {\n\ttype A = 1;\n  }\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: '\n  {\n\tinterface A {}\n  }\n  type A = 1;\n\t\t',
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Enum member shadow ----
+    {
+      code: '\n\t\tconst A = 2;\n\t\tenum Test {\n\t\t\tA = 1,\n\t\t\tB = A,\n\t\t}\n\t',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- infer T shadow ----
+    {
+      code: 'type X<T> = T extends (infer U) ? (U extends (infer U) ? U : never) : never;',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Object literal method param shadow ----
+    {
+      code: 'const x = 1; const o = { foo(x: number) { return x; } };',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const x = 1; const o = { get foo() { const x = 2; return x; } };',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const x = 1; const o = { async foo(x: number) { return x; } };',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'const x = 1; const o = { *foo(x: number) { yield x; } };',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- using declarations ----
+    {
+      code: 'using u = { [Symbol.dispose]() {} }; { using u = { [Symbol.dispose]() {} }; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Class generic shadowed by instance method generic ----
+    {
+      code: 'class C<T> { static s<T>(): T { return null as any; } i<T>(): T { return null as any; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Object pattern rename shadow ----
+    {
+      code: 'const a = 1; function f({ x: a }: any) { return a; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Function expression name shadowed by its own param ----
+    {
+      code: 'const fn = function f(f: number) { return f; };',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Decorator: shadowing inside decorated method body ----
+    {
+      code: 'function dec(x: any) { return x; }\n@dec class CD { method() { const dec = 1; return dec; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Computed property name with class member shadow ----
+    {
+      code: "const k = 'x'; class C { foo() { const k = 1; return k; } }",
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Default param referencing outer var of same name ----
+    {
+      code: 'const a = 1; function f({ a = a }: any) { return a; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Catch-clause destructure shadow ----
+    {
+      code: 'const e = 1; try {} catch ({ message: e }) { return e; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Async generator with for-await-of ----
+    {
+      code: 'async function* g() { const v = 1; for await (const v of [Promise.resolve(1)]) yield v; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Multi-decl single statement ----
+    {
+      code: 'const a = 1, b = 2; function f() { const a = 3, b = 4; return a + b; }',
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+
+    // ---- Switch case lexical scope ----
+    {
+      code: 'function f() { const z = 1; switch (z) { case 1: { const z = 2; break; } case 2: { const z = 3; break; } } }',
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+
+    // ---- Namespace import param shadow ----
+    {
+      code: "import * as Mods from 'fs'; function f(Mods: number) { return Mods; }",
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Arrow returning class with shadowed name ----
+    {
+      code: 'const Z = 1; const make = () => class Z {};',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- typeof reference + parameter shadow ----
+    {
+      code: 'const t = 1; type T = typeof t; function f(t: number) { return t; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Default parameter with type reference ----
+    {
+      code: 'const opts = { x: 1 }; function f(opts: typeof opts = opts) { return opts; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Anonymous function expression with same-name inner const ----
+    {
+      code: 'const a = 1; const fn = function() { const a = 2; return a; };',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Nested class with shadowed name ----
+    {
+      code: 'const A = 1; class A_outer { x = class A {}; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Rest pattern shadow inner destructure ----
+    {
+      code: 'function f(...args: number[]) { function g({ args }: any) { return args; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Generator with for-of shadow ----
+    {
+      code: 'function* g() { const v = 1; for (const v of [1,2,3]) { yield v; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Function type in parameter annotation with shadow generic ----
+    {
+      code: 'function f<A>(fn: <A>(x: A) => A): A { return fn as any; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: 'function f<T>(): <T>(x: T) => T { return null as any; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Nested catch clause ----
+    {
+      code: 'try {} catch (e) { try {} catch (e) {} }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Class generic shadowed by method generic ----
+    {
+      code: 'class C<T> { m<T>(x: T): T { return x; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Double shadow chain ----
+    {
+      code: 'const x = 1; function f(x: number) { function g(x: number) { return x; } return g; }',
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+
+    // ---- Array elision pattern ----
+    {
+      code: 'const a = 1; function f([, a]: any[]) { return a; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Optional chain call with arrow ----
+    {
+      code: 'const a = 1; const fn = { call: (cb: any) => cb }; fn.call?.(a => a);',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- Parameter property + method shadow ----
+    {
+      code: 'const x = 1; class C { constructor(public x: number) {} m() { const x = 1; return x; } }',
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+
+    // ---- Dynamic import callback ----
+    {
+      code: "const mod = 1; import('m').then((mod) => mod);",
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ---- TS 4.7 infer T extends + nested same name ----
+    {
+      code: 'type X<T> = T extends Array<infer U> ? (U extends Array<infer U> ? U : never) : never;',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- TS 4.7 generic instantiation expression shadowing builtin Array ----
+    {
+      code: 'const g = Array<number>; function f(Array: any) { return Array; }',
+      options: [{ builtinGlobals: true }] as any,
+      errors: [{ messageId: 'noShadowGlobal' }],
+    },
+    // ---- TS 4.9 accessor ----
+    {
+      code: 'const x = 1; class C { accessor x = 1; m() { const x = 2; return x; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Async iteration destructure shadow ----
+    {
+      code: 'async function f() { const x = 1; for await (const { v: x } of [Promise.resolve({ v: 1 })]) { return x; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- using + for-of shadow ----
+    {
+      code: 'async function f() { using u = { [Symbol.dispose]() {} }; for (const u of [] as any[]) { void u; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Destructure with computed key + inner rebind ----
+    {
+      code: "const k = 'a'; function f({ [k]: v }: any) { const k = 1; return [v, k]; }",
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- HOC pattern ----
+    {
+      code: 'function withTheme<P>(Component: any) { return function ThemedComponent(props: P) { const Component = 1; return Component; }; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Reducer with case block ----
+    {
+      code: "type A = { type: 'inc' } | { type: 'set'; value: number }; function reducer(state: number, action: A) { switch (action.type) { case 'inc': { const state = 1; return state + 1; } case 'set': return action.value; } }",
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Array chain with 3 same-name callbacks ----
+    {
+      code: 'function chain() { const item = { id: 1 }; [1, 2, 3].map(item => item + 1).filter(item => item > 1).forEach(item => void item); void item; }',
+      errors: [
+        { messageId: 'noShadow' },
+        { messageId: 'noShadow' },
+        { messageId: 'noShadow' },
+      ],
+    },
+    // ---- Triply nested try/catch ----
+    {
+      code: 'const e = 1; try { try { throw new Error(); } catch (e) { try { throw e; } catch (e) {} } } catch (e) {} void e;',
+      errors: [
+        { messageId: 'noShadow' },
+        { messageId: 'noShadow' },
+        { messageId: 'noShadow' },
+      ],
+    },
+    // ---- Computed method name + param shadow ----
+    {
+      code: "const methodName = 'foo'; const obj = { [methodName](methodName: string) { return methodName; } };",
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Nested for loops with same loop var ----
+    {
+      code: 'function f() { for (let i = 0; i < 1; i++) { for (let i = 0; i < 1; i++) {} } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Method overload: impl-signature param shadow ----
+    {
+      code: 'const a = 1; class C { m(x: string): void; m(x: number): void; m(a: any): void { void a; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Factory returning obj method with generic shadow ----
+    {
+      code: 'function mk<T>(x: T) { return { get<T>(): T { return null as any; } }; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Empty block followed by shadowed block ----
+    {
+      code: 'const c = 1; { /* empty */ } { const c = 2; void c; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- const enum + param shadow ----
+    {
+      code: 'const enum E { A, B } function f(E: number) { return E; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Abstract class generic shadow ----
+    {
+      code: 'abstract class C<T extends object> { abstract m<T>(): T; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Symbol.iterator method with shadowed param ----
+    {
+      code: 'const iter = 1; class C { [Symbol.iterator](iter: number) { return iter; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Constructor with optional param shadow ----
+    {
+      code: 'const x = 1; class C { constructor(x?: number) { void x; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- typeof type query + same-name parameter ----
+    {
+      code: 'const val = { x: 1 }; function f(val: typeof val) { return val; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Async method param shadow ----
+    {
+      code: 'const x = 1; class C { async m(x: number) { return x; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Generator method param shadow ----
+    {
+      code: 'const x = 1; class C { *m(x: number) { yield x; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Ambient function shadowed by inner const (bot #1 / #3) ----
+    {
+      code: 'declare function foo(): void; function bar() { const foo = 1; return foo; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Heritage clause IIFE shadow (bot #2) ----
+    {
+      code: 'const h = 1; class C extends (function() { const h = 2; return class {}; })() {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Heritage clause comma-expression arrow shadow ----
+    {
+      code: 'const h = 1; class C extends ((h => h)(1), Object) {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Class decorator factory body shadow (bot #2) ----
+    {
+      code: 'function dec(x: any) { return x; }\n@((target: any) => { const dec = 1; return dec && target; })\nclass D {}',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Method decorator body shadow ----
+    {
+      code: 'const md = 1; class C { @((t: any, k: string) => { const md = 1; void md; }) method() {} }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Parameter decorator body shadow ----
+    {
+      code: 'const pd = 1; class C { method(@((t: any, k: any, i: number) => { const pd = 1; void pd; }) x: number) {} }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Computed key on class method (self-discovered during audit) ----
+    {
+      code: 'const k = 1; class C { [((k) => k)(2)]() {} }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Computed key on class property ----
+    {
+      code: 'const k = 1; class C { [((k) => k)(2)] = 1; }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Computed key on getter ----
+    {
+      code: 'const g = 1; class C { get [((g) => g)(1)]() { return 1; } }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+    // ---- Computed key on async generator method ----
+    {
+      code: 'const m = 1; class C { async *[((m) => m)(1)]() {} }',
+      errors: [{ messageId: 'noShadow' }],
+    },
+
+    // ==== Additional invalid cases mirroring Go ====
+    {
+      code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`,
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`,
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+	if (true) {
+		const foo = 6;
+	}
+
+	function foo() { }
+		`,
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		`,
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: `
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		`,
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`,
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `let x = foo((x,y) => {});
+let y;`,
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: `function a() {}
+foo(a => {});`,
+      options: [{ ignoreOnInitialization: true }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `let x = ((x,y) => {})();
+let y;`,
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: `let x = false; export const a = wrap(function a() { if (!x) { x = true; a(); } });`,
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  type T = 1;
+  {
+	type T = 2;
+  }
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  type T = 1;
+  function foo<T>(arg: T) {}
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  function foo<T>() {
+	return function <T>() {};
+  }
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  type T = string;
+  function foo<T extends (arg: any) => void>(arg: T) {}
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  const arg = 0;
+  
+  declare const Test: {
+	new (arg: string): typeof arg;
+  };
+		`,
+      options: [{ ignoreFunctionTypeParameterNameValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  import type { foo } from './foo';
+  function doThing(foo: number) {}
+		`,
+      options: [{ ignoreTypeValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  import { type foo } from './foo';
+  function doThing(foo: number) {}
+		`,
+      options: [{ ignoreTypeValueShadow: false }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  import { foo } from './foo';
+  function doThing(foo: number, bar: number) {}
+		`,
+      options: [{ ignoreTypeValueShadow: true }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  interface Foo {}
+  
+  declare module 'bar' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  import type { Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  import { type Foo } from 'bar';
+  
+  declare module 'baz' {
+	export interface Foo {
+	  x: string;
+	}
+  }
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  let x = foo((x, y) => {});
+  let y;
+		`,
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  let x = foo((x, y) => {});
+  let y;
+		`,
+      options: [{ hoist: 'functions' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`,
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`,
+      options: [{ hoist: 'all' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+	if (true) {
+		const foo = 6;
+	}
+
+	function foo() { }
+		`,
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		`,
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }, { messageId: 'noShadow' }],
+    },
+    {
+      code: `
+	// types
+	type Bar<Foo> = 1;
+	type Foo = 1;
+
+	// functions
+	if (true) {
+		const b = 6;
+	}
+
+	function b() { }
+		`,
+      options: [{ hoist: 'types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+  {
+	interface A {}
+  }
+  type A = 1;
+		`,
+      options: [{ hoist: 'functions-and-types' }] as any,
+      errors: [{ messageId: 'noShadow' }],
+    },
+    {
+      code: `
+			const A = 2;
+			enum Test {
+				A = 1,
+				B = A,
+			}
+		`,
+      errors: [{ messageId: 'noShadow' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `no-shadow` rule from ESLint to rslint.

The rule disallows variable declarations from shadowing variables declared in the outer scope. A custom scope tracker was built (rslint has no eslint-scope equivalent) covering function / block / catch / for / class / namespace / conditional-type / function-expression-name / type scopes.

All options supported: `builtinGlobals`, `hoist` (`all`/`functions`/`never`/`types`/`functions-and-types`), `allow`, `ignoreOnInitialization`, `ignoreTypeValueShadow`, `ignoreFunctionTypeParameterNameValueShadow`.

Alignment was verified by:
- Migrating the full ESLint test suite (framework-level concepts such as `languageOptions.globals`, `parserOptions.ecmaFeatures.globalReturn`, and `sourceType: \"script\"` are marked \`SKIP\` with a comment).
- Running the compiled binary against rsbuild and rspack and diffing every report against ESLint. Both projects produce byte-for-byte identical output (rsbuild 64 reports, rspack 217 reports, zero divergence).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-shadow
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-shadow.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).