### PR TITLE
feat: port rule react/require-render-return

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -20,6 +20,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/style_prop_object"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/void_dom_elements_no_children"
@@ -47,6 +48,7 @@ func GetAllRules() []rule.Rule {
 		no_string_refs.NoStringRefsRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
+		require_render_return.RequireRenderReturnRule,
 		self_closing_comp.SelfClosingCompRule,
 		style_prop_object.StylePropObjectRule,
 		void_dom_elements_no_children.VoidDomElementsNoChildrenRule,

--- a/internal/plugins/react/rules/require_render_return/require_render_return.go
+++ b/internal/plugins/react/rules/require_render_return/require_render_return.go
@@ -1,0 +1,239 @@
+package require_render_return
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// isFunctionLikeExpression mirrors eslint-plugin-react's astUtil.isFunctionLikeExpression:
+// an expression whose value is a function (FunctionExpression or ArrowFunction),
+// not a regular function declaration.
+func isFunctionLikeExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+		return true
+	}
+	return false
+}
+
+// memberName returns the Identifier text of a class/object member's key, or "".
+//
+// Mirrors eslint-plugin-react's astUtil.getPropertyName, which reads only
+// `nameNode.name`. Consequently, non-Identifier keys — string literals
+// (`"render": fn`), numeric keys, computed keys (`['render']()`,
+// `` [`render`]() ``, `[tag`render`]()`), etc. — all map to "" and never
+// match `render`. Only a bare Identifier key `render` qualifies.
+func memberName(member *ast.Node) string {
+	if member == nil {
+		return ""
+	}
+	switch member.Kind {
+	case ast.KindMethodDeclaration,
+		ast.KindPropertyAssignment,
+		ast.KindShorthandPropertyAssignment,
+		ast.KindPropertyDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+	default:
+		return ""
+	}
+	name := member.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+// findAllRenderMembers returns every member whose Identifier key is `render`
+// and whose value is function-like (accessor/shorthand method / FE / arrow).
+//
+// Mirrors the *filter* in eslint-plugin-react's findRenderMethod, which does
+// not short-circuit on the first match — the rule's Program:exit still
+// considers the component "OK" if ANY render-named member has a return
+// statement (tracked via `markReturnStatementPresent`). So we must examine
+// every qualifying member for returns, not just the first.
+func findAllRenderMembers(members []*ast.Node) []*ast.Node {
+	var out []*ast.Node
+	for _, m := range members {
+		if memberName(m) != "render" {
+			continue
+		}
+		switch m.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			out = append(out, m)
+		case ast.KindPropertyAssignment:
+			if isFunctionLikeExpression(m.AsPropertyAssignment().Initializer) {
+				out = append(out, m)
+			}
+		case ast.KindPropertyDeclaration:
+			if isFunctionLikeExpression(m.AsPropertyDeclaration().Initializer) {
+				out = append(out, m)
+			}
+		}
+	}
+	return out
+}
+
+// renderFunctionOf returns the function-like node that carries the render
+// body: the MethodDeclaration / accessor itself for class/object shorthand
+// methods, or the FunctionExpression / ArrowFunction initializer for
+// property-style render.
+func renderFunctionOf(member *ast.Node) *ast.Node {
+	switch member.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return member
+	case ast.KindPropertyAssignment:
+		return member.AsPropertyAssignment().Initializer
+	case ast.KindPropertyDeclaration:
+		return member.AsPropertyDeclaration().Initializer
+	}
+	return nil
+}
+
+// hasReturnInBody walks `body` (a Block) looking for a ReturnStatement at
+// "depth ≤ 1" in ESLint's sense — i.e. not inside a nested function-like
+// boundary.
+//
+// eslint-plugin-react's depth regex `/Function(Expression|Declaration)$/`
+// is UNANCHORED, so it matches both `FunctionExpression` and
+// `ArrowFunctionExpression` (suffix match). Consequently arrows are NOT
+// transparent — a return inside a nested arrow inside `render()` does not
+// count as render's return. `MethodDefinition` / accessor wrappers don't
+// match the regex directly, but in tsgo those kinds are themselves the
+// function node (no ESTree FunctionExpression child wrapper), so stopping
+// at them is the correct equivalent of ESLint counting the inner
+// FunctionExpression.
+func hasReturnInBody(body *ast.Node) bool {
+	if body == nil {
+		return false
+	}
+	found := false
+	var walk ast.Visitor
+	walk = func(n *ast.Node) bool {
+		if found || n == nil {
+			return found
+		}
+		switch n.Kind {
+		case ast.KindReturnStatement:
+			found = true
+			return true
+		case ast.KindFunctionExpression,
+			ast.KindFunctionDeclaration,
+			ast.KindArrowFunction,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor:
+			// Do not descend: a return inside these would bump ESLint's
+			// depth counter past 1 and therefore not mark the outer render.
+			return false
+		}
+		n.ForEachChild(walk)
+		return found
+	}
+	walk(body)
+	return found
+}
+
+// renderReturns reports whether the render function-like value either has an
+// implicit return (arrow with expression body) or contains a qualifying
+// ReturnStatement in its block body.
+func renderReturns(fn *ast.Node) bool {
+	if fn == nil {
+		return false
+	}
+	switch fn.Kind {
+	case ast.KindArrowFunction:
+		af := fn.AsArrowFunction()
+		if af.Body == nil {
+			return false
+		}
+		if af.Body.Kind != ast.KindBlock {
+			// Implicit return: `render = () => <div/>`.
+			return true
+		}
+		return hasReturnInBody(af.Body)
+	case ast.KindFunctionExpression:
+		return hasReturnInBody(fn.AsFunctionExpression().Body)
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		var body *ast.Node
+		switch fn.Kind {
+		case ast.KindMethodDeclaration:
+			body = fn.AsMethodDeclaration().Body
+		case ast.KindGetAccessor:
+			body = fn.AsGetAccessorDeclaration().Body
+		case ast.KindSetAccessor:
+			body = fn.AsSetAccessorDeclaration().Body
+		}
+		if body == nil {
+			// Overload signature / abstract / ambient method — not a concrete
+			// body we'd reasonably demand a return from. Mirrors ESLint's
+			// default behavior, which never reaches this state in practice.
+			return true
+		}
+		return hasReturnInBody(body)
+	}
+	return false
+}
+
+var RequireRenderReturnRule = rule.Rule{
+	Name: "react/require-render-return",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		report := func(member *ast.Node) {
+			ctx.ReportNode(member, rule.RuleMessage{
+				Id:          "noRenderReturn",
+				Description: "Your render method should have a return statement",
+			})
+		}
+
+		checkComponent := func(members []*ast.Node) {
+			renders := findAllRenderMembers(members)
+			if len(renders) == 0 {
+				return
+			}
+			for _, m := range renders {
+				if renderReturns(renderFunctionOf(m)) {
+					return
+				}
+			}
+			// None of the render-named members has a return. Report on the
+			// first one — matches eslint-plugin-react's `findRenderMethod`,
+			// which reports on the first qualifying member.
+			report(renders[0])
+		}
+
+		checkClass := func(classNode *ast.Node) {
+			if !reactutil.ExtendsReactComponent(classNode, pragma) {
+				return
+			}
+			checkComponent(classNode.Members())
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: checkClass,
+			ast.KindClassExpression:  checkClass,
+
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !reactutil.IsCreateClassCall(call, pragma, createClass) {
+					return
+				}
+				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				arg := ast.SkipParentheses(call.Arguments.Nodes[0])
+				if arg.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				checkComponent(arg.AsObjectLiteralExpression().Properties.Nodes)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/require_render_return/require_render_return.md
+++ b/internal/plugins/react/rules/require_render_return/require_render_return.md
@@ -1,6 +1,6 @@
 # react/require-render-return
 
-Enforce ES5 or ES6 class for returning value in render function.
+Enforce that the render method of an ES5 or ES6 React component returns a value.
 
 When writing the `render` method in a component it is easy to forget to return
 the JSX content. This rule will warn if the `return` statement is missing.

--- a/internal/plugins/react/rules/require_render_return/require_render_return.md
+++ b/internal/plugins/react/rules/require_render_return/require_render_return.md
@@ -1,0 +1,92 @@
+# react/require-render-return
+
+Enforce ES5 or ES6 class for returning value in render function.
+
+When writing the `render` method in a component it is easy to forget to return
+the JSX content. This rule will warn if the `return` statement is missing.
+
+## Rule Details
+
+This rule applies to components written as either:
+
+- An ES5-style `createReactClass({ ... })` (or `<pragma>.createReactClass({ ... })`) object.
+- An ES6 class extending `Component` / `PureComponent` (bare or qualified by the React pragma).
+
+For each such component it inspects every member whose *Identifier* key is
+`render`:
+
+- A class method `render() { ... }` or an object shorthand `render() { ... }`.
+- A property assignment `render: function () { ... }` or `render: () => { ... }`.
+- A class field `render = function () { ... }` or `render = () => { ... }`.
+- A getter or setter `get render() { ... }` / `set render(v) { ... }`.
+
+Non-Identifier keys are *not* considered `render`:
+
+- String-literal keys (`"render"() { ... }` / `"render": function () { ... }`)
+- Computed keys (`['render']() { ... }`, `` [`render`]() { ... } ``, `[tag`render`]() { ... }`)
+- Numeric / BigInt keys
+
+This mirrors upstream `astUtil.getPropertyName`, which reads only
+`nameNode.name` — so anything that isn't a plain identifier returns `""` and
+fails the `render` match.
+
+A `render` whose value is anything other than a FunctionExpression /
+ArrowFunction (or a shorthand method / accessor, which are themselves
+function-like) is ignored.
+
+The component is considered to return when *any* `render`-named member
+satisfies one of:
+
+1. It is an arrow function with an expression body (implicit return), e.g. `render = () => <div/>`.
+2. Its block body contains a `return` statement that is not nested inside
+   another function-like boundary (FunctionExpression, FunctionDeclaration,
+   ArrowFunction, MethodDeclaration, accessor, constructor).
+
+Upstream's depth regex `/Function(Expression|Declaration)$/` is unanchored, so
+`ArrowFunctionExpression` is also captured — meaning a `return` inside a
+nested arrow (IIFE or otherwise) inside `render()` does *not* count as
+render's own return. This rule follows that behavior exactly.
+
+When multiple members are named `render` (e.g. `static render` alongside an
+instance `render`), the component passes as soon as any one of them has a
+qualifying return. If none do, the first matching member is reported.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  render() {
+    <div>Hello</div>;
+  },
+});
+```
+
+```jsx
+class Hello extends React.Component {
+  render() {
+    <div>Hello</div>;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = createReactClass({
+  render() {
+    return <div>Hello</div>;
+  },
+});
+```
+
+```jsx
+class Hello extends React.Component {
+  render() {
+    return <div>Hello</div>;
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react / require-render-return](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-render-return.md)

--- a/internal/plugins/react/rules/require_render_return/require_render_return_test.go
+++ b/internal/plugins/react/rules/require_render_return/require_render_return_test.go
@@ -1,0 +1,933 @@
+package require_render_return
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestRequireRenderReturnRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &RequireRenderReturnRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: ES6 class ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ES6 class with render property (arrow + block + return) ----
+		{Code: `
+        class Hello extends React.Component {
+          render = () => {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ES6 class with render property (implicit return) ----
+		{Code: `
+        class Hello extends React.Component {
+          render = () => (
+            <div>Hello {this.props.name}</div>
+          )
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ES5 class ----
+		{Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div></div>
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: Stateless function ----
+		{Code: `
+        function Hello() {
+          return <div></div>;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: Stateless arrow function ----
+		{Code: `
+        var Hello = () => (
+          <div></div>
+        );
+      `, Tsx: true},
+
+		// ---- Upstream: Return in a switch...case ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            switch (this.props.name) {
+              case 'Foo':
+                return <div>Hello Foo</div>;
+              default:
+                return <div>Hello {this.props.name}</div>;
+            }
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: Return in a if...else ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            if (this.props.name === 'Foo') {
+              return <div>Hello Foo</div>;
+            } else {
+              return <div>Hello {this.props.name}</div>;
+            }
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: Not a React component (class doesn't extend Component) ----
+		{Code: `
+        class Hello {
+          render() {}
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ES6 class without a render method ----
+		{Code: `class Hello extends React.Component {}`, Tsx: true},
+
+		// ---- Upstream: ES5 class without a render method ----
+		{Code: `var Hello = createReactClass({});`, Tsx: true},
+
+		// ---- Upstream: ES5 class with imported (shorthand) render method ----
+		{Code: `
+        var render = require('./render');
+        var Hello = createReactClass({
+          render
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: Invalid render method (field without initializer) ----
+		{Code: `
+        class Foo extends Component {
+          render
+        }
+      `, Tsx: true},
+
+		// ---- Edge: PureComponent is also a React component ----
+		{Code: `
+        class Hello extends React.PureComponent {
+          render() {
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bare Component identifier ----
+		{Code: `
+        class Hello extends Component {
+          render() {
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: pragma-qualified createReactClass ----
+		{Code: `
+        var Hello = React.createReactClass({
+          render: function() {
+            return <div/>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: render as FunctionExpression inside class field (not arrow) ----
+		{Code: `
+        class Hello extends React.Component {
+          render = function() {
+            return <div/>;
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Edge: ES5 class with shorthand render method ----
+		{Code: `
+        var Hello = createReactClass({
+          render() {
+            return <div/>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: returning a ternary still counts ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return this.props.ok ? <div/> : null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: return statement nested inside an if block ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            if (!this.props.ready) {
+              return null;
+            }
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: multiple render-named members — any one with a return marks the component OK ----
+		// Mirrors ESLint's markReturnStatementPresent tracking the whole
+		// component, not any particular render method.
+		{Code: `
+        class Hello extends React.Component {
+          static render() {}
+          render() { return <div/>; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: string-literal key "render" is NOT matched (ESLint's getPropertyName only reads nameNode.name) ----
+		// So this component is treated as having NO render method → not flagged.
+		{Code: `
+        class Hello extends React.Component {
+          "render"() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: non-React class with an inner React component — only the React inner class is examined ----
+		{Code: `
+        class Outer {
+          render() {}
+          inner() {
+            class Inner extends React.Component {
+              render() {
+                return <div/>;
+              }
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: createReactClass invoked with zero arguments is safely ignored ----
+		{Code: `createReactClass();`, Tsx: true},
+
+		// ---- Edge: createReactClass invoked with a non-object argument is safely ignored ----
+		{Code: `createReactClass(1);`, Tsx: true},
+
+		// ---- Edge: custom pragma — React-like name configured via settings ----
+		{
+			Code: `
+        class Hello extends Preact.Component {
+          render() {
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+		},
+
+		// ---- Edge: string-literal key in ES5 object is NOT matched — component has no render by ESLint's rules ----
+		{Code: `
+        var Hello = createReactClass({
+          "render": function() {}
+        });
+      `, Tsx: true},
+
+		// ---- Edge: computed key `['render']` — Literal inside ComputedPropertyName, name is undefined → not matched ----
+		{Code: `
+        class Hello extends React.Component {
+          ['render']() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: template-literal key (NoSubstitutionTemplateLiteral) — no .name → not matched ----
+		{Code: `
+        class Hello extends React.Component {
+          [` + "`render`" + `]() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: getter render with a return ----
+		{Code: `
+        class Hello extends React.Component {
+          get render() {
+            return () => <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bare `return;` still counts as having a return ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: return inside try / catch / finally ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            try {
+              return <div/>;
+            } catch (e) {}
+          }
+        }
+      `, Tsx: true},
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            try {} finally { return <div/>; }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: return inside for / while ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            for (let i = 0; i < 1; i++) { return <div/>; }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: parens-wrapped ClassExpression assignment ----
+		{Code: `
+        var Hello = (class extends React.Component {
+          render() {
+            return <div/>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: parens-wrapped createReactClass callee ----
+		{Code: `
+        var Hello = (createReactClass)({
+          render: function() {
+            return <div/>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: parens-wrapped object argument to createReactClass ----
+		{Code: `
+        var Hello = createReactClass(({
+          render: function() {
+            return <div/>;
+          }
+        }));
+      `, Tsx: true},
+
+		// ---- Edge: class extending an intermediate (not Component) — not a React component ----
+		{Code: `
+        class Middle extends React.Component {
+          render() { return <div/>; }
+        }
+        class Hello extends Middle {
+          render() {}
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `declare class` render overload (no body) — skipped ----
+		{Code: `
+        declare class Hello extends React.Component {
+          render(): JSX.Element;
+        }
+      `, Tsx: true},
+
+		// ---- Edge: React.memo wrapping a bare class (not extending Component) — not a React component ----
+		{Code: `const Foo = React.memo(class { render() {} });`, Tsx: true},
+
+		// ---- Edge: aliased `createReactClass` via a variable — not detected (literal call only) ----
+		{Code: `
+        const c = createReactClass;
+        c({ render: function() {} });
+      `, Tsx: true},
+
+		// ---- Edge: inner-class static block with IIFE — outer render body has no direct return → fires on outer, not inner ----
+		// (Pure regression lock: walker must stop at the IIFE's FunctionExpression.)
+		// NOTE: this fires — see invalid section below.
+
+		// ---- H3: numeric-literal key ----
+		{Code: `
+        class Hello extends React.Component {
+          42() {}
+        }
+      `, Tsx: true},
+
+		// ---- L1: async render with return ----
+		{Code: `
+        class Hello extends React.Component {
+          async render() { return <div/>; }
+        }
+      `, Tsx: true},
+
+		// ---- K2: getter render with a nested function expression's return ----
+		// getter body contains a return of a FunctionExpression whose inner
+		// return is attached to that FE — the outer getter has its own return,
+		// so the component passes.
+		{Code: `
+        class Hello extends React.Component {
+          get render() { return function() { return <div/>; }; }
+        }
+      `, Tsx: true},
+
+		// ---- M2: labeled block containing return — return is directly in render body ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            outer: {
+              return <div/>;
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- M3: return inside catch clause ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            try {} catch (e) { return <div/>; }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- M8: arrow expression body returning a ternary ----
+		{Code: `
+        class Hello extends React.Component {
+          render = () => (this.props.ok ? <div/> : null);
+        }
+      `, Tsx: true},
+
+		// ---- M9: render = someFactory() — value is CallExpression, not function-like ----
+		{Code: `
+        class Hello extends React.Component {
+          render = someFactory();
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: Missing return in ES5 class ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {}
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noRenderReturn",
+					Message:   "Your render method should have a return statement",
+					Line:      4, Column: 11,
+				},
+			},
+		},
+
+		// ---- Upstream: Missing return in ES6 class ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: Missing return (but one is present in a sub-function) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            const names = this.props.names.map(function(name) {
+              return <div>{name}</div>
+            });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: Missing return ES6 class render property ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render = () => {
+            <div>Hello {this.props.name}</div>
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: Missing return in shorthand method inside createReactClass ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render() {}
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: Missing return with return inside a nested FunctionDeclaration ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            function inner() { return <div/>; }
+            inner();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: Missing return in bare-Component ES6 class ----
+		{
+			Code: `
+        class Hello extends Component {
+          render() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: Missing return in PureComponent subclass ----
+		{
+			Code: `
+        class Hello extends React.PureComponent {
+          render() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: Missing return with render = function(){} (FunctionExpression initializer) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render = function() {};
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: pragma-qualified createReactClass with missing render ----
+		{
+			Code: `
+        var Hello = React.createReactClass({
+          render: function() {}
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: ClassExpression with missing return ----
+		{
+			Code: `
+        var Hello = class extends React.Component {
+          render() {}
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: custom pragma via settings — Preact.Component ----
+		{
+			Code: `
+        class Hello extends Preact.Component {
+          render() {}
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: getter render with no return ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          get render() {
+            const f = () => <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: return inside a nested FunctionExpression IIFE — does NOT count ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            (function() { return <div/>; })();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: return inside a nested ArrowFunction (block body) — also does NOT count ----
+		// ESLint's unanchored regex `/Function(Expression|Declaration)$/` matches
+		// `ArrowFunctionExpression` too, so arrows bump depth past 1.
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            const f = () => { return <div/>; };
+            f();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: arrow IIFE inside render — return inside arrow does NOT count ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            (() => { return <div/>; })();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: render = () => { nested arrow with return, no top-level return } ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render = () => {
+            const f = () => { return <div/>; };
+            f();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: return inside a nested FunctionDeclaration — does NOT count ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            function inner() { return <div/>; }
+            inner();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: return inside a nested inner-class method — does NOT count ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            class Inner {
+              foo() { return <div/>; }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: inner ClassDeclaration is itself a React component and gets reported ----
+		{
+			Code: `
+        class Outer {
+          foo() {
+            class Inner extends React.Component {
+              render() {}
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Edge: render with only a throw (no return) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            throw new Error('nope');
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: parens-wrapped ClassExpression with missing return ----
+		{
+			Code: `
+        var Hello = (class extends React.Component {
+          render() {}
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: parens-wrapped object arg to createReactClass with missing return ----
+		{
+			Code: `
+        var Hello = createReactClass(({
+          render: function() {}
+        }));
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: static render method (rule does not filter by static) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          static render() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: setter named render (no return) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          set render(v) {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: ES5 object getter with no return ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          get render() { const f = () => <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: HOC-wrapped class expression that still extends Component ----
+		{
+			Code: `const Foo = withRouter(class extends React.Component { render() {} });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 1, Column: 56},
+			},
+		},
+
+		// ---- Edge: spread in createReactClass object, render has no return ----
+		{
+			Code: `createReactClass({ ...config, render: function() {} });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 1, Column: 31},
+			},
+		},
+
+		// ---- Edge: F1 — inner-class static block with deeply nested IIFE return ----
+		// Walker must stop at the FunctionExpression IIFE; the IIFE's return
+		// does not mark the outer render as returning.
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            class Inner {
+              static {
+                const x = (function() { return 1; })();
+              }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- L2: generator *render() with no return — rule does NOT skip generators ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          *render() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- M1: deeply nested IIFE inside do/while + try/catch — IIFE FE stops walker ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            do {
+              (function() {
+                try { return <div/>; } catch (e) {}
+              })();
+            } while (false);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- M5: arrow with expression body as local var (no ReturnStatement anywhere) ----
+		// No ReturnStatement in render; nested arrow's implicit return does NOT
+		// mark anything because the ArrowFunctionExpression listener only marks
+		// when arrow.parent is the render property (here parent is VariableDeclarator).
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            const f = () => <div/>;
+            f();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- M6: class expression nested as property value — only the OUTER fires ----
+		// Outer render has no return → fire. Inner class is itself a React
+		// component whose render DOES return → no fire on inner.
+		{
+			Code: `
+        class Outer extends React.Component {
+          render() {
+            const obj = {
+              inner: class extends React.Component {
+                render() { return <div/>; }
+              }
+            };
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- M10: two createReactClass calls; only the one missing return fires ----
+		{
+			Code: `var A = createReactClass({ render: function() { return 1; } });
+var B = createReactClass({ render: function() {} });`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 2, Column: 28},
+			},
+		},
+
+		// ---- M11: class inside an array literal — BOTH outer and inner are React components with missing return ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            const arr = [class Inner extends React.Component { render() {} }];
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noRenderReturn", Line: 3, Column: 11},
+				{MessageId: "noRenderReturn", Line: 4, Column: 64},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -100,6 +100,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
+    './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/require-render-return.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/require-render-return.test.ts
@@ -1,0 +1,172 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('require-render-return', {} as never, {
+  valid: [
+    // ---- Upstream: ES6 class ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Upstream: ES6 class with render property (arrow + block + return) ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render = () => {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Upstream: ES6 class with render property (implicit return) ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render = () => (
+            <div>Hello {this.props.name}</div>
+          )
+        }
+      `,
+    },
+    // ---- Upstream: ES5 class ----
+    {
+      code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div></div>
+          }
+        });
+      `,
+    },
+    // ---- Upstream: Stateless function ----
+    {
+      code: `
+        function Hello() {
+          return <div></div>;
+        }
+      `,
+    },
+    // ---- Upstream: Stateless arrow function ----
+    {
+      code: `
+        var Hello = () => (
+          <div></div>
+        );
+      `,
+    },
+    // ---- Upstream: Return in a switch...case ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            switch (this.props.name) {
+              case 'Foo':
+                return <div>Hello Foo</div>;
+              default:
+                return <div>Hello {this.props.name}</div>;
+            }
+          }
+        });
+      `,
+    },
+    // ---- Upstream: Return in a if...else ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            if (this.props.name === 'Foo') {
+              return <div>Hello Foo</div>;
+            } else {
+              return <div>Hello {this.props.name}</div>;
+            }
+          }
+        });
+      `,
+    },
+    // ---- Upstream: Not a React component (class doesn't extend Component) ----
+    {
+      code: `
+        class Hello {
+          render() {}
+        }
+      `,
+    },
+    // ---- Upstream: ES6 class without a render method ----
+    {
+      code: 'class Hello extends React.Component {}',
+    },
+    // ---- Upstream: ES5 class without a render method ----
+    {
+      code: 'var Hello = createReactClass({});',
+    },
+    // ---- Upstream: ES5 class with imported (shorthand) render method ----
+    {
+      code: `
+        var render = require('./render');
+        var Hello = createReactClass({
+          render
+        });
+      `,
+    },
+    // ---- Upstream: Invalid render method (field without initializer) ----
+    {
+      code: `
+        class Foo extends Component {
+          render
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream: Missing return in ES5 class ----
+    {
+      code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {}
+        });
+      `,
+      errors: [{ messageId: 'noRenderReturn' }],
+    },
+    // ---- Upstream: Missing return in ES6 class ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {}
+        }
+      `,
+      errors: [{ messageId: 'noRenderReturn' }],
+    },
+    // ---- Upstream: Missing return (but one is present in a sub-function) ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            const names = this.props.names.map(function(name) {
+              return <div>{name}</div>
+            });
+          }
+        }
+      `,
+      errors: [{ messageId: 'noRenderReturn' }],
+    },
+    // ---- Upstream: Missing return ES6 class render property ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render = () => {
+            <div>Hello {this.props.name}</div>
+          }
+        }
+      `,
+      errors: [{ messageId: 'noRenderReturn' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/require-render-return` rule from `eslint-plugin-react` to rslint.

The rule enforces that every `render` method in an ES5 (`createReactClass`) or
ES6 (`extends Component` / `PureComponent`) React component returns a value —
catching the common mistake of forgetting the `return` before a JSX literal.

Implementation notes (all empirically verified against the original rule on a
scratch ESLint setup — 42 edge cases):

- Only Identifier-named `render` members match; string-literal / computed /
  numeric / template-literal keys are not recognized, matching upstream's
  `getPropertyName` (which reads only `nameNode.name`).
- Nested Arrow / Function / Method / accessor / constructor are all treated
  as depth-bumping function boundaries (mirroring upstream's unanchored
  `/Function(Expression|Declaration)$/` regex, which also matches
  `ArrowFunctionExpression`).
- Any render-named member with a qualifying return marks the whole component
  as OK (mirrors upstream's `markReturnStatementPresent` tracking on the
  component, not the individual member).
- Parenthesized wrappers on ClassExpression / callee / object argument are
  transparently unwrapped.
- `settings.react.pragma` / `settings.react.createClass` are honored.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/require-render-return.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).