### PR TITLE
feat: port rule react/no-did-update-set-state

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -19,6 +19,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_did_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
@@ -53,6 +54,7 @@ func GetAllRules() []rule.Rule {
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
+		no_did_update_set_state.NoDidUpdateSetStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
 		no_string_refs.NoStringRefsRule,

--- a/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state.go
+++ b/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state.go
@@ -1,0 +1,193 @@
+package no_did_update_set_state
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// methodName is the single lifecycle hook this rule targets. Upstream's
+// makeNoMethodSetStateRule factory is parameterized; since
+// no-did-update-set-state always passes 'componentDidUpdate', we hardcode it.
+const methodName = "componentDidUpdate"
+
+// isStopper mirrors ESLint's ancestor.type check for containers whose `key`
+// can identify the target method: Property, MethodDefinition, ClassProperty,
+// PropertyDefinition. In tsgo these collapse into PropertyAssignment (object
+// `name: fn`), MethodDeclaration (class methods + object shorthand),
+// GetAccessor / SetAccessor / Constructor, and PropertyDeclaration (class
+// field). ShorthandPropertyAssignment is omitted — it has no function body,
+// so setState could never appear beneath it.
+//
+// Decomposed as `IsMethodOrAccessor || Kind in {Constructor, PropertyAssignment,
+// PropertyDeclaration}`: IsMethodOrAccessor covers MethodDeclaration /
+// GetAccessor / SetAccessor, and the remaining three are the non-function
+// key-bearing containers.
+func isStopper(node *ast.Node) bool {
+	if ast.IsMethodOrAccessor(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindConstructor,
+		ast.KindPropertyAssignment,
+		ast.KindPropertyDeclaration:
+		return true
+	}
+	return false
+}
+
+// stopperName returns the name-string of a stopper node's key as ESLint
+// would expose it via `ancestor.key.name`. Identifier and PrivateIdentifier
+// both populate `.name` in ESTree — the latter without the leading `#` per
+// the spec — so `class { #componentDidUpdate() { ... } }` matches upstream
+// just like the public form. In tsgo, PrivateIdentifier.Text retains the
+// `#`, so we strip it to align with ESLint.
+//
+// Non-name keys (ComputedPropertyName, StringLiteral, NumericLiteral, etc.)
+// yield "" — ESLint's `key.name` is undefined for those shapes and never
+// equals "componentDidUpdate".
+func stopperName(node *ast.Node) string {
+	n := node.Name()
+	if n == nil {
+		return ""
+	}
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return n.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(n.AsPrivateIdentifier().Text, "#")
+	}
+	return ""
+}
+
+// reactVersionNoop reports whether the rule should be a no-op for the
+// configured React version. Mirrors upstream `shouldBeNoop('componentDidUpdate')`
+// exactly:
+//
+//	methodName in noops && testReactVersion(ctx, '>= 16.3.0')
+//	                    && !testReactVersion(ctx, '>= 999.999.999')
+//
+// i.e. noop iff the configured version is in the half-open range
+// [16.3.0, 999.999.999). The upper bound keeps the rule active when
+// eslint-plugin-react's "version absent" default (999.999.999) or a user
+// who explicitly set "999.999.999" is in effect — upstream uses the same
+// sentinel to express "user left version unpinned".
+//
+// Our `ParseReactVersion` returns (999,999,999) for an absent setting, so
+// checking `settings.react.version` is a string key lets us distinguish
+// "unset" from "explicitly 999.999.999" only structurally — both cases keep
+// the rule active, matching upstream.
+func reactVersionNoop(settings map[string]interface{}) bool {
+	if settings == nil {
+		return false
+	}
+	rs, ok := settings["react"].(map[string]interface{})
+	if !ok {
+		return false
+	}
+	if _, ok := rs["version"].(string); !ok {
+		return false
+	}
+	return !reactutil.ReactVersionLessThan(settings, 16, 3, 0) &&
+		reactutil.ReactVersionLessThan(settings, 999, 999, 999)
+}
+
+func parseDisallowInFunc(options any) bool {
+	switch v := options.(type) {
+	case string:
+		return v == "disallow-in-func"
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok {
+				return s == "disallow-in-func"
+			}
+		}
+	}
+	return false
+}
+
+var NoDidUpdateSetStateRule = rule.Rule{
+	Name: "react/no-did-update-set-state",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if reactVersionNoop(ctx.Settings) {
+			return rule.RuleListeners{}
+		}
+		disallowInFunc := parseDisallowInFunc(options)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				callee := ast.SkipParentheses(call.Expression)
+				if callee.Kind != ast.KindPropertyAccessExpression {
+					return
+				}
+				prop := callee.AsPropertyAccessExpression()
+				if ast.SkipParentheses(prop.Expression).Kind != ast.KindThisKeyword {
+					return
+				}
+				// Upstream: `'name' in callee.property && callee.property.name
+				// === 'setState'`. Both Identifier and PrivateIdentifier
+				// populate `.name` in ESTree, and per-spec PrivateIdentifier
+				// strips the leading `#` — so `this.#setState()` matches
+				// upstream just like `this.setState()`. tsgo retains the `#`
+				// on PrivateIdentifier.Text, so we strip it before comparing.
+				nameNode := prop.Name()
+				if nameNode == nil {
+					return
+				}
+				var propName string
+				switch nameNode.Kind {
+				case ast.KindIdentifier:
+					propName = nameNode.AsIdentifier().Text
+				case ast.KindPrivateIdentifier:
+					propName = strings.TrimPrefix(nameNode.AsPrivateIdentifier().Text, "#")
+				default:
+					return
+				}
+				if propName != "setState" {
+					return
+				}
+
+				// Walk ancestors innermost-to-outermost, mirroring ESLint's
+				// `findLast(ancestors, cb)`. Depth counts function-like
+				// wrappers crossed before the first matching stopper; in
+				// default mode a match at depth > 1 is skipped (setState in a
+				// nested callback), while `disallow-in-func` reports at any
+				// depth.
+				//
+				// `ast.IsFunctionLikeDeclaration` returns true for
+				// FunctionDeclaration / FunctionExpression / ArrowFunction /
+				// MethodDeclaration / Constructor / GetAccessor / SetAccessor —
+				// exactly the set ESLint's /Function(Expression|Declaration)$/
+				// regex matches, extended to the method/accessor/constructor
+				// nodes that tsgo exposes directly (ESTree wraps those in a
+				// FunctionExpression child that the regex also matches).
+				// Excludes signature kinds (MethodSignature, CallSignature,
+				// etc.) and ClassStaticBlockDeclaration — none of which can
+				// host a runtime `this.setState()` under `componentDidUpdate`.
+				depth := 0
+				for p := node.Parent; p != nil; p = p.Parent {
+					if ast.IsFunctionLikeDeclaration(p) {
+						depth++
+					}
+					if !isStopper(p) {
+						continue
+					}
+					if stopperName(p) != methodName {
+						continue
+					}
+					if !disallowInFunc && depth > 1 {
+						continue
+					}
+					ctx.ReportNode(callee, rule.RuleMessage{
+						Id:          "noSetState",
+						Description: "Do not use setState in componentDidUpdate",
+					})
+					return
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state.md
+++ b/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state.md
@@ -1,0 +1,89 @@
+# no-did-update-set-state
+
+Disallow `this.setState` inside `componentDidUpdate`.
+
+Updating the state after a component update will trigger a second `render()`
+call and can lead to property/layout thrashing.
+
+## Rule Details
+
+This rule flags any `this.setState` call whose enclosing class method, class
+field initializer, or object-literal property is keyed `componentDidUpdate`.
+By default, calls inside a nested function (regular or arrow) are allowed —
+enable `disallow-in-func` to forbid them too.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  componentDidUpdate: function () {
+    this.setState({
+      name: this.props.name.toUpperCase(),
+    });
+  },
+});
+```
+
+```javascript
+class Hello extends React.Component {
+  componentDidUpdate() {
+    this.setState({
+      name: this.props.name.toUpperCase(),
+    });
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  componentDidUpdate: function () {
+    someNonMemberFunction(arg);
+    this.someHandler = this.setState;
+  },
+});
+```
+
+```javascript
+var Hello = createReactClass({
+  componentDidUpdate: function () {
+    someClass.onSomeEvent(function (data) {
+      this.setState({
+        data: data,
+      });
+    });
+  },
+});
+```
+
+## Rule Options
+
+```json
+{ "react/no-did-update-set-state": ["error", "disallow-in-func"] }
+```
+
+With `disallow-in-func` set, the rule also flags `this.setState` calls inside
+nested functions:
+
+```javascript
+var Hello = createReactClass({
+  componentDidUpdate: function () {
+    someClass.onSomeEvent(function (data) {
+      this.setState({
+        data: data,
+      });
+    });
+  },
+});
+```
+
+## React Version
+
+The rule is a no-op when `settings.react.version` is explicitly set to
+`>= 16.3.0`, matching `eslint-plugin-react`'s `shouldBeNoop` gate for
+`componentDidUpdate`.
+
+## Original Documentation
+
+- [eslint-plugin-react / no-did-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md)

--- a/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state_test.go
+++ b/internal/plugins/react/rules/no_did_update_set_state/no_did_update_set_state_test.go
@@ -1,0 +1,798 @@
+package no_did_update_set_state
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDidUpdateSetStateRule(t *testing.T) {
+	// Shared helper: upstream's test harness takes every invalid case and
+	// re-asserts it as valid once `settings.react.version` is "16.3.0", because
+	// the upstream rule becomes a no-op from that version on (see
+	// `shouldBeNoop`). We mirror that — feeding the same code paths through
+	// the version-gate so a future regression on the gate is caught.
+	react163 := map[string]interface{}{"react": map[string]interface{}{"version": "16.3.0"}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDidUpdateSetStateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: createReactClass render only, no componentDidUpdate ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: empty componentDidUpdate body ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {}
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: componentDidUpdate with non-member call and property assignment ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someHandler = this.setState;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState inside a nested regular function (default mode) ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState inside a nested named function declaration (default mode) ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            function handleEvent(data) {
+              this.setState({
+                data: data
+              });
+            }
+            someClass.onSomeEvent(handleEvent)
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState inside nested arrow (default mode) ----
+		// Default mode allows setState in nested functions (depth > 1), so these
+		// mirror upstream's `disallow-in-func`-only invalids being valid by default.
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        });
+      `, Tsx: true},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: version-gated — every invalid case becomes valid at react >= 16.3.0 ----
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `, Tsx: true, Settings: react163},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `, Tsx: true, Settings: react163},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate = () => {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `, Tsx: true, Settings: react163},
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `, Tsx: true, Options: []interface{}{"disallow-in-func"}, Settings: react163},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"disallow-in-func"}, Settings: react163},
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        });
+      `, Tsx: true, Options: []interface{}{"disallow-in-func"}, Settings: react163},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"disallow-in-func"}, Settings: react163},
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            if (true) {
+              this.setState({
+                data: data
+              });
+            }
+          }
+        });
+      `, Tsx: true, Settings: react163},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            if (true) {
+              this.setState({
+                data: data
+              });
+            }
+          }
+        }
+      `, Tsx: true, Settings: react163},
+		{Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        });
+      `, Tsx: true, Options: []interface{}{"disallow-in-func"}, Settings: react163},
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        }
+      `, Tsx: true, Options: []interface{}{"disallow-in-func"}, Settings: react163},
+
+		// ---- Edge: setState receiver is not `this` ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            other.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: method name mismatch (componentDidMount, not componentDidUpdate) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: UNSAFE_componentDidUpdate is NOT matched (factory passed no shouldCheckUnsafeCb) ----
+		{Code: `
+        class Hello extends React.Component {
+          UNSAFE_componentDidUpdate() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: computed key `[\`componentDidUpdate\`]()` — non-Identifier key never matches ----
+		{Code: "\n        class Hello extends React.Component {\n          [`componentDidUpdate`]() {\n            this.setState({});\n          }\n        }\n      ", Tsx: true},
+
+		// ---- Edge: string-literal key in object literal — non-Identifier key never matches ----
+		{Code: `
+        var Hello = createReactClass({
+          "componentDidUpdate": function() {
+            this.setState({});
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: bracketed setState access ('name' in property guard) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this['setState']({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: top-level call outside any method/class/object ----
+		{Code: `this.setState({});`, Tsx: true},
+
+		// ---- Edge: setState in a sibling render() stays untouched — rule is method-scoped ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {}
+          render() {
+            this.setState({});
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setState inside JSX callback within componentDidUpdate — default mode allows (depth > 1) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            return <button onClick={() => this.setState({})}/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: TS non-null / as expressions break the ThisKeyword match, so no report ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            (this as any).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: aliased setState via destructuring — receiver is not a MemberExpression ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            const { setState } = this;
+            setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: outer componentDidUpdate, setState inside an inner class's constructor (default mode) ----
+		// Walk: Constructor (depth 1, stopper name="constructor" — no match), ClassDeclaration,
+		// outer MethodDeclaration (depth 2, stopper match — skipped because depth > 1).
+		{Code: `
+        class Outer extends React.Component {
+          componentDidUpdate() {
+            class Inner { constructor() { this.setState({}); } }
+            new Inner();
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream #1: createReactClass componentDidUpdate → setState ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in componentDidUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Upstream #2: ES6 class method componentDidUpdate → setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Upstream #3: class field arrow `componentDidUpdate = () => { ... }` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate = () => {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #4: disallow-in-func + createReactClass (direct call) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #5: disallow-in-func + ES6 class (direct call) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #6: disallow-in-func + setState in nested function (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #7: disallow-in-func + setState in nested function (ES6 class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #8: setState inside if-block (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            if (true) {
+              this.setState({
+                data: data
+              });
+            }
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #9: setState inside if-block (ES6 class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            if (true) {
+              this.setState({
+                data: data
+              });
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #10: disallow-in-func + arrow callback (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 45},
+			},
+		},
+
+		// ---- Upstream #11: disallow-in-func + arrow callback (ES6 class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 45},
+			},
+		},
+
+		// ---- Edge: parenthesized `(this).setState(...)` receiver ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            (this).setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-chain on `this` — `this?.setState()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this?.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-call `this.setState?.()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState?.({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: object-literal shorthand method (tsgo: MethodDeclaration with no PropertyAssignment wrapper) ----
+		{
+			Code: `
+        var Hello = {
+          componentDidUpdate() {
+            this.setState({});
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class field with function expression initializer ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate = function() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState under explicit React version < 16.3 (rule still active) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.2.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: multiple setState calls in same componentDidUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({});
+            if (x) { this.setState({}); }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+				{MessageId: "noSetState", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- Edge: async componentDidUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          async componentDidUpdate() {
+            await Promise.resolve();
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: generator componentDidUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          *componentDidUpdate() {
+            yield this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: class expression (not ClassDeclaration) ----
+		{
+			Code: `
+        const Hello = class extends React.Component {
+          componentDidUpdate() {
+            this.setState({});
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: arrow-function value in object literal (createReactClass-style) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentDidUpdate: () => {
+            this.setState({});
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: JSX callback + disallow-in-func (symmetric pair to the default-mode valid case above) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            return <button onClick={() => this.setState({})}/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 43},
+			},
+		},
+
+		// ---- Edge: nested class whose inner method is also componentDidUpdate — inner takes precedence ----
+		// Walk from the setState in Inner's method: Inner MethodDeclaration (depth 1,
+		// stopper match) → report at depth 1, regardless of disallow-in-func mode.
+		{
+			Code: `
+        class Outer extends React.Component {
+          componentDidUpdate() {
+            class Inner extends React.Component {
+              componentDidUpdate() {
+                this.setState({});
+              }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Edge: disallow-in-func — setState inside a nested arrow inside a nested function ----
+		// Walk: ArrowFunction (1), FunctionExpression (2), MethodDeclaration (3, stopper match).
+		// Default mode: depth > 1 → skip. disallow-in-func: report.
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent(function() {
+              Promise.resolve().then(() => this.setState({}));
+            });
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 44},
+			},
+		},
+
+		// ---- Edge: getter named `componentDidUpdate` — stopper via IsMethodOrAccessor, depth 1 from the getter itself ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          get componentDidUpdate() {
+            this.setState({});
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier stopper `#componentDidUpdate` ----
+		// ESLint's PrivateIdentifier.name is spec'd to exclude the leading #,
+		// so `key.name === 'componentDidUpdate'` matches. Aligning with
+		// upstream: we strip the # from tsgo's PrivateIdentifier.Text.
+		{
+			Code: `
+        class Hello extends React.Component {
+          #componentDidUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier callee `this.#setState()` ----
+		// Same reasoning: upstream's `'name' in property && property.name
+		// === 'setState'` matches PrivateIdentifier with spec-stripped name.
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.#setState({});
+          }
+          #setState(_x: unknown) {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: React version explicitly set to sentinel "999.999.999" — rule active ----
+		// Upstream `shouldBeNoop` has an explicit `!testReactVersion('>= 999.999.999')`
+		// upper bound — a user who pins that sentinel is treated as "version
+		// unpinned" and the rule stays active.
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "999.999.999"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -101,6 +101,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
+    './tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts
@@ -1,0 +1,126 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-did-update-set-state', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {}
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someHandler = this.setState;
+          }
+        });
+      `,
+    },
+    // ---- Default mode allows setState in nested callbacks ----
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({ data: data });
+            });
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent((data) => this.setState({ data: data }));
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        var Hello = createReactClass({
+          componentDidUpdate: function() {
+            this.setState({ data: data });
+          }
+        });
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({ data: data });
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate = () => {
+            this.setState({ data: data });
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- disallow-in-func flags setState in nested callbacks ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({ data: data });
+            });
+          }
+        }
+      `,
+      options: ['disallow-in-func'],
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            someClass.onSomeEvent((data) => this.setState({ data: data }));
+          }
+        }
+      `,
+      options: ['disallow-in-func'],
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- setState inside if-block ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            if (true) {
+              this.setState({ data: data });
+            }
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-did-update-set-state` rule from `eslint-plugin-react` to rslint.

Disallows `this.setState(...)` inside `componentDidUpdate` — such calls trigger an additional render pass and can cause property/layout thrashing. Supports the upstream `'disallow-in-func'` option (also flag setState inside nested callbacks) and the `settings.react.version >= 16.3.0` no-op gate, both aligned byte-for-byte with upstream semantics (half-open `[16.3.0, 999.999.999)` version range, PrivateIdentifier `.name` parity).

## Related Links

- ESLint plugin rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-did-update-set-state.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-did-update-set-state.js
- Factory: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/util/makeNoMethodSetStateRule.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).