### PR TITLE
feat: port rule react/jsx-pascal-case

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -10,6 +10,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_bind"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_duplicate_props"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_pascal_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_multi_spaces"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
@@ -41,6 +42,7 @@ func GetAllRules() []rule.Rule {
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,
 		jsx_no_bind.JsxNoBindRule,
 		jsx_no_duplicate_props.JsxNoDuplicatePropsRule,
+		jsx_pascal_case.JsxPascalCaseRule,
 		jsx_props_no_multi_spaces.JsxPropsNoMultiSpacesRule,
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -395,6 +395,66 @@ func GetJsxElementAttributes(element *ast.Node) []*ast.Node {
 	return list.Properties.Nodes
 }
 
+// GetJsxElementTypeString returns the jsx-ast-utils `elementType(node)`
+// equivalent — the dotted / namespaced display string of a JSX tag name as
+// an ESTree-compatible source caller would see it. `node` may be either a
+// JsxOpeningElement / JsxSelfClosingElement, or a raw tag-name node. Returns
+// "" for shapes that don't correspond to a legal React/JSX element type
+// (e.g. a computed member access), so callers can treat "" as "not a user
+// component".
+//
+// Supported tag shapes:
+//
+//   - `<Foo>` / `<foo>`       → "Foo" / "foo"
+//   - `<Foo.Bar.Baz>`         → "Foo.Bar.Baz" (PropertyAccessExpression chain)
+//   - `<this.Foo>`            → "this.Foo" (ThisKeyword base)
+//   - `<ns:Name>`             → "ns:Name" (JsxNamespacedName)
+//
+// This is AST-driven — interior whitespace or comments in unusual forms
+// (e.g. `<Foo . Bar />`) are normalized away, matching jsx-ast-utils.
+func GetJsxElementTypeString(node *ast.Node) string {
+	tagName := node
+	if node != nil {
+		if t := GetJsxTagName(node); t != nil {
+			tagName = t
+		}
+	}
+	return tagNameString(tagName)
+}
+
+func tagNameString(tagName *ast.Node) string {
+	if tagName == nil {
+		return ""
+	}
+	switch tagName.Kind {
+	case ast.KindIdentifier:
+		return tagName.AsIdentifier().Text
+	case ast.KindThisKeyword:
+		return "this"
+	case ast.KindJsxNamespacedName:
+		ns := tagName.AsJsxNamespacedName()
+		if ns.Namespace == nil || ns.Name() == nil {
+			return ""
+		}
+		if ns.Namespace.Kind != ast.KindIdentifier || ns.Name().Kind != ast.KindIdentifier {
+			return ""
+		}
+		return ns.Namespace.AsIdentifier().Text + ":" + ns.Name().AsIdentifier().Text
+	case ast.KindPropertyAccessExpression:
+		pa := tagName.AsPropertyAccessExpression()
+		base := tagNameString(pa.Expression)
+		if base == "" {
+			return ""
+		}
+		nameNode := pa.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return ""
+		}
+		return base + "." + nameNode.AsIdentifier().Text
+	}
+	return ""
+}
+
 // IsDOMComponent reports whether a JSX opening/self-closing element refers to
 // an intrinsic (DOM) element like <div> or <svg:path>, rather than a user
 // component like <Foo> or <Foo.Bar>.

--- a/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.go
+++ b/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.go
@@ -1,0 +1,366 @@
+package jsx_pascal_case
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	msgUsePascalCase        = "Imported JSX component {{name}} must be in PascalCase"
+	msgUsePascalOrSnakeCase = "Imported JSX component {{name}} must be in PascalCase or SCREAMING_SNAKE_CASE"
+)
+
+type pascalCaseOptions struct {
+	allowAllCaps           bool
+	allowLeadingUnderscore bool
+	allowNamespace         bool
+	ignore                 []compiledPattern
+}
+
+// compiledPattern pairs the raw ignore entry with its regex translation. The
+// raw string handles the exact-match fast path and the regex covers
+// minimatch-style globs (including extglob `+(a|b)`). `re` may be nil when
+// the pattern failed to compile — in that case only the exact-match arm
+// matches, which degrades gracefully on malformed input.
+type compiledPattern struct {
+	raw string
+	re  *regexp.Regexp
+}
+
+func parseOptions(opts any) pascalCaseOptions {
+	cfg := pascalCaseOptions{}
+	optsMap := utils.GetOptionsMap(opts)
+	if optsMap == nil {
+		return cfg
+	}
+	if v, ok := optsMap["allowAllCaps"].(bool); ok {
+		cfg.allowAllCaps = v
+	}
+	if v, ok := optsMap["allowLeadingUnderscore"].(bool); ok {
+		cfg.allowLeadingUnderscore = v
+	}
+	if v, ok := optsMap["allowNamespace"].(bool); ok {
+		cfg.allowNamespace = v
+	}
+	if raw, ok := optsMap["ignore"].([]interface{}); ok {
+		for _, entry := range raw {
+			if s, ok := entry.(string); ok {
+				cfg.ignore = append(cfg.ignore, compiledPattern{raw: s, re: compileMinimatch(s)})
+			}
+		}
+	}
+	return cfg
+}
+
+// testDigit mirrors the upstream ASCII-only digit check (`charCode 48-57`).
+func testDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
+// testUpperCase mirrors upstream `char === char.toUpperCase() && upperCase !== char.toLowerCase()`.
+// True iff the rune is a cased letter in its upper form — excludes digits
+// and non-letter symbols (where upper == lower).
+func testUpperCase(r rune) bool {
+	return unicode.ToUpper(r) == r && unicode.ToLower(r) != r
+}
+
+// testLowerCase mirrors upstream `char === char.toLowerCase() && lowerCase !== char.toUpperCase()`.
+func testLowerCase(r rune) bool {
+	return unicode.ToLower(r) == r && unicode.ToUpper(r) != r
+}
+
+// isNonAlphaNumeric mirrors upstream
+// `char.toLowerCase() === char.toUpperCase() && !testDigit(char)` — true for
+// symbols like `_`, `-`, `$`, where upper and lower coincide, excluding digits.
+func isNonAlphaNumeric(r rune) bool {
+	return unicode.ToLower(r) == unicode.ToUpper(r) && !testDigit(r)
+}
+
+// testPascalCase returns true when `name` begins with an upper-case letter,
+// contains no non-alphanumeric characters after the first, and includes at
+// least one lower-case letter or digit after the first position. A bare
+// uppercase letter (e.g. `"T"`) fails the final "has lower/digit" check and
+// returns false — callers short-circuit on single-character names before
+// reaching here, so the bare-upper case never reaches testPascalCase.
+func testPascalCase(name string) bool {
+	runes := []rune(name)
+	if len(runes) == 0 {
+		return false
+	}
+	if !testUpperCase(runes[0]) {
+		return false
+	}
+	rest := runes[1:]
+	for _, r := range rest {
+		if isNonAlphaNumeric(r) {
+			return false
+		}
+	}
+	for _, r := range rest {
+		if testLowerCase(r) || testDigit(r) {
+			return true
+		}
+	}
+	return false
+}
+
+// testAllCaps mirrors upstream: first char upper or digit, every interior
+// char upper / digit / underscore, last char upper or digit. Names of length
+// 1 never reach this function because `splitName.length === 1` short-circuits.
+func testAllCaps(name string) bool {
+	runes := []rune(name)
+	if len(runes) == 0 {
+		return false
+	}
+	first := runes[0]
+	if !testUpperCase(first) && !testDigit(first) {
+		return false
+	}
+	// Upstream loops `i = 1; i < name.length - 1` — i.e. strictly interior
+	// positions only. For a 2-char name the loop body never executes.
+	for i := 1; i < len(runes)-1; i++ {
+		c := runes[i]
+		if !testUpperCase(c) && !testDigit(c) && c != '_' {
+			return false
+		}
+	}
+	last := runes[len(runes)-1]
+	return testUpperCase(last) || testDigit(last)
+}
+
+func ignoreCheck(patterns []compiledPattern, name string) bool {
+	for _, p := range patterns {
+		if name == p.raw {
+			return true
+		}
+		if p.re != nil && p.re.MatchString(name) {
+			return true
+		}
+	}
+	return false
+}
+
+// compileMinimatch translates a minimatch-style glob (with extglob support)
+// into an anchored Go regex. Covers the syntax used by
+// eslint-plugin-react/jsx-pascal-case `ignore` entries:
+//
+//   - `*`          — any run of characters
+//   - `?`          — a single character
+//   - `[...]`      — character class (leading `!` / `^` inverts)
+//   - `?(a|b)`     — zero or one of alternatives
+//   - `*(a|b)`     — zero or more of alternatives
+//   - `+(a|b)`     — one or more of alternatives
+//   - `@(a|b)`     — exactly one of alternatives
+//
+// Upstream passes `{ noglobstar: true }` — `**` is collapsed to `*`. Returns
+// nil on malformed patterns; callers treat that as "exact-match only".
+// NOTE: `!(...)` negation would require lookarounds which RE2 does not
+// support. None of the upstream tests exercise it; we still emit a non-nil
+// regex so the pattern isn't silently dropped, but it matches permissively
+// (equivalent to `(?:...)?`). Document if a user-facing divergence appears.
+func compileMinimatch(pattern string) *regexp.Regexp {
+	body := minimatchBody([]rune(pattern))
+	re, err := regexp.Compile("^" + body + "$")
+	if err != nil {
+		return nil
+	}
+	return re
+}
+
+// minimatchBody / findMatchingClose / splitTopLevelAlts operate on `[]rune`
+// so that indices and slicing are codepoint-aligned — essential when
+// `ignore` patterns contain non-ASCII characters (`Año_*`, CJK, emoji).
+// Mixing rune indices with `string` byte offsets would misalign after the
+// first multi-byte rune; keeping all three helpers on the same rune slice
+// avoids that trap.
+func minimatchBody(runes []rune) string {
+	var sb strings.Builder
+	i := 0
+	for i < len(runes) {
+		r := runes[i]
+		if i+1 < len(runes) && runes[i+1] == '(' && strings.ContainsRune("?*+@!", r) {
+			if end, ok := findMatchingClose(runes, i+2); ok {
+				alts := splitTopLevelAlts(runes[i+2 : end])
+				parts := make([]string, len(alts))
+				for j, a := range alts {
+					parts[j] = minimatchBody(a)
+				}
+				body := strings.Join(parts, "|")
+				switch r {
+				case '?':
+					sb.WriteString("(?:" + body + ")?")
+				case '*':
+					sb.WriteString("(?:" + body + ")*")
+				case '+':
+					sb.WriteString("(?:" + body + ")+")
+				case '@':
+					sb.WriteString("(?:" + body + ")")
+				case '!':
+					// RE2 lacks lookarounds; approximate as "zero or one"
+					// so the pattern still compiles. The upstream test
+					// suite doesn't exercise `!(...)`.
+					sb.WriteString("(?:" + body + ")?")
+				}
+				i = end + 1
+				continue
+			}
+		}
+		switch r {
+		case '*':
+			for i < len(runes) && runes[i] == '*' {
+				i++
+			}
+			sb.WriteString(".*")
+		case '?':
+			sb.WriteString(".")
+			i++
+		case '[':
+			closeIdx := -1
+			for j := i + 1; j < len(runes); j++ {
+				if runes[j] == ']' {
+					closeIdx = j
+					break
+				}
+			}
+			// Need at least two runes between `[` and `]` so `[^x]` / `[!x]`
+			// negation doesn't collapse to an empty inverted class (`[^]`),
+			// which RE2 rejects as malformed.
+			if closeIdx > i+1 {
+				body := string(runes[i+1 : closeIdx])
+				if len(body) > 1 && (body[0] == '!' || body[0] == '^') {
+					body = "^" + body[1:]
+				}
+				sb.WriteString("[" + body + "]")
+				i = closeIdx + 1
+			} else {
+				sb.WriteString("\\[")
+				i++
+			}
+		case '\\':
+			if i+1 < len(runes) {
+				sb.WriteString(regexp.QuoteMeta(string(runes[i+1])))
+				i += 2
+			} else {
+				sb.WriteString("\\\\")
+				i++
+			}
+		default:
+			sb.WriteString(regexp.QuoteMeta(string(r)))
+			i++
+		}
+	}
+	return sb.String()
+}
+
+func findMatchingClose(runes []rune, start int) (int, bool) {
+	depth := 1
+	for j := start; j < len(runes); j++ {
+		switch runes[j] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return j, true
+			}
+		}
+	}
+	return -1, false
+}
+
+func splitTopLevelAlts(runes []rune) [][]rune {
+	var parts [][]rune
+	depth := 0
+	start := 0
+	for i := range runes {
+		switch runes[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '|':
+			if depth == 0 {
+				parts = append(parts, runes[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, runes[start:])
+	return parts
+}
+
+var JsxPascalCaseRule = rule.Rule{
+	Name: "react/jsx-pascal-case",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		cfg := parseOptions(options)
+
+		check := func(element *ast.Node) {
+			if reactutil.IsDOMComponent(element) {
+				return
+			}
+			name := reactutil.GetJsxElementTypeString(element)
+			if name == "" {
+				return
+			}
+
+			// Upstream splits on `:` first, else on `.` — never on both.
+			var checkNames []string
+			if strings.LastIndex(name, ":") > -1 {
+				checkNames = strings.Split(name, ":")
+			} else if strings.LastIndex(name, ".") > -1 {
+				checkNames = strings.Split(name, ".")
+			} else {
+				checkNames = []string{name}
+			}
+
+			for index := range checkNames {
+				splitName := checkNames[index]
+				// Single-character parts are always allowed — matches upstream
+				// `if (splitName.length === 1) return undefined;` which bails
+				// out of the whole rule for this element.
+				if len([]rune(splitName)) == 1 {
+					return
+				}
+				isIgnored := ignoreCheck(cfg.ignore, splitName)
+
+				checkName := splitName
+				if cfg.allowLeadingUnderscore && strings.HasPrefix(splitName, "_") {
+					checkName = splitName[1:]
+				}
+				isPascal := testPascalCase(checkName)
+				isAllowedAllCaps := cfg.allowAllCaps && testAllCaps(checkName)
+
+				if !isPascal && !isAllowedAllCaps && !isIgnored {
+					msgId := "usePascalCase"
+					msg := msgUsePascalCase
+					if cfg.allowAllCaps {
+						msgId = "usePascalOrSnakeCase"
+						msg = msgUsePascalOrSnakeCase
+					}
+					ctx.ReportNode(element, rule.RuleMessage{
+						Id:          msgId,
+						Description: strings.ReplaceAll(msg, "{{name}}", splitName),
+					})
+					break
+				}
+				// Upstream's `do...while (index < checkNames.length && !allowNamespace)`:
+				// with allowNamespace, the loop exits after the first successful
+				// iteration; without, it continues through every split part.
+				if cfg.allowNamespace {
+					break
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
+++ b/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
@@ -1,0 +1,117 @@
+# react/jsx-pascal-case
+
+Enforce PascalCase for user-defined JSX components.
+
+## Rule Details
+
+JSX tag names that start with a lowercase letter are interpreted by React as
+HTML intrinsics (`<div>`, `<span>`, …) and are skipped. For user components
+(`<TestComponent>`), this rule requires PascalCase: the first character must
+be an upper-case letter, the remaining characters must be alphanumeric, and
+at least one lower-case letter or digit must follow.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<Test_component />
+```
+
+```jsx
+<TEST_COMPONENT />
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<div />
+```
+
+```jsx
+<TestComponent />
+```
+
+```jsx
+<TestComponent>
+  <div />
+</TestComponent>
+```
+
+```jsx
+<CSSTransitionGroup />
+```
+
+## Rule Options
+
+```json
+{
+  "react/jsx-pascal-case": [
+    "error",
+    {
+      "allowAllCaps": false,
+      "allowNamespace": false,
+      "allowLeadingUnderscore": false,
+      "ignore": []
+    }
+  ]
+}
+```
+
+- `allowAllCaps` (default `false`): allow SCREAMING\_SNAKE\_CASE component names.
+- `allowNamespace` (default `false`): skip the check for parts after the first
+  dot or colon in a namespaced / member-access tag.
+- `allowLeadingUnderscore` (default `false`): strip a single leading `_` before
+  running the PascalCase / all-caps check.
+- `ignore` (default `[]`): array of names to exempt. Entries are matched as
+  minimatch-style globs — supports `*`, `?`, character classes, and extglob
+  groups such as `+(a|b)`.
+
+### `allowAllCaps`
+
+Examples of **correct** code for this rule, when `allowAllCaps` is `true`:
+
+```json
+{ "react/jsx-pascal-case": ["error", { "allowAllCaps": true }] }
+```
+
+```jsx
+<ALLOWED />
+<TEST_COMPONENT />
+```
+
+### `allowNamespace`
+
+Examples of **correct** code for this rule, when `allowNamespace` is `true`:
+
+```json
+{ "react/jsx-pascal-case": ["error", { "allowNamespace": true }] }
+```
+
+```jsx
+<Allowed.div />
+<TestComponent.p />
+```
+
+### `allowLeadingUnderscore`
+
+Examples of **correct** code for this rule, when `allowLeadingUnderscore` is
+`true`:
+
+```json
+{ "react/jsx-pascal-case": ["error", { "allowLeadingUnderscore": true }] }
+```
+
+```jsx
+<_AllowedComponent />
+<_AllowedComponent>
+  <div />
+</_AllowedComponent>
+```
+
+## Differences from ESLint
+
+- `ignore` entries do not support the `!(a|b)` negative extglob syntax.
+
+## Original Documentation
+
+- ESLint-plugin-react rule: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md>
+- Source: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js>

--- a/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case_test.go
+++ b/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case_test.go
@@ -1,0 +1,444 @@
+package jsx_pascal_case
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxPascalCaseRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxPascalCaseRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		// Lowercase-leading tags are DOM intrinsics and not checked.
+		{Code: `<testcomponent />;`, Tsx: true},
+		{Code: `<testComponent />;`, Tsx: true},
+		{Code: `<test_component />;`, Tsx: true},
+		// Canonical PascalCase names.
+		{Code: `<TestComponent />;`, Tsx: true},
+		{Code: `<CSSTransitionGroup />;`, Tsx: true},
+		{Code: `<BetterThanCSS />;`, Tsx: true},
+		{Code: `<TestComponent><div /></TestComponent>;`, Tsx: true},
+		{Code: `<Test1Component />;`, Tsx: true},
+		{Code: `<TestComponent1 />;`, Tsx: true},
+		{Code: `<T3StComp0Nent />;`, Tsx: true},
+		// Unicode letters in PascalCase names.
+		{Code: `<Éurströmming />;`, Tsx: true},
+		{Code: `<Año />;`, Tsx: true},
+		{Code: `<Søknad />;`, Tsx: true},
+		// Single-char names always allowed.
+		{Code: `<T />;`, Tsx: true},
+		// allowAllCaps: SCREAMING_SNAKE_CASE names accepted.
+		{Code: `<YMCA />;`, Tsx: true, Options: map[string]interface{}{"allowAllCaps": true}},
+		{Code: `<TEST_COMPONENT />;`, Tsx: true, Options: map[string]interface{}{"allowAllCaps": true}},
+		// Member-access tag: each dotted part is checked independently.
+		{Code: `<Modal.Header />;`, Tsx: true},
+		{Code: `<qualification.T3StComp0Nent />;`, Tsx: true},
+		// ignore list exact / glob / extglob entries.
+		{Code: `<IGNORED />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"IGNORED"}}},
+		{Code: `<Foo_DEPRECATED />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"*_D*D"}}},
+		{Code: `<Foo_DEPRECATED />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"*_+(DEPRECATED|IGNORED)"}}},
+		// Single-char `$` / `_` — length-1 short-circuit exempts them.
+		{Code: `<$ />;`, Tsx: true},
+		{Code: `<_ />;`, Tsx: true},
+		// `H1` is PascalCase (upper, then digit counts as a follow-up char).
+		{Code: `<H1>Hello!</H1>;`, Tsx: true},
+		// Without allowNamespace, each dotted part is still checked — "P" is
+		// length-1 so it's allowed.
+		{Code: `<Typography.P />;`, Tsx: true},
+		// allowNamespace exits after the first valid part; "h1" is not
+		// checked because "Styled" already passed.
+		{Code: `<Styled.h1 />;`, Tsx: true, Options: map[string]interface{}{"allowNamespace": true}},
+		// allowLeadingUnderscore strips `_` before pascal/all-caps tests.
+		{Code: `<_TEST_COMPONENT />;`, Tsx: true, Options: map[string]interface{}{"allowAllCaps": true, "allowLeadingUnderscore": true}},
+		{Code: `<_TestComponent />;`, Tsx: true, Options: map[string]interface{}{"allowLeadingUnderscore": true}},
+
+		// ---- Additional edge cases ----
+		// JSX within JSX — inner DOM child isn't checked.
+		{Code: `<Wrapper><span /></Wrapper>;`, Tsx: true},
+		// Self-closing on a member-access base with single-char leaf.
+		{Code: `<Foo.T />;`, Tsx: true},
+		// `<this.Foo>` — IsDOMComponent classifies as DOM (leading "this"
+		// lowercase), so no report is emitted.
+		{Code: `<this.Foo />;`, Tsx: true},
+		// Chained member access with every level PascalCase.
+		{Code: `<Foo.Bar.Baz />;`, Tsx: true},
+		{Code: `<Foo.Bar.Baz.Qux />;`, Tsx: true},
+		// Member access where a middle / leaf part is single-char — the
+		// length-1 short-circuit exempts the whole element.
+		{Code: `<Foo.T.Bar />;`, Tsx: true},
+		{Code: `<Foo.Bar.T />;`, Tsx: true},
+		// allowAllCaps combined with member access — ALL-CAPS leaf allowed.
+		{Code: `<Foo.BAR />;`, Tsx: true, Options: map[string]interface{}{"allowAllCaps": true}},
+		// allowNamespace combined with allowAllCaps — first ALL-CAPS passes,
+		// `h1` never reached.
+		{
+			Code:    `<FOO.h1 />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true, "allowNamespace": true},
+		},
+		// All four options together on a "happy path" name.
+		{
+			Code:    `<_SAFE />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true, "allowLeadingUnderscore": true, "allowNamespace": true, "ignore": []interface{}{"Never"}},
+		},
+		// Multiple JSX elements in a single source — DOM intrinsics are
+		// skipped, user components validated independently.
+		{Code: `<div><Wrapper /><span /><OtherOK /></div>;`, Tsx: true},
+		// JSX nested inside a JSX expression container — both outer and
+		// inner elements are checked.
+		{Code: `<Outer>{true && <Inner />}</Outer>;`, Tsx: true},
+		// JSX passed as a JSX attribute value (prop children-style) — the
+		// nested <Inner /> is its own element and must also pass.
+		{Code: `<Outer prop={<Inner />} />;`, Tsx: true},
+		// JSX fragment wrapping user components — the fragment itself has
+		// no tag name, children are still checked.
+		{Code: `<><Foo /><Bar /></>;`, Tsx: true},
+		// Conditional / ternary with two user components.
+		{Code: `const cond = true; <Outer>{cond ? <Yes /> : <No />}</Outer>;`, Tsx: true},
+		// Ignore patterns: character class `[A-Z]` — exact length 2.
+		{Code: `<AB />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"[A-Z][A-Z]"}}},
+		// Ignore patterns: @() extglob — "match exactly one of".
+		{Code: `<Foo_BAR />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"Foo_@(BAR|BAZ)"}}},
+		// Ignore patterns: ? single-char wildcard.
+		{Code: `<A_B />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"A_?"}}},
+		// Upstream valid case — JSX namespaced tag. tsgo parses this
+		// natively (KindJsxNamespacedName), so unlike what the upstream
+		// test's `features: ['jsx namespace']` flag suggests, no special
+		// parser opt-in is needed here.
+		{Code: `<Modal:Header />;`, Tsx: true},
+
+		// ---- Robustness: Unicode in ignore patterns ----
+		// Non-ASCII literal in pattern — must match rune-for-rune, not
+		// byte-for-byte (byte iteration would produce broken regex).
+		{Code: `<Año_Old />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"Año_*"}}},
+		// Unicode + `?` single-rune wildcard — one `?` must match exactly
+		// one rune, not one byte.
+		{Code: `<Año_KEEP />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"Año_KE?P"}}},
+
+		// ---- Robustness: malformed ignore patterns don't crash ----
+		// Unclosed `[` — the `[` is treated as a literal (regex class
+		// never opened); ignore entry effectively exact-matches "[invalid"
+		// which doesn't match "Good_Name" → rule runs normally and sees
+		// PascalCase → valid.
+		{Code: `<Good />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"[invalid"}}},
+		// `[^]` — only one rune inside the class (plus the negation marker)
+		// would produce the invalid regex `[^]` under a naive translation;
+		// our guard emits `\[` instead so compile succeeds with no match.
+		{Code: `<Good />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"[^]"}}},
+		// Empty `[]` class — same guard, no crash.
+		{Code: `<Good />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"[]"}}},
+
+		// ---- TypeScript generics on JSX tag ----
+		// Type arguments don't change TagName; rule inspects the tag only.
+		{Code: `<Foo<string> />;`, Tsx: true},
+		// Real-world namespaced intrinsics: SVG with `svg:` prefix. The
+		// elementType ("svg:path") starts lowercase → DOM → skipped.
+		{Code: `<svg:path />;`, Tsx: true},
+		// Namespaced tag with SCREAMING_SNAKE_CASE leaf + allowAllCaps.
+		{Code: `<Modal:NAMED />;`, Tsx: true, Options: map[string]interface{}{"allowAllCaps": true}},
+		// Namespace + leading underscore leaf, stripped and validated.
+		{Code: `<Modal:_Header />;`, Tsx: true, Options: map[string]interface{}{"allowLeadingUnderscore": true}},
+		// Namespace + allowNamespace: first part passes → loop exits
+		// before checking the lowercase leaf "h1".
+		{Code: `<Styled:h1 />;`, Tsx: true, Options: map[string]interface{}{"allowNamespace": true}},
+		// Namespace + ignore: second part matched via glob.
+		{Code: `<Modal:Foo_DEPRECATED />;`, Tsx: true, Options: map[string]interface{}{"ignore": []interface{}{"*_DEPRECATED"}}},
+
+		// tsgo rejects these shapes at parse time (they're invalid JSX per
+		// spec — namespaces are single-level and don't mix with `.`):
+		//   <A:B:C />                 → TS1003 Identifier expected
+		//   <Modal:Header.Sub />      → TS1003 Identifier expected
+		//   <Foo.Modal:Header />      → TS1003 Identifier expected
+		// ESLint/Babel's parser behaves the same.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `<Test_component />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component Test_component must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<TEST_COMPONENT />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component TEST_COMPONENT must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<YMCA />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component YMCA must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<_TEST_COMPONENT />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component _TEST_COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<TEST_COMPONENT_ />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component TEST_COMPONENT_ must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<TEST-COMPONENT />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component TEST-COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<__ />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<_div />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowLeadingUnderscore": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component _div must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<__ />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true, "allowLeadingUnderscore": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<$a />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component $a must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code:    `<Foo_DEPRECATED />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"*_FOO"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component Foo_DEPRECATED must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			// Member-access: second part "h1" starts lowercase → usePascalCase
+			// with name "h1".
+			Code: `<Styled.h1 />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component h1 must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<$Typography.P />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component $Typography must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		{
+			// With allowNamespace, the outer loop still checks the FIRST
+			// part; "STYLED" fails both PascalCase and ALL_CAPS (allowAllCaps
+			// is off), so we report before reaching "h1".
+			Code:    `<STYLED.h1 />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowNamespace": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component STYLED must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Additional edge cases ----
+		// Multi-line JSX: position assertions anchor at the element opening.
+		{
+			Code: "<TEST_COMPONENT\n  foo=\"bar\"\n/>;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Line: 1, Column: 1, EndLine: 3, EndColumn: 3},
+			},
+		},
+		// Opening form (not self-closing) still reports — listener covers both.
+		{
+			Code: `<TEST_COMPONENT>hi</TEST_COMPONENT>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Line: 1, Column: 1},
+			},
+		},
+		// allowLeadingUnderscore doesn't rescue a name that's invalid even
+		// after stripping the underscore.
+		{
+			Code:    `<_test />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowLeadingUnderscore": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Line: 1, Column: 1},
+			},
+		},
+		// ignore doesn't match a different casing of the name.
+		{
+			Code:    `<BAD_NAME />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"GOOD_NAME"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Member access where the first part is valid pascal but second is
+		// lowercase — reports on the second part by its name.
+		{
+			Code: `<Foo.bar />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component bar must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Chained member access: middle part is lowercase — reports that
+		// middle name, not the leaf or the root.
+		{
+			Code: `<Foo.bad_name.Baz />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component bad_name must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Leaf is invalid (trailing lowercase) — reports leaf.
+		{
+			Code: `<Foo.Bar.baz />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component baz must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Multiple invalid components in one element — rule fires once per
+		// offending element, not once per file. `ALL_CAPS` names fail
+		// PascalCase (the underscore trips the non-alphanumeric check).
+		{
+			Code: `<div><FOO_A /><FOO_B /></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component FOO_A must be in PascalCase", Line: 1, Column: 6},
+				{MessageId: "usePascalCase", Message: "Imported JSX component FOO_B must be in PascalCase", Line: 1, Column: 15},
+			},
+		},
+		// Invalid component nested inside a JSX expression container.
+		{
+			Code: `<Wrapper>{true && <Bad_Inner />}</Wrapper>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component Bad_Inner must be in PascalCase", Line: 1, Column: 19},
+			},
+		},
+		// Invalid component passed as a JSX attribute value.
+		{
+			Code: `<Wrapper prop={<Bad_Attr />} />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component Bad_Attr must be in PascalCase", Line: 1, Column: 16},
+			},
+		},
+		// allowAllCaps switches the messageId to usePascalOrSnakeCase even
+		// when the failing reason isn't a SCREAMING_SNAKE_CASE candidate.
+		{
+			Code:    `<$Weird />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component $Weird must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		// Member access multi-line — position assertion across lines.
+		{
+			Code: "<Foo.\n  bar />;",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component bar must be in PascalCase", Line: 1, Column: 1, EndLine: 2, EndColumn: 9},
+			},
+		},
+		// Namespace with lowercase-Name-with-underscore leaf — report on leaf.
+		{
+			Code: `<Modal:bad_header />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component bad_header must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Namespace with uppercase namespace that fails PascalCase — report
+		// on namespace part (first split segment).
+		{
+			Code: `<BAD_NS:Header />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component BAD_NS must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Namespace + allowAllCaps: leaf is not SCREAMING_SNAKE_CASE and
+		// not PascalCase → usePascalOrSnakeCase.
+		{
+			Code:    `<Modal:bad_Name />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAllCaps": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalOrSnakeCase", Message: "Imported JSX component bad_Name must be in PascalCase or SCREAMING_SNAKE_CASE", Line: 1, Column: 1},
+			},
+		},
+		// Namespace + allowNamespace: first part fails → still reported
+		// (allowNamespace only skips subsequent parts after first success).
+		{
+			Code:    `<BAD_NS:Header />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowNamespace": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component BAD_NS must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Member-access leaf with leading special char — reports the
+		// specific failing segment, not the whole chain.
+		{
+			Code: `<Foo.$Bar />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component $Bar must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// TS generic on an otherwise-invalid tag name still reports.
+		{
+			Code: `<Bad_Name<string> />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component Bad_Name must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+		// Unicode ignore pattern — if the ignore regex is built byte-wise
+		// instead of rune-wise, it fails to match `<Año_BAD />` via
+		// `Año_B*`, and the rule falsely reports usePascalCase. The
+		// inverse assertion: a non-matching Unicode pattern lets the
+		// rule fire on a genuinely bad name.
+		{
+			Code:    `<Año_BAD />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"Año_DIFFERENT"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usePascalCase", Message: "Imported JSX component Año_BAD must be in PascalCase", Line: 1, Column: 1},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -93,6 +93,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts
@@ -1,0 +1,337 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-pascal-case', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    { code: `<testcomponent />;` },
+    { code: `<testComponent />;` },
+    { code: `<test_component />;` },
+    { code: `<TestComponent />;` },
+    { code: `<CSSTransitionGroup />;` },
+    { code: `<BetterThanCSS />;` },
+    { code: `<TestComponent><div /></TestComponent>;` },
+    { code: `<Test1Component />;` },
+    { code: `<TestComponent1 />;` },
+    { code: `<T3StComp0Nent />;` },
+    { code: `<Éurströmming />;` },
+    { code: `<Año />;` },
+    { code: `<Søknad />;` },
+    { code: `<T />;` },
+    { code: `<YMCA />;`, options: [{ allowAllCaps: true }] },
+    { code: `<TEST_COMPONENT />;`, options: [{ allowAllCaps: true }] },
+    { code: `<Modal.Header />;` },
+    { code: `<qualification.T3StComp0Nent />;` },
+    { code: `<IGNORED />;`, options: [{ ignore: ['IGNORED'] }] },
+    { code: `<Foo_DEPRECATED />;`, options: [{ ignore: ['*_D*D'] }] },
+    {
+      code: `<Foo_DEPRECATED />;`,
+      options: [{ ignore: ['*_+(DEPRECATED|IGNORED)'] }],
+    },
+    { code: `<$ />;` },
+    { code: `<_ />;` },
+    { code: `<H1>Hello!</H1>;` },
+    { code: `<Typography.P />;` },
+    { code: `<Styled.h1 />;`, options: [{ allowNamespace: true }] },
+    {
+      code: `<_TEST_COMPONENT />;`,
+      options: [{ allowAllCaps: true, allowLeadingUnderscore: true }],
+    },
+    {
+      code: `<_TestComponent />;`,
+      options: [{ allowLeadingUnderscore: true }],
+    },
+
+    // ---- Additional edge cases ----
+    { code: `<Wrapper><span /></Wrapper>;` },
+    { code: `<Foo.T />;` },
+    { code: `<this.Foo />;` },
+    { code: `<Foo.Bar.Baz />;` },
+    { code: `<Foo.Bar.Baz.Qux />;` },
+    { code: `<Foo.T.Bar />;` },
+    { code: `<Foo.Bar.T />;` },
+    { code: `<Foo.BAR />;`, options: [{ allowAllCaps: true }] },
+    {
+      code: `<FOO.h1 />;`,
+      options: [{ allowAllCaps: true, allowNamespace: true }],
+    },
+    {
+      code: `<_SAFE />;`,
+      options: [
+        {
+          allowAllCaps: true,
+          allowLeadingUnderscore: true,
+          allowNamespace: true,
+          ignore: ['Never'],
+        },
+      ],
+    },
+    { code: `<div><Wrapper /><span /><OtherOK /></div>;` },
+    { code: `<Outer>{true && <Inner />}</Outer>;` },
+    { code: `<Outer prop={<Inner />} />;` },
+    { code: `<><Foo /><Bar /></>;` },
+    { code: `const cond = true; <Outer>{cond ? <Yes /> : <No />}</Outer>;` },
+    { code: `<AB />;`, options: [{ ignore: ['[A-Z][A-Z]'] }] },
+    { code: `<Foo_BAR />;`, options: [{ ignore: ['Foo_@(BAR|BAZ)'] }] },
+    { code: `<A_B />;`, options: [{ ignore: ['A_?'] }] },
+    { code: `<Modal:Header />;` },
+    { code: `<svg:path />;` },
+    { code: `<Modal:NAMED />;`, options: [{ allowAllCaps: true }] },
+    { code: `<Modal:_Header />;`, options: [{ allowLeadingUnderscore: true }] },
+    { code: `<Styled:h1 />;`, options: [{ allowNamespace: true }] },
+    {
+      code: `<Modal:Foo_DEPRECATED />;`,
+      options: [{ ignore: ['*_DEPRECATED'] }],
+    },
+    { code: `<Año_Old />;`, options: [{ ignore: ['Año_*'] }] },
+    { code: `<Año_KEEP />;`, options: [{ ignore: ['Año_KE?P'] }] },
+    { code: `<Good />;`, options: [{ ignore: ['[invalid'] }] },
+    { code: `<Good />;`, options: [{ ignore: ['[^]'] }] },
+    { code: `<Foo<string> />;` },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `<Test_component />;`,
+      errors: [
+        {
+          message:
+            'Imported JSX component Test_component must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<TEST_COMPONENT />;`,
+      errors: [
+        {
+          message:
+            'Imported JSX component TEST_COMPONENT must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<YMCA />;`,
+      errors: [
+        { message: 'Imported JSX component YMCA must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<_TEST_COMPONENT />;`,
+      options: [{ allowAllCaps: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component _TEST_COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<TEST_COMPONENT_ />;`,
+      options: [{ allowAllCaps: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component TEST_COMPONENT_ must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<TEST-COMPONENT />;`,
+      options: [{ allowAllCaps: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component TEST-COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<__ />;`,
+      options: [{ allowAllCaps: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<_div />;`,
+      options: [{ allowLeadingUnderscore: true }],
+      errors: [
+        { message: 'Imported JSX component _div must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<__ />;`,
+      options: [{ allowAllCaps: true, allowLeadingUnderscore: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<$a />;`,
+      errors: [{ message: 'Imported JSX component $a must be in PascalCase' }],
+    },
+    {
+      code: `<Foo_DEPRECATED />;`,
+      options: [{ ignore: ['*_FOO'] }],
+      errors: [
+        {
+          message:
+            'Imported JSX component Foo_DEPRECATED must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<Styled.h1 />;`,
+      errors: [{ message: 'Imported JSX component h1 must be in PascalCase' }],
+    },
+    {
+      code: `<$Typography.P />;`,
+      errors: [
+        {
+          message: 'Imported JSX component $Typography must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<STYLED.h1 />;`,
+      options: [{ allowNamespace: true }],
+      errors: [
+        { message: 'Imported JSX component STYLED must be in PascalCase' },
+      ],
+    },
+
+    // ---- Additional edge cases ----
+    {
+      code: '<TEST_COMPONENT\n  foo="bar"\n/>;',
+      errors: [
+        {
+          message:
+            'Imported JSX component TEST_COMPONENT must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<TEST_COMPONENT>hi</TEST_COMPONENT>;`,
+      errors: [
+        {
+          message:
+            'Imported JSX component TEST_COMPONENT must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<_test />;`,
+      options: [{ allowLeadingUnderscore: true }],
+      errors: [
+        { message: 'Imported JSX component _test must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<BAD_NAME />;`,
+      options: [{ ignore: ['GOOD_NAME'] }],
+      errors: [
+        { message: 'Imported JSX component BAD_NAME must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Foo.bar />;`,
+      errors: [{ message: 'Imported JSX component bar must be in PascalCase' }],
+    },
+    {
+      code: `<Foo.bad_name.Baz />;`,
+      errors: [
+        { message: 'Imported JSX component bad_name must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Foo.Bar.baz />;`,
+      errors: [{ message: 'Imported JSX component baz must be in PascalCase' }],
+    },
+    {
+      code: `<div><FOO_A /><FOO_B /></div>;`,
+      errors: [
+        { message: 'Imported JSX component FOO_A must be in PascalCase' },
+        { message: 'Imported JSX component FOO_B must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Wrapper>{true && <Bad_Inner />}</Wrapper>;`,
+      errors: [
+        { message: 'Imported JSX component Bad_Inner must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Wrapper prop={<Bad_Attr />} />;`,
+      errors: [
+        { message: 'Imported JSX component Bad_Attr must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<$Weird />;`,
+      options: [{ allowAllCaps: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component $Weird must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<Modal:bad_header />;`,
+      errors: [
+        {
+          message: 'Imported JSX component bad_header must be in PascalCase',
+        },
+      ],
+    },
+    {
+      code: `<BAD_NS:Header />;`,
+      errors: [
+        { message: 'Imported JSX component BAD_NS must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Modal:bad_Name />;`,
+      options: [{ allowAllCaps: true }],
+      errors: [
+        {
+          message:
+            'Imported JSX component bad_Name must be in PascalCase or SCREAMING_SNAKE_CASE',
+        },
+      ],
+    },
+    {
+      code: `<BAD_NS:Header />;`,
+      options: [{ allowNamespace: true }],
+      errors: [
+        { message: 'Imported JSX component BAD_NS must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Foo.$Bar />;`,
+      errors: [
+        { message: 'Imported JSX component $Bar must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Bad_Name<string> />;`,
+      errors: [
+        { message: 'Imported JSX component Bad_Name must be in PascalCase' },
+      ],
+    },
+    {
+      code: `<Año_BAD />;`,
+      options: [{ ignore: ['Año_DIFFERENT'] }],
+      errors: [
+        { message: 'Imported JSX component Año_BAD must be in PascalCase' },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -214,3 +214,12 @@ xtest
 πfoo
 Дelta
 дelta
+extglob
+noglobstar
+lookarounds
+testcomponent
+Nent
+Éurströmming
+Søknad
+codepoint
+misalign


### PR DESCRIPTION
## Summary

Port the `react/jsx-pascal-case` rule from `eslint-plugin-react` to rslint.

The rule enforces PascalCase for user-defined JSX components. DOM intrinsics (tags starting with a lowercase letter) are skipped. Supports all four upstream options: `allowAllCaps`, `allowLeadingUnderscore`, `allowNamespace`, and `ignore` (minimatch-style globs with extglob).

## Related Links

- ESLint rule: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md>
- Source: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js>

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).