### PR TITLE
feat: port rule react/no-find-dom-node

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -14,6 +14,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
@@ -39,6 +40,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_danger.NoDangerRule,
+		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
 		no_string_refs.NoStringRefsRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,

--- a/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node.go
+++ b/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node.go
@@ -1,0 +1,55 @@
+package no_find_dom_node
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+const noFindDOMNodeMessage = "Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode"
+
+// matchesFindDOMNodeCallee mirrors ESLint's two-branch check on `callee`:
+//
+//	('name' in callee && callee.name === 'findDOMNode') ||
+//	('property' in callee && callee.property && 'name' in callee.property && callee.property.name === 'findDOMNode')
+//
+// The first branch matches a bare `findDOMNode(...)` identifier call. The
+// second matches `<anything>.findDOMNode(...)` (property-access; bracket /
+// element access is excluded because `Literal` has no `.name` in ESTree).
+// ESTree's `PrivateIdentifier.name` has no leading `#`, so `this.#findDOMNode()`
+// also matches upstream — we mirror that here.
+func matchesFindDOMNodeCallee(callee *ast.Node) bool {
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text == "findDOMNode"
+	case ast.KindPropertyAccessExpression:
+		name := callee.AsPropertyAccessExpression().Name()
+		if name == nil {
+			return false
+		}
+		switch name.Kind {
+		case ast.KindIdentifier:
+			return name.AsIdentifier().Text == "findDOMNode"
+		case ast.KindPrivateIdentifier:
+			return name.AsPrivateIdentifier().Text == "#findDOMNode"
+		}
+	}
+	return false
+}
+
+var NoFindDomNodeRule = rule.Rule{
+	Name: "react/no-find-dom-node",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				callee := ast.SkipParentheses(node.AsCallExpression().Expression)
+				if !matchesFindDOMNodeCallee(callee) {
+					return
+				}
+				ctx.ReportNode(callee, rule.RuleMessage{
+					Id:          "noFindDOMNode",
+					Description: noFindDOMNodeMessage,
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node.md
+++ b/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node.md
@@ -1,0 +1,56 @@
+# no-find-dom-node
+
+Disallow usage of `findDOMNode`.
+
+Facebook will eventually deprecate `findDOMNode` as it blocks certain
+improvements in React in the future. It is recommended to use callback refs
+instead.
+
+## Rule Details
+
+This rule flags any call whose callee is the identifier `findDOMNode` (bare
+call) or a member-access whose property name is `findDOMNode`
+(`React.findDOMNode(...)`, `ReactDOM.findDOMNode(...)`, etc.). Computed
+(bracket) access such as `React['findDOMNode'](...)` is intentionally not
+flagged — this mirrors the upstream rule's AST check.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+class MyComponent extends Component {
+  componentDidMount() {
+    findDOMNode(this).scrollIntoView();
+  }
+  render() {
+    return <div />;
+  }
+}
+```
+
+```jsx
+class MyComponent extends Component {
+  componentDidMount() {
+    React.findDOMNode(this).scrollIntoView();
+  }
+  render() {
+    return <div />;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+class MyComponent extends Component {
+  componentDidMount() {
+    this.node.scrollIntoView();
+  }
+  render() {
+    return <div ref={(node) => (this.node = node)} />;
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react / no-find-dom-node](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md)

--- a/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node_test.go
+++ b/internal/plugins/react/rules/no_find_dom_node/no_find_dom_node_test.go
@@ -1,0 +1,412 @@
+package no_find_dom_node
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoFindDomNodeRule(t *testing.T) {
+	const msg = "Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode"
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoFindDomNodeRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: plain function declaration ----
+		{Code: `
+        var Hello = function() {};
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass with no findDOMNode reference ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: findDOMNode referenced as a value but not called ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            someNonMemberFunction(arg);
+            this.someFunc = React.findDOMNode;
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: unrelated method on React ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            React.someFunc(this);
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: bracket notation is NOT matched (ESLint's `'name' in property` guard) ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React['findDOMNode'](this).scrollIntoView();
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: similar-but-not-equal identifier name ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            findDOMNodes(this);
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: property with a different name ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React.findNode(this);
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: `new findDOMNode(...)` is a NewExpression, not a CallExpression ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            new findDOMNode(this);
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: tagged template is not a CallExpression ----
+		{Code: `
+        const r = findDOMNode` + "`hello`" + `;
+      `, Tsx: true},
+
+		// ---- Edge: findDOMNode passed as a value, never invoked ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            foo(this.findDOMNode);
+            bar(React.findDOMNode);
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: object-literal property key happens to be `findDOMNode` ----
+		{Code: `
+        var api = { findDOMNode: function() {} };
+      `, Tsx: true},
+
+		// ---- Edge: assignment target, no call ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            this.findDOMNode = null;
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: `new findDOMNode(this)` is a NewExpression, not a CallExpression ----
+		{Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            new React.findDOMNode(this);
+          }
+        };
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: React.findDOMNode inside createReactClass ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            React.findDOMNode(this).scrollIntoView();
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Message: msg, Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: ReactDOM.findDOMNode inside createReactClass ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            ReactDOM.findDOMNode(this).scrollIntoView();
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: bare findDOMNode(this) in class method ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            findDOMNode(this).scrollIntoView();
+          }
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: bare findDOMNode stored on a field ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            this.node = findDOMNode(this);
+          }
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 25},
+			},
+		},
+
+		// ---- Edge: parenthesized callee ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            (findDOMNode)(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 14},
+			},
+		},
+
+		// ---- Edge: parenthesized member-access callee ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            (React.findDOMNode)(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 14},
+			},
+		},
+
+		// ---- Edge: optional-chain member access — `React?.findDOMNode(this)` ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React?.findDOMNode(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-call — `React.findDOMNode?.(this)` ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React.findDOMNode?.(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: chained access — findDOMNode is the last property ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            pkg.react.findDOMNode(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: private-identifier property (ESLint parity — `.name === 'findDOMNode'`) ----
+		{
+			Code: `
+        class Hello extends Component {
+          #findDOMNode() { return null; }
+          componentDidMount() {
+            this.#findDOMNode();
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: callee is a member of a call result — `getDom().findDOMNode(this)` ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            getDom().findDOMNode(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: multiple violations in the same method ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            findDOMNode(this);
+            React.findDOMNode(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+				{MessageId: "noFindDOMNode", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: nested — outer call flags, inner call also flags ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            foo(findDOMNode(this));
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 17},
+			},
+		},
+
+		// ---- Edge: TypeScript type arguments on the call ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React.findDOMNode<HTMLDivElement>(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: non-null assertion on the receiver — `React!.findDOMNode(this)` ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React!.findDOMNode(this);
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: inside a JSX attribute arrow callback (nested function expr) ----
+		{
+			Code: `
+        class Hello extends Component {
+          render() {
+            return <div onClick={() => findDOMNode(this)} />;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 40},
+			},
+		},
+
+		// ---- Edge: inside a SpreadElement of an array literal ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            const list = [...findDOMNode(this)];
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 30},
+			},
+		},
+
+		// ---- Edge: inside a template-literal expression slot ----
+		{
+			Code: "\n" +
+				"        class Hello extends Component {\n" +
+				"          componentDidMount() {\n" +
+				"            const s = `id=${findDOMNode(this).id}`;\n" +
+				"          }\n" +
+				"        };\n" +
+				"      ",
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noFindDOMNode", Line: 4, Column: 29},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -95,6 +95,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
+    './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-find-dom-node.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-find-dom-node.test.ts
@@ -1,0 +1,164 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-find-dom-node', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var Hello = function() {};
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            someNonMemberFunction(arg);
+            this.someFunc = React.findDOMNode;
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            React.someFunc(this);
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+    },
+    // ---- Edge: bracket notation is NOT matched ----
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React['findDOMNode'](this).scrollIntoView();
+          }
+        };
+      `,
+    },
+    // ---- Edge: similar-but-not-equal identifier name ----
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            findDOMNodes(this);
+          }
+        };
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            React.findDOMNode(this).scrollIntoView();
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidMount: function() {
+            ReactDOM.findDOMNode(this).scrollIntoView();
+          },
+          render: function() {
+            return <div>Hello</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            findDOMNode(this).scrollIntoView();
+          }
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            this.node = findDOMNode(this);
+          }
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    // ---- Edge: parenthesized / optional / private / deeply chained ----
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            (React.findDOMNode)(this);
+          }
+        };
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React?.findDOMNode(this);
+          }
+        };
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            React.findDOMNode?.(this);
+          }
+        };
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+    {
+      code: `
+        class Hello extends Component {
+          componentDidMount() {
+            pkg.react.findDOMNode(this);
+          }
+        };
+      `,
+      errors: [{ messageId: 'noFindDOMNode' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-find-dom-node` rule from `eslint-plugin-react` to rslint.

The rule flags any call whose callee is the identifier `findDOMNode` (bare call) or a member access whose property name is `findDOMNode` (`React.findDOMNode(...)`, `ReactDOM.findDOMNode(...)`, etc.). Computed (bracket) access such as `React['findDOMNode'](...)` is intentionally not flagged — matches the upstream rule's AST check.

Verified against the upstream suite plus additional edge cases (parenthesized callees, optional chains, optional calls, private identifiers, non-null assertion receivers, type arguments, nested expressions in JSX callbacks / spread elements / template literals) and a real-world smoke test against rsbuild and rspack (no false positives).

## Related Links

- Rule doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-find-dom-node.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).