### PR TITLE
feat: port rule react/jsx-key

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -7,6 +7,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_equals_spacing"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_filename_extension"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_first_prop_new_line"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_key"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_bind"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_duplicate_props"
@@ -38,6 +39,7 @@ func GetAllRules() []rule.Rule {
 		jsx_equals_spacing.JsxEqualsSpacingRule,
 		jsx_filename_extension.JsxFilenameExtensionRule,
 		jsx_first_prop_new_line.JsxFirstPropNewLineRule,
+		jsx_key.JsxKeyRule,
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,
 		jsx_no_bind.JsxNoBindRule,
 		jsx_no_duplicate_props.JsxNoDuplicatePropsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -34,6 +34,29 @@ func GetReactPragma(settings map[string]interface{}) string {
 	return pragma
 }
 
+// DefaultReactFragment is the fallback fragment name for JSX shorthand
+// fragment diagnostics when `settings.react.fragment` is not configured,
+// matching eslint-plugin-react.
+const DefaultReactFragment = "Fragment"
+
+// GetReactFragmentPragma reads `settings.react.fragment` from the config
+// settings map. Returns DefaultReactFragment when the setting is absent,
+// not a string, or empty.
+func GetReactFragmentPragma(settings map[string]interface{}) string {
+	if settings == nil {
+		return DefaultReactFragment
+	}
+	reactSettings, ok := settings["react"].(map[string]interface{})
+	if !ok {
+		return DefaultReactFragment
+	}
+	v, ok := reactSettings["fragment"].(string)
+	if !ok || v == "" {
+		return DefaultReactFragment
+	}
+	return v
+}
+
 // GetReactCreateClass reads `settings.react.createClass` from the config
 // settings map. Returns DefaultReactCreateClass when the setting is absent,
 // not a string, or empty.

--- a/internal/plugins/react/rules/jsx_key/jsx_key.go
+++ b/internal/plugins/react/rules/jsx_key/jsx_key.go
@@ -1,0 +1,539 @@
+package jsx_key
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+type options struct {
+	checkFragmentShorthand   bool
+	checkKeyMustBeforeSpread bool
+	warnOnDuplicates         bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["checkFragmentShorthand"].(bool); ok {
+		opts.checkFragmentShorthand = v
+	}
+	if v, ok := m["checkKeyMustBeforeSpread"].(bool); ok {
+		opts.checkKeyMustBeforeSpread = v
+	}
+	if v, ok := m["warnOnDuplicates"].(bool); ok {
+		opts.warnOnDuplicates = v
+	}
+	return opts
+}
+
+var JsxKeyRule = rule.Rule{
+	Name: "react/jsx-key",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		reactPragma := reactutil.GetReactPragma(ctx.Settings)
+		fragmentPragma := reactutil.GetReactFragmentPragma(ctx.Settings)
+
+		missingIterKeyUsePragDesc := `Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use ` + reactPragma + `.` + fragmentPragma + ` instead`
+		missingArrayKeyUsePragDesc := `Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use ` + reactPragma + `.` + fragmentPragma + ` instead`
+
+		// isWithinChildrenToArray mirrors eslint-plugin-react's flag of the
+		// same name: a plain boolean flipped on enter / off on exit of a
+		// `<pragma>.Children.toArray(...)` or `Children.toArray(...)` call.
+		//
+		// Intentionally a boolean, not a depth counter — upstream's
+		// implementation has an observable quirk for nested Children.toArray:
+		// an inner call's exit resets the flag even while the outer call
+		// still encloses the code. Real input
+		//   React.Children.toArray([React.Children.toArray(a), xs.map(x=><A/>)])
+		// reports `missingIterKey` on `<A/>` under ESLint, because the inner
+		// exit clobbered the flag before `xs.map` was visited. A depth counter
+		// would silently diverge here; mirroring the boolean keeps 1:1 parity
+		// with eslint-plugin-react.
+		isWithinChildrenToArray := false
+
+		reportMissingIterKey := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "missingIterKey",
+				Description: `Missing "key" prop for element in iterator`,
+			})
+		}
+		reportMissingIterKeyUsePrag := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "missingIterKeyUsePrag",
+				Description: missingIterKeyUsePragDesc,
+			})
+		}
+		reportMissingArrayKey := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "missingArrayKey",
+				Description: `Missing "key" prop for element in array`,
+			})
+		}
+		reportMissingArrayKeyUsePrag := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "missingArrayKeyUsePrag",
+				Description: missingArrayKeyUsePragDesc,
+			})
+		}
+		reportKeyBeforeSpread := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "keyBeforeSpread",
+				Description: "`key` prop must be placed before any `{...spread}, to avoid conflicting with React\u2019s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`",
+			})
+		}
+		reportNonUniqueKeys := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "nonUniqueKeys",
+				Description: "`key` prop must be unique",
+			})
+		}
+
+		// checkIteratorElement handles a node that was identified as the
+		// "JSX return" of a map/from callback. Non-JSX nodes are no-ops,
+		// matching eslint-plugin-react's helper of the same name.
+		checkIteratorElement := func(node *ast.Node) {
+			if node == nil {
+				return
+			}
+			if isJsxElementLike(node) {
+				attrs := getJsxAttributeProps(node)
+				if !hasKeyAttribute(attrs) {
+					reportMissingIterKey(node)
+					return
+				}
+				if opts.checkKeyMustBeforeSpread && isKeyAfterSpread(attrs) {
+					reportKeyBeforeSpread(node)
+				}
+				return
+			}
+			if opts.checkFragmentShorthand && ast.IsJsxFragment(node) {
+				reportMissingIterKeyUsePrag(node)
+			}
+		}
+
+		// peelToJsxCandidates peels ONE level of ternary / logical off the
+		// given expression and calls checkIteratorElement on every JSX leaf
+		// it exposes. Intentionally shallow: upstream only inspects
+		// consequent/alternate of a single ternary, or .right of a single
+		// logical — it does NOT recurse. Deeply nested ternaries intentionally
+		// slip through (matches eslint-plugin-react).
+		peelToJsxCandidates := func(expr *ast.Node) {
+			expr = ast.SkipParentheses(expr)
+			if expr == nil {
+				return
+			}
+			if ast.IsConditionalExpression(expr) {
+				ce := expr.AsConditionalExpression()
+				if ce.WhenTrue != nil {
+					t := ast.SkipParentheses(ce.WhenTrue)
+					if isJsxNode(t) {
+						checkIteratorElement(t)
+					}
+				}
+				if ce.WhenFalse != nil {
+					f := ast.SkipParentheses(ce.WhenFalse)
+					if isJsxNode(f) {
+						checkIteratorElement(f)
+					}
+				}
+				return
+			}
+			if ast.IsLogicalOrCoalescingBinaryExpression(expr) {
+				right := expr.AsBinaryExpression().Right
+				if right != nil {
+					r := ast.SkipParentheses(right)
+					if isJsxNode(r) {
+						checkIteratorElement(r)
+					}
+				}
+				return
+			}
+			checkIteratorElement(expr)
+		}
+
+		// checkArrowBodyJSX mirrors upstream checkArrowFunctionWithJSX.
+		// Only arrows with expression bodies go through this path; block
+		// bodies are handled by checkFunctionsBlockStatement below.
+		checkArrowBodyJSX := func(fn *ast.Node) {
+			if !ast.IsArrowFunction(fn) {
+				return
+			}
+			body := fn.AsArrowFunction().Body
+			if body == nil {
+				return
+			}
+			inner := ast.SkipParentheses(body)
+			if isJsxNode(inner) {
+				checkIteratorElement(inner)
+			}
+			if ast.IsConditionalExpression(inner) {
+				ce := inner.AsConditionalExpression()
+				if ce.WhenTrue != nil {
+					t := ast.SkipParentheses(ce.WhenTrue)
+					if isJsxNode(t) {
+						checkIteratorElement(t)
+					}
+				}
+				if ce.WhenFalse != nil {
+					f := ast.SkipParentheses(ce.WhenFalse)
+					if isJsxNode(f) {
+						checkIteratorElement(f)
+					}
+				}
+			} else if ast.IsLogicalOrCoalescingBinaryExpression(inner) {
+				right := inner.AsBinaryExpression().Right
+				if right != nil {
+					r := ast.SkipParentheses(right)
+					if isJsxNode(r) {
+						checkIteratorElement(r)
+					}
+				}
+			}
+		}
+
+		// checkFunctionsBlockStatement mirrors upstream's helper: walk the
+		// top-level `return` statements of a block body (descending only
+		// through `if` branches) and dispatch each argument.
+		checkFunctionsBlockStatement := func(fn *ast.Node) {
+			if !ast.IsFunctionExpressionOrArrowFunction(fn) {
+				return
+			}
+			var body *ast.Node
+			if ast.IsArrowFunction(fn) {
+				body = fn.AsArrowFunction().Body
+			} else {
+				body = fn.AsFunctionExpression().Body
+			}
+			if body == nil || !ast.IsBlock(body) {
+				return
+			}
+			var returns []*ast.Node
+			returns = collectReturnStatements(body, returns)
+			for _, rs := range returns {
+				arg := rs.AsReturnStatement().Expression
+				if arg == nil {
+					continue
+				}
+				peelToJsxCandidates(arg)
+			}
+		}
+
+		processMapOrFromCallback := func(fn *ast.Node) {
+			fn = ast.SkipParentheses(fn)
+			if !ast.IsFunctionExpressionOrArrowFunction(fn) {
+				return
+			}
+			checkArrowBodyJSX(fn)
+			checkFunctionsBlockStatement(fn)
+		}
+
+		processArrayLikeSiblings := func(elements []*ast.Node, parentNode *ast.Node, inArray bool) {
+			if len(elements) == 0 {
+				return
+			}
+			var jsxEls []*ast.Node
+			for _, el := range elements {
+				if isJsxElementLike(el) {
+					jsxEls = append(jsxEls, el)
+				}
+			}
+			if len(jsxEls) == 0 {
+				return
+			}
+			var keysByText map[string][]*ast.Node
+			if opts.warnOnDuplicates {
+				keysByText = map[string][]*ast.Node{}
+			}
+			for _, el := range jsxEls {
+				attrs := getJsxAttributeProps(el)
+				keyAttrs := getKeyAttributes(attrs)
+				if len(keyAttrs) == 0 {
+					if inArray {
+						reportMissingArrayKey(el)
+					}
+					continue
+				}
+				for _, k := range keyAttrs {
+					if opts.warnOnDuplicates {
+						text := keyValueText(ctx.SourceFile, k)
+						keysByText[text] = append(keysByText[text], k)
+					}
+					if opts.checkKeyMustBeforeSpread && isKeyAfterSpread(attrs) {
+						// Upstream reports on the container (the array or
+						// outer JSX parent), not on the offending element.
+						reportKeyBeforeSpread(parentNode)
+					}
+				}
+			}
+			for _, group := range keysByText {
+				if len(group) <= 1 {
+					continue
+				}
+				for _, attr := range group {
+					reportNonUniqueKeys(attr)
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if isChildrenToArrayCall(call, reactPragma) {
+					isWithinChildrenToArray = true
+					return
+				}
+				if isWithinChildrenToArray {
+					return
+				}
+				switch calleePropertyName(call) {
+				case "map":
+					if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+						return
+					}
+					processMapOrFromCallback(call.Arguments.Nodes[0])
+				case "from":
+					if call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+						return
+					}
+					processMapOrFromCallback(call.Arguments.Nodes[1])
+				}
+			},
+			rule.ListenerOnExit(ast.KindCallExpression): func(node *ast.Node) {
+				if isChildrenToArrayCall(node.AsCallExpression(), reactPragma) {
+					isWithinChildrenToArray = false
+				}
+			},
+			ast.KindArrayLiteralExpression: func(node *ast.Node) {
+				if isWithinChildrenToArray {
+					return
+				}
+				arr := node.AsArrayLiteralExpression()
+				if arr.Elements == nil {
+					return
+				}
+				processArrayLikeSiblings(arr.Elements.Nodes, node, true)
+			},
+			ast.KindJsxElement: func(node *ast.Node) {
+				if isWithinChildrenToArray {
+					return
+				}
+				jsxEl := node.AsJsxElement()
+				if jsxEl.Children == nil {
+					return
+				}
+				processArrayLikeSiblings(jsxEl.Children.Nodes, node, false)
+			},
+			ast.KindJsxFragment: func(node *ast.Node) {
+				if isWithinChildrenToArray || !opts.checkFragmentShorthand {
+					return
+				}
+				parent := node.Parent
+				for parent != nil && ast.IsParenthesizedExpression(parent) {
+					parent = parent.Parent
+				}
+				if parent != nil && ast.IsArrayLiteralExpression(parent) {
+					reportMissingArrayKeyUsePrag(node)
+				}
+			},
+		}
+	},
+}
+
+// isJsxElementLike returns true for JsxElement (`<Foo>...</Foo>`) or
+// JsxSelfClosingElement (`<Foo />`). ESTree collapses both into
+// `JSXElement`; tsgo distinguishes them.
+func isJsxElementLike(node *ast.Node) bool {
+	return ast.IsJsxElement(node) || ast.IsJsxSelfClosingElement(node)
+}
+
+// isJsxNode mirrors eslint-plugin-react's `isJSX` — true for a JSX element
+// (either tag form) or a JSX fragment.
+func isJsxNode(node *ast.Node) bool {
+	return isJsxElementLike(node) || ast.IsJsxFragment(node)
+}
+
+// getJsxAttributeProps returns the JsxAttributes.Properties list for a
+// JsxElement or JsxSelfClosingElement, or nil otherwise.
+func getJsxAttributeProps(node *ast.Node) []*ast.Node {
+	if node == nil {
+		return nil
+	}
+	var attrs *ast.Node
+	switch {
+	case ast.IsJsxElement(node):
+		opening := node.AsJsxElement().OpeningElement
+		if opening == nil {
+			return nil
+		}
+		attrs = opening.AsJsxOpeningElement().Attributes
+	case ast.IsJsxSelfClosingElement(node):
+		attrs = node.AsJsxSelfClosingElement().Attributes
+	default:
+		return nil
+	}
+	if attrs == nil {
+		return nil
+	}
+	props := attrs.AsJsxAttributes().Properties
+	if props == nil {
+		return nil
+	}
+	return props.Nodes
+}
+
+// getKeyAttributes returns the JsxAttribute nodes in `attrs` whose attribute
+// name is the identifier `key`. Mirrors jsx-ast-utils' `hasProp` behavior:
+// JsxSpreadAttribute is opaque (a `{...{key: x}}` spread is NOT a match).
+func getKeyAttributes(attrs []*ast.Node) []*ast.Node {
+	var out []*ast.Node
+	for _, a := range attrs {
+		if !ast.IsJsxAttribute(a) {
+			continue
+		}
+		name := a.AsJsxAttribute().Name()
+		if !ast.IsIdentifier(name) {
+			continue
+		}
+		if name.AsIdentifier().Text == "key" {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+func hasKeyAttribute(attrs []*ast.Node) bool {
+	return len(getKeyAttributes(attrs)) > 0
+}
+
+// isKeyAfterSpread reports whether a `key` JsxAttribute appears after a
+// JsxSpreadAttribute in the attribute list.
+func isKeyAfterSpread(attrs []*ast.Node) bool {
+	sawSpread := false
+	for _, a := range attrs {
+		if ast.IsJsxSpreadAttribute(a) {
+			sawSpread = true
+			continue
+		}
+		if !ast.IsJsxAttribute(a) || !sawSpread {
+			continue
+		}
+		name := a.AsJsxAttribute().Name()
+		if ast.IsIdentifier(name) && name.AsIdentifier().Text == "key" {
+			return true
+		}
+	}
+	return false
+}
+
+// calleePropertyName returns the property-access name for a call's callee,
+// e.g. `"map"` for `xs.map(...)` / `xs?.map(...)` / `xs.map?.(...)`. Returns
+// the empty string for bracket access or non-property callees.
+func calleePropertyName(call *ast.CallExpression) string {
+	if call == nil || call.Expression == nil {
+		return ""
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	if !ast.IsPropertyAccessExpression(callee) {
+		return ""
+	}
+	name := callee.AsPropertyAccessExpression().Name()
+	if !ast.IsIdentifier(name) {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+// isChildrenToArrayCall returns true when `call`'s callee matches either
+// `<pragma>.Children.toArray` or `Children.toArray`. Parens are skipped on
+// both the callee and its sub-expressions.
+func isChildrenToArrayCall(call *ast.CallExpression, pragma string) bool {
+	if call == nil || call.Expression == nil {
+		return false
+	}
+	if pragma == "" {
+		pragma = reactutil.DefaultReactPragma
+	}
+	callee := ast.SkipParentheses(call.Expression)
+	if !ast.IsPropertyAccessExpression(callee) {
+		return false
+	}
+	pa := callee.AsPropertyAccessExpression()
+	name := pa.Name()
+	if !ast.IsIdentifier(name) || name.AsIdentifier().Text != "toArray" {
+		return false
+	}
+	obj := ast.SkipParentheses(pa.Expression)
+	switch {
+	case ast.IsIdentifier(obj):
+		return obj.AsIdentifier().Text == "Children"
+	case ast.IsPropertyAccessExpression(obj):
+		innerPa := obj.AsPropertyAccessExpression()
+		innerName := innerPa.Name()
+		if !ast.IsIdentifier(innerName) || innerName.AsIdentifier().Text != "Children" {
+			return false
+		}
+		inner2 := ast.SkipParentheses(innerPa.Expression)
+		return ast.IsIdentifier(inner2) && inner2.AsIdentifier().Text == pragma
+	}
+	return false
+}
+
+// collectReturnStatements mirrors eslint-plugin-react's getReturnStatements.
+// From a function body BlockStatement it collects top-level ReturnStatements,
+// descending only into IfStatement branches. Nested function bodies,
+// switch/for/while/try bodies, etc. are intentionally NOT traversed — this
+// matches the upstream semantics exactly.
+func collectReturnStatements(node *ast.Node, out []*ast.Node) []*ast.Node {
+	if node == nil {
+		return out
+	}
+	switch {
+	case ast.IsIfStatement(node):
+		ifs := node.AsIfStatement()
+		if ifs.ThenStatement != nil {
+			out = collectReturnStatements(ifs.ThenStatement, out)
+		}
+		if ifs.ElseStatement != nil {
+			out = collectReturnStatements(ifs.ElseStatement, out)
+		}
+	case ast.IsReturnStatement(node):
+		out = append(out, node)
+	case ast.IsBlock(node):
+		stmts := node.AsBlock().Statements
+		if stmts == nil {
+			return out
+		}
+		for _, stmt := range stmts.Nodes {
+			switch {
+			case ast.IsIfStatement(stmt):
+				out = collectReturnStatements(stmt, out)
+			case ast.IsReturnStatement(stmt):
+				out = append(out, stmt)
+			}
+		}
+	}
+	return out
+}
+
+// keyValueText returns the raw source text of a JsxAttribute's value — used
+// to group identical keys under `warnOnDuplicates`. Matches upstream's
+// `SourceCode.getText(attr.value)`: two keys are duplicates iff their
+// initializer source text is byte-identical. `<Foo key />` (no initializer,
+// = `key={true}` shorthand) yields the empty string; multiple such elements
+// do cluster together under warnOnDuplicates, same as upstream treating
+// `undefined` consistently.
+func keyValueText(sf *ast.SourceFile, attr *ast.Node) string {
+	if attr == nil || sf == nil {
+		return ""
+	}
+	init := attr.AsJsxAttribute().Initializer
+	if init == nil {
+		return ""
+	}
+	return utils.TrimmedNodeText(sf, init)
+}

--- a/internal/plugins/react/rules/jsx_key/jsx_key.go
+++ b/internal/plugins/react/rules/jsx_key/jsx_key.go
@@ -167,33 +167,7 @@ var JsxKeyRule = rule.Rule{
 			if body == nil {
 				return
 			}
-			inner := ast.SkipParentheses(body)
-			if isJsxNode(inner) {
-				checkIteratorElement(inner)
-			}
-			if ast.IsConditionalExpression(inner) {
-				ce := inner.AsConditionalExpression()
-				if ce.WhenTrue != nil {
-					t := ast.SkipParentheses(ce.WhenTrue)
-					if isJsxNode(t) {
-						checkIteratorElement(t)
-					}
-				}
-				if ce.WhenFalse != nil {
-					f := ast.SkipParentheses(ce.WhenFalse)
-					if isJsxNode(f) {
-						checkIteratorElement(f)
-					}
-				}
-			} else if ast.IsLogicalOrCoalescingBinaryExpression(inner) {
-				right := inner.AsBinaryExpression().Right
-				if right != nil {
-					r := ast.SkipParentheses(right)
-					if isJsxNode(r) {
-						checkIteratorElement(r)
-					}
-				}
-			}
+			peelToJsxCandidates(body)
 		}
 
 		// checkFunctionsBlockStatement mirrors upstream's helper: walk the

--- a/internal/plugins/react/rules/jsx_key/jsx_key.md
+++ b/internal/plugins/react/rules/jsx_key/jsx_key.md
@@ -1,0 +1,125 @@
+# jsx-key
+
+Disallow missing `key` props in iterators / collection literals.
+
+## Rule Details
+
+Warn if a JSX element that likely needs a `key` prop — namely, one inside an
+array literal or returned from an arrow function / function expression passed
+to `Array.prototype.map` or `Array.from` — is missing one.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+[<Hello />, <Hello />, <Hello />];
+```
+
+```jsx
+data.map(x => <Hello>{x}</Hello>);
+```
+
+```jsx
+Array.from([1, 2, 3], (x) => <Hello>{x}</Hello>);
+```
+
+```jsx
+<Hello {...{ key: id, id, caption }} />
+```
+
+In the last example the key is being spread, which is currently possible but
+discouraged in favor of a statically provided key.
+
+Examples of **correct** code for this rule:
+
+```jsx
+[<Hello key="first" />, <Hello key="second" />, <Hello key="third" />];
+```
+
+```jsx
+data.map((x) => <Hello key={x.id}>{x}</Hello>);
+```
+
+```jsx
+Array.from([1, 2, 3], (x) => <Hello key={x}>{x}</Hello>);
+```
+
+```jsx
+<Hello key={id} {...{ id, caption }} />
+```
+
+## Rule Options
+
+```json
+{
+  "react/jsx-key": [
+    "error",
+    {
+      "checkFragmentShorthand": false,
+      "checkKeyMustBeforeSpread": false,
+      "warnOnDuplicates": false
+    }
+  ]
+}
+```
+
+### `checkFragmentShorthand` (default: `false`)
+
+When `true`, report the shorthand fragment syntax (`<></>`) used in arrays /
+iterators, since shorthand fragments cannot carry a `key`. The reported
+suggestion uses the configured pragma, e.g. `React.Fragment` or, with
+`settings.react.pragma`/`settings.react.fragment`, `Act.Frag`.
+
+```json
+{ "react/jsx-key": ["error", { "checkFragmentShorthand": true }] }
+```
+
+```jsx
+[<></>, <></>, <></>];
+```
+
+```jsx
+data.map(x => <>{x}</>);
+```
+
+### `checkKeyMustBeforeSpread` (default: `false`)
+
+When `true`, report any `key` prop that appears after a `{...spread}`
+attribute. Required by React's new JSX transform.
+
+```json
+{ "react/jsx-key": ["error", { "checkKeyMustBeforeSpread": true }] }
+```
+
+```jsx
+<span {...spread} key="key-after-spread" />;
+```
+
+### `warnOnDuplicates` (default: `false`)
+
+When `true`, report keys whose source-text value is identical within the same
+container (array literal or JSX parent).
+
+```json
+{ "react/jsx-key": ["error", { "warnOnDuplicates": true }] }
+```
+
+```jsx
+const spans = [
+  <span key="notunique" />,
+  <span key="notunique" />,
+];
+```
+
+Key values are compared as raw source text. `key="a"` and `key={'a'}` do NOT
+count as duplicates of each other — they are different source strings.
+
+## When Not To Use It
+
+If you are not using JSX then you can disable this rule.
+
+Also, if you frequently use arrow functions that return JSX but never render
+the JSX inside an iterable, you may want to disable this rule.
+
+## Original Documentation
+
+- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md

--- a/internal/plugins/react/rules/jsx_key/jsx_key_test.go
+++ b/internal/plugins/react/rules/jsx_key/jsx_key_test.go
@@ -1,0 +1,834 @@
+package jsx_key
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxKeyRule(t *testing.T) {
+	checkFragmentShorthand := map[string]interface{}{"checkFragmentShorthand": true}
+	checkKeyMustBeforeSpread := map[string]interface{}{"checkKeyMustBeforeSpread": true}
+	warnOnDuplicates := map[string]interface{}{"warnOnDuplicates": true}
+	pragmaSettings := map[string]interface{}{
+		"react": map[string]interface{}{"pragma": "Act", "fragment": "Frag"},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxKeyRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{
+			Code: `
+[1, 2, 3].map((item) => {
+  return item === 'bar' ? <div key={item}>{item}</div> : <span key={item}>{item}</span>;
+})
+`,
+			Tsx: true,
+		},
+		{Code: `fn()`, Tsx: true},
+		{Code: `[1, 2, 3].map(function () {})`, Tsx: true},
+		{Code: `<App />;`, Tsx: true},
+		{Code: `[<App key={0} />, <App key={1} />];`, Tsx: true},
+		{Code: `[1, 2, 3].map(function(x) { return <App key={x} /> });`, Tsx: true},
+		{Code: `[1, 2, 3].map(x => <App key={x} />);`, Tsx: true},
+		{Code: `[1, 2 ,3].map(x => x && <App x={x} key={x} />);`, Tsx: true},
+		{Code: `[1, 2 ,3].map(x => x ? <App x={x} key="1" /> : <OtherApp x={x} key="2" />);`, Tsx: true},
+		{Code: `[1, 2, 3].map(x => { return <App key={x} /> });`, Tsx: true},
+		{Code: `Array.from([1, 2, 3], function(x) { return <App key={x} /> });`, Tsx: true},
+		{Code: `Array.from([1, 2, 3], (x => <App key={x} />));`, Tsx: true},
+		{Code: `Array.from([1, 2, 3], (x => {return <App key={x} />}));`, Tsx: true},
+		{Code: `Array.from([1, 2, 3], someFn);`, Tsx: true},
+		{Code: `Array.from([1, 2, 3]);`, Tsx: true},
+		{Code: `[1, 2, 3].foo(x => <App />);`, Tsx: true},
+		{Code: `var App = () => <div />;`, Tsx: true},
+		{Code: `[1, 2, 3].map(function(x) { return; });`, Tsx: true},
+		{Code: `foo(() => <div />);`, Tsx: true},
+		{Code: `foo(() => <></>);`, Tsx: true},
+		{Code: `<></>;`, Tsx: true},
+		{Code: `<App {...{}} />;`, Tsx: true},
+		{
+			Code:    `<App key="keyBeforeSpread" {...{}} />;`,
+			Tsx:     true,
+			Options: checkKeyMustBeforeSpread,
+		},
+		{
+			Code:    `<div key="keyBeforeSpread" {...{}} />;`,
+			Tsx:     true,
+			Options: checkKeyMustBeforeSpread,
+		},
+		{
+			Code: `
+const spans = [
+  <span key="notunique"/>,
+  <span key="notunique"/>,
+];
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+function Component(props) {
+  return hasPayment ? (
+    <div className="stuff">
+      <BookingDetailSomething {...props} />
+      {props.modal && props.calculatedPrice && (
+        <SomeOtherThing items={props.something} discount={props.discount} />
+      )}
+    </div>
+  ) : null;
+}
+`,
+			Tsx: true,
+		},
+		{
+			Code: `
+// testrule.jsx
+const trackLink = () => {};
+const getAnalyticsUiElement = () => {};
+
+const onTextButtonClick = (e, item) => trackLink([, getAnalyticsUiElement(item), item.name], e);
+`,
+			Tsx: true,
+		},
+		{
+			Code: "\nfunction Component({ allRatings }) {\n  return (\n    <RatingDetailsStyles>\n      {Object.entries(allRatings)?.map(([key, value], index) => {\n        const rate = value?.split(/(?=[%, /])/);\n\n        if (!rate) return null;\n\n        return (\n          <li key={`${entertainment.tmdbId}${index}`}>\n            <img src={`/assets/rating/${key}.png`} />\n            <span className=\"rating-details--rate\">{rate?.[0]}</span>\n            <span className=\"rating-details--rate-suffix\">{rate?.[1]}</span>\n          </li>\n        );\n      })}\n    </RatingDetailsStyles>\n  );\n}\n",
+			Tsx:  true,
+		},
+		{
+			Code: "\nconst baz = foo?.bar?.()?.[1] ?? 'qux';\n\nqux()?.map()\n\nconst directiveRanges = comments?.map(tryParseTSDirective)\n",
+			Tsx:  true,
+		},
+		// ---- React.Children.toArray / destructured Children.toArray ----
+		{Code: `React.Children.toArray([1, 2, 3].map(x => <App />));`, Tsx: true},
+		{
+			Code: `
+import { Children } from "react";
+Children.toArray([1, 2, 3].map(x => <App />));
+`,
+			Tsx: true,
+		},
+		{
+			// Pragma setting — Act.Children.toArray also counts.
+			Code: `
+import Act from 'react';
+import { Children as ReactChildren } from 'react';
+
+const { Children } = Act;
+const { toArray } = Children;
+
+Act.Children.toArray([1, 2, 3].map(x => <App />));
+Act.Children.toArray(Array.from([1, 2, 3], x => <App />));
+Children.toArray([1, 2, 3].map(x => <App />));
+Children.toArray(Array.from([1, 2, 3], x => <App />));
+`,
+			Tsx:      true,
+			Settings: pragmaSettings,
+		},
+		{Code: `[1, 2, 3].map(x => { return x && <App key={x} />; });`, Tsx: true},
+		{Code: `[1, 2, 3].map(x => { return x && y && <App key={x} />; });`, Tsx: true},
+		{Code: `[1, 2, 3].map(x => { return x && foo(); });`, Tsx: true},
+
+		// ---- Additional edge cases ----
+		// Nested JSX: keys are not required on direct JSX children of a
+		// JSX parent.
+		{Code: `<ul><li/><li/></ul>;`, Tsx: true},
+		// Array.from with no callback (non-function 2nd arg) — no report.
+		{Code: `Array.from([1, 2, 3], "not a function");`, Tsx: true},
+		// `xs?.map(...)` — optional chaining on the call. Same behavior as
+		// `xs.map(...)`.
+		{Code: `xs?.map(x => <App key={x} />);`, Tsx: true},
+		// `xs.map?.(...)` — optional call. Same behavior.
+		{Code: `xs.map?.(x => <App key={x} />);`, Tsx: true},
+		// Parenthesized arrow callback.
+		{Code: `[1,2,3].map((x => <App key={x} />));`, Tsx: true},
+		// Spread element alongside keyed JSX in an array — spread is not a
+		// JsxElement, only the keyed element is inspected.
+		{Code: `const rest = []; [<App key="k" />, ...rest];`, Tsx: true},
+		// Omitted array element (hole) is not a JsxElement.
+		{Code: `[, <App key="k" />];`, Tsx: true},
+		// warnOnDuplicates: distinct literal texts do not trigger.
+		{
+			Code: `
+const spans = [
+  <span key="a"/>,
+  <span key="b"/>,
+];
+`,
+			Tsx:     true,
+			Options: warnOnDuplicates,
+		},
+		// checkKeyMustBeforeSpread false (default): key after spread in an
+		// array is NOT flagged.
+		{Code: `[<App {...obj} key="k" />, <App key="k2" />];`, Tsx: true},
+		// checkFragmentShorthand false (default): fragment in iterator is
+		// not flagged.
+		{Code: `[1, 2, 3].map(x => <>{x}</>);`, Tsx: true},
+		// checkFragmentShorthand false: fragment in array literal is not
+		// flagged.
+		{Code: `[<></>];`, Tsx: true},
+		// Typed FC returning JSX — a real-world shape from upstream's test
+		// suite. Should not report.
+		{
+			Code: `
+import React, { FC, useRef, useState } from 'react';
+
+type Props = {
+  videoUrl: string;
+  videoTitle: string;
+};
+const ResourceVideo: FC<Props> = ({
+  videoUrl,
+  videoTitle,
+}: Props): JSX.Element => {
+  return (
+    <div className="resource-video">
+      <VimeoVideoPlayInModal videoUrl={videoUrl} />
+      <h3>{videoTitle}</h3>
+    </div>
+  );
+};
+
+export default ResourceVideo;
+`,
+			Tsx: true,
+		},
+		// mobx `observable.map(...)` is NOT Array.prototype.map — the callee
+		// is `observable.map`, property name "map". Upstream actually flags
+		// this if there's a JSX-returning arrow argument; here the single
+		// argument is a type argument generic so no callback is present.
+		{
+			Code: `
+import { observable } from "mobx";
+
+export interface ClusterFrameInfo {
+  frameId: number;
+  processId: number;
+}
+
+export const clusterFrameMap = observable.map<string, ClusterFrameInfo>();
+`,
+			Tsx: true,
+		},
+		// Nested React.Children.toArray — both the inner Children.toArray
+		// and the deepest map are skipped.
+		{
+			Code: `
+React.Children.toArray(
+  React.Children.toArray([1, 2, 3].map(x => <App />))
+);
+`,
+			Tsx: true,
+		},
+		// Children.toArray balanced with an adjacent unguarded map: only
+		// the unguarded one would normally flag, but it's keyed — no report.
+		{
+			Code: `
+React.Children.toArray([1, 2, 3].map(x => <A />));
+[1, 2, 3].map(x => <B key={x} />);
+`,
+			Tsx: true,
+		},
+		// Fragment appearing as a JSX child (not an array element) — even
+		// with checkFragmentShorthand on, upstream only reports array-level
+		// fragments. Locks that behavior.
+		{
+			Code:    `<div><></><></></div>;`,
+			Tsx:     true,
+			Options: checkFragmentShorthand,
+		},
+		// Map callback with async arrow — still an ArrowFunction, still
+		// subject to the iterator check. Keyed → no report.
+		{Code: `[1, 2, 3].map(async x => <App key={x} />);`, Tsx: true},
+		// Deeply nested parens around the arrow callback.
+		{Code: `[1, 2, 3].map((((x => <App key={x} />))));`, Tsx: true},
+		// Bracket access `xs["map"]` is NOT matched by the rule (upstream
+		// uses `callee.property.name="map"`, i.e. dot access only).
+		{Code: `xs["map"](x => <App />);`, Tsx: true},
+		// Chained calls: `xs.filter(...).map(x => <A key={x} />)` — keyed.
+		{Code: `xs.filter(x => x > 0).map(x => <App key={x} />);`, Tsx: true},
+		// Array.from with a non-function second argument (identifier/any).
+		{Code: `Array.from([1, 2, 3], 123);`, Tsx: true},
+		// Generic call — `.map<T>(...)` still a PropertyAccessExpression.
+		{Code: `xs.map<number>(x => <App key={x} />);`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `
+[1, 2, 3].map((item) => {
+  return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+})`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `
+[1, 2, 3].map(function(item) {
+  return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+})`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `
+Array.from([1, 2, 3], (item) => {
+  return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+})`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `
+import { Fragment } from 'react';
+
+const ITEMS = ['bar', 'foo'];
+
+export default function BugIssue() {
+  return (
+    <Fragment>
+      {ITEMS.map((item) => {
+        return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+      })}
+    </Fragment>
+  );
+}
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[<App />];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingArrayKey", Line: 1, Column: 2},
+			},
+		},
+		{
+			Code: `[<App {...key} />];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingArrayKey", Line: 1, Column: 2},
+			},
+		},
+		{
+			Code: `[<App key={0}/>, <App />];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingArrayKey", Line: 1, Column: 18},
+			},
+		},
+		{
+			Code: `[1, 2 ,3].map(function(x) { return <App /> });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2 ,3].map(x => <App />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2 ,3].map(x => x && <App x={x} />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2 ,3].map(x => x ? <App x={x} key="1" /> : <OtherApp x={x} />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2 ,3].map(x => x ? <App x={x} /> : <OtherApp x={x} key="2" />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2 ,3].map(x => { return <App /> });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `Array.from([1, 2 ,3], function(x) { return <App /> });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `Array.from([1, 2 ,3], (x => { return <App /> }));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `Array.from([1, 2 ,3], (x => <App />));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2, 3]?.map(x => <App />)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code:     `[1, 2, 3].map(x => <>{x}</>);`,
+			Tsx:      true,
+			Options:  checkFragmentShorthand,
+			Settings: pragmaSettings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingIterKeyUsePrag",
+					Message:   `Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use Act.Frag instead`,
+				},
+			},
+		},
+		{
+			Code:     `[<></>];`,
+			Tsx:      true,
+			Options:  checkFragmentShorthand,
+			Settings: pragmaSettings,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingArrayKeyUsePrag",
+					Message:   `Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use Act.Frag instead`,
+				},
+			},
+		},
+		{
+			Code:    `[<App {...obj} key="keyAfterSpread" />];`,
+			Tsx:     true,
+			Options: checkKeyMustBeforeSpread,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "keyBeforeSpread"},
+			},
+		},
+		{
+			Code:    `[<div {...obj} key="keyAfterSpread" />];`,
+			Tsx:     true,
+			Options: checkKeyMustBeforeSpread,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "keyBeforeSpread"},
+			},
+		},
+		{
+			Code: `
+const spans = [
+  <span key="notunique"/>,
+  <span key="notunique"/>,
+];
+`,
+			Tsx:     true,
+			Options: warnOnDuplicates,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nonUniqueKeys", Line: 3},
+				{MessageId: "nonUniqueKeys", Line: 4},
+			},
+		},
+		{
+			Code: `
+const div = (
+  <div>
+    <span key="notunique"/>
+    <span key="notunique"/>
+  </div>
+);
+`,
+			Tsx:     true,
+			Options: warnOnDuplicates,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nonUniqueKeys", Line: 4},
+				{MessageId: "nonUniqueKeys", Line: 5},
+			},
+		},
+		{
+			Code: `
+const Test = () => {
+  const list = [1, 2, 3, 4, 5];
+
+  return (
+    <div>
+      {list.map(item => {
+        if (item < 2) {
+          return <div>{item}</div>;
+        }
+
+        return <div />;
+      })}
+    </div>
+  );
+};
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `
+const TestO = () => {
+  const list = [1, 2, 3, 4, 5];
+
+  return (
+    <div>
+      {list.map(item => {
+        if (item < 2) {
+          return <div>{item}</div>;
+        } else if (item < 5) {
+          return <div></div>
+        }  else {
+          return <div></div>
+        }
+
+        return <div />;
+      })}
+    </div>
+  );
+};
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `
+const TestCase = () => {
+  const list = [1, 2, 3, 4, 5];
+
+  return (
+    <div>
+      {list.map(item => {
+        if (item < 2) return <div>{item}</div>;
+        else if (item < 5) return <div />;
+        else return <div />;
+      })}
+    </div>
+  );
+};
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `
+const TestCase = () => {
+  const list = [1, 2, 3, 4, 5];
+
+  return (
+    <div>
+      {list.map(x => <div {...spread} key={x} />)}
+    </div>
+  );
+};
+`,
+			Tsx:     true,
+			Options: checkKeyMustBeforeSpread,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "keyBeforeSpread"},
+			},
+		},
+		{
+			Code: `[1, 2, 3].map(x => { return x && <App />; });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `[1, 2, 3].map(x => { return x || y || <App />; });`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+
+		// ---- Additional edge cases ----
+		// Line / column coverage on a simple array-missing-key case.
+		{
+			Code: "\n[\n  <App />,\n  <App />,\n];\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingArrayKey", Line: 3, Column: 3},
+				{MessageId: "missingArrayKey", Line: 4, Column: 3},
+			},
+		},
+		// Full message-text assertion on a plain missingIterKey.
+		{
+			Code: `[1].map(x => <App />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingIterKey",
+					Message:   `Missing "key" prop for element in iterator`,
+					Line:      1,
+					Column:    14,
+				},
+			},
+		},
+		// Full message-text assertion on missingArrayKey.
+		{
+			Code: `[<App />];`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingArrayKey",
+					Message:   `Missing "key" prop for element in array`,
+					Line:      1,
+					Column:    2,
+				},
+			},
+		},
+		// Default pragma — missingIterKeyUsePrag uses "React.Fragment".
+		{
+			Code:    `[1, 2, 3].map(x => <>{x}</>);`,
+			Tsx:     true,
+			Options: checkFragmentShorthand,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingIterKeyUsePrag",
+					Message:   `Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use React.Fragment instead`,
+				},
+			},
+		},
+		// Default pragma — missingArrayKeyUsePrag uses "React.Fragment".
+		{
+			Code:    `[<></>];`,
+			Tsx:     true,
+			Options: checkFragmentShorthand,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingArrayKeyUsePrag",
+					Message:   `Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use React.Fragment instead`,
+				},
+			},
+		},
+		// Optional chaining on both the member access and the call.
+		{
+			Code: `[1, 2, 3].map?.(x => <App />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		{
+			Code: `xs?.map(x => <App />);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		// Parenthesized arrow callback inside Array.from — ESTree flattens
+		// the parens; tsgo preserves them. Regression case.
+		{
+			Code: `Array.from([1, 2, 3], ((x => <App />)));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		// Parenthesized JSX body of arrow map callback.
+		{
+			Code: `[1,2,3].map(x => (<App />));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey"},
+			},
+		},
+		// warnOnDuplicates with checkKeyMustBeforeSpread both on —
+		// independent diagnostics on the same element.
+		{
+			Code: `
+const spans = [
+  <span {...o} key="a"/>,
+  <span key="a"/>,
+];
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"warnOnDuplicates":         true,
+				"checkKeyMustBeforeSpread": true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "keyBeforeSpread"},
+				{MessageId: "nonUniqueKeys", Line: 3},
+				{MessageId: "nonUniqueKeys", Line: 4},
+			},
+		},
+		// warnOnDuplicates groups keys by raw source text — `{'a'}` and
+		// `"a"` are different texts, so they're NOT duplicates (matches
+		// upstream's `getText` behavior).
+		{
+			Code: `
+const spans = [
+  <span key={'a'}/>,
+  <span key="a"/>,
+  <span key={'a'}/>,
+];
+`,
+			Tsx:     true,
+			Options: warnOnDuplicates,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "nonUniqueKeys", Line: 3},
+				{MessageId: "nonUniqueKeys", Line: 5},
+			},
+		},
+		// ---- Additional container / positioning coverage ----
+		// Map callback missing key: assert precise Line/Column/EndLine/
+		// EndColumn for the JSX element in a multi-line case.
+		{
+			Code: "\n[1, 2, 3].map(x =>\n  <App />\n);\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingIterKey",
+					Line:      3,
+					Column:    3,
+					EndLine:   3,
+					EndColumn: 10,
+				},
+			},
+		},
+		// Array-missing-key: precise end line/column on a multi-line element.
+		{
+			Code: "\n[\n  <App\n    x={1}\n  />,\n];\n",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "missingArrayKey",
+					Line:      3,
+					Column:    3,
+					EndLine:   5,
+					EndColumn: 5,
+				},
+			},
+		},
+		// keyBeforeSpread in array context reports on the array, not the
+		// offending element.
+		{
+			Code:    "\n[\n  <App {...x} key=\"k\" />,\n];\n",
+			Tsx:     true,
+			Options: checkKeyMustBeforeSpread,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "keyBeforeSpread",
+					Line:      2,
+					Column:    1,
+				},
+			},
+		},
+		// Three-way independence: keys across sibling arrays don't collide.
+		// The outer array has JSX children (the inner arrays) that are
+		// themselves arrays, not JSX — no missing-array-key on the outer.
+		// Each inner array evaluates its own keys independently.
+		{
+			Code: `
+const nested = [
+  [<A key="x" />, <A />],
+  [<A key="x" />],
+];
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingArrayKey", Line: 3, Column: 19},
+			},
+		},
+		// ---- Upstream nested-`Children.toArray` boolean-flag quirk ----
+		//
+		// eslint-plugin-react uses a plain boolean `isWithinChildrenToArray`
+		// that gets toggled on/off per Children.toArray enter/exit. When TWO
+		// Children.toArray calls both lexically enclose some code, the inner
+		// call's exit clobbers the flag even though the outer is still
+		// enclosing. Subsequent map/from calls inside the outer are then
+		// treated as "not inside toArray" and reported.
+		//
+		// These cases reproduce the quirk and lock our output 1:1 with
+		// upstream ESLint — verified by running eslint-plugin-react@7
+		// against these exact inputs. A depth-counter implementation would
+		// silently diverge (zero reports); do not "fix" the boolean.
+		{
+			Code: `
+React.Children.toArray([
+  React.Children.toArray(a),
+  xs.map(x => <A/>),
+]);
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey", Line: 4, Column: 15},
+			},
+		},
+		{
+			Code: `
+React.Children.toArray(
+  bar(
+    React.Children.toArray(a),
+    xs.map(y => <A/>)
+  )
+);
+`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingIterKey", Line: 5, Column: 17},
+			},
+		},
+		// Multiple JSX children of a JSX parent, duplicate keys across
+		// spread/non-spread siblings. checkKeyMustBeforeSpread catches the
+		// spread violator; warnOnDuplicates clusters the identical keys.
+		{
+			Code: `
+const div = (
+  <div>
+    <span {...o} key="a" />
+    <span key="a" />
+  </div>
+);
+`,
+			Tsx: true,
+			Options: map[string]interface{}{
+				"warnOnDuplicates":         true,
+				"checkKeyMustBeforeSpread": true,
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "keyBeforeSpread"},
+				{MessageId: "nonUniqueKeys", Line: 4},
+				{MessageId: "nonUniqueKeys", Line: 5},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -89,6 +89,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-equals-spacing.test.ts',
     './tests/eslint-plugin-react/rules/jsx-filename-extension.test.ts',
     './tests/eslint-plugin-react/rules/jsx-first-prop-new-line.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-key.test.ts',
     './tests/eslint-plugin-react/rules/jsx-max-props-per-line.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-key.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-key.test.ts
@@ -1,0 +1,294 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-key', {} as never, {
+  valid: [
+    // Keyed map callback — no report.
+    {
+      code: `
+        [1, 2, 3].map((item) => {
+          return item === 'bar' ? <div key={item}>{item}</div> : <span key={item}>{item}</span>;
+        });
+      `,
+    },
+    { code: 'fn();' },
+    { code: '[1, 2, 3].map(function () {});' },
+    { code: '<App />;' },
+    { code: '[<App key={0} />, <App key={1} />];' },
+    { code: '[1, 2, 3].map(function (x) { return <App key={x} /> });' },
+    { code: '[1, 2, 3].map(x => <App key={x} />);' },
+    { code: '[1, 2, 3].map(x => x && <App x={x} key={x} />);' },
+    {
+      code: '[1, 2, 3].map(x => x ? <App x={x} key="1" /> : <OtherApp x={x} key="2" />);',
+    },
+    { code: '[1, 2, 3].map(x => { return <App key={x} /> });' },
+    { code: 'Array.from([1, 2, 3], function (x) { return <App key={x} /> });' },
+    { code: 'Array.from([1, 2, 3], (x => <App key={x} />));' },
+    { code: 'Array.from([1, 2, 3], (x => { return <App key={x} /> }));' },
+    { code: 'Array.from([1, 2, 3], someFn);' },
+    { code: 'Array.from([1, 2, 3]);' },
+    // .foo() is not .map() — ignored.
+    { code: '[1, 2, 3].foo(x => <App />);' },
+    { code: 'var App = () => <div />;' },
+    { code: '[1, 2, 3].map(function (x) { return; });' },
+    { code: 'foo(() => <div />);' },
+    { code: 'foo(() => <></>);' },
+    { code: '<></>;' },
+    { code: '<App {...{}} />;' },
+    // Key before spread on a JSX element — not an array / iterator context,
+    // so checkKeyMustBeforeSpread doesn't kick in.
+    {
+      code: '<App key="keyBeforeSpread" {...{}} />;',
+      options: [{ checkKeyMustBeforeSpread: true }],
+    },
+    {
+      code: '<div key="keyBeforeSpread" {...{}} />;',
+      options: [{ checkKeyMustBeforeSpread: true }],
+    },
+    // warnOnDuplicates default (false) — duplicate keys allowed.
+    {
+      code: `
+        const spans = [
+          <span key="notunique" />,
+          <span key="notunique" />,
+        ];
+      `,
+    },
+    // React.Children.toArray — rule goes dormant inside.
+    { code: 'React.Children.toArray([1, 2, 3].map(x => <App />));' },
+    // Destructured Children.toArray — also dormant.
+    {
+      code: `
+        import { Children } from "react";
+        Children.toArray([1, 2, 3].map(x => <App />));
+      `,
+    },
+    // Logical returns with keyed JSX.
+    { code: '[1, 2, 3].map(x => { return x && <App key={x} />; });' },
+    { code: '[1, 2, 3].map(x => { return x && y && <App key={x} />; });' },
+    // Logical returns where right-hand side is not JSX.
+    { code: '[1, 2, 3].map(x => { return x && foo(); });' },
+    // Nested JSX without keys — direct JSX children of JSX don't need keys
+    // according to this rule.
+    { code: '<ul><li /><li /></ul>;' },
+    // Optional chaining on the map call itself.
+    { code: 'xs?.map(x => <App key={x} />);' },
+    { code: 'xs.map?.(x => <App key={x} />);' },
+  ],
+  invalid: [
+    // Ternary inside map callback — two missing iter keys.
+    {
+      code: `
+        [1, 2, 3].map((item) => {
+          return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+        });
+      `,
+      errors: [
+        { message: 'Missing "key" prop for element in iterator' },
+        { message: 'Missing "key" prop for element in iterator' },
+      ],
+    },
+    // FunctionExpression body variant.
+    {
+      code: `
+        [1, 2, 3].map(function (item) {
+          return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+        });
+      `,
+      errors: [
+        { message: 'Missing "key" prop for element in iterator' },
+        { message: 'Missing "key" prop for element in iterator' },
+      ],
+    },
+    // Array.from callback.
+    {
+      code: `
+        Array.from([1, 2, 3], (item) => {
+          return item === 'bar' ? <div>{item}</div> : <span>{item}</span>;
+        });
+      `,
+      errors: [
+        { message: 'Missing "key" prop for element in iterator' },
+        { message: 'Missing "key" prop for element in iterator' },
+      ],
+    },
+    // Array literal — missing key on array member.
+    {
+      code: '[<App />];',
+      errors: [{ message: 'Missing "key" prop for element in array' }],
+    },
+    // Spread-providing-key still counts as missing array key.
+    {
+      code: '[<App {...key} />];',
+      errors: [{ message: 'Missing "key" prop for element in array' }],
+    },
+    // Mixed: first has key, second doesn't.
+    {
+      code: '[<App key={0} />, <App />];',
+      errors: [{ message: 'Missing "key" prop for element in array' }],
+    },
+    // Plain map with FunctionExpression.
+    {
+      code: '[1, 2, 3].map(function (x) { return <App /> });',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Plain map with arrow.
+    {
+      code: '[1, 2, 3].map(x => <App />);',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Logical-right JSX inside map.
+    {
+      code: '[1, 2, 3].map(x => x && <App x={x} />);',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Ternary with one keyed and one unkeyed.
+    {
+      code: '[1, 2, 3].map(x => x ? <App x={x} key="1" /> : <OtherApp x={x} />);',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Array.from with arrow wrapped in parens.
+    {
+      code: 'Array.from([1, 2, 3], (x => <App />));',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Optional chain call.
+    {
+      code: '[1, 2, 3]?.map(x => <App />);',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Optional member access.
+    {
+      code: 'xs?.map(x => <App />);',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Optional call.
+    {
+      code: '[1, 2, 3].map?.(x => <App />);',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Fragment shorthand in iterator (option on).
+    {
+      code: '[1, 2, 3].map(x => <>{x}</>);',
+      options: [{ checkFragmentShorthand: true }],
+      errors: [
+        {
+          message:
+            'Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use React.Fragment instead',
+        },
+      ],
+    },
+    // Fragment shorthand in array literal (option on).
+    {
+      code: '[<></>];',
+      options: [{ checkFragmentShorthand: true }],
+      errors: [
+        {
+          message:
+            'Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use React.Fragment instead',
+        },
+      ],
+    },
+    // checkKeyMustBeforeSpread — key after spread in array context.
+    {
+      code: '[<App {...obj} key="keyAfterSpread" />];',
+      options: [{ checkKeyMustBeforeSpread: true }],
+      errors: [
+        {
+          message:
+            '`key` prop must be placed before any `{...spread}, to avoid conflicting with React\u2019s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`',
+        },
+      ],
+    },
+    // warnOnDuplicates — two identical keys.
+    {
+      code: `
+        const spans = [
+          <span key="notunique" />,
+          <span key="notunique" />,
+        ];
+      `,
+      options: [{ warnOnDuplicates: true }],
+      errors: [
+        { message: '`key` prop must be unique' },
+        { message: '`key` prop must be unique' },
+      ],
+    },
+    // warnOnDuplicates inside JSX parent.
+    {
+      code: `
+        const div = (
+          <div>
+            <span key="notunique" />
+            <span key="notunique" />
+          </div>
+        );
+      `,
+      options: [{ warnOnDuplicates: true }],
+      errors: [
+        { message: '`key` prop must be unique' },
+        { message: '`key` prop must be unique' },
+      ],
+    },
+    // if/else if/else with missing keys.
+    {
+      code: `
+        const TestCase = () => {
+          const list = [1, 2, 3, 4, 5];
+
+          return (
+            <div>
+              {list.map(item => {
+                if (item < 2) return <div>{item}</div>;
+                else if (item < 5) return <div />;
+                else return <div />;
+              })}
+            </div>
+          );
+        };
+      `,
+      errors: [
+        { message: 'Missing "key" prop for element in iterator' },
+        { message: 'Missing "key" prop for element in iterator' },
+        { message: 'Missing "key" prop for element in iterator' },
+      ],
+    },
+    // checkKeyMustBeforeSpread inside a map callback — reports on the
+    // element itself, not the containing array.
+    {
+      code: `
+        const TestCase = () => {
+          const list = [1, 2, 3, 4, 5];
+
+          return (
+            <div>
+              {list.map(x => <div {...spread} key={x} />)}
+            </div>
+          );
+        };
+      `,
+      options: [{ checkKeyMustBeforeSpread: true }],
+      errors: [
+        {
+          message:
+            '`key` prop must be placed before any `{...spread}, to avoid conflicting with React\u2019s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`',
+        },
+      ],
+    },
+    // Logical / disjunction in return argument.
+    {
+      code: '[1, 2, 3].map(x => { return x && <App />; });',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    {
+      code: '[1, 2, 3].map(x => { return x || y || <App />; });',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+    // Parenthesized JSX body.
+    {
+      code: '[1,2,3].map(x => (<App />));',
+      errors: [{ message: 'Missing "key" prop for element in iterator' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -17,6 +17,7 @@ bleh
 bmatcuk
 bodyless
 cachedvfs
+callees
 catchable
 clazz
 clientrc
@@ -95,6 +96,7 @@ marginx
 marginy
 Metas
 minimatch
+mobx
 morestack
 multilines
 myfunc
@@ -110,6 +112,7 @@ nonconstructor
 nonoctal
 noregabi
 notcool
+notunique
 nsec
 nullary
 Nullishness
@@ -119,6 +122,7 @@ optionable
 osvfs
 parenless
 preact
+Prag
 Prettier
 propertyassignment
 Ptrs
@@ -160,6 +164,7 @@ sourcegraph
 spreadassignment
 spreadelement
 stdjson
+stmts
 stringutil
 stub
 stype
@@ -167,8 +172,10 @@ subclassing
 symb
 symbolname
 testdata
+testrule
 textnodes
 thenables
+tmdb
 tmpl
 trae
 tsconfiga


### PR DESCRIPTION
## Summary

Port the \`react/jsx-key\` rule from eslint-plugin-react to rslint.

Warns when a JSX element that likely needs a \`key\` prop — one inside an array literal or returned from an arrow / function callback passed to \`Array.prototype.map\` / \`Array.from\` — is missing one. All three upstream options are supported: \`checkFragmentShorthand\`, \`checkKeyMustBeforeSpread\`, \`warnOnDuplicates\`.

Output was cross-verified byte-for-byte against \`eslint-plugin-react@7\` on the upstream unit-test suite, plus real \`rsbuild\` and \`rspack\` codebases — rslint and ESLint produce identical diagnostics (position, messageId, message text).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-key.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).