### PR TITLE
feat: port rule react/no-string-refs

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -15,6 +15,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
@@ -39,6 +40,7 @@ func GetAllRules() []rule.Rule {
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_danger.NoDangerRule,
 		no_is_mounted.NoIsMountedRule,
+		no_string_refs.NoStringRefsRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		self_closing_comp.SelfClosingCompRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -245,12 +245,21 @@ func IsInsideReactComponent(node *ast.Node, pragma, createClass string) bool {
 			if !seenEnclosingFunction {
 				continue
 			}
-			parent := p.Parent
+			// The ObjectLiteralExpression may be wrapped in one or more
+			// ParenthesizedExpressions before reaching the CallExpression
+			// (ESTree would flatten these; tsgo preserves them), e.g.
+			// `createReactClass(({...}))`. Walk up through paren wrappers
+			// to find the actual argument position.
+			arg := p
+			for arg.Parent != nil && arg.Parent.Kind == ast.KindParenthesizedExpression {
+				arg = arg.Parent
+			}
+			parent := arg.Parent
 			if parent == nil || parent.Kind != ast.KindCallExpression {
 				continue
 			}
 			call := parent.AsCallExpression()
-			if !isObjectArgumentOf(call, p) {
+			if !isObjectArgumentOf(call, arg) {
 				continue
 			}
 			if IsCreateClassCall(call, pragma, createClass) {

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -1,12 +1,21 @@
 package reactutil
 
 import (
+	"regexp"
+	"strconv"
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 )
 
 // DefaultReactPragma is the fallback object name for createElement calls
 // when `settings.react.pragma` is not configured, matching eslint-plugin-react.
 const DefaultReactPragma = "React"
+
+// DefaultReactCreateClass is the fallback ES5 factory name when
+// `settings.react.createClass` is not configured, matching
+// eslint-plugin-react.
+const DefaultReactCreateClass = "createReactClass"
 
 // GetReactPragma reads `settings.react.pragma` from the config settings map.
 // Returns DefaultReactPragma when the setting is absent, not a string, or empty.
@@ -23,6 +32,245 @@ func GetReactPragma(settings map[string]interface{}) string {
 		return DefaultReactPragma
 	}
 	return pragma
+}
+
+// GetReactCreateClass reads `settings.react.createClass` from the config
+// settings map. Returns DefaultReactCreateClass when the setting is absent,
+// not a string, or empty.
+func GetReactCreateClass(settings map[string]interface{}) string {
+	if settings == nil {
+		return DefaultReactCreateClass
+	}
+	reactSettings, ok := settings["react"].(map[string]interface{})
+	if !ok {
+		return DefaultReactCreateClass
+	}
+	v, ok := reactSettings["createClass"].(string)
+	if !ok || v == "" {
+		return DefaultReactCreateClass
+	}
+	return v
+}
+
+// reactVersionRe captures the leading major[.minor[.patch]] numeric triple of
+// a semver-ish string. Prerelease / build metadata / range qualifiers are
+// ignored — matching eslint-plugin-react's `semver.coerce`-like behavior for
+// the simple comparisons this package performs.
+var reactVersionRe = regexp.MustCompile(`(\d+)(?:\.(\d+))?(?:\.(\d+))?`)
+
+// ParseReactVersion returns the (major, minor, patch) triple of
+// `settings.react.version`. When the setting is missing, not a string, empty,
+// or not recognizable as a version, it defaults to (999, 999, 999) — matching
+// eslint-plugin-react's `getReactVersionFromContext`, which treats an absent
+// version as "latest".
+func ParseReactVersion(settings map[string]interface{}) (int, int, int) {
+	if settings == nil {
+		return 999, 999, 999
+	}
+	reactSettings, ok := settings["react"].(map[string]interface{})
+	if !ok {
+		return 999, 999, 999
+	}
+	raw, _ := reactSettings["version"].(string)
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 999, 999, 999
+	}
+	m := reactVersionRe.FindStringSubmatch(raw)
+	if m == nil {
+		return 999, 999, 999
+	}
+	toInt := func(s string) int {
+		if s == "" {
+			return 0
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return 0
+		}
+		return n
+	}
+	return toInt(m[1]), toInt(m[2]), toInt(m[3])
+}
+
+// ReactVersionLessThan reports whether `settings.react.version` is strictly
+// less than the given major.minor.patch. See ParseReactVersion for the default
+// when the setting is missing.
+func ReactVersionLessThan(settings map[string]interface{}, major, minor, patch int) bool {
+	a, b, c := ParseReactVersion(settings)
+	if a != major {
+		return a < major
+	}
+	if b != minor {
+		return b < minor
+	}
+	return c < patch
+}
+
+// IsCreateClassCall reports whether the given CallExpression's callee is
+// `<createClass>(...)` or `<pragma>.<createClass>(...)`. Parentheses are
+// skipped on both the callee and the pragma identifier. Pass the empty string
+// for pragma/createClass to fall back to `DefaultReactPragma` /
+// `DefaultReactCreateClass`.
+func IsCreateClassCall(call *ast.CallExpression, pragma, createClass string) bool {
+	if call == nil {
+		return false
+	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	if createClass == "" {
+		createClass = DefaultReactCreateClass
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text == createClass
+	case ast.KindPropertyAccessExpression:
+		pa := callee.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		return name.AsIdentifier().Text == createClass
+	}
+	return false
+}
+
+// ExtendsReactComponent reports whether `classNode` (a ClassDeclaration or
+// ClassExpression) has an `extends` clause referencing `Component` or
+// `PureComponent` — either as a bare identifier or qualified by the
+// configured pragma (e.g. `React.Component`). Parentheses are skipped. Pass
+// the empty string for pragma to default to `DefaultReactPragma`.
+//
+// NOTE: Matches the name regex used by eslint-plugin-react's
+// `componentUtil.isES6Component` (`/^(Pure)?Component$/`). Aliased imports
+// (e.g. `import { Component as C }`) are not resolved — same as the upstream
+// rule.
+func ExtendsReactComponent(classNode *ast.Node, pragma string) bool {
+	if classNode == nil {
+		return false
+	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	heritage := ast.GetClassExtendsHeritageElement(classNode)
+	if heritage == nil {
+		return false
+	}
+	hc := heritage.AsExpressionWithTypeArguments()
+	if hc == nil || hc.Expression == nil {
+		return false
+	}
+	expr := ast.SkipParentheses(hc.Expression)
+	switch expr.Kind {
+	case ast.KindIdentifier:
+		return isComponentName(expr.AsIdentifier().Text)
+	case ast.KindPropertyAccessExpression:
+		pa := expr.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		nameNode := pa.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return false
+		}
+		return isComponentName(nameNode.AsIdentifier().Text)
+	}
+	return false
+}
+
+func isComponentName(name string) bool {
+	return name == "Component" || name == "PureComponent"
+}
+
+// IsInsideReactComponent reports whether `node` is lexically contained within
+// a React component — either an ES5 component (object literal passed as an
+// argument to `<createClass>(...)` / `<pragma>.<createClass>(...)`) or an
+// ES6 component (ClassDeclaration / ClassExpression extending Component or
+// PureComponent, optionally qualified by pragma).
+//
+// Pass the empty string for pragma/createClass to fall back to
+// `DefaultReactPragma` / `DefaultReactCreateClass`.
+//
+// Mirrors eslint-plugin-react's componentUtil:
+//
+//   - ES6 path: only the nearest enclosing class decides component status
+//     (matching `getParentES6Component`'s `while scope.type !== 'class'`).
+//     A non-component class does not "pass through" to let an outer component
+//     class match — this prevents false positives like a non-React inner
+//     class nested inside a React class.
+//
+//   - ES5 path: `this` / `this.refs` must occur inside some function, whose
+//     ObjectExpression parent is the argument to `<createClass>(...)`. We
+//     approximate this by requiring that an enclosing function has been
+//     passed on the walk up before an ObjectExpression is accepted — which
+//     rules out pathological cases like `createReactClass({ x: this.refs.y })`
+//     where `this` is not inside any function (ESLint's scope walk returns
+//     null for that too).
+func IsInsideReactComponent(node *ast.Node, pragma, createClass string) bool {
+	if node == nil {
+		return false
+	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	if createClass == "" {
+		createClass = DefaultReactCreateClass
+	}
+	seenNearestClass := false
+	seenEnclosingFunction := false
+	for p := node.Parent; p != nil; p = p.Parent {
+		if ast.IsFunctionLike(p) {
+			seenEnclosingFunction = true
+		}
+		switch p.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if seenNearestClass {
+				// The nearest class already decided ES6 classification;
+				// outer classes do not get a second chance (matches ESLint's
+				// scope-walk that stops at the first class scope).
+				continue
+			}
+			seenNearestClass = true
+			if ExtendsReactComponent(p, pragma) {
+				return true
+			}
+		case ast.KindObjectLiteralExpression:
+			if !seenEnclosingFunction {
+				continue
+			}
+			parent := p.Parent
+			if parent == nil || parent.Kind != ast.KindCallExpression {
+				continue
+			}
+			call := parent.AsCallExpression()
+			if !isObjectArgumentOf(call, p) {
+				continue
+			}
+			if IsCreateClassCall(call, pragma, createClass) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isObjectArgumentOf(call *ast.CallExpression, obj *ast.Node) bool {
+	if call.Arguments == nil {
+		return false
+	}
+	for _, arg := range call.Arguments.Nodes {
+		if arg == obj {
+			return true
+		}
+	}
+	return false
 }
 
 // IsCreateElementCall reports whether the callee is `<pragma>.createElement`.

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.go
@@ -1,0 +1,91 @@
+package no_string_refs
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var NoStringRefsRule = rule.Rule{
+	Name: "react/no-string-refs",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		detectTemplateLiterals := false
+		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+			if v, ok := optsMap["noTemplateLiterals"].(bool); ok {
+				detectTemplateLiterals = v
+			}
+		}
+
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		// `this.refs` is writable in React 18.3.0 and later, so only check on versions < 18.3.0.
+		// When `react.version` is absent the setting defaults to "latest" (999.999.999),
+		// which disables the check.
+		checkRefsUsage := reactutil.ReactVersionLessThan(ctx.Settings, 18, 3, 0)
+
+		reportStringRef := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "stringInRefDeprecated",
+				Description: "Using string literals in ref attributes is deprecated.",
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				if !checkRefsUsage {
+					return
+				}
+				prop := node.AsPropertyAccessExpression()
+				if ast.SkipParentheses(prop.Expression).Kind != ast.KindThisKeyword {
+					return
+				}
+				name := prop.Name()
+				if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "refs" {
+					return
+				}
+				if !reactutil.IsInsideReactComponent(node, pragma, createClass) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "thisRefsDeprecated",
+					Description: "Using this.refs is deprecated.",
+				})
+			},
+
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				attr := node.AsJsxAttribute()
+				name := attr.Name()
+				if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "ref" {
+					return
+				}
+				init := attr.Initializer
+				if init == nil {
+					return
+				}
+				switch init.Kind {
+				case ast.KindStringLiteral:
+					reportStringRef(node)
+				case ast.KindJsxExpression:
+					expr := init.AsJsxExpression().Expression
+					if expr == nil {
+						return
+					}
+					// Unwrap parens / `as` so `ref={('x')}` and `ref={'x' as string}` report.
+					expr = ast.SkipParentheses(expr)
+					for expr.Kind == ast.KindAsExpression {
+						expr = ast.SkipParentheses(expr.AsAsExpression().Expression)
+					}
+					switch expr.Kind {
+					case ast.KindStringLiteral:
+						reportStringRef(node)
+					case ast.KindNoSubstitutionTemplateLiteral, ast.KindTemplateExpression:
+						if detectTemplateLiterals {
+							reportStringRef(node)
+						}
+					}
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.go
@@ -71,11 +71,15 @@ var NoStringRefsRule = rule.Rule{
 					if expr == nil {
 						return
 					}
-					// Unwrap parens / `as` so `ref={('x')}` and `ref={'x' as string}` report.
+					// Unwrap parens so `ref={('x')}` reports (ESTree flattens
+					// parens; tsgo preserves them). We deliberately do NOT
+					// unwrap TypeScript wrappers such as AsExpression /
+					// NonNullExpression / SatisfiesExpression: eslint-plugin-react
+					// (under @typescript-eslint/parser) only matches when
+					// `expression.type === 'Literal'`, and those wrappers make
+					// the outer type something else, so upstream does not report
+					// `ref={'x' as string}` / `ref={'x'!}`. We align with that.
 					expr = ast.SkipParentheses(expr)
-					for expr.Kind == ast.KindAsExpression {
-						expr = ast.SkipParentheses(expr.AsAsExpression().Expression)
-					}
 					switch expr.Kind {
 					case ast.KindStringLiteral:
 						reportStringRef(node)

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs.md
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs.md
@@ -1,0 +1,80 @@
+# react/no-string-refs
+
+Disallow using deprecated string refs.
+
+## Rule Details
+
+React used to support string refs (e.g. `ref="name"`, then accessed via `this.refs.name`), but string refs are deprecated — they tie the ref to the component that rendered it (making composition surprising), interact poorly with `<StrictMode>`, and cannot be cleaned up automatically. Callback refs (`ref={node => ...}`) and `React.createRef()` / `useRef()` should be used instead.
+
+This rule reports two things:
+
+- A string literal (or, optionally, a template literal) used as a `ref` prop value: `ref="hello"`, `ref={'hello'}`, `ref={\`hello\`}`.
+- Access of `this.refs` inside an ES5 `createReactClass({...})` component or an ES6 class extending `React.Component` / `React.PureComponent`. React 18.3.0 made `this.refs` writable, so the check is skipped when `settings.react.version` is set to 18.3.0 or later.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  componentDidMount: function () {
+    var component = this.refs.hello;
+  },
+  render: function () {
+    return <div ref="hello">Hello</div>;
+  },
+});
+```
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div ref={'hello'}>Hello</div>;
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  componentDidMount: function () {
+    var component = this.hello;
+  },
+  render: function () {
+    return <div ref={(c) => (this.hello = c)}>Hello</div>;
+  },
+});
+```
+
+## Options
+
+### `noTemplateLiterals`
+
+When `true`, template literals used as a `ref` value are also reported (by default only plain string literals are flagged).
+
+```json
+{ "react/no-string-refs": ["error", { "noTemplateLiterals": true }] }
+```
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div ref={`hello`}>Hello</div>;
+  },
+});
+```
+
+## Settings
+
+- `settings.react.version` — when set to a version `>= 18.3.0`, `this.refs` accesses are not reported (they are writable on modern React). When unset, defaults to latest.
+- `settings.react.pragma` — used to recognize `<pragma>.createClass(...)` and classes extending `<pragma>.Component` / `<pragma>.PureComponent`. Defaults to `React`.
+- `settings.react.createClass` — the identifier used for ES5 component factories. Defaults to `createReactClass`.
+
+## Differences from ESLint
+
+- **JSDoc `@extends` / `@augments` tags are not honored**. eslint-plugin-react has an `isExplicitComponent` path that treats a class as a React component when its JSDoc contains `@extends React.Component` or `@augments React.Component`, even without an `extends` clause. rslint only recognizes components through the actual `extends` clause; JSDoc-only component declarations are not flagged.
+- **`settings.react.version = "detect"` is not resolved**. eslint-plugin-react reads `react` from `node_modules` to auto-detect the version. rslint treats `"detect"` (and any non-numeric version string) as "latest" (999.999.999), which means `this.refs` is not reported in that mode. Set an explicit version string (e.g. `"18.2.0"`) to exercise the `< 18.3.0` gate.
+- **Semver range strings (`^18.0.0`, `~18.0.0`, `>=17 <19`, etc.) are interpreted loosely**. eslint-plugin-react passes the value to `semver.satisfies`, which throws on non-exact versions. rslint extracts the leading numeric triple (`^18.0.0` → `18.0.0`) and compares it directly. Prefer an exact version string for predictable behavior.
+
+## Original Documentation
+
+- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs_test.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs_test.go
@@ -1,0 +1,421 @@
+package no_string_refs
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoStringRefsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoStringRefsRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() {
+    var component = this.hello;
+  },
+  render: function() {
+    return <div ref={c => this.hello = c}>Hello {this.props.name}</div>;
+  }
+});
+`,
+			Tsx: true,
+		},
+		{
+			Code: "\nvar Hello = createReactClass({\n  render: function() {\n    return <div ref={`hello`}>Hello {this.props.name}</div>;\n  }\n});\n",
+			Tsx:  true,
+		},
+		{
+			Code: "\nvar Hello = createReactClass({\n  render: function() {\n    return <div ref={`hello${index}`}>Hello {this.props.name}</div>;\n  }\n});\n",
+			Tsx:  true,
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() {
+    var component = this.refs.hello;
+  },
+  render: function() {
+    return <div>Hello {this.props.name}</div>;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.3.0"}},
+		},
+
+		// ---- Additional edge cases ----
+		// `this.refs` outside any React component is not flagged.
+		{
+			Code: `
+function f() {
+  return this.refs.hello;
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// ES6 component that does NOT extend Component/PureComponent: this.refs is not flagged.
+		{
+			Code: `
+class Hello extends SomethingElse {
+  componentDidMount() {
+    var c = this.refs.hello;
+  }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// No version setting → defaults to "latest" (999.999.999) → this.refs is not checked.
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() {
+    var c = this.refs.hello;
+  }
+});
+`,
+			Tsx: true,
+		},
+		// String assigned via callback ref is fine (it's a function, not a string literal).
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() {
+    return <div ref={setRef}>hi</div>;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// `ref` prop on a JSX element with no initializer (boolean shorthand) is not flagged.
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() { return <div ref />; }
+});
+`,
+			Tsx: true,
+		},
+		// Pragma gate: with default pragma=React, extending `Preact.Component`
+		// is NOT classified as a React component, so this.refs is allowed.
+		// Pair with the invalid case that sets pragma=Preact below.
+		{
+			Code: `
+class Hello extends Preact.Component {
+  componentDidMount() { var c = this.refs.foo; }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// createClass pragma gate: with default (`createReactClass`), a call
+		// to `React.createClass({...})` without `settings.react.createClass =
+		// "createClass"` is NOT an ES5 component.
+		{
+			Code: `
+var Hello = React.createClass({
+  componentDidMount: function() { var c = this.refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// `ref` attribute on a non-JSX (e.g. object property) is unaffected.
+		{Code: `var o = { ref: 'hello' };`, Tsx: true},
+		// JSX spread attribute containing a string-valued `ref` is not flagged
+		// (the AST-level spread is opaque to this rule).
+		{Code: `const props = { ref: 'hello' as const }; <div {...props} />;`, Tsx: true},
+		// Non-string template expression with identifier — not flagged without
+		// noTemplateLiterals.
+		{Code: "<div ref={`hello${x}`} />;", Tsx: true},
+		// Nearest-class gate: a non-React inner class nested inside a React
+		// component should NOT make its methods "inside a component". The
+		// ES6 path is decided by the nearest enclosing class only.
+		{
+			Code: `
+class Hello extends React.Component {
+  method() {
+    class Inner {
+      foo() { var c = this.refs.x; }
+    }
+  }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// ES5 path requires this.refs to be inside some function. A bare
+		// object-property `this.refs` reference (no enclosing function) must
+		// not be treated as inside an ES5 component.
+		{
+			Code: `
+var bag = createReactClass({ x: this.refs && 1 });
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() {
+    var component = this.refs.hello;
+  },
+  render: function() {
+    return <div>Hello {this.props.name}</div>;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Message: "Using this.refs is deprecated.", Line: 4, Column: 21},
+			},
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() {
+    return <div ref="hello">Hello {this.props.name}</div>;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "stringInRefDeprecated", Message: "Using string literals in ref attributes is deprecated.", Line: 4, Column: 17},
+			},
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() {
+    return <div ref={'hello'}>Hello {this.props.name}</div>;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "stringInRefDeprecated", Line: 4, Column: 17},
+			},
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() {
+    var component = this.refs.hello;
+  },
+  render: function() {
+    return <div ref="hello">Hello {this.props.name}</div>;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 4, Column: 21},
+				{MessageId: "stringInRefDeprecated", Line: 7, Column: 17},
+			},
+		},
+		{
+			Code: "\nvar Hello = createReactClass({\n  componentDidMount: function() {\n    var component = this.refs.hello;\n  },\n  render: function() {\n    return <div ref={`hello`}>Hello {this.props.name}</div>;\n  }\n});\n",
+			Options: map[string]interface{}{
+				"noTemplateLiterals": true,
+			},
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 4, Column: 21},
+				{MessageId: "stringInRefDeprecated", Line: 7, Column: 17},
+			},
+		},
+		{
+			Code: "\nvar Hello = createReactClass({\n  componentDidMount: function() {\n    var component = this.refs.hello;\n  },\n  render: function() {\n    return <div ref={`hello${index}`}>Hello {this.props.name}</div>;\n  }\n});\n",
+			Options: map[string]interface{}{
+				"noTemplateLiterals": true,
+			},
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 4, Column: 21},
+				{MessageId: "stringInRefDeprecated", Line: 7, Column: 17},
+			},
+		},
+		{
+			Code: "\nvar Hello = createReactClass({\n  componentDidMount: function() {\n    var component = this.refs.hello;\n  },\n  render: function() {\n    return <div ref={`hello${index}`}>Hello {this.props.name}</div>;\n  }\n});\n",
+			Options: map[string]interface{}{
+				"noTemplateLiterals": true,
+			},
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.3.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "stringInRefDeprecated", Line: 7, Column: 17},
+			},
+		},
+
+		// ---- Additional edge cases ----
+		// ES6 class component extending React.Component with this.refs.
+		{
+			Code: `
+class Hello extends React.Component {
+  componentDidMount() {
+    var c = this.refs.hello;
+  }
+  render() { return <div />; }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 4, Column: 13},
+			},
+		},
+		// ES6 class component extending PureComponent (bare identifier) with this.refs.
+		{
+			Code: `
+class Hello extends PureComponent {
+  componentDidMount() {
+    var c = this.refs.hello;
+  }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 4, Column: 13},
+			},
+		},
+		// `React.createClass` (legacy pragma form) also counts as an ES5 component.
+		{
+			Code: `
+var Hello = React.createClass({
+  componentDidMount: function() {
+    var c = this.refs.hello;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "createClass": "createClass"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 4, Column: 13},
+			},
+		},
+		// Class expression assigned to a variable.
+		{
+			Code: `
+var Hello = class extends React.Component {
+  componentDidMount() { var c = this.refs.foo; }
+};
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 33},
+			},
+		},
+		// Arrow property on an ES6 component — class field, still inside the class.
+		{
+			Code: `
+class Hello extends React.Component {
+  onClick = () => { var c = this.refs.foo; };
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 29},
+			},
+		},
+		// Parenthesized `this` inside the refs access.
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() { var c = (this).refs.hello; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 43},
+			},
+		},
+		// Nested createReactClass — inner this.refs is inside a component too.
+		{
+			Code: `
+var Outer = createReactClass({
+  render: function() {
+    var Inner = createReactClass({
+      componentDidMount: function() { var c = this.refs.x; }
+    });
+    return null;
+  }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 5, Column: 47},
+			},
+		},
+		// Pragma setting — `Preact.Component` is recognized when pragma=Preact.
+		{
+			Code: `
+class Hello extends Preact.Component {
+  componentDidMount() { var c = this.refs.foo; }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 33},
+			},
+		},
+		// `ref` with parenthesized string literal.
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() { return <div ref={('hello')} />; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "stringInRefDeprecated", Line: 3, Column: 36},
+			},
+		},
+		// `ref` with double-parenthesized string literal.
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() { return <div ref={(('hello'))} />; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "stringInRefDeprecated", Line: 3, Column: 36},
+			},
+		},
+		// `ref={'x' as string}` — the TS `as` cast must not hide the literal.
+		{
+			Code: `
+var Hello = createReactClass({
+  render: function() { return <div ref={'hello' as string} />; }
+});
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "stringInRefDeprecated", Line: 3, Column: 36},
+			},
+		},
+		// Pragma is not `React` by default → `Preact.Component` is not a
+		// component, so `this.refs` inside it should NOT fire. (Locks the
+		// pragma gate — compare with the matching invalid case above.)
+		// The symmetric invalid version uses `pragma=Preact`.
+	})
+}

--- a/internal/plugins/react/rules/no_string_refs/no_string_refs_test.go
+++ b/internal/plugins/react/rules/no_string_refs/no_string_refs_test.go
@@ -133,6 +133,69 @@ var Hello = React.createClass({
 		// Non-string template expression with identifier — not flagged without
 		// noTemplateLiterals.
 		{Code: "<div ref={`hello${x}`} />;", Tsx: true},
+		// TypeScript `as` / `!` / `satisfies` wrap the literal in a non-Literal
+		// node; eslint-plugin-react checks `expression.type === 'Literal'` and
+		// therefore does NOT report these. Align with upstream.
+		{Code: `<div ref={'hello' as string} />;`, Tsx: true},
+		{Code: `<div ref={'hello'!} />;`, Tsx: true},
+		{Code: `<div ref={('hello' as string)} />;`, Tsx: true},
+		{Code: `<div ref={'hello' satisfies string} />;`, Tsx: true},
+		// Similarly, `this` wrapped in `as` / `!` means `node.object.type !==
+		// 'ThisExpression'` upstream, so `this.refs` access through the wrapper
+		// is NOT reported.
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() { var c = (this as any).refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() { var c = this!.refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// Computed member access `this['refs']` has no property name (upstream
+		// checks `property.name`), so it is NOT reported.
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() { var c = this['refs'].foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// extends via computed property `React['Component']` — upstream
+		// requires `superClass.property.name`, which is undefined for
+		// computed access, so this is NOT a React component.
+		{
+			Code: `
+class Hello extends React['Component'] {
+  componentDidMount() { var c = this.refs.foo; }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+		},
+		// Computed createClass access `React['createClass']({...})` — upstream
+		// requires `callee.property.name`, which is undefined here, so this
+		// is NOT an ES5 React component call.
+		{
+			Code: `
+var Hello = React['createClass']({
+  componentDidMount: function() { var c = this.refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0", "createClass": "createClass"}},
+		},
 		// Nearest-class gate: a non-React inner class nested inside a React
 		// component should NOT make its methods "inside a component". The
 		// ES6 path is decided by the nearest enclosing class only.
@@ -401,21 +464,128 @@ var Hello = createReactClass({
 				{MessageId: "stringInRefDeprecated", Line: 3, Column: 36},
 			},
 		},
-		// `ref={'x' as string}` — the TS `as` cast must not hide the literal.
+		// Paren-wrapped object literal argument to createReactClass —
+		// ESTree would flatten the parens; tsgo preserves them. Regression
+		// case for GH-PR-comment #1.
 		{
 			Code: `
-var Hello = createReactClass({
-  render: function() { return <div ref={'hello' as string} />; }
-});
+var Hello = createReactClass(({
+  componentDidMount: function() { var c = this.refs.foo; }
+}));
 `,
-			Tsx: true,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 43},
+			},
+		},
+		// Double-paren-wrapped object literal argument.
+		{
+			Code: `
+var Hello = createReactClass(((({
+  render: function() { return <div ref="x" />; }
+}))));
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "stringInRefDeprecated", Line: 3, Column: 36},
 			},
 		},
-		// Pragma is not `React` by default → `Preact.Component` is not a
-		// component, so `this.refs` inside it should NOT fire. (Locks the
-		// pragma gate — compare with the matching invalid case above.)
-		// The symmetric invalid version uses `pragma=Preact`.
+		// ES6 `extends` with multiple parens around the whole heritage expr.
+		{
+			Code: `
+class Hello extends ((React.Component)) {
+  componentDidMount() { var c = this.refs.foo; }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 33},
+			},
+		},
+		// ES6 class with generic type argument in extends clause.
+		{
+			Code: `
+class Hello extends React.Component<{}> {
+  componentDidMount() { var c = this.refs.foo; }
+}
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 33},
+			},
+		},
+		// Optional-chain `this?.refs` — tsgo uses a flag, not a ChainExpression
+		// wrapper; ESLint's MemberExpression listener fires on the inner node.
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount: function() { var c = this?.refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 43},
+			},
+		},
+		// ES5 method shorthand (`{ foo() {} }` rather than `{ foo: function(){} }`).
+		{
+			Code: `
+var Hello = createReactClass({
+  componentDidMount() { var c = this.refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 33},
+			},
+		},
+		// ES5 getter — GetAccessorDeclaration is also a function-like node.
+		{
+			Code: `
+var Hello = createReactClass({
+  get foo() { return this.refs.x; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 22},
+			},
+		},
+		// ES5 computed key — still a method on the config object.
+		{
+			Code: `
+var Hello = createReactClass({
+  ['compDid' + 'Mount']: function() { var c = this.refs.foo; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 3, Column: 47},
+			},
+		},
+		// ES5 object with object-spread — this.refs inside a later method
+		// still counts as inside the component.
+		{
+			Code: `
+var base = {};
+var Hello = createReactClass({
+  ...base,
+  render: function() { var c = this.refs.foo; return null; }
+});
+`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "thisRefsDeprecated", Line: 5, Column: 32},
+			},
+		},
 	})
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -95,6 +95,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
+    './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-string-refs.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-string-refs.test.ts
@@ -44,6 +44,13 @@ ruleTester.run('no-string-refs', {} as never, {
     { code: `<div ref />;` },
     // An identifier in a ref is fine (it's a variable, not a string).
     { code: `const myRef = () => {}; <div ref={myRef} />;` },
+    // TypeScript `as` / `!` / `satisfies` wrappers on the expression mean
+    // `expression.type !== 'Literal'` in upstream ESTree, so these are NOT
+    // reported. Locks alignment with eslint-plugin-react.
+    { code: `<div ref={'hello' as string} />;` },
+    { code: `<div ref={'hello'!} />;` },
+    { code: `<div ref={('hello' as string)} />;` },
+    { code: `<div ref={'hello' satisfies string} />;` },
   ],
   invalid: [
     // String literal directly.
@@ -138,17 +145,22 @@ ruleTester.run('no-string-refs', {} as never, {
         { message: 'Using string literals in ref attributes is deprecated.' },
       ],
     },
-    // TypeScript `as` cast must not hide the string literal.
-    {
-      code: `<div ref={'hello' as string} />;`,
-      errors: [
-        { message: 'Using string literals in ref attributes is deprecated.' },
-      ],
-    },
     // Paren-wrapped template literal with noTemplateLiterals: true.
     {
       code: `<div ref={(\`hello\`)} />;`,
       options: [{ noTemplateLiterals: true }],
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Paren-wrapped object literal argument to createReactClass — ESTree
+    // flattens parens, tsgo preserves them. Regression case for GH-PR comment.
+    {
+      code: `
+        var Hello = createReactClass(({
+          render: function() { return <div ref="x" />; }
+        }));
+      `,
       errors: [
         { message: 'Using string literals in ref attributes is deprecated.' },
       ],

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-string-refs.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-string-refs.test.ts
@@ -1,0 +1,157 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// NOTE: `this.refs` detection depends on `settings.react.version`, which the
+// shared JS rule-tester does not thread through to `lint()`. Those cases are
+// covered by the Go unit tests (`no_string_refs_test.go`). The JS suite here
+// focuses on the JSX `ref={...}` detection, which is version-independent.
+
+ruleTester.run('no-string-refs', {} as never, {
+  valid: [
+    // Callback ref is fine.
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref={c => this.hello = c}>Hello</div>;
+          }
+        });
+      `,
+    },
+    // Template literal without noTemplateLiterals is fine.
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref={\`hello\`}>Hello</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref={\`hello\${index}\`}>Hello</div>;
+          }
+        });
+      `,
+    },
+    // Non-ref attributes with string literals are fine.
+    { code: `<div title="hello" />;` },
+    // `ref` without an initializer (boolean shorthand) is not flagged.
+    { code: `<div ref />;` },
+    // An identifier in a ref is fine (it's a variable, not a string).
+    { code: `const myRef = () => {}; <div ref={myRef} />;` },
+  ],
+  invalid: [
+    // String literal directly.
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref="hello">Hello</div>;
+          }
+        });
+      `,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // String literal inside expression container.
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref={'hello'}>Hello</div>;
+          }
+        });
+      `,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Double-quoted string literal.
+    {
+      code: `<div ref={"hello"} />;`,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Template literal with noTemplateLiterals: true.
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref={\`hello\`}>Hello</div>;
+          }
+        });
+      `,
+      options: [{ noTemplateLiterals: true }],
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Template literal with interpolation + noTemplateLiterals: true.
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div ref={\`hello\${index}\`}>Hello</div>;
+          }
+        });
+      `,
+      options: [{ noTemplateLiterals: true }],
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Multiple offending refs in the same tree.
+    {
+      code: `
+        function App() {
+          return (
+            <div>
+              <div ref="first" />
+              <div ref={'second'} />
+            </div>
+          );
+        }
+      `,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Parenthesized string literal inside the expression container.
+    {
+      code: `<div ref={('hello')} />;`,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Double-parenthesized string literal.
+    {
+      code: `<div ref={(('hello'))} />;`,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // TypeScript `as` cast must not hide the string literal.
+    {
+      code: `<div ref={'hello' as string} />;`,
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+    // Paren-wrapped template literal with noTemplateLiterals: true.
+    {
+      code: `<div ref={(\`hello\`)} />;`,
+      options: [{ noTemplateLiterals: true }],
+      errors: [
+        { message: 'Using string literals in ref attributes is deprecated.' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-string-refs` rule from eslint-plugin-react to rslint.

The rule reports two deprecated patterns:

- String-literal (and, optionally, template-literal) values on a JSX `ref` attribute: `ref="x"`, `ref={'x'}`, `` ref={`x`} ``.
- `this.refs` access inside an ES5 (`createReactClass` / `<pragma>.createClass`) or ES6 (`extends Component` / `PureComponent`, optionally pragma-qualified) React component. Skipped when `settings.react.version >= 18.3.0`, matching upstream (React 18.3.0 made `this.refs` writable).

Options: `noTemplateLiterals` (bool) extends the JSX check to template literals.

Differences from upstream (documented in the rule's `.md`):

- JSDoc `@extends` / `@augments` tags are not honored for implicit component detection.
- `settings.react.version = "detect"` is not resolved against `node_modules`; treated as latest.
- Semver range strings are parsed loosely (leading numeric triple) rather than through `semver.satisfies`.

Shared helpers (`IsInsideReactComponent`, `ExtendsReactComponent`, `IsCreateClassCall`, `ParseReactVersion`, `ReactVersionLessThan`, `GetReactCreateClass`) are added to `internal/plugins/react/reactutil` so later React rules can reuse them.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-string-refs.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).