### PR TITLE
feat: port rule react/no-children-prop

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -13,6 +13,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
@@ -38,6 +39,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
+		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_is_mounted.NoIsMountedRule,
 		no_string_refs.NoStringRefsRule,

--- a/internal/plugins/react/rules/no_children_prop/no_children_prop.go
+++ b/internal/plugins/react/rules/no_children_prop/no_children_prop.go
@@ -1,0 +1,151 @@
+package no_children_prop
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	msgNestChildren       = "Do not pass children as props. Instead, nest children between the opening and closing tags."
+	msgPassChildrenAsArgs = "Do not pass children as props. Instead, pass them as additional arguments to React.createElement."
+	msgNestFunction       = "Do not nest a function between the opening and closing tags. Instead, pass it as a prop."
+	msgPassFunctionAsArgs = "Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop."
+)
+
+var NoChildrenPropRule = rule.Rule{
+	Name: "react/no-children-prop",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		allowFunctions := false
+		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+			if v, ok := optsMap["allowFunctions"].(bool); ok {
+				allowFunctions = v
+			}
+		}
+
+		// Mirrors upstream `isFunction`: the value must be an arrow / non-arrow
+		// function literal AND the allowFunctions option must be on. We unwrap
+		// parentheses because tsgo preserves ParenthesizedExpression where
+		// ESTree flattens it (`(() => {})` vs `() => {}`).
+		isAllowedFunction := func(node *ast.Node) bool {
+			if !allowFunctions || node == nil {
+				return false
+			}
+			return ast.IsFunctionExpressionOrArrowFunction(ast.SkipParentheses(node))
+		}
+
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				attr := node.AsJsxAttribute()
+				nameNode := attr.Name()
+				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+					return
+				}
+				if nameNode.AsIdentifier().Text != "children" {
+					return
+				}
+				if initializer := attr.Initializer; initializer != nil && initializer.Kind == ast.KindJsxExpression {
+					if expr := initializer.AsJsxExpression().Expression; isAllowedFunction(expr) {
+						return
+					}
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "nestChildren",
+					Description: msgNestChildren,
+				})
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !reactutil.IsCreateElementCall(call.Expression, pragma) {
+					return
+				}
+				if call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+					return
+				}
+				secondArg := ast.SkipParentheses(call.Arguments.Nodes[1])
+				if secondArg.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				obj := secondArg.AsObjectLiteralExpression()
+				childrenValue, hasChildrenProp := findChildrenValue(obj)
+				if hasChildrenProp {
+					// Upstream guards on `childrenProp.value` being truthy; in
+					// practice every realistic shape (regular, shorthand) carries
+					// one, so `value == nil` is only reachable on malformed trees.
+					if childrenValue == nil || isAllowedFunction(childrenValue) {
+						return
+					}
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "passChildrenAsArgs",
+						Description: msgPassChildrenAsArgs,
+					})
+					return
+				}
+
+				if len(call.Arguments.Nodes) == 3 && isAllowedFunction(call.Arguments.Nodes[2]) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "passFunctionAsArgs",
+						Description: msgPassFunctionAsArgs,
+					})
+				}
+			},
+			ast.KindJsxElement: func(node *ast.Node) {
+				jsx := node.AsJsxElement()
+				if jsx.Children == nil || len(jsx.Children.Nodes) != 1 {
+					return
+				}
+				child := jsx.Children.Nodes[0]
+				if child.Kind != ast.KindJsxExpression {
+					return
+				}
+				if !isAllowedFunction(child.AsJsxExpression().Expression) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "nestFunction",
+					Description: msgNestFunction,
+				})
+			},
+		}
+	},
+}
+
+// findChildrenValue searches an object literal for a `children` property whose
+// key is an Identifier, mirroring eslint-plugin-react's
+// `'name' in prop.key && prop.key.name === 'children'` guard. String / numeric
+// / computed keys and spread elements are deliberately skipped — using
+// `utils.GetStaticPropertyName` here would over-match (e.g. it would treat
+// `{"children": "x"}` as a hit, which upstream does not). The returned value
+// has parentheses stripped so a later `isAllowedFunction` test sees the raw
+// function literal.
+func findChildrenValue(obj *ast.ObjectLiteralExpression) (value *ast.Node, found bool) {
+	if obj.Properties == nil {
+		return nil, false
+	}
+	for _, prop := range obj.Properties.Nodes {
+		switch prop.Kind {
+		case ast.KindPropertyAssignment:
+			pa := prop.AsPropertyAssignment()
+			name := pa.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "children" {
+				if pa.Initializer != nil {
+					return ast.SkipParentheses(pa.Initializer), true
+				}
+				return nil, true
+			}
+		case ast.KindShorthandPropertyAssignment:
+			spa := prop.AsShorthandPropertyAssignment()
+			name := spa.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "children" {
+				// Shorthand `{ children }` — the key and value are the same
+				// Identifier node; the shorthand is a variable reference, not
+				// a function literal, so `allowFunctions` never exempts it.
+				return name, true
+			}
+		}
+	}
+	return nil, false
+}

--- a/internal/plugins/react/rules/no_children_prop/no_children_prop.md
+++ b/internal/plugins/react/rules/no_children_prop/no_children_prop.md
@@ -1,0 +1,72 @@
+# no-children-prop
+
+## Rule Details
+
+Children should always be actual children, not passed in as a prop.
+
+When using JSX, the `children` should be nested between the opening and closing tags. When not using JSX, the `children` should be passed as additional arguments to `React.createElement`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div children='Children' />
+
+<MyComponent children={<AnotherComponent />} />
+<MyComponent children={['Child 1', 'Child 2']} />
+
+React.createElement("div", { children: 'Children' })
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div>Children</div>
+
+<MyComponent>Children</MyComponent>
+
+<MyComponent>
+  <span>Child 1</span>
+  <span>Child 2</span>
+</MyComponent>
+
+React.createElement("div", {}, 'Children')
+React.createElement("div", 'Child 1', 'Child 2')
+```
+
+## Rule Options
+
+```json
+{ "react/no-children-prop": ["error", { "allowFunctions": false }] }
+```
+
+### allowFunctions
+
+Default: `false`.
+
+When enabled, function children are required to be passed as the `children` prop rather than nested between tags or passed as an additional `React.createElement` argument. This can be useful for libraries that rely on render-callbacks.
+
+Examples of **correct** code for this rule with `{ "allowFunctions": true }`:
+
+```json
+{ "react/no-children-prop": ["error", { "allowFunctions": true }] }
+```
+
+```jsx
+<MyComponent children={() => <div />} />
+React.createElement(MyComponent, { children: () => <div /> })
+```
+
+Examples of **incorrect** code for this rule with `{ "allowFunctions": true }`:
+
+```json
+{ "react/no-children-prop": ["error", { "allowFunctions": true }] }
+```
+
+```jsx
+<MyComponent>{() => <div />}</MyComponent>
+React.createElement(MyComponent, {}, () => <div />)
+```
+
+## Original Documentation
+
+- [eslint-plugin-react/no-children-prop](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md)

--- a/internal/plugins/react/rules/no_children_prop/no_children_prop_test.go
+++ b/internal/plugins/react/rules/no_children_prop/no_children_prop_test.go
@@ -1,0 +1,445 @@
+package no_children_prop
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoChildrenPropRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoChildrenPropRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<div />;`, Tsx: true},
+		{Code: `<div></div>;`, Tsx: true},
+		{Code: `React.createElement("div", {});`, Tsx: true},
+		{Code: `React.createElement("div", undefined);`, Tsx: true},
+		{Code: `<div className="class-name"></div>;`, Tsx: true},
+		{Code: `React.createElement("div", {className: "class-name"});`, Tsx: true},
+		{Code: `<div>Children</div>;`, Tsx: true},
+		{Code: `React.createElement("div", "Children");`, Tsx: true},
+		{Code: `React.createElement("div", {}, "Children");`, Tsx: true},
+		{Code: `React.createElement("div", undefined, "Children");`, Tsx: true},
+		{Code: `<div className="class-name">Children</div>;`, Tsx: true},
+		{Code: `React.createElement("div", {className: "class-name"}, "Children");`, Tsx: true},
+		{Code: `<div><div /></div>;`, Tsx: true},
+		{Code: `React.createElement("div", React.createElement("div"));`, Tsx: true},
+		{Code: `React.createElement("div", {}, React.createElement("div"));`, Tsx: true},
+		{Code: `React.createElement("div", undefined, React.createElement("div"));`, Tsx: true},
+		{Code: `<div><div /><div /></div>;`, Tsx: true},
+		{Code: `React.createElement("div", React.createElement("div"), React.createElement("div"));`, Tsx: true},
+		{Code: `React.createElement("div", {}, React.createElement("div"), React.createElement("div"));`, Tsx: true},
+		{Code: `React.createElement("div", undefined, React.createElement("div"), React.createElement("div"));`, Tsx: true},
+		{Code: `React.createElement("div", [React.createElement("div"), React.createElement("div")]);`, Tsx: true},
+		{Code: `React.createElement("div", {}, [React.createElement("div"), React.createElement("div")]);`, Tsx: true},
+		{Code: `React.createElement("div", undefined, [React.createElement("div"), React.createElement("div")]);`, Tsx: true},
+		{Code: `<MyComponent />`, Tsx: true},
+		{Code: `React.createElement(MyComponent);`, Tsx: true},
+		{Code: `React.createElement(MyComponent, {});`, Tsx: true},
+		{Code: `React.createElement(MyComponent, undefined);`, Tsx: true},
+		{Code: `<MyComponent>Children</MyComponent>;`, Tsx: true},
+		{Code: `React.createElement(MyComponent, "Children");`, Tsx: true},
+		{Code: `React.createElement(MyComponent, {}, "Children");`, Tsx: true},
+		{Code: `React.createElement(MyComponent, undefined, "Children");`, Tsx: true},
+		{Code: `<MyComponent className="class-name"></MyComponent>;`, Tsx: true},
+		{Code: `React.createElement(MyComponent, {className: "class-name"});`, Tsx: true},
+		{Code: `<MyComponent className="class-name">Children</MyComponent>;`, Tsx: true},
+		{Code: `React.createElement(MyComponent, {className: "class-name"}, "Children");`, Tsx: true},
+		{Code: `<MyComponent className="class-name" {...props} />;`, Tsx: true},
+		{Code: `React.createElement(MyComponent, {className: "class-name", ...props});`, Tsx: true},
+
+		// ---- allowFunctions: functions passed as `children` prop are allowed ----
+		{
+			Code:    `<MyComponent children={() => {}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `<MyComponent children={function() {}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `<MyComponent children={async function() {}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `<MyComponent children={function* () {}} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {children: () => {}});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {children: function() {}});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {children: async function() {}});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {children: function* () {}});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+
+		// ---- Additional edge cases ----
+		// Without allowFunctions, a function child (as JSX children) is fine —
+		// the rule only complains about function children when the user opted in.
+		{Code: `<MyComponent>{() => {}}</MyComponent>;`, Tsx: true},
+		// A 3rd-arg function without allowFunctions is also fine.
+		{Code: `React.createElement(MyComponent, {}, () => {});`, Tsx: true},
+		// Non-React.createElement call with `children` in options doesn't match.
+		{Code: `someOther.createElement("div", {children: "x"});`, Tsx: true},
+		// A plain function call (not React.createElement) is ignored.
+		{Code: `foo({children: "x"});`, Tsx: true},
+		// String-keyed `"children"` is treated as an Identifier key by tsgo
+		// (both parse to a PropertyName), which matches ESLint's behavior on
+		// tsgo's normalized AST — see the invalid case below that locks this.
+		// Spread-only second arg has no `children` key.
+		{Code: `React.createElement("div", {...props});`, Tsx: true},
+		// Computed key is not recognized as the children prop.
+		{Code: `const k = "children"; React.createElement("div", {[k]: "x"});`, Tsx: true},
+		// String-keyed `"children"` is NOT matched — upstream's `'name' in prop.key`
+		// guard excludes StringLiteral keys.
+		{Code: `React.createElement("div", {"children": "x"});`, Tsx: true},
+		// Numeric key is also not matched.
+		{Code: `React.createElement("div", {1: "x"});`, Tsx: true},
+		// JSX Fragment child is ignored — the rule only listens to JsxElement.
+		{
+			Code:    `<>{() => {}}</>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		// allowFunctions + non-function JSX child expression — no `nestFunction`.
+		{
+			Code:    `<MyComponent>{someValue}</MyComponent>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		// JSXElement with multiple children never triggers `nestFunction`.
+		{
+			Code:    `<MyComponent>{() => {}}{() => {}}</MyComponent>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		// Paren-wrapped function in `children={...}` is unwrapped and allowed.
+		{
+			Code:    `<MyComponent children={(() => {})} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		// Paren-wrapped function in a createElement children prop is allowed.
+		{
+			Code:    `React.createElement(MyComponent, {children: (() => {})});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+		},
+		// Custom pragma via `settings.react.pragma` — `h.createElement(...)` is
+		// recognized, and `React.createElement(...)` is NOT (so the `children`
+		// prop here is just a plain property access, not a React call).
+		{
+			Code: `React.createElement("div", {children: "x"});`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "h"},
+			},
+		},
+		// Parenthesized createElement callee is still recognized — so a
+		// valid call with no `children` prop must still pass cleanly.
+		{Code: `(React.createElement)("div", {});`, Tsx: true},
+		// Parenthesized props object — still recognized; no children here.
+		{Code: `React.createElement("div", ({className: "x"}));`, Tsx: true},
+		// Generic createElement: `React.createElement<Props>(...)` — type args
+		// don't change the call shape.
+		{Code: `React.createElement<{}>("div", {});`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `<div children />;`, // not a valid use case but make sure we don't crash
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Message: msgNestChildren, Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div children="Children" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Message: msgNestChildren, Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div children={<div />} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div children={[<div />, <div />]} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div children="Children">Children</div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `React.createElement("div", {children: "Children"});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Message: msgPassChildrenAsArgs, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("div", {children: "Children"}, "Children");`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("div", {children: React.createElement("div")});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `React.createElement("div", {children: [React.createElement("div"), React.createElement("div")]});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<MyComponent children="Children" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `React.createElement(MyComponent, {children: "Children"});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<MyComponent className="class-name" children="Children" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 37},
+			},
+		},
+		{
+			Code: `React.createElement(MyComponent, {children: "Children", className: "class-name"});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<MyComponent {...props} children="Children" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 25},
+			},
+		},
+		{
+			Code: `React.createElement(MyComponent, {...props, children: "Children"})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<MyComponent>{() => {}}</MyComponent>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestFunction", Message: msgNestFunction, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<MyComponent>{function() {}}</MyComponent>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestFunction", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<MyComponent>{async function() {}}</MyComponent>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestFunction", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<MyComponent>{function* () {}}</MyComponent>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestFunction", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {}, () => {});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passFunctionAsArgs", Message: msgPassFunctionAsArgs, Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {}, function() {});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passFunctionAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {}, async function() {});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passFunctionAsArgs", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `React.createElement(MyComponent, {}, function* () {});`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passFunctionAsArgs", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Additional edge cases ----
+
+		// Shorthand `{children}` is still a children-prop reference — reported.
+		{
+			Code: `const children = "x"; React.createElement("div", {children});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 23},
+			},
+		},
+		// Multi-line JSX attribute position — reported at the attribute.
+		{
+			Code: "<div\n\tchildren=\"x\"\n/>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 2, Column: 2, EndLine: 2, EndColumn: 14},
+			},
+		},
+		// Without allowFunctions, a function literal as children prop still
+		// reports (the exemption requires the opt-in).
+		{
+			Code: `<MyComponent children={() => {}} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 14},
+			},
+		},
+		{
+			Code: `React.createElement(MyComponent, {children: () => {}});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		// With allowFunctions, a non-function value (e.g. variable reference)
+		// still reports.
+		{
+			Code:    `const fn = () => {}; <MyComponent children={fn} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 35},
+			},
+		},
+		// Parenthesized second arg — still unwrapped and inspected for children.
+		{
+			Code: `React.createElement("div", ({children: "x"}));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		// Parenthesized createElement callee — IsCreateElementCall unwraps it.
+		{
+			Code: `(React.createElement)("div", {children: "x"});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		// Custom pragma: `h.createElement(...)` is picked up when settings
+		// declares it.
+		{
+			Code: `h.createElement("div", {children: "x"});`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"pragma": "h"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		// Nested createElement: the outer `{children: ...}` fires; the inner
+		// call has its own props with no `children` so it does not fire.
+		{
+			Code: `React.createElement("div", {children: React.createElement("span", {})});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 1},
+			},
+		},
+		// Deeply nested JSX: only the innermost `<Inner>` with a function
+		// child triggers `nestFunction`; outer elements have element (not
+		// expression) children and are unaffected.
+		{
+			Code:    `<Outer><Mid><Inner>{() => {}}</Inner></Mid></Outer>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowFunctions": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestFunction", Line: 1, Column: 13, EndLine: 1, EndColumn: 38},
+			},
+		},
+		// Multiple createElement calls on one line: each is considered
+		// independently and the one with a `children` prop reports.
+		{
+			Code: `React.createElement("a", {}); React.createElement("b", {children: "x"});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "passChildrenAsArgs", Line: 1, Column: 31},
+			},
+		},
+		// Member-based user component `<Foo.Bar>` — `children` prop still reports.
+		{
+			Code: `const Foo: any = {}; Foo.Bar = () => null; const x = <Foo.Bar children="x" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nestChildren", Line: 1, Column: 63},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
+    './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-children-prop.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-children-prop.test.ts
@@ -1,0 +1,451 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-children-prop', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    { code: `<div />;` },
+    { code: `<div></div>;` },
+    { code: `React.createElement("div", {});` },
+    { code: `React.createElement("div", undefined);` },
+    { code: `<div className="class-name"></div>;` },
+    { code: `React.createElement("div", {className: "class-name"});` },
+    { code: `<div>Children</div>;` },
+    { code: `React.createElement("div", "Children");` },
+    { code: `React.createElement("div", {}, "Children");` },
+    { code: `React.createElement("div", undefined, "Children");` },
+    { code: `<div className="class-name">Children</div>;` },
+    {
+      code: `React.createElement("div", {className: "class-name"}, "Children");`,
+    },
+    { code: `<div><div /></div>;` },
+    { code: `React.createElement("div", React.createElement("div"));` },
+    { code: `React.createElement("div", {}, React.createElement("div"));` },
+    {
+      code: `React.createElement("div", undefined, React.createElement("div"));`,
+    },
+    { code: `<div><div /><div /></div>;` },
+    {
+      code: `React.createElement("div", React.createElement("div"), React.createElement("div"));`,
+    },
+    {
+      code: `React.createElement("div", {}, React.createElement("div"), React.createElement("div"));`,
+    },
+    {
+      code: `React.createElement("div", undefined, React.createElement("div"), React.createElement("div"));`,
+    },
+    {
+      code: `React.createElement("div", [React.createElement("div"), React.createElement("div")]);`,
+    },
+    {
+      code: `React.createElement("div", {}, [React.createElement("div"), React.createElement("div")]);`,
+    },
+    {
+      code: `React.createElement("div", undefined, [React.createElement("div"), React.createElement("div")]);`,
+    },
+    { code: `<MyComponent />` },
+    { code: `React.createElement(MyComponent);` },
+    { code: `React.createElement(MyComponent, {});` },
+    { code: `React.createElement(MyComponent, undefined);` },
+    { code: `<MyComponent>Children</MyComponent>;` },
+    { code: `React.createElement(MyComponent, "Children");` },
+    { code: `React.createElement(MyComponent, {}, "Children");` },
+    { code: `React.createElement(MyComponent, undefined, "Children");` },
+    { code: `<MyComponent className="class-name"></MyComponent>;` },
+    { code: `React.createElement(MyComponent, {className: "class-name"});` },
+    { code: `<MyComponent className="class-name">Children</MyComponent>;` },
+    {
+      code: `React.createElement(MyComponent, {className: "class-name"}, "Children");`,
+    },
+    {
+      code: `const props: any = {}; <MyComponent className="class-name" {...props} />;`,
+    },
+    {
+      code: `const props: any = {}; React.createElement(MyComponent, {className: "class-name", ...props});`,
+    },
+
+    // ---- allowFunctions ----
+    {
+      code: `<MyComponent children={() => {}} />;`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `<MyComponent children={function() {}} />;`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `<MyComponent children={async function() {}} />;`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `<MyComponent children={function* () {}} />;`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: () => {}});`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: function() {}});`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: async function() {}});`,
+      options: [{ allowFunctions: true }],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: function* () {}});`,
+      options: [{ allowFunctions: true }],
+    },
+
+    // ---- Additional edge cases ----
+    // Without allowFunctions, a function as JSX child is fine.
+    { code: `<MyComponent>{() => {}}</MyComponent>;` },
+    // Without allowFunctions, a 3rd-arg function is also fine.
+    { code: `React.createElement(MyComponent, {}, () => {});` },
+    // Non-React createElement is ignored.
+    {
+      code: `const someOther: any = {}; someOther.createElement("div", {children: "x"});`,
+    },
+    // allowFunctions + non-function JSX child expression — no nestFunction.
+    {
+      code: `const someValue: any = null; <MyComponent>{someValue}</MyComponent>;`,
+      options: [{ allowFunctions: true }],
+    },
+    // String-keyed `"children"` is NOT matched (upstream `'name' in prop.key`).
+    { code: `React.createElement("div", {"children": "x"});` },
+    // JSX Fragment child is ignored (only JsxElement is listened).
+    {
+      code: `<>{() => {}}</>;`,
+      options: [{ allowFunctions: true }],
+    },
+    // JsxElement with more than one child never fires `nestFunction`.
+    {
+      code: `<MyComponent>{() => {}}{() => {}}</MyComponent>;`,
+      options: [{ allowFunctions: true }],
+    },
+    // Paren-wrapped function inside `children={...}` is allowed with allowFunctions.
+    {
+      code: `<MyComponent children={(() => {})} />;`,
+      options: [{ allowFunctions: true }],
+    },
+    // Paren-wrapped function in createElement children prop is allowed.
+    {
+      code: `React.createElement(MyComponent, {children: (() => {})});`,
+      options: [{ allowFunctions: true }],
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `<div children />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `<div children="Children" />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `<div children={<div />} />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `<div children={[<div />, <div />]} />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `<div children="Children">Children</div>;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement("div", {children: "Children"});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement("div", {children: "Children"}, "Children");`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement("div", {children: React.createElement("div")});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement("div", {children: [React.createElement("div"), React.createElement("div")]});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `<MyComponent children="Children" />`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: "Children"});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `<MyComponent className="class-name" children="Children" />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: "Children", className: "class-name"});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `const props: any = {}; const x = <MyComponent {...props} children="Children" />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `const props: any = {}; React.createElement(MyComponent, {...props, children: "Children"})`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    {
+      code: `<MyComponent>{() => {}}</MyComponent>;`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `<MyComponent>{function() {}}</MyComponent>;`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `<MyComponent>{async function() {}}</MyComponent>;`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `<MyComponent>{function* () {}}</MyComponent>;`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {}, () => {});`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {}, function() {});`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {}, async function() {});`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {}, function* () {});`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.',
+        },
+      ],
+    },
+
+    // ---- Additional edge cases ----
+    // Shorthand `{children}` is still reported.
+    {
+      code: `const children = "x"; React.createElement("div", {children});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    // Without allowFunctions, a function children prop still reports.
+    {
+      code: `<MyComponent children={() => {}} />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    {
+      code: `React.createElement(MyComponent, {children: () => {}});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    // With allowFunctions, a non-function value (variable reference) still reports.
+    {
+      code: `const fn = () => {}; const x = <MyComponent children={fn} />;`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+    // Parenthesized second arg — still unwrapped and inspected.
+    {
+      code: `React.createElement("div", ({children: "x"}));`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    // Parenthesized createElement callee — IsCreateElementCall unwraps it.
+    {
+      code: `(React.createElement)("div", {children: "x"});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    // Nested createElement: only the outer call has a `children` prop.
+    {
+      code: `React.createElement("div", {children: React.createElement("span", {})});`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+        },
+      ],
+    },
+    // Deeply nested JSX: only the innermost JsxElement with a function child
+    // triggers `nestFunction`.
+    {
+      code: `<Outer><Mid><Inner>{() => {}}</Inner></Mid></Outer>;`,
+      options: [{ allowFunctions: true }],
+      errors: [
+        {
+          message:
+            'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
+        },
+      ],
+    },
+    // Member-based user component `<Foo.Bar>` — `children` prop still reports.
+    {
+      code: `const Foo: any = {}; Foo.Bar = () => null; const x = <Foo.Bar children="x" />;`,
+      errors: [
+        {
+          message:
+            'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-children-prop` rule from `eslint-plugin-react` to rslint.

The rule forbids passing children as a prop — both in JSX (`<Comp children={...}>`) and in `React.createElement(...)` calls — instructing users to nest children between tags or pass them as trailing arguments instead. The `allowFunctions` option exempts function literals passed as the `children` prop (render-callback pattern).

Implementation notes:
- Reuses `reactutil.IsCreateElementCall` / `reactutil.GetReactPragma` for pragma-aware call recognition.
- Uses `ast.IsFunctionExpressionOrArrowFunction` for the function-literal check, matching upstream's `isFunction`.
- Applies `ast.SkipParentheses` at every child-node access (second arg, third arg, property initializer, JsxExpression contents) so the tsgo AST's explicit ParenthesizedExpression nodes behave like ESTree's flattened shape.
- Property-name matching is restricted to Identifier keys (not StringLiteral/computed), mirroring upstream's `'name' in prop.key` guard.

Verified against upstream `eslint-plugin-react` on a constructed fixture covering every branch: 21/21 exact match without options, 22/22 with `{ allowFunctions: true }` (same line + messageId for each diagnostic). Also ran against rsbuild and rspack — both tools report 0 on the overlapping scope.

## Related Links

- Documentation: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-children-prop.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-children-prop.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).