### PR TITLE
feat: port rule react/jsx-no-duplicate-props

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -9,6 +9,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_bind"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_duplicate_props"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_multi_spaces"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
@@ -35,6 +36,7 @@ func GetAllRules() []rule.Rule {
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,
 		jsx_no_bind.JsxNoBindRule,
+		jsx_no_duplicate_props.JsxNoDuplicatePropsRule,
 		jsx_props_no_multi_spaces.JsxPropsNoMultiSpacesRule,
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -369,6 +369,32 @@ func GetJsxTagName(element *ast.Node) *ast.Node {
 	return nil
 }
 
+// GetJsxElementAttributes returns the attribute nodes of a JsxOpeningElement or
+// JsxSelfClosingElement, or nil for other kinds or when the element has no
+// attributes. Each returned node is either a JsxAttribute or a JsxSpreadAttribute.
+func GetJsxElementAttributes(element *ast.Node) []*ast.Node {
+	if element == nil {
+		return nil
+	}
+	var attrs *ast.Node
+	switch element.Kind {
+	case ast.KindJsxOpeningElement:
+		attrs = element.AsJsxOpeningElement().Attributes
+	case ast.KindJsxSelfClosingElement:
+		attrs = element.AsJsxSelfClosingElement().Attributes
+	default:
+		return nil
+	}
+	if attrs == nil {
+		return nil
+	}
+	list := attrs.AsJsxAttributes()
+	if list == nil || list.Properties == nil {
+		return nil
+	}
+	return list.Properties.Nodes
+}
+
 // IsDOMComponent reports whether a JSX opening/self-closing element refers to
 // an intrinsic (DOM) element like <div> or <svg:path>, rather than a user
 // component like <Foo> or <Foo.Bar>.

--- a/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props.go
+++ b/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props.go
@@ -1,0 +1,67 @@
+package jsx_no_duplicate_props
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var JsxNoDuplicatePropsRule = rule.Rule{
+	Name: "react/jsx-no-duplicate-props",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		ignoreCase := false
+		if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+			if v, ok := optsMap["ignoreCase"].(bool); ok {
+				ignoreCase = v
+			}
+		}
+
+		check := func(node *ast.Node) {
+			attrs := reactutil.GetJsxElementAttributes(node)
+			if len(attrs) == 0 {
+				return
+			}
+
+			seen := map[string]struct{}{}
+			for _, attr := range attrs {
+				// Spread attributes ({...x}) are filtered here; duplicate tracking
+				// across a spread continues to flag names seen before the spread,
+				// matching upstream eslint-plugin-react.
+				if !ast.IsJsxAttribute(attr) {
+					continue
+				}
+				nameNode := attr.AsJsxAttribute().Name()
+				if nameNode == nil {
+					continue
+				}
+				// Upstream: `if (typeof decl.name.name !== 'string') return;` —
+				// JSXNamespacedName's `.name` is a JSXIdentifier node, not a
+				// string, so namespaced attributes (e.g. `a:b`) are skipped
+				// entirely and do not participate in duplicate tracking.
+				if nameNode.Kind != ast.KindIdentifier {
+					continue
+				}
+				name := nameNode.AsIdentifier().Text
+				if ignoreCase {
+					name = strings.ToLower(name)
+				}
+				if _, dup := seen[name]; dup {
+					ctx.ReportNode(attr, rule.RuleMessage{
+						Id:          "noDuplicateProps",
+						Description: "No duplicate props allowed",
+					})
+					continue
+				}
+				seen[name] = struct{}{}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props.md
+++ b/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props.md
@@ -1,0 +1,43 @@
+# jsx-no-duplicate-props
+
+Disallow duplicate properties in JSX.
+
+## Rule Details
+
+Creating JSX elements with duplicate props can cause unexpected behavior in your application.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Hello name="John" name="John" />;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<Hello first="John" last="Doe" />;
+```
+
+## Rule Options
+
+```json
+{ "react/jsx-no-duplicate-props": ["error", { "ignoreCase": true }] }
+```
+
+### `ignoreCase`
+
+When `true` the rule ignores the case of the props. Defaults to `false`.
+
+Examples of **incorrect** code for this rule with `{ "ignoreCase": true }`:
+
+```json
+{ "react/jsx-no-duplicate-props": ["error", { "ignoreCase": true }] }
+```
+
+```jsx
+<Hello name="John" Name="John" />;
+```
+
+## Original Documentation
+
+- [eslint-plugin-react docs](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md)

--- a/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props_test.go
+++ b/internal/plugins/react/rules/jsx_no_duplicate_props/jsx_no_duplicate_props_test.go
@@ -1,0 +1,255 @@
+package jsx_no_duplicate_props
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoDuplicatePropsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoDuplicatePropsRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<App />;`, Tsx: true},
+		{Code: `<App {...this.props} />;`, Tsx: true},
+		{Code: `<App a b c />;`, Tsx: true},
+		{Code: `<App a b c A />;`, Tsx: true},
+		{Code: `<App {...this.props} a b c />;`, Tsx: true},
+		{Code: `<App c {...this.props} a b />;`, Tsx: true},
+		{Code: `<App a="c" b="b" c="a" />;`, Tsx: true},
+		{Code: `<App {...this.props} a="c" b="b" c="a" />;`, Tsx: true},
+		{Code: `<App c="a" {...this.props} a="c" b="b" />;`, Tsx: true},
+		{Code: `<App A a />;`, Tsx: true},
+		{Code: `<App A b a />;`, Tsx: true},
+		{Code: `<App A="a" b="b" B="B" />;`, Tsx: true},
+		{
+			Code:    `<App a:b="c" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreCase": true},
+		},
+
+		// ---- Additional edge cases ----
+		// Non-self-closing element without duplicates.
+		{Code: `<App a b></App>;`, Tsx: true},
+		// Spread between distinct props is fine.
+		{Code: `<App a {...x} b />;`, Tsx: true},
+		// Default (case-sensitive): different case counts as different.
+		{Code: `<App foo Foo FOO />;`, Tsx: true},
+		// Namespaced attributes skipped entirely (even if textually duplicated).
+		{Code: `<App a:b="1" a:b="2" />;`, Tsx: true},
+		// Namespaced attr next to Identifier attr of the same local name — still
+		// valid because namespaced is skipped and Identifier appears only once.
+		{Code: `<App a:b="1" a="2" a:b="3" />;`, Tsx: true},
+		// Nested JSX, each element's attributes are independent.
+		{Code: `<Outer a><Inner b /></Outer>;`, Tsx: true},
+		// JSX inside JSX expression container — the inner element is independent.
+		{Code: `<Outer a={<Inner b />} b />;`, Tsx: true},
+		// JSX Fragment wrapping duplicates-free children.
+		{Code: `<><A a /><B b /></>;`, Tsx: true},
+		// Member-access tag name (e.g. <Foo.Bar>) — rule acts on attributes only.
+		{Code: `<Foo.Bar a b />;`, Tsx: true},
+		// Boolean-shorthand attrs interleaved with equality-valued attrs.
+		{Code: `<App a b={1} c="x" />;`, Tsx: true},
+		// Only spread attributes — always valid.
+		{Code: `<App {...a} {...b} />;`, Tsx: true},
+		// Two identical spreads — still valid (spreads never participate).
+		{Code: `<App {...a} {...a} />;`, Tsx: true},
+		// Namespaced attrs stay unreported even under ignoreCase.
+		{
+			Code:    `<App a:b="1" A:B="2" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreCase": true},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `<App a a />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noDuplicateProps",
+					Message:   "No duplicate props allowed",
+					Line:      1, Column: 8, EndLine: 1, EndColumn: 9,
+				},
+			},
+		},
+		{
+			Code: `<App A b c A />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+			},
+		},
+		{
+			Code: `<App a="a" b="b" a="a" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 18, EndLine: 1, EndColumn: 23},
+			},
+		},
+		{
+			Code:    `<App A a />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreCase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+			},
+		},
+		{
+			Code:    `<App a b c A />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreCase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+			},
+		},
+		{
+			Code:    `<App A="a" b="b" B="B" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreCase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 18, EndLine: 1, EndColumn: 23},
+			},
+		},
+
+		// ---- Additional edge cases ----
+		// Duplicate inside a non-self-closing element.
+		{
+			Code: `<App a a></App>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+			},
+		},
+		// Spread does not reset duplicate tracking.
+		{
+			Code: `<App a {...x} a />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+			},
+		},
+		// Three duplicates — each subsequent dup reports.
+		{
+			Code: `<App a a a />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				{MessageId: "noDuplicateProps", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+			},
+		},
+		// Multi-line: the duplicate is on a later line.
+		{
+			Code: "<App\n  a\n  a\n/>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 3, Column: 3, EndLine: 3, EndColumn: 4},
+			},
+		},
+		// Namespaced attrs are skipped, but Identifier duplicates around them
+		// are still detected.
+		{
+			Code: `<App a:b="1" c c />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+			},
+		},
+		// Nested JSX: inner element has duplicates, outer is fine.
+		{
+			Code: `<Outer a><Inner b b /></Outer>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 19, EndLine: 1, EndColumn: 20},
+			},
+		},
+		// JSX inside JSX expression container — both outer and inner can report
+		// independently, proving per-element scoping.
+		{
+			Code: `<Outer a a={<Inner b b />} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 10, EndLine: 1, EndColumn: 27},
+				{MessageId: "noDuplicateProps", Line: 1, Column: 22, EndLine: 1, EndColumn: 23},
+			},
+		},
+		// Member-access tag with duplicate props.
+		{
+			Code: `<Foo.Bar x x />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+			},
+		},
+		// Fragment wrapping multiple elements — each checked independently.
+		{
+			Code: `<><A a a /><B b b /></>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				{MessageId: "noDuplicateProps", Line: 1, Column: 17, EndLine: 1, EndColumn: 18},
+			},
+		},
+		// Two distinct duplicate pairs — each dup reports.
+		{
+			Code: `<App a a b b />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+				{MessageId: "noDuplicateProps", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+			},
+		},
+		// Comment between dup and rest does not affect column of the dup itself.
+		{
+			Code: `<App a a /* comment */ />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 8, EndLine: 1, EndColumn: 9},
+			},
+		},
+		// Reserved word used as attribute name is still an Identifier and checked.
+		{
+			Code: `<App class class />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 12, EndLine: 1, EndColumn: 17},
+			},
+		},
+		// Prototype-like attribute names — Go map does not false-negative via
+		// prototype inheritance; upstream uses an ownership check to reach the same answer.
+		{
+			Code: `<App hasOwnProperty hasOwnProperty />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 21, EndLine: 1, EndColumn: 35},
+			},
+		},
+		// Boolean-shorthand attribute duplicated by a valued attribute of the
+		// same name — name-only comparison, initializer is irrelevant.
+		{
+			Code: `<App disabled disabled={true} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 15, EndLine: 1, EndColumn: 30},
+			},
+		},
+		// Expression-initialized attributes (numeric literal).
+		{
+			Code: `<App a={1} a={2} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 12, EndLine: 1, EndColumn: 17},
+			},
+		},
+		// ignoreCase: three case-insensitive duplicates — two reports.
+		{
+			Code:    `<App foo Foo FOO />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignoreCase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDuplicateProps", Line: 1, Column: 10, EndLine: 1, EndColumn: 13},
+				{MessageId: "noDuplicateProps", Line: 1, Column: 14, EndLine: 1, EndColumn: 17},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -91,6 +91,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts
@@ -1,0 +1,72 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-duplicate-props', {} as never, {
+  valid: [
+    { code: `<App />;` },
+    { code: `<App {...this.props} />;` },
+    { code: `<App a b c />;` },
+    { code: `<App a b c A />;` },
+    { code: `<App {...this.props} a b c />;` },
+    { code: `<App c {...this.props} a b />;` },
+    { code: `<App a="c" b="b" c="a" />;` },
+    { code: `<App {...this.props} a="c" b="b" c="a" />;` },
+    { code: `<App c="a" {...this.props} a="c" b="b" />;` },
+    { code: `<App A a />;` },
+    { code: `<App A b a />;` },
+    { code: `<App A="a" b="b" B="B" />;` },
+    { code: `<App a:b="c" />;`, options: [{ ignoreCase: true }] },
+    // Non-self-closing element without duplicates.
+    { code: `<App a b></App>;` },
+    // Spread between distinct props is fine.
+    { code: `<App a {...x} b />;` },
+  ],
+  invalid: [
+    {
+      code: `<App a a />;`,
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    {
+      code: `<App A b c A />;`,
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    {
+      code: `<App a="a" b="b" a="a" />;`,
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    {
+      code: `<App A a />;`,
+      options: [{ ignoreCase: true }],
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    {
+      code: `<App a b c A />;`,
+      options: [{ ignoreCase: true }],
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    {
+      code: `<App A="a" b="b" B="B" />;`,
+      options: [{ ignoreCase: true }],
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    // Non-self-closing element with duplicates.
+    {
+      code: `<App a a></App>;`,
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    // Spread does not reset duplicate tracking.
+    {
+      code: `<App a {...x} a />;`,
+      errors: [{ message: 'No duplicate props allowed' }],
+    },
+    // Three duplicates — each subsequent dup reports.
+    {
+      code: `<App a a a />;`,
+      errors: [
+        { message: 'No duplicate props allowed' },
+        { message: 'No duplicate props allowed' },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-duplicate-props` rule from eslint-plugin-react to rslint.

The rule disallows duplicate properties in JSX. It listens on every JSX element and reports each repeated attribute name; `JSXSpreadAttribute` and `JSXNamespacedName` attributes are skipped (matching upstream's `typeof name !== 'string'` filter). Supports the `ignoreCase` option (default `false`).

Differential validation against `eslint-plugin-react@latest`:

- 19/19 upstream test cases migrated; 40 total Go cases (22 valid + 18 invalid) including nested JSX, fragments, multi-line elements, namespaced/Identifier mixes, member-access tags, reserved-word attribute names, prototype-like attribute names.
- Ran both tools on a probe with 10 edge scenarios inside `web-infra-dev/rsbuild` and `web-infra-dev/rspack`; every report (11 default, 12 with `ignoreCase: true`) matches `line` / `column` / `endLine` / `endColumn` byte-for-byte against the original rule.

## Related Links

- Rule doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-duplicate-props.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).