### PR TITLE
feat: port rule react/jsx-no-comment-textnodes

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -24,6 +24,8 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/style_prop_object"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/void_dom_elements_no_children"
 	"github.com/web-infra-dev/rslint/internal/rule"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_comment_textnodes"
 )
 
 func GetAllRules() []rule.Rule {
@@ -50,5 +52,6 @@ func GetAllRules() []rule.Rule {
 		self_closing_comp.SelfClosingCompRule,
 		style_prop_object.StylePropObjectRule,
 		void_dom_elements_no_children.VoidDomElementsNoChildrenRule,
+		jsx_no_comment_textnodes.JsxNoCommentTextnodesRule,
 	}
 }

--- a/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes.go
+++ b/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes.go
@@ -1,0 +1,137 @@
+package jsx_no_comment_textnodes
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// hasCommentLikeLine mirrors ESLint's `/^\s*\/(\/|\*)/m` test. It cannot be
+// expressed as a Go `regexp`: ECMAScript's `\s` covers Unicode WhiteSpace
+// (NBSP, BOM, Zs category, …) and `/m`'s `^` fires after LS/PS line
+// separators — Go's `regexp` does neither. We iterate lines manually instead.
+func hasCommentLikeLine(text string) bool {
+	rest := text
+	for {
+		lineEnd, termLen := indexJsLineTerminator(rest)
+		var line string
+		if lineEnd < 0 {
+			line = rest
+		} else {
+			line = rest[:lineEnd]
+		}
+		trimmed := strings.TrimLeftFunc(line, isJsWhitespace)
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
+			return true
+		}
+		if lineEnd < 0 {
+			return false
+		}
+		rest = rest[lineEnd+termLen:]
+	}
+}
+
+// indexJsLineTerminator returns the byte offset and width of the first
+// ECMAScript LineTerminator in s (LF, CR, CRLF, LS U+2028, PS U+2029), or
+// -1, 0 if none.
+func indexJsLineTerminator(s string) (int, int) {
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c == '\n' {
+			return i, 1
+		}
+		if c == '\r' {
+			if i+1 < len(s) && s[i+1] == '\n' {
+				return i, 2
+			}
+			return i, 1
+		}
+		if c < 0x80 {
+			i++
+			continue
+		}
+		if c == 0xE2 && i+2 < len(s) && s[i+1] == 0x80 && (s[i+2] == 0xA8 || s[i+2] == 0xA9) {
+			return i, 3
+		}
+		i++
+	}
+	return -1, 0
+}
+
+// isJsWhitespace matches ECMAScript `\s` minus LineTerminator (handled
+// separately): tab, vertical tab, form feed, space, NBSP (U+00A0), BOM
+// (U+FEFF), and any rune in Unicode category Zs.
+func isJsWhitespace(r rune) bool {
+	switch r {
+	case '\t', '\v', '\f', ' ', '\u00A0', '\uFEFF':
+		return true
+	}
+	return unicode.Is(unicode.Zs, r)
+}
+
+var JsxNoCommentTextnodesRule = rule.Rule{
+	Name: "react/jsx-no-comment-textnodes",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		return rule.RuleListeners{
+			// In tsgo, comment-like source (e.g. `<div>// foo</div>`) is parsed
+			// as a JsxText child of the surrounding JsxElement / JsxFragment.
+			// ESLint additionally registers a `Literal` listener because Babel
+			// can emit such text as a `Literal`, but tsgo never does — the two
+			// listeners collapse into this one.
+			ast.KindJsxText: func(node *ast.Node) {
+				parent := node.Parent
+				// ESLint's `parent.type !== 'JSXAttribute' && parent.type !==
+				// 'JSXExpressionContainer' && parent.type.indexOf('JSX') !== -1`
+				// collapses to this positive check — in tsgo, JsxText only ever
+				// appears as a direct child of JsxElement / JsxFragment.
+				if parent == nil || (!ast.IsJsxElement(parent) && !ast.IsJsxFragment(parent)) {
+					return
+				}
+				// Fast path: the parser marks JsxText nodes that are entirely
+				// whitespace/newlines — those can never match the comment regex.
+				jsxText := node.AsJsxText()
+				if jsxText == nil || jsxText.ContainsOnlyTriviaWhiteSpaces {
+					return
+				}
+				// Use raw source text, not any cooked representation: the
+				// upstream rule deliberately calls `getText(context, node)` so
+				// that HTML entities such as `&#x2F;` are NOT decoded before
+				// the comment test (see the `<pre>&#x2F;&#x2F; ...</pre>`
+				// valid case in the ESLint test suite).
+				//
+				// WARNING: `scanner.GetSourceTextOfNodeFromSourceFile` and
+				// `utils.TrimmedNodeText` can NOT be used here — they both
+				// advance past leading trivia via the TypeScript scanner, which
+				// interprets a JsxText starting with `//` or `/*` as a JS
+				// comment and returns a start position past the end of the
+				// node (producing an inverted slice). JsxText in JSX grammar
+				// is not subject to JS trivia rules, so slicing the source
+				// buffer directly is the only correct read.
+				source := ctx.SourceFile.Text()
+				startPos, endPos := node.Pos(), node.End()
+				if startPos < 0 || endPos > len(source) || startPos >= endPos {
+					return
+				}
+				raw := source[startPos:endPos]
+				if !hasCommentLikeLine(raw) {
+					return
+				}
+				// Report on the raw JsxText range, NOT via ReportNode: rslint's
+				// ReportNode trims leading trivia via the TypeScript scanner,
+				// which — faced with a JsxText that literally starts with `//`
+				// or `/*` — would treat those characters as comment trivia and
+				// skip past them, sending the diagnostic to the wrong position
+				// (or into the next token entirely). `//` inside a JsxText is
+				// not a comment in the JSX grammar, so we must keep the range
+				// verbatim.
+				ctx.ReportRange(core.NewTextRange(startPos, endPos), rule.RuleMessage{
+					Id:          "putCommentInBraces",
+					Description: "Comments inside children section of tag should be placed inside braces",
+				})
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes.md
+++ b/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes.md
@@ -1,0 +1,73 @@
+# jsx-no-comment-textnodes
+
+Disallow comments from being inserted as text nodes.
+
+This rule prevents comment strings (e.g. beginning with `//` or `/*`) from being
+accidentally injected as a text node in JSX statements. Comments in JSX must be
+wrapped in an expression container (`{/* ... */}`) to be treated as actual
+comments instead of literal text.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div>// empty div</div>;
+  },
+});
+
+var Hello = createReactClass({
+  render: function () {
+    return (
+      <div>
+        /* empty div */
+      </div>
+    );
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  displayName: 'Hello',
+  render: function () {
+    return <div>{/* empty div */}</div>;
+  },
+});
+
+var Hello = createReactClass({
+  displayName: 'Hello',
+  render: function () {
+    return <div /* empty div */></div>;
+  },
+});
+
+var Hello = createReactClass({
+  displayName: 'Hello',
+  render: function () {
+    return <div className={'foo' /* temp class */}></div>;
+  },
+});
+```
+
+## Legitimate uses
+
+It is possible to intentionally output comment-start characters (`//` or `/*`)
+inside a JSX text node — wrap the content in an expression container so the
+text is parsed as a string literal instead of a raw text node:
+
+```jsx
+var Hello = createReactClass({
+  render: function () {
+    return <div>{'/* This will be output as a text node */'}</div>;
+  },
+});
+```
+
+## Original Documentation
+
+- [eslint-plugin-react / jsx-no-comment-textnodes](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md)

--- a/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes_test.go
+++ b/internal/plugins/react/rules/jsx_no_comment_textnodes/jsx_no_comment_textnodes_test.go
@@ -1,0 +1,528 @@
+// cspell:ignore asdjfl
+package jsx_no_comment_textnodes
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoCommentTextnodesRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoCommentTextnodesRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: expression-container comment inside JsxElement ----
+		{Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {/* valid */}
+              </div>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: expression-container comment inside JsxFragment ----
+		{Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <>
+                {/* valid */}
+              </>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: inline expression-container comment ----
+		{Code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>{/* valid */}</div>);
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: parenthesized JSX assigned to variable ----
+		{Code: `
+        class Comp1 extends Component {
+          render() {
+            const bar = (<div>{/* valid */}</div>);
+            return bar;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass property is JSX with embedded comment ----
+		{Code: `
+        var Hello = createReactClass({
+          foo: (<div>{/* valid */}</div>),
+          render() {
+            return this.foo;
+          },
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: multiple valid expression-container comments ----
+		{Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {/* valid */}
+                {/* valid 2 */}
+                {/* valid 3 */}
+              </div>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: empty element ----
+		{Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+              </div>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: non-JSX source ----
+		{Code: `
+        var foo = require('foo');
+      `, Tsx: true},
+
+		// ---- Upstream: expression-container comment with attribute on parent ----
+		{Code: `
+        <Foo bar='test'>
+          {/* valid */}
+        </Foo>
+      `, Tsx: true},
+
+		// ---- Upstream: URL-like text with `//` embedded (not at line start) ----
+		{Code: `
+        <strong>
+          &nbsp;https://www.example.com/attachment/download/1
+        </strong>
+      `, Tsx: true},
+
+		// ---- Upstream: leading-trivia comment inside element declaration ----
+		{Code: `
+        <Foo /* valid */ placeholder={'foo'}/>
+      `, Tsx: true},
+
+		// ---- Upstream: leading-trivia comment between fragment tokens ----
+		{Code: `
+        </* valid */></>
+      `, Tsx: true},
+
+		// ---- Upstream: leading-trivia comment inside attribute expression ----
+		{Code: `
+        <Foo title={'foo' /* valid */}/>
+      `, Tsx: true},
+
+		// ---- Upstream: HTML-entity `//` is NOT decoded before the regex test ----
+		{Code: `<pre>&#x2F;&#x2F; TODO: Write perfect code</pre>`, Tsx: true},
+
+		// ---- Upstream: HTML-entity `/* ... */` is NOT decoded before the regex test ----
+		{Code: `<pre>&#x2F;&#42; TODO: Write perfect code &#42;&#x2F;</pre>`, Tsx: true},
+
+		// ---- Upstream: `//` entities inside a nested <span> with sibling text ----
+		{Code: `
+        <div>
+          <span className="pl-c"><span className="pl-c">&#47;&#47;</span> ...</span><br />
+        </div>
+      `, Tsx: true},
+
+		// ---- Edge: text contains `//` mid-line (not at line start) ----
+		{Code: `<div>value // trailing</div>`, Tsx: true},
+
+		// ---- Edge: purely whitespace text between siblings ----
+		{Code: `
+        <div>
+          <span/>
+          <span/>
+        </div>
+      `, Tsx: true},
+
+		// ---- Edge: single slash is not comment-like ----
+		{Code: `<div>/ not a comment</div>`, Tsx: true},
+
+		// ---- Edge: `//` appears mid-line and end-of-text, no line-start occurrence ----
+		{Code: `<div>hello //</div>`, Tsx: true},
+
+		// ---- Edge: `/ *` (space between) is not a block-comment open ----
+		{Code: `<div>/ * not a block comment</div>`, Tsx: true},
+
+		// ---- Edge: JSX inside a conditional expression — text has no `//` ----
+		{Code: `
+        const render = (ok) => ok ? <div>ok</div> : <div>fail</div>;
+      `, Tsx: true},
+
+		// ---- Edge: JSX inside a .map callback — text has no `//` ----
+		{Code: `
+        const list = items.map((i) => <li key={i}>{i}</li>);
+      `, Tsx: true},
+
+		// ---- Edge: JsxText between sibling JsxElements carries `//` INSIDE an
+		// expression container, not as bare text — still valid ----
+		{Code: `
+        <div>
+          <span />
+          {'// string literal is fine'}
+          <span />
+        </div>
+      `, Tsx: true},
+
+		// ---- Edge: deeply-nested JSX without any comment-like text ----
+		{Code: `
+        <div><section><article><p>hello world</p></article></section></div>
+      `, Tsx: true},
+
+		// ---- Edge: member-expression tag (Foo.Bar) with valid embedded comment ----
+		{Code: `<Foo.Bar>{/* valid */}</Foo.Bar>`, Tsx: true},
+
+		// ---- SKIP: ESLint accepts `<></* valid *//>` as a self-closing fragment
+		// with a leading-trivia comment between `<>` and `</>`. tsgo's parser
+		// rejects this as invalid JSX syntax, so there is no AST for the rule
+		// to inspect. Tracked upstream as `features: ['no-ts']`.
+		{Code: `<></* valid *//>`, Tsx: true, Skip: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: inline `// invalid` in JsxElement ----
+		{
+			Code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>// invalid</div>);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 4, Column: 26},
+			},
+		},
+
+		// ---- Upstream: inline `// invalid` in JsxFragment ----
+		{
+			Code: `
+        class Comp1 extends Component {
+          render() {
+            return (<>// invalid</>);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 4, Column: 23},
+			},
+		},
+
+		// ---- Upstream: inline `/* invalid */` in JsxElement ----
+		{
+			Code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>/* invalid */</div>);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 4, Column: 26},
+			},
+		},
+
+		// ---- Upstream: multi-line `// invalid` ----
+		{
+			Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                // invalid
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 5, Column: 20},
+			},
+		},
+
+		// ---- Upstream: `/* invalid */` surrounded by text lines ----
+		{
+			Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                asdjfl
+                /* invalid */
+                foo
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 5, Column: 20},
+			},
+		},
+
+		// ---- Upstream: `// invalid` between two expression containers splits
+		// JsxText into three — only the middle text node reports ----
+		{
+			Code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {'asdjfl'}
+                // invalid
+                {'foo'}
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 6, Column: 27},
+			},
+		},
+
+		// ---- Upstream: arrow function returning JSX with `/*` text ----
+		{
+			Code: `
+        const Component2 = () => {
+          return <span>/*</span>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces",
+					Message: "Comments inside children section of tag should be placed inside braces",
+					Line:    3, Column: 24},
+			},
+		},
+
+		// ---- Edge: comment-like text in a JsxFragment across multiple lines ----
+		{
+			Code: `
+        const C = () => (
+          <>
+            // invalid
+          </>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 3, Column: 13},
+			},
+		},
+
+		// ---- Edge: two sibling JsxElements, each with its own comment-like
+		// text — both should report (two separate JsxText nodes) ----
+		{
+			Code: `
+        const C = () => (
+          <div>
+            <span>// a</span>
+            <span>// b</span>
+          </div>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 4, Column: 19},
+				{MessageId: "putCommentInBraces", Line: 5, Column: 19},
+			},
+		},
+
+		// ---- Edge: nested JsxElement — the INNER <span> hosts the bad text,
+		// so exactly one diagnostic fires even though outer JsxText also
+		// surrounds it ----
+		{
+			Code: `
+        const C = () => (
+          <div>
+            <span>/* bad */</span>
+          </div>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: deeply-nested JsxElement (5 levels), bad text at innermost ----
+		{
+			Code: `
+        const C = () => (
+          <section>
+            <article>
+              <header>
+                <h1>
+                  <span>// deep</span>
+                </h1>
+              </header>
+            </article>
+          </section>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 7, Column: 25},
+			},
+		},
+
+		// ---- Edge: same JsxText contains BOTH `//` and `/*` — still a single
+		// diagnostic (one diagnostic per JsxText node, regardless of how many
+		// comment markers fall inside it) ----
+		{
+			Code: `
+        const C = () => (
+          <div>
+            // first
+            /* second */
+          </div>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 3, Column: 16},
+			},
+		},
+
+		// ---- Edge: tab-indented comment line (upstream regex uses `\s*`, so
+		// tabs qualify as leading whitespace) ----
+		{
+			Code: "<div>\n\t\t// tab-indented\n</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Edge: JSX in a conditional expression, bad text in one branch ----
+		{
+			Code: `
+        const render = (ok) => ok ? <div>// bad</div> : <div>ok</div>;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 2, Column: 42},
+			},
+		},
+
+		// ---- Edge: JSX inside `.map` callback with bad text ----
+		{
+			Code: `
+        const list = items.map((i) => <li key={i}>// {i}</li>);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 2, Column: 51},
+			},
+		},
+
+		// ---- Edge: member-expression tag (Foo.Bar) with bad text ----
+		{
+			Code: `<Foo.Bar>// bad</Foo.Bar>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 1, Column: 10},
+			},
+		},
+
+		// ---- Edge: JsxText with bad text split across multiple non-leading
+		// lines (content has text on first line, then `//` on a later line) ----
+		{
+			Code: `
+        const C = () => (
+          <div>
+            line1
+            line2
+            // bad
+          </div>
+        );
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 3, Column: 16},
+			},
+		},
+
+		// ---- Edge: NBSP (U+00A0) as leading whitespace before `//`. ESLint's
+		// `\s` covers Unicode WhiteSpace — mirrored via `unicode.Is(Zs, r)`. ----
+		{
+			Code: "<div>\n\u00A0\u00A0// bad\n</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Edge: LINE SEPARATOR (U+2028) acts as a line boundary under
+		// ECMAScript `/m` — so text after it should be scanned for `//`. ----
+		{
+			Code: "<div>\u2028// bad</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Edge: IDEOGRAPHIC SPACE (U+3000, Zs category) as indent ----
+		{
+			Code: "<div>\n\u3000// bad\n</div>",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Edge: multi-byte characters (CJK, 3 UTF-8 bytes / 1 UTF-16 unit)
+		// preceding the JsxText. Locks in that node.Pos()/End() are UTF-8 byte
+		// offsets into SourceFile.Text() — slicing must stay byte-aligned while
+		// the reported column remains in UTF-16 units (matching ESLint). ----
+		{
+			Code: "const x = '你好';\nconst y = <div>// bad</div>;\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 2, Column: 16},
+			},
+		},
+
+		// ---- Edge: CJK inside the JsxText, followed by `//` on the next line.
+		// The slice must include the multi-byte prefix without corrupting it. ----
+		{
+			Code: "const C = () => <div>你好\n// bad\n</div>;\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 1, Column: 22},
+			},
+		},
+
+		// ---- Edge: emoji (4 UTF-8 bytes / 2 UTF-16 surrogate units) before
+		// the JsxText. Verifies the byte-slice path on supplementary-plane
+		// characters too. ----
+		{
+			Code: "const e = '🚀';\nconst y = <div>/* bad */</div>;\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "putCommentInBraces", Line: 2, Column: 16},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -91,6 +91,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts
@@ -1,0 +1,247 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-comment-textnodes', {} as never, {
+  valid: [
+    // ---- Upstream: expression-container comment inside JsxElement ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {/* valid */}
+              </div>
+            );
+          }
+        }
+      `,
+    },
+    // ---- Upstream: expression-container comment inside JsxFragment ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <>
+                {/* valid */}
+              </>
+            );
+          }
+        }
+      `,
+    },
+    // ---- Upstream: inline expression-container comment ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>{/* valid */}</div>);
+          }
+        }
+      `,
+    },
+    // ---- Upstream: createReactClass property is JSX with embedded comment ----
+    {
+      code: `
+        var Hello = createReactClass({
+          foo: (<div>{/* valid */}</div>),
+          render() {
+            return this.foo;
+          },
+        });
+      `,
+    },
+    // ---- Upstream: empty element ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+              </div>
+            );
+          }
+        }
+      `,
+    },
+    // ---- Upstream: URL-like text with `//` embedded (not at line start) ----
+    {
+      code: `
+        <strong>
+          &nbsp;https://www.example.com/attachment/download/1
+        </strong>
+      `,
+    },
+    // ---- Upstream: leading-trivia comment inside element declaration ----
+    {
+      code: `
+        <Foo /* valid */ placeholder={'foo'}/>
+      `,
+    },
+    // ---- Upstream: HTML-entity `//` is NOT decoded before the regex test ----
+    {
+      code: `<pre>&#x2F;&#x2F; TODO: Write perfect code</pre>`,
+    },
+    // ---- Upstream: HTML-entity `/* ... */` is NOT decoded ----
+    {
+      code: `<pre>&#x2F;&#42; TODO: Write perfect code &#42;&#x2F;</pre>`,
+    },
+    // ---- Edge: text contains `//` mid-line (not at line start) ----
+    {
+      code: `<div>value // trailing</div>`,
+    },
+    // ---- Edge: single slash is not a comment marker ----
+    {
+      code: `<div>/ not a comment</div>`,
+    },
+    // ---- Edge: `/ *` (space between) is not a block-comment open ----
+    {
+      code: `<div>/ * not a block comment</div>`,
+    },
+    // ---- Edge: member-expression tag with valid embedded comment ----
+    {
+      code: `<Foo.Bar>{/* valid */}</Foo.Bar>`,
+    },
+    // ---- Edge: JSX in .map callback, no bad text ----
+    {
+      code: `const list = items.map((i) => <li key={i}>{i}</li>);`,
+    },
+  ],
+  invalid: [
+    // ---- Upstream: inline `// invalid` in JsxElement ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>// invalid</div>);
+          }
+        }
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Upstream: inline `// invalid` in JsxFragment ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (<>// invalid</>);
+          }
+        }
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Upstream: inline `/* invalid */` in JsxElement ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>/* invalid */</div>);
+          }
+        }
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Upstream: multi-line `// invalid` ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                // invalid
+              </div>
+            );
+          }
+        }
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Upstream: `/* invalid */` surrounded by text lines ----
+    {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                asdjfl
+                /* invalid */
+                foo
+              </div>
+            );
+          }
+        }
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Upstream: arrow function returning JSX with `/*` text ----
+    {
+      code: `
+        const Component2 = () => {
+          return <span>/*</span>;
+        };
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Edge: two sibling JsxElements, each with its own comment-like text ----
+    {
+      code: `
+        const C = () => (
+          <div>
+            <span>// a</span>
+            <span>// b</span>
+          </div>
+        );
+      `,
+      errors: [
+        { messageId: 'putCommentInBraces' },
+        { messageId: 'putCommentInBraces' },
+      ],
+    },
+    // ---- Edge: deeply-nested JSX with bad text at innermost ----
+    {
+      code: `
+        const C = () => (
+          <section>
+            <article>
+              <header>
+                <h1>
+                  <span>// deep</span>
+                </h1>
+              </header>
+            </article>
+          </section>
+        );
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Edge: JSX in conditional expression — bad text in one branch ----
+    {
+      code: `const render = (ok) => ok ? <div>// bad</div> : <div>ok</div>;`,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Edge: JSX in .map callback with bad text ----
+    {
+      code: `const list = items.map((i) => <li key={i}>// {i}</li>);`,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Edge: member-expression tag with bad text ----
+    {
+      code: `<Foo.Bar>// bad</Foo.Bar>`,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+    // ---- Edge: same JsxText carries BOTH `//` and `/*` → single diagnostic ----
+    {
+      code: `
+        const C = () => (
+          <div>
+            // first
+            /* second */
+          </div>
+        );
+      `,
+      errors: [{ messageId: 'putCommentInBraces' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-comment-textnodes` rule from `eslint-plugin-react` to rslint.

The rule flags comment-like strings (e.g. starting with `//` or `/*`) that appear as JSX text nodes instead of being wrapped in an expression container (`{/* ... */}`).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-comment-textnodes.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-comment-textnodes.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).