### PR TITLE
feat: port rule no-is-mounted

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
@@ -37,6 +38,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_danger.NoDangerRule,
+		no_is_mounted.NoIsMountedRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		self_closing_comp.SelfClosingCompRule,

--- a/internal/plugins/react/rules/no_is_mounted/no_is_mounted.go
+++ b/internal/plugins/react/rules/no_is_mounted/no_is_mounted.go
@@ -1,0 +1,70 @@
+package no_is_mounted
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// isPropertyOrMethodDefinition mirrors ESLint's check for an ancestor whose
+// AST type is `Property` (object-literal member) or `MethodDefinition` (class
+// method/accessor/constructor). SpreadAssignment (`{...x}`) and class-body
+// fields / static-blocks are deliberately excluded — they are neither
+// Property nor MethodDefinition in ESTree.
+func isPropertyOrMethodDefinition(node *ast.Node) bool {
+	if ast.IsMethodOrAccessor(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindPropertyAssignment,
+		ast.KindShorthandPropertyAssignment,
+		ast.KindConstructor:
+		return true
+	}
+	return false
+}
+
+var NoIsMountedRule = rule.Rule{
+	Name: "react/no-is-mounted",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				callee := ast.SkipParentheses(call.Expression)
+				if callee.Kind != ast.KindPropertyAccessExpression {
+					return
+				}
+				prop := callee.AsPropertyAccessExpression()
+				if ast.SkipParentheses(prop.Expression).Kind != ast.KindThisKeyword {
+					return
+				}
+				// ESLint's check is `'name' in property && property.name === 'isMounted'`,
+				// which is satisfied by both Identifier (`this.isMounted`) and
+				// PrivateIdentifier (`this.#isMounted`). In tsgo the
+				// PrivateIdentifier's Text retains the leading `#`.
+				nameNode := prop.Name()
+				if nameNode == nil {
+					return
+				}
+				switch nameNode.Kind {
+				case ast.KindIdentifier:
+					if nameNode.AsIdentifier().Text != "isMounted" {
+						return
+					}
+				case ast.KindPrivateIdentifier:
+					if nameNode.AsPrivateIdentifier().Text != "#isMounted" {
+						return
+					}
+				default:
+					return
+				}
+				if ast.FindAncestor(node.Parent, isPropertyOrMethodDefinition) == nil {
+					return
+				}
+				ctx.ReportNode(callee, rule.RuleMessage{
+					Id:          "noIsMounted",
+					Description: "Do not use isMounted",
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_is_mounted/no_is_mounted.md
+++ b/internal/plugins/react/rules/no_is_mounted/no_is_mounted.md
@@ -1,0 +1,77 @@
+# no-is-mounted
+
+Disallow usage of `isMounted`.
+
+`isMounted` is an anti-pattern, is not available when using ES6 classes, and is
+[officially deprecated](https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html)
+by the React team.
+
+## Rule Details
+
+This rule flags calls to `this.isMounted()` inside properties of an object
+literal (e.g. a `createReactClass` spec) or inside methods / getters / setters /
+constructors of a class. Calls outside any such method are ignored.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  componentDidUpdate: function () {
+    if (!this.isMounted()) {
+      return;
+    }
+  },
+  render: function () {
+    return <div>Hello</div>;
+  },
+});
+```
+
+```javascript
+class Hello extends React.Component {
+  someMethod() {
+    if (!this.isMounted()) {
+      return;
+    }
+  }
+  render() {
+    return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  render: function () {
+    return <div>Hello</div>;
+  },
+});
+```
+
+```javascript
+var Hello = createReactClass({
+  componentDidUpdate: function () {
+    someNonMemberFunction(arg);
+    this.someFunc = this.isMounted;
+  },
+  render: function () {
+    return <div>Hello</div>;
+  },
+});
+```
+
+```javascript
+class Hello extends React.Component {
+  notIsMounted() {}
+  render() {
+    this.notIsMounted();
+    return <div>Hello</div>;
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react / no-is-mounted](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md)

--- a/internal/plugins/react/rules/no_is_mounted/no_is_mounted_test.go
+++ b/internal/plugins/react/rules/no_is_mounted/no_is_mounted_test.go
@@ -1,0 +1,470 @@
+package no_is_mounted
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoIsMountedRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoIsMountedRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: function declaration without isMounted call ----
+		{Code: `
+        var Hello = function() {
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass render without isMounted call ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: this.isMounted referenced but NOT called ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someFunc = this.isMounted;
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: class with similarly-named method (notIsMounted) ----
+		{Code: `
+        class Hello extends React.Component {
+          notIsMounted() {}
+          render() {
+            this.notIsMounted();
+            return <div>Hello</div>;
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: top-level, outside any property / method ----
+		{Code: `this.isMounted();`, Tsx: true},
+
+		// ---- Edge: plain function at top level, no class / object context ----
+		{Code: `
+        function foo() {
+          this.isMounted();
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bracket notation is NOT matched (mirrors ESLint's `'name' in property` guard) ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            if (!this['isMounted']()) { return; }
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: property name mismatch ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.isMountedNot();
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: receiver is not `this` ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            other.isMounted();
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: private field name mismatch ----
+		{Code: `
+        class Hello extends React.Component {
+          #isMountedNot() { return true; }
+          someMethod() {
+            this.#isMountedNot();
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: class field initializer (PropertyDeclaration is NOT MethodDefinition) ----
+		{Code: `
+        class Hello extends React.Component {
+          foo = this.isMounted();
+        };
+      `, Tsx: true},
+
+		// ---- Edge: class static block (StaticBlock is NOT MethodDefinition) ----
+		{Code: `
+        class Hello extends React.Component {
+          static { this.isMounted(); }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: object-literal spread — SpreadElement is NOT Property ----
+		{Code: `
+        var obj = { ...this.isMounted() };
+      `, Tsx: true},
+
+		// ---- Edge: method that merely references isMounted (without invoking) ----
+		{Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            const fn = this.isMounted;
+            return fn;
+          }
+        };
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: createReactClass componentDidUpdate ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            if (!this.isMounted()) {
+              return;
+            }
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noIsMounted",
+					Message:   "Do not use isMounted",
+					Line:      4, Column: 18,
+				},
+			},
+		},
+
+		// ---- Upstream: createReactClass custom method ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          someMethod: function() {
+            if (!this.isMounted()) {
+              return;
+            }
+          },
+          render: function() {
+            return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 18},
+			},
+		},
+
+		// ---- Upstream: ES6 class component ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            if (!this.isMounted()) {
+              return;
+            }
+          }
+          render() {
+            return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 18},
+			},
+		},
+
+		// ---- Edge: class getter ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          get mounted() {
+            return this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Edge: class setter ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          set mounted(_v) {
+            this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class constructor ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor() {
+            super();
+            this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: static class method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          static foo() {
+            this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: async method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          async foo() {
+            await Promise.resolve();
+            this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: generator method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          *foo() {
+            yield this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: computed-name class method (method name is irrelevant) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          ['foo']() {
+            this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: object-literal shorthand method ----
+		{
+			Code: `
+        var Hello = {
+          someMethod() {
+            this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: object-literal getter ----
+		{
+			Code: `
+        var Hello = {
+          get mounted() {
+            return this.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Edge: optional-call on receiver — `this.isMounted?.()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this.isMounted?.();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-chain on `this` — `this?.isMounted()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            this?.isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: parenthesized receiver ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            (this).isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: parenthesized callee ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          someMethod() {
+            (this.isMounted)();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 14},
+			},
+		},
+
+		// ---- Edge: deeply nested inside an arrow function chain inside a method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            const f = () => () => () => this.isMounted();
+            f();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 41},
+			},
+		},
+
+		// ---- Edge: inside a nested function expression, still flagged (ESLint walks all ancestors) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            setTimeout(function() {
+              if (!this.isMounted()) { return; }
+            });
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 5, Column: 20},
+			},
+		},
+
+		// ---- Edge: nested object literal inside a class method (ancestor chain hits PropertyAssignment first) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          foo() {
+            const obj = { bar: () => this.isMounted() };
+            return obj;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 38},
+			},
+		},
+
+		// ---- Edge: private method `this.#isMounted()` — ESLint parity ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          #isMounted() { return true; }
+          someMethod() {
+            this.#isMounted();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: multiple violations in the same method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          foo() {
+            this.isMounted();
+            if (this.isMounted()) {}
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noIsMounted", Line: 4, Column: 13},
+				{MessageId: "noIsMounted", Line: 5, Column: 17},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
+    './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-is-mounted.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-is-mounted.test.ts
@@ -1,0 +1,151 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-is-mounted', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var Hello = function() {
+        };
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someFunc = this.isMounted;
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          notIsMounted() {}
+          render() {
+            this.notIsMounted();
+            return <div>Hello</div>;
+          }
+        };
+      `,
+    },
+    // ---- Edge: bracket notation is NOT matched ----
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod() {
+            if (!this['isMounted']()) { return; }
+          }
+        };
+      `,
+    },
+    // ---- Edge: top-level, outside any property / method ----
+    {
+      code: `this.isMounted();`,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            if (!this.isMounted()) {
+              return;
+            }
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          someMethod: function() {
+            if (!this.isMounted()) {
+              return;
+            }
+          },
+          render: function() {
+            return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          someMethod() {
+            if (!this.isMounted()) {
+              return;
+            }
+          }
+          render() {
+            return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+    // ---- Edge: class getter / setter / constructor / object shorthand method ----
+    {
+      code: `
+        class Hello extends React.Component {
+          get mounted() {
+            return this.isMounted();
+          }
+        };
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          set mounted(_v) {
+            this.isMounted();
+          }
+        };
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          constructor() {
+            super();
+            this.isMounted();
+          }
+        };
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+    {
+      code: `
+        var Hello = {
+          someMethod() {
+            this.isMounted();
+          }
+        };
+      `,
+      errors: [{ messageId: 'noIsMounted' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-is-mounted` rule from `eslint-plugin-react` to rslint.

The rule flags calls to `this.isMounted()` that appear inside an object-literal `Property` or a class `MethodDefinition` (method / getter / setter / constructor). `this.isMounted` is an [anti-pattern](https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html) the React team officially deprecated.

Alignment verified by differential comparison against real ESLint + `eslint-plugin-react` on 21 hand-crafted fixtures covering private identifiers, optional chaining, parenthesized receivers / callees, static / async / generator / computed methods, class field initializers, static blocks, spread elements, bracket notation, deep nesting, and multi-violation files — 0 diffs.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-is-mounted.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).