### PR TITLE
feat: port rule react/no-typos

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -22,6 +22,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
@@ -56,6 +57,7 @@ func GetAllRules() []rule.Rule {
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
 		no_string_refs.NoStringRefsRule,
+		no_typos.NoTyposRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		require_render_return.RequireRenderReturnRule,

--- a/internal/plugins/react/rules/no_typos/no_typos.go
+++ b/internal/plugins/react/rules/no_typos/no_typos.go
@@ -1,0 +1,813 @@
+package no_typos
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// propTypesNames is the set of valid PropTypes.* property names, mirroring
+// `Object.keys(require('prop-types'))` in eslint-plugin-react's no-typos.
+var propTypesNames = map[string]bool{
+	"array":             true,
+	"bigint":            true,
+	"bool":              true,
+	"func":              true,
+	"number":            true,
+	"object":            true,
+	"string":            true,
+	"symbol":            true,
+	"any":               true,
+	"arrayOf":           true,
+	"element":           true,
+	"elementType":       true,
+	"instanceOf":        true,
+	"node":              true,
+	"objectOf":          true,
+	"oneOf":             true,
+	"oneOfType":         true,
+	"shape":             true,
+	"exact":             true,
+	"checkPropTypes":    true,
+	"resetWarningCache": true,
+	"PropTypes":         true,
+}
+
+// staticClassProperties are the React component static-class-property names
+// whose casing the rule enforces. Matching is case-insensitive.
+var staticClassProperties = []string{
+	"propTypes", "contextTypes", "childContextTypes", "defaultProps",
+}
+
+// lifecycleInstance lists React's instance-scope lifecycle method names (plus
+// the ES5 `createReactClass` companions). Matching is case-insensitive.
+var lifecycleInstance = []string{
+	"getDefaultProps", "getInitialState", "getChildContext",
+	"componentWillMount", "UNSAFE_componentWillMount",
+	"componentDidMount",
+	"componentWillReceiveProps", "UNSAFE_componentWillReceiveProps",
+	"shouldComponentUpdate",
+	"componentWillUpdate", "UNSAFE_componentWillUpdate",
+	"getSnapshotBeforeUpdate",
+	"componentDidUpdate",
+	"componentDidCatch",
+	"componentWillUnmount",
+	"render",
+}
+
+// lifecycleStatic lists lifecycle methods that must be declared `static`.
+var lifecycleStatic = []string{"getDerivedStateFromProps"}
+
+var NoTyposRule = rule.Rule{
+	Name: "react/no-typos",
+	Run:  runRule,
+}
+
+func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
+	pragma := reactutil.GetReactPragma(ctx.Settings)
+	createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+	propTypesPackageName := ""
+	reactPackageName := ""
+
+	// componentsByName records names bound to a React component anywhere in
+	// the file — an ES6 class extending React.Component / PureComponent
+	// (optionally via `const X = class extends ...`) or a function that
+	// returns JSX. Used by the `Foo.PropTypes = {}` branch, which needs a
+	// file-wide name lookup (ESLint's `utils.getRelatedComponent`).
+	componentsByName := map[string]bool{}
+
+	// Pre-walk the source file: collect imports (for propTypesPackageName /
+	// reactPackageName), emit noReactBinding / noPropTypesBinding, and
+	// populate componentsByName. Listeners can then rely on these.
+	var pre ast.Visitor
+	pre = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindImportDeclaration:
+			handleImportDecl(ctx, n, &propTypesPackageName, &reactPackageName)
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			if reactutil.ExtendsReactComponent(n, pragma) || hasJSDocExtendsReactComponent(n) {
+				if name := declName(n); name != "" {
+					componentsByName[name] = true
+				}
+			}
+		case ast.KindFunctionDeclaration:
+			if functionReturnsJSX(n) {
+				if nm := n.Name(); nm != nil && nm.Kind == ast.KindIdentifier {
+					componentsByName[nm.AsIdentifier().Text] = true
+				}
+			}
+		case ast.KindVariableDeclaration:
+			vd := n.AsVariableDeclaration()
+			if vd == nil || vd.Initializer == nil || vd.Name() == nil || vd.Name().Kind != ast.KindIdentifier {
+				break
+			}
+			init := ast.SkipParentheses(vd.Initializer)
+			name := vd.Name().AsIdentifier().Text
+			switch init.Kind {
+			case ast.KindClassExpression:
+				if reactutil.ExtendsReactComponent(init, pragma) {
+					componentsByName[name] = true
+				}
+			case ast.KindFunctionExpression, ast.KindArrowFunction:
+				if functionReturnsJSX(init) {
+					componentsByName[name] = true
+				}
+			}
+		}
+		n.ForEachChild(pre)
+		return false
+	}
+	ctx.SourceFile.Node.ForEachChild(pre)
+
+	// isPropTypesPackage reports whether `expr` refers to the imported
+	// PropTypes namespace — either the default/namespace binding from
+	// `prop-types` (e.g. `PropTypes`), or `<reactPkg>.PropTypes` (e.g.
+	// `React.PropTypes`).
+	isPropTypesPackage := func(expr *ast.Node) bool {
+		if propTypesPackageName == "" && reactPackageName == "" {
+			return false
+		}
+		expr = ast.SkipParentheses(expr)
+		switch expr.Kind {
+		case ast.KindIdentifier:
+			return propTypesPackageName != "" && expr.AsIdentifier().Text == propTypesPackageName
+		case ast.KindPropertyAccessExpression:
+			if reactPackageName == "" {
+				return false
+			}
+			pa := expr.AsPropertyAccessExpression()
+			obj := ast.SkipParentheses(pa.Expression)
+			name := pa.Name()
+			if name == nil || name.Kind != ast.KindIdentifier || name.AsIdentifier().Text != "PropTypes" {
+				return false
+			}
+			return obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == reactPackageName
+		}
+		return false
+	}
+
+	// checkValidPropType reports a typoPropType diagnostic when `node` is an
+	// Identifier whose text is not a known PropTypes property name.
+	checkValidPropType := func(node *ast.Node) {
+		if node == nil || node.Kind != ast.KindIdentifier {
+			return
+		}
+		name := node.AsIdentifier().Text
+		if name == "" {
+			return
+		}
+		if propTypesNames[name] {
+			return
+		}
+		ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "typoPropType",
+			Description: "Typo in declared prop type: " + name,
+		})
+	}
+
+	// checkValidPropTypeQualifier reports typoPropTypeChain when `node` is
+	// not the literal identifier `isRequired`.
+	checkValidPropTypeQualifier := func(node *ast.Node) {
+		if node == nil || node.Kind != ast.KindIdentifier {
+			return
+		}
+		name := node.AsIdentifier().Text
+		if name == "isRequired" {
+			return
+		}
+		ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "typoPropTypeChain",
+			Description: "Typo in prop type chain qualifier: " + name,
+		})
+	}
+
+	// Mutual recursion: checkValidProp may call checkValidCallExpression,
+	// which in turn descends into prop values via checkValidPropObject /
+	// checkValidProp.
+	var checkValidProp func(node *ast.Node)
+	var checkValidCallExpression func(node *ast.Node)
+	var checkValidPropObject func(node *ast.Node)
+
+	checkValidCallExpression = func(node *ast.Node) {
+		if node == nil || node.Kind != ast.KindCallExpression {
+			return
+		}
+		call := node.AsCallExpression()
+		callee := ast.SkipParentheses(call.Expression)
+		if callee.Kind != ast.KindPropertyAccessExpression {
+			return
+		}
+		pa := callee.AsPropertyAccessExpression()
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return
+		}
+		args := call.Arguments
+		switch name.AsIdentifier().Text {
+		case "shape":
+			if args == nil || len(args.Nodes) == 0 {
+				return
+			}
+			checkValidPropObject(args.Nodes[0])
+		case "oneOfType":
+			if args == nil || len(args.Nodes) == 0 {
+				return
+			}
+			first := ast.SkipParentheses(args.Nodes[0])
+			if first.Kind != ast.KindArrayLiteralExpression {
+				return
+			}
+			for _, el := range first.AsArrayLiteralExpression().Elements.Nodes {
+				checkValidProp(el)
+			}
+		}
+	}
+
+	checkValidProp = func(node *ast.Node) {
+		if propTypesPackageName == "" && reactPackageName == "" {
+			return
+		}
+		if node == nil {
+			return
+		}
+		node = ast.SkipParentheses(node)
+		switch node.Kind {
+		case ast.KindPropertyAccessExpression:
+			pa := node.AsPropertyAccessExpression()
+			obj := ast.SkipParentheses(pa.Expression)
+			propName := pa.Name()
+			if propName == nil || propName.Kind != ast.KindIdentifier {
+				return
+			}
+			// PropTypes.myProp.isRequired
+			if obj.Kind == ast.KindPropertyAccessExpression {
+				innerPa := obj.AsPropertyAccessExpression()
+				innerObj := ast.SkipParentheses(innerPa.Expression)
+				if isPropTypesPackage(innerObj) {
+					checkValidPropType(innerPa.Name())
+					checkValidPropTypeQualifier(propName)
+					return
+				}
+			}
+			// PropTypes.myProp
+			if isPropTypesPackage(obj) && propName.AsIdentifier().Text != "isRequired" {
+				checkValidPropType(propName)
+				return
+			}
+			// (PropTypes.shape({...})).isRequired / .somethingElse
+			if obj.Kind == ast.KindCallExpression {
+				checkValidPropTypeQualifier(propName)
+				checkValidCallExpression(obj)
+			}
+		case ast.KindCallExpression:
+			checkValidCallExpression(node)
+		}
+	}
+
+	checkValidPropObject = func(node *ast.Node) {
+		if node == nil {
+			return
+		}
+		node = ast.SkipParentheses(node)
+		if node.Kind != ast.KindObjectLiteralExpression {
+			return
+		}
+		for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
+			value := propertyValueNode(prop)
+			if value != nil {
+				checkValidProp(value)
+			}
+		}
+	}
+
+	// reportErrorIfPropertyCasingTypo reports typoStaticClassProp /
+	// typoPropDeclaration when `key` is an identifier whose lowercased text
+	// equals one of the static class property names but casing differs. When
+	// the property name is one of propTypes / contextTypes / childContextTypes
+	// (exact casing), it also recurses into `value` via checkValidPropObject.
+	reportErrorIfPropertyCasingTypo := func(value *ast.Node, key *ast.Node, isClassProperty bool) {
+		if key == nil || key.Kind != ast.KindIdentifier {
+			return
+		}
+		propertyName := key.AsIdentifier().Text
+		if propertyName == "" {
+			return
+		}
+		// Recurse into declared propTypes / contextTypes / childContextTypes.
+		if propertyName == "propTypes" || propertyName == "contextTypes" || propertyName == "childContextTypes" {
+			checkValidPropObject(value)
+		}
+		lower := strings.ToLower(propertyName)
+		for _, canonical := range staticClassProperties {
+			if strings.ToLower(canonical) != lower || canonical == propertyName {
+				continue
+			}
+			messageId := "typoPropDeclaration"
+			description := "Typo in property declaration"
+			if isClassProperty {
+				messageId = "typoStaticClassProp"
+				description = "Typo in static class property declaration"
+			}
+			ctx.ReportNode(key, rule.RuleMessage{
+				Id:          messageId,
+				Description: description,
+			})
+			return
+		}
+	}
+
+	// reportErrorIfLifecycleMethodCasingTypo reports on a class/object member
+	// whose key mis-cases a lifecycle method. `isStatic` is the actual
+	// static-ness of the declaration (object literal members are always
+	// non-static).
+	reportErrorIfLifecycleMethodCasingTypo := func(member *ast.Node, isStatic bool) {
+		key := member.Name()
+		if key == nil {
+			return
+		}
+		var nodeKeyName string
+		switch key.Kind {
+		case ast.KindIdentifier:
+			nodeKeyName = key.AsIdentifier().Text
+		case ast.KindStringLiteral:
+			nodeKeyName = key.AsStringLiteral().Text
+		case ast.KindNoSubstitutionTemplateLiteral:
+			nodeKeyName = key.AsNoSubstitutionTemplateLiteral().Text
+		case ast.KindPrivateIdentifier:
+			// ESLint short-circuits on PrivateName.
+			return
+		default:
+			// Computed keys that resolve to a non-string value (numbers,
+			// expressions) are excluded, matching ESLint's
+			// `typeof nodeKeyName !== 'string'` guard.
+			return
+		}
+		if nodeKeyName == "" {
+			return
+		}
+		lowerKey := strings.ToLower(nodeKeyName)
+
+		// staticLifecycleMethod: declared non-static but name matches a static
+		// lifecycle method (case-insensitively).
+		if !isStatic {
+			for _, method := range lifecycleStatic {
+				if strings.ToLower(method) == lowerKey {
+					ctx.ReportNode(member, rule.RuleMessage{
+						Id:          "staticLifecycleMethod",
+						Description: "Lifecycle method should be static: " + nodeKeyName,
+					})
+					break
+				}
+			}
+		}
+
+		// typoLifecycleMethod: name case-insensitively matches a known
+		// lifecycle method (instance or static) but casing differs.
+		for _, method := range lifecycleInstance {
+			if strings.ToLower(method) == lowerKey && method != nodeKeyName {
+				ctx.ReportNode(member, rule.RuleMessage{
+					Id:          "typoLifecycleMethod",
+					Description: "Typo in component lifecycle method declaration: " + nodeKeyName + " should be " + method,
+				})
+				return
+			}
+		}
+		for _, method := range lifecycleStatic {
+			if strings.ToLower(method) == lowerKey && method != nodeKeyName {
+				ctx.ReportNode(member, rule.RuleMessage{
+					Id:          "typoLifecycleMethod",
+					Description: "Typo in component lifecycle method declaration: " + nodeKeyName + " should be " + method,
+				})
+				return
+			}
+		}
+	}
+
+	return rule.RuleListeners{
+		ast.KindPropertyDeclaration: func(node *ast.Node) {
+			// ES6 class field: `static propTypes = {...}`. Only reports when
+			// declared static on a class that extends React.Component.
+			if !ast.IsStatic(node) {
+				return
+			}
+			classNode := enclosingClass(node)
+			if classNode == nil || !reactutil.ExtendsReactComponent(classNode, pragma) {
+				return
+			}
+			pd := node.AsPropertyDeclaration()
+			reportErrorIfPropertyCasingTypo(pd.Initializer, pd.Name(), true)
+		},
+
+		ast.KindMethodDeclaration: func(node *ast.Node) {
+			// ES6 class method only — object literal methods are handled
+			// uniformly by the ObjectLiteralExpression listener, matching
+			// ESLint's ESTree split between `MethodDefinition` (class) and
+			// `Property` (object).
+			parent := node.Parent
+			if parent == nil {
+				return
+			}
+			switch parent.Kind {
+			case ast.KindClassDeclaration, ast.KindClassExpression:
+				if !reactutil.ExtendsReactComponent(parent, pragma) {
+					return
+				}
+				reportErrorIfLifecycleMethodCasingTypo(node, ast.IsStatic(node))
+			}
+		},
+
+		// `Foo.PropTypes = {}` — handled at the assignment level so we can
+		// examine both the property (LHS) and the value (RHS).
+		ast.KindBinaryExpression: func(node *ast.Node) {
+			bin := node.AsBinaryExpression()
+			if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken {
+				return
+			}
+			left := ast.SkipParentheses(bin.Left)
+			if left.Kind != ast.KindPropertyAccessExpression {
+				return
+			}
+			pa := left.AsPropertyAccessExpression()
+			base := ast.SkipParentheses(pa.Expression)
+			if base.Kind != ast.KindIdentifier {
+				return
+			}
+			propertyName := pa.Name()
+			if propertyName == nil || propertyName.Kind != ast.KindIdentifier {
+				return
+			}
+			lower := strings.ToLower(propertyName.AsIdentifier().Text)
+			anyMatch := false
+			for _, canonical := range staticClassProperties {
+				if strings.ToLower(canonical) == lower {
+					anyMatch = true
+					break
+				}
+			}
+			if !anyMatch {
+				return
+			}
+			if !componentsByName[base.AsIdentifier().Text] {
+				return
+			}
+			reportErrorIfPropertyCasingTypo(bin.Right, propertyName, true)
+		},
+
+		ast.KindObjectLiteralExpression: func(node *ast.Node) {
+			// Component defined via createReactClass({...}): inspect top-level
+			// properties for prop-declaration typos and lifecycle typos.
+			if !isCreateClassObjectArg(node, pragma, createClass) {
+				return
+			}
+			for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
+				if prop.Kind == ast.KindSpreadAssignment {
+					continue
+				}
+				key := prop.Name()
+				value := propertyValueNode(prop)
+				if key != nil {
+					reportErrorIfPropertyCasingTypo(value, key, false)
+				}
+				reportErrorIfLifecycleMethodCasingTypo(prop, false)
+			}
+		},
+	}
+}
+
+// handleImportDecl inspects an ImportDeclaration: tracks propTypesPackageName
+// and reactPackageName for prop-type typo detection, and reports
+// noPropTypesBinding / noReactBinding when the import has no value binding
+// (e.g. `import 'prop-types'`).
+func handleImportDecl(ctx rule.RuleContext, node *ast.Node, propTypesPackageName, reactPackageName *string) {
+	decl := node.AsImportDeclaration()
+	if decl == nil || decl.ModuleSpecifier == nil || decl.ModuleSpecifier.Kind != ast.KindStringLiteral {
+		return
+	}
+	moduleName := decl.ModuleSpecifier.AsStringLiteral().Text
+	if moduleName != "prop-types" && moduleName != "react" {
+		return
+	}
+	specifiers := importSpecifierLocalNames(decl)
+	if moduleName == "prop-types" {
+		if len(specifiers) == 0 {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noPropTypesBinding",
+				Description: "`'prop-types'` imported without a local `PropTypes` binding.",
+			})
+			return
+		}
+		// ESLint reads `node.specifiers[0].local.name`, so we mirror that —
+		// the first specifier's local name becomes the PropTypes binding.
+		*propTypesPackageName = specifiers[0]
+		return
+	}
+	// react
+	if len(specifiers) == 0 {
+		ctx.ReportNode(node, rule.RuleMessage{
+			Id:          "noReactBinding",
+			Description: "`'react'` imported without a local `React` binding.",
+		})
+		return
+	}
+	*reactPackageName = specifiers[0]
+	// If any named import is `PropTypes`, treat its local name as the
+	// PropTypes binding (overrides any previous state — matches upstream).
+	if propTypesLocal := findPropTypesNamedImport(decl); propTypesLocal != "" {
+		*propTypesPackageName = propTypesLocal
+	}
+}
+
+// importSpecifierLocalNames returns the local names of all value-binding
+// specifiers in `decl`, in declaration order. The default binding (if any)
+// comes first, followed by namespace / named specifiers. Mirrors ESLint's
+// `node.specifiers` traversal order on ESTree.
+func importSpecifierLocalNames(decl *ast.ImportDeclaration) []string {
+	if decl.ImportClause == nil {
+		return nil
+	}
+	clause := decl.ImportClause.AsImportClause()
+	if clause == nil {
+		return nil
+	}
+	var names []string
+	if clause.Name() != nil && clause.Name().Kind == ast.KindIdentifier {
+		names = append(names, clause.Name().AsIdentifier().Text)
+	}
+	if clause.NamedBindings != nil {
+		switch clause.NamedBindings.Kind {
+		case ast.KindNamespaceImport:
+			ns := clause.NamedBindings.AsNamespaceImport()
+			if ns != nil && ns.Name() != nil && ns.Name().Kind == ast.KindIdentifier {
+				names = append(names, ns.Name().AsIdentifier().Text)
+			}
+		case ast.KindNamedImports:
+			named := clause.NamedBindings.AsNamedImports()
+			if named != nil && named.Elements != nil {
+				for _, elem := range named.Elements.Nodes {
+					spec := elem.AsImportSpecifier()
+					if spec == nil || spec.Name() == nil || spec.Name().Kind != ast.KindIdentifier {
+						continue
+					}
+					names = append(names, spec.Name().AsIdentifier().Text)
+				}
+			}
+		}
+	}
+	return names
+}
+
+// findPropTypesNamedImport returns the local binding name of a `PropTypes`
+// named import (`import { PropTypes as X } from 'react'`), or "" if no such
+// specifier exists.
+func findPropTypesNamedImport(decl *ast.ImportDeclaration) string {
+	if decl.ImportClause == nil {
+		return ""
+	}
+	clause := decl.ImportClause.AsImportClause()
+	if clause == nil || clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
+		return ""
+	}
+	named := clause.NamedBindings.AsNamedImports()
+	if named == nil || named.Elements == nil {
+		return ""
+	}
+	for _, elem := range named.Elements.Nodes {
+		spec := elem.AsImportSpecifier()
+		if spec == nil {
+			continue
+		}
+		// `imported` is PropertyName (the name in the module's namespace).
+		// Under tsgo, the "propertyName" field captures `imported` when
+		// `import { X as Y }`; otherwise `name` captures the imported name.
+		imported := spec.PropertyName
+		local := spec.Name()
+		if imported == nil {
+			imported = local
+		}
+		if imported == nil || imported.Kind != ast.KindIdentifier {
+			continue
+		}
+		if imported.AsIdentifier().Text != "PropTypes" {
+			continue
+		}
+		if local != nil && local.Kind == ast.KindIdentifier {
+			return local.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+// propertyValueNode extracts the value expression of an object-literal
+// property. Returns nil for shorthand / spread / method shorthand, whose
+// "value" is not a separate expression in tsgo.
+func propertyValueNode(prop *ast.Node) *ast.Node {
+	if prop == nil {
+		return nil
+	}
+	switch prop.Kind {
+	case ast.KindPropertyAssignment:
+		return prop.AsPropertyAssignment().Initializer
+	case ast.KindShorthandPropertyAssignment:
+		// In ESTree, value === key for shorthand. Upstream still calls
+		// `reportErrorIfPropertyCasingTypo(property.value, property.key, ...)`;
+		// `checkValidPropObject` early-returns when `value.type !== 'ObjectExpression'`,
+		// so shorthand is effectively a no-op there. For static-class-property
+		// typo detection the value is unused, so returning nil is fine.
+		return nil
+	}
+	return nil
+}
+
+// declName returns the identifier text of a named declaration (class or
+// function), or "" when the declaration is anonymous or the name is not a
+// bare Identifier.
+func declName(n *ast.Node) string {
+	name := n.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+// enclosingClass returns the nearest ClassDeclaration / ClassExpression
+// ancestor of `node`, or nil. Used to find the class of a PropertyDeclaration
+// so we can test the extends clause.
+func enclosingClass(node *ast.Node) *ast.Node {
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindClassDeclaration, ast.KindClassExpression:
+			return p
+		}
+	}
+	return nil
+}
+
+// isCreateClassObjectArg reports whether `obj` is the first argument of a
+// `<createClass>(...)` / `<pragma>.<createClass>(...)` call. ES5 component
+// detection hinges on this shape.
+func isCreateClassObjectArg(obj *ast.Node, pragma, createClass string) bool {
+	if obj == nil || obj.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	// Walk up through any parenthesized wrappers to find the call argument
+	// position — tsgo preserves parens that ESTree would flatten.
+	cur := obj
+	for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
+		cur = cur.Parent
+	}
+	parent := cur.Parent
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := parent.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 || call.Arguments.Nodes[0] != cur {
+		return false
+	}
+	return reactutil.IsCreateClassCall(call, pragma, createClass)
+}
+
+// functionReturnsJSX reports whether the given function-like node contains a
+// JSX element / fragment in a position that a `return <...>` would produce —
+// either as the arrow-expression body or inside a return statement in the
+// block body. Nested functions are not descended into.
+func functionReturnsJSX(fn *ast.Node) bool {
+	if fn == nil {
+		return false
+	}
+	var body *ast.Node
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		body = fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		body = fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		af := fn.AsArrowFunction()
+		if af.Body == nil {
+			return false
+		}
+		if af.Body.Kind != ast.KindBlock {
+			// Implicit return: check whether the expression contains a JSX
+			// element / fragment transitively.
+			return containsJSX(af.Body)
+		}
+		body = af.Body
+	default:
+		return false
+	}
+	if body == nil {
+		return false
+	}
+	found := false
+	var walk ast.Visitor
+	walk = func(n *ast.Node) bool {
+		if found || n == nil {
+			return found
+		}
+		switch n.Kind {
+		case ast.KindFunctionExpression, ast.KindFunctionDeclaration, ast.KindArrowFunction:
+			return false
+		case ast.KindReturnStatement:
+			rs := n.AsReturnStatement()
+			if rs.Expression != nil && containsJSX(rs.Expression) {
+				found = true
+				return true
+			}
+		}
+		n.ForEachChild(walk)
+		return found
+	}
+	walk(body)
+	return found
+}
+
+// containsJSX reports whether `node` contains a JSX element / fragment /
+// self-closing element anywhere in its subtree, not crossing nested
+// function-like boundaries.
+func containsJSX(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	var walk ast.Visitor
+	walk = func(n *ast.Node) bool {
+		if found || n == nil {
+			return found
+		}
+		switch n.Kind {
+		case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
+			found = true
+			return true
+		case ast.KindFunctionExpression, ast.KindFunctionDeclaration, ast.KindArrowFunction:
+			return false
+		}
+		n.ForEachChild(walk)
+		return found
+	}
+	walk(node)
+	return found
+}
+
+// hasJSDocExtendsReactComponent reports whether a class has a JSDoc
+// `@extends React.Component` / `@augments React.Component` tag.
+//
+// Mirrors eslint-plugin-react's componentUtil which, on a class with a
+// `@extends` JSDoc tag, treats it as a React component even when the
+// syntactic `extends` clause does not name React.Component. Only the
+// simple `.Component` / `.PureComponent` qualifier (with or without the
+// `React.` prefix) is recognized — matches the regex ESLint uses.
+func hasJSDocExtendsReactComponent(classNode *ast.Node) bool {
+	if classNode == nil {
+		return false
+	}
+	jsDocs := classNode.JSDoc(nil) // nil file → walks to the enclosing SourceFile
+	for _, doc := range jsDocs {
+		jd := doc.AsJSDoc()
+		if jd == nil || jd.Tags == nil {
+			continue
+		}
+		for _, tag := range jd.Tags.Nodes {
+			if !ast.IsJSDocAugmentsTag(tag) {
+				continue
+			}
+			aug := tag.AsJSDocAugmentsTag()
+			if aug == nil || aug.ClassName == nil {
+				continue
+			}
+			if jsDocTypeRefMatchesComponent(aug.ClassName) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// jsDocTypeRefMatchesComponent recognizes `Component` / `PureComponent` and
+// `<any>.Component` / `<any>.PureComponent` shapes inside a JSDoc @extends /
+// @augments tag's type reference.
+func jsDocTypeRefMatchesComponent(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		t := node.AsIdentifier().Text
+		return t == "Component" || t == "PureComponent"
+	case ast.KindExpressionWithTypeArguments:
+		return jsDocTypeRefMatchesComponent(node.AsExpressionWithTypeArguments().Expression)
+	case ast.KindPropertyAccessExpression:
+		pa := node.AsPropertyAccessExpression()
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		t := name.AsIdentifier().Text
+		return t == "Component" || t == "PureComponent"
+	}
+	return false
+}

--- a/internal/plugins/react/rules/no_typos/no_typos.md
+++ b/internal/plugins/react/rules/no_typos/no_typos.md
@@ -1,0 +1,122 @@
+<!-- cspell:disable — rule docs deliberately contain casing-typo identifiers (e.g. `componentwillMount`, `isrequired`) that the rule is designed to flag. -->
+
+# react/no-typos
+
+Disallow common typos in React component declarations.
+
+## Rule Details
+
+This rule catches casing mistakes in React-specific identifiers that are easy to
+miss because the surrounding code still runs — just not the way the author
+expected.
+
+It flags four classes of typo:
+
+1. **Static class property names** on React components: `propTypes`,
+   `contextTypes`, `childContextTypes`, `defaultProps`. Any identifier whose
+   lowercased form equals one of these but whose casing differs is reported —
+   whether declared as a static class field (`static PropTypes = {}`) or
+   assigned externally (`Component.PropTypes = {}`).
+2. **React lifecycle method names** on class components or inside
+   `createReactClass({ ... })`:
+   - Instance: `getDefaultProps`, `getInitialState`, `getChildContext`,
+     `componentWillMount`, `UNSAFE_componentWillMount`, `componentDidMount`,
+     `componentWillReceiveProps`, `UNSAFE_componentWillReceiveProps`,
+     `shouldComponentUpdate`, `componentWillUpdate`, `UNSAFE_componentWillUpdate`,
+     `getSnapshotBeforeUpdate`, `componentDidUpdate`, `componentDidCatch`,
+     `componentWillUnmount`, `render`.
+   - Static: `getDerivedStateFromProps`.
+3. **Static lifecycle declared non-static**: `getDerivedStateFromProps` (or a
+   casing variant of it) declared as an instance method triggers
+   `staticLifecycleMethod` in addition to any casing typo.
+4. **`PropTypes` usage errors** — when a `prop-types` or `react` import is
+   present:
+   - A property name in `PropTypes.<name>` / `<alias>.<name>` that is not one
+     of the keys exported by `prop-types` (e.g. `PropTypes.Number`,
+     `PropTypes.bools`) emits `typoPropType`.
+   - A chain qualifier that is not `isRequired` (e.g. `.isrequired`) emits
+     `typoPropTypeChain`.
+   - `import 'react'` with no binding emits `noReactBinding`.
+   - `import 'prop-types'` with no binding emits `noPropTypesBinding`.
+
+### Component detection
+
+A class is considered a React component when it `extends` `Component` or
+`PureComponent` — either as a bare identifier or qualified by the React
+pragma (`React.Component` by default, configurable via
+`settings.react.pragma`). Classes with a JSDoc `@extends React.Component` /
+`@augments React.Component` tag are also recognized.
+
+For `Component.PropTypes = ...` / `Component.propTypes = ...` assignments the
+rule resolves `Component` file-wide to:
+
+- a class (declared with either `class Foo` or `const Foo = class`) matching
+  the above extends rule, or
+- a function declaration / expression / arrow function whose body directly
+  contains a `return <jsx />`.
+
+Classes and functions that don't satisfy those conditions — including
+`React.forwardRef` / `React.memo` / `styled.xxx` results — are not treated as
+components, matching `eslint-plugin-react`'s behavior.
+
+## Differences from ESLint
+
+- **Computed / bracket-notation access is not tracked.** Upstream documents
+  `Component['PropTypes']` as "currently not supported" and this rule follows
+  suit — only `PropertyAccessExpression` (`a.b`) is examined. Code like
+  `Foo['prop' + 'Types'] = {}` silently passes, matching ESLint.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+class MyComponent extends React.Component {
+  static PropTypes = {};
+}
+```
+
+```jsx
+class MyComponent extends React.Component {
+  componentwillMount() {}
+}
+```
+
+```jsx
+import PropTypes from 'prop-types';
+class MyComponent extends React.Component {}
+MyComponent.propTypes = {
+  a: PropTypes.Number,
+  b: PropTypes.string.isrequired,
+};
+```
+
+```jsx
+class MyComponent extends React.Component {
+  getDerivedStateFromProps() {}
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+class MyComponent extends React.Component {
+  static propTypes = {};
+  componentWillMount() {}
+  static getDerivedStateFromProps() {}
+  render() {
+    return null;
+  }
+}
+```
+
+```jsx
+import PropTypes from 'prop-types';
+class MyComponent extends React.Component {}
+MyComponent.propTypes = {
+  a: PropTypes.number,
+  b: PropTypes.string.isRequired,
+};
+```
+
+## Original Documentation
+
+- [eslint-plugin-react / no-typos](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-typos.md)

--- a/internal/plugins/react/rules/no_typos/no_typos_test.go
+++ b/internal/plugins/react/rules/no_typos/no_typos_test.go
@@ -1,0 +1,1232 @@
+// cspell:disable — test cases deliberately contain casing-typo identifiers
+// (e.g. `componentwillmount`, `isrequired`, `objectof`) that this rule is
+// designed to flag. Disabling cspell for the whole file keeps the intent
+// obvious and avoids sprinkling per-line pragmas across ~600 lines.
+package no_typos
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoTyposRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoTyposRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: non-component classes / functions are ignored ----
+		{Code: `
+          import createReactClass from 'create-react-class'
+          function hello (extra = {}) {
+            return createReactClass({
+              noteType: 'hello',
+              renderItem () {
+                return null
+              },
+              ...extra
+            })
+          }
+        `, Tsx: true},
+		{Code: `
+          class First {
+            static PropTypes = {key: "myValue"};
+            static ContextTypes = {key: "myValue"};
+            static ChildContextTypes = {key: "myValue"};
+            static DefaultProps = {key: "myValue"};
+          }
+        `, Tsx: true},
+		{Code: `
+          class First {}
+          First.PropTypes = {key: "myValue"};
+          First.ContextTypes = {key: "myValue"};
+          First.ChildContextTypes = {key: "myValue"};
+          First.DefaultProps = {key: "myValue"};
+        `, Tsx: true},
+
+		// ---- Upstream: exact casing on static class properties ----
+		{Code: `
+          class First extends React.Component {
+            static propTypes = {key: "myValue"};
+            static contextTypes = {key: "myValue"};
+            static childContextTypes = {key: "myValue"};
+            static defaultProps = {key: "myValue"};
+          }
+        `, Tsx: true},
+		{Code: `
+          class First extends React.Component {}
+          First.propTypes = {key: "myValue"};
+          First.contextTypes = {key: "myValue"};
+          First.childContextTypes = {key: "myValue"};
+          First.defaultProps = {key: "myValue"};
+        `, Tsx: true},
+
+		// ---- Upstream: non-static members of non-component class are fine ----
+		{Code: `
+          class MyClass {
+            propTypes = {key: "myValue"};
+            contextTypes = {key: "myValue"};
+            childContextTypes = {key: "myValue"};
+            defaultProps = {key: "myValue"};
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            PropTypes = {key: "myValue"};
+            ContextTypes = {key: "myValue"};
+            ChildContextTypes = {key: "myValue"};
+            DefaultProps = {key: "myValue"};
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            proptypes = {key: "myValue"};
+            contexttypes = {key: "myValue"};
+            childcontextypes = {key: "myValue"};
+            defaultprops = {key: "myValue"};
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            static PropTypes() {};
+            static ContextTypes() {};
+            static ChildContextTypes() {};
+            static DefaultProps() {};
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            static proptypes() {};
+            static contexttypes() {};
+            static childcontexttypes() {};
+            static defaultprops() {};
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {}
+          MyClass.prototype.PropTypes = function() {};
+          MyClass.prototype.ContextTypes = function() {};
+          MyClass.prototype.ChildContextTypes = function() {};
+          MyClass.prototype.DefaultProps = function() {};
+        `, Tsx: true},
+		{Code: `
+          class MyClass {}
+          MyClass.PropTypes = function() {};
+          MyClass.ContextTypes = function() {};
+          MyClass.ChildContextTypes = function() {};
+          MyClass.DefaultProps = function() {};
+        `, Tsx: true},
+		{Code: `
+          function MyRandomFunction() {}
+          MyRandomFunction.PropTypes = {};
+          MyRandomFunction.ContextTypes = {};
+          MyRandomFunction.ChildContextTypes = {};
+          MyRandomFunction.DefaultProps = {};
+        `, Tsx: true},
+
+		// ---- Upstream: unsupported dynamic computed keys (bracket notation) ----
+		{Code: `
+          class First extends React.Component {}
+          First["prop" + "Types"] = {};
+          First["context" + "Types"] = {};
+          First["childContext" + "Types"] = {};
+          First["default" + "Props"] = {};
+        `, Tsx: true},
+		{Code: `
+          class First extends React.Component {}
+          First["PROP" + "TYPES"] = {};
+          First["CONTEXT" + "TYPES"] = {};
+          First["CHILDCONTEXT" + "TYPES"] = {};
+          First["DEFAULT" + "PROPS"] = {};
+        `, Tsx: true},
+		{Code: `
+          const propTypes = "PROPTYPES"
+          const contextTypes = "CONTEXTTYPES"
+          const childContextTypes = "CHILDCONTEXTTYPES"
+          const defaultProps = "DEFAULTPROPS"
+
+          class First extends React.Component {}
+          First[propTypes] = {};
+          First[contextTypes] = {};
+          First[childContextTypes] = {};
+          First[defaultProps] = {};
+        `, Tsx: true},
+
+		// ---- Upstream: well-cased lifecycle methods ----
+		{Code: `
+          class Hello extends React.Component {
+            static getDerivedStateFromProps() { }
+            componentWillMount() { }
+            componentDidMount() { }
+            componentWillReceiveProps() { }
+            shouldComponentUpdate() { }
+            componentWillUpdate() { }
+            componentDidUpdate() { }
+            componentWillUnmount() { }
+            render() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          }
+        `, Tsx: true},
+		{Code: `
+          class Hello extends React.Component {
+            "componentDidMount"() { }
+            "my-method"() { }
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            componentWillMount() { }
+            componentDidMount() { }
+            componentWillReceiveProps() { }
+            shouldComponentUpdate() { }
+            componentWillUpdate() { }
+            componentDidUpdate() { }
+            componentWillUnmount() { }
+            render() { }
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            componentwillmount() { }
+            componentdidmount() { }
+            componentwillreceiveprops() { }
+            shouldcomponentupdate() { }
+            componentwillupdate() { }
+            componentdidupdate() { }
+            componentwillUnmount() { }
+            render() { }
+          }
+        `, Tsx: true},
+		{Code: `
+          class MyClass {
+            Componentwillmount() { }
+            Componentdidmount() { }
+            Componentwillreceiveprops() { }
+            Shouldcomponentupdate() { }
+            Componentwillupdate() { }
+            Componentdidupdate() { }
+            ComponentwillUnmount() { }
+            Render() { }
+          }
+        `, Tsx: true},
+
+		// ---- Upstream: issue #1353 — unrelated .bind ----
+		{Code: `
+          function test(b) {
+            return a.bind(b);
+          }
+          function a() {}
+        `, Tsx: true},
+
+		// ---- Upstream: well-formed PropTypes usage ----
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.number.isRequired
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            e: PropTypes.shape({
+              ea: PropTypes.string,
+            })
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.string,
+            b: PropTypes.string.isRequired,
+            c: PropTypes.shape({
+              d: PropTypes.string,
+              e: PropTypes.number.isRequired,
+            }).isRequired
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.oneOfType([
+              PropTypes.string,
+              PropTypes.number
+            ])
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.oneOf([
+              'hello',
+              'hi'
+            ])
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.childContextTypes = {
+            a: PropTypes.string,
+            b: PropTypes.string.isRequired,
+            c: PropTypes.shape({
+              d: PropTypes.string,
+              e: PropTypes.number.isRequired,
+            }).isRequired
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.contextTypes = {
+            a: PropTypes.string,
+            b: PropTypes.string.isRequired,
+            c: PropTypes.shape({
+              d: PropTypes.string,
+              e: PropTypes.number.isRequired,
+            }).isRequired
+          }
+        `, Tsx: true},
+
+		// ---- Upstream: external types alongside prop-types ----
+		{Code: `
+          import PropTypes from 'prop-types'
+          import * as MyPropTypes from 'lib/my-prop-types'
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.string,
+            b: MyPropTypes.MYSTRING,
+            c: MyPropTypes.MYSTRING.isRequired,
+          }
+        `, Tsx: true},
+		{Code: `
+          import PropTypes from "prop-types"
+          import * as MyPropTypes from 'lib/my-prop-types'
+          class Component extends React.Component {};
+          Component.propTypes = {
+            b: PropTypes.string,
+            a: MyPropTypes.MYSTRING,
+          }
+        `, Tsx: true},
+		{Code: `
+          import CustomReact from "react"
+          class Component extends React.Component {};
+          Component.propTypes = {
+            b: CustomReact.PropTypes.string,
+          }
+        `, Tsx: true},
+
+		// ---- Upstream: absent arg to PropTypes.shape must not crash ----
+		{Code: `
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.shape(),
+          };
+          Component.contextTypes = {
+            a: PropTypes.shape(),
+          };
+        `, Tsx: true},
+
+		// ---- Upstream: unrelated patterns ----
+		{Code: `
+          const fn = (err, res) => {
+            const { body: data = {} } = { ...res };
+            data.time = data.time || {};
+          };
+        `, Tsx: true},
+		{Code: `
+          class Component extends React.Component {};
+          Component.propTypes = {
+            b: string.isRequired,
+            c: PropTypes.shape({
+              d: number.isRequired,
+            }).isRequired
+          }
+        `, Tsx: true},
+
+		// ---- Upstream: createReactClass with PropTypes ----
+		{Code: `
+          import React from 'react';
+          import PropTypes from 'prop-types';
+          const Component = React.createReactClass({
+            propTypes: {
+              a: PropTypes.string.isRequired,
+              b: PropTypes.shape({
+                c: PropTypes.number
+              }).isRequired
+            }
+          });
+        `, Tsx: true},
+		{Code: `
+          import React from 'react';
+          import PropTypes from 'prop-types';
+          const Component = React.createReactClass({
+            childContextTypes: {
+              a: PropTypes.bool,
+              b: PropTypes.array,
+              c: PropTypes.func,
+              d: PropTypes.object,
+            }
+          });
+        `, Tsx: true},
+		{Code: `
+          import React from 'react';
+          const Component = React.createReactClass({
+            propTypes: {},
+            childContextTypes: {},
+            contextTypes: {},
+            componentWillMount() { },
+            componentDidMount() { },
+            componentWillReceiveProps() { },
+            shouldComponentUpdate() { },
+            componentWillUpdate() { },
+            componentDidUpdate() { },
+            componentWillUnmount() { },
+            render() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          });
+        `, Tsx: true},
+
+		// ---- Upstream: destructured named imports from prop-types ----
+		{Code: `
+          import { string, element } from "prop-types";
+
+          class Sample extends React.Component {
+            render() { return null; }
+          }
+
+          Sample.propTypes = {
+            title: string.isRequired,
+            body: element.isRequired
+          };
+        `, Tsx: true},
+
+		// ---- Upstream: computed key with PropertyAccessExpression base ----
+		{Code: `
+          import React from 'react';
+
+          const A = { B: 'C' };
+
+          export default class MyComponent extends React.Component {
+            [A.B] () {
+              return null
+            }
+          }
+        `, Tsx: true},
+
+		// ---- Upstream: React.forwardRef / styled-components escape hatches ----
+		{Code: `
+          const MyComponent = React.forwardRef((props, ref) => <div />);
+          MyComponent.defaultProps = { value: "" };
+        `, Tsx: true},
+		{Code: `
+          import styled from "styled-components";
+
+          const MyComponent = styled.div;
+          MyComponent.defaultProps = { value: "" };
+        `, Tsx: true},
+
+		// ---- Upstream: private method should not trigger lifecycle typo ----
+		{Code: `
+          class Editor extends React.Component {
+              #somethingPrivate() {
+                // ...
+              }
+
+              render() {
+              const { value = '' } = this.props;
+
+              return (
+                <textarea>
+                  {value}
+                </textarea>
+              );
+            }
+          }
+        `, Tsx: true},
+
+		// ---- Edge: PureComponent is also a React component (well-cased) ----
+		{Code: `
+          class Hello extends React.PureComponent {
+            componentDidMount() {}
+            render() { return <div/>; }
+          }
+          Hello.propTypes = {};
+        `, Tsx: true},
+
+		// ---- Edge: bare Component / PureComponent identifiers ----
+		{Code: `
+          class Hello extends Component {
+            componentDidMount() {}
+            render() { return <div/>; }
+          }
+          Hello.propTypes = {};
+        `, Tsx: true},
+		{Code: `
+          class Hello extends PureComponent {}
+          Hello.defaultProps = {};
+        `, Tsx: true},
+
+		// ---- Edge: ClassExpression assigned to const ----
+		{Code: `
+          const Foo = class extends React.Component {
+            render() { return <div/>; }
+          };
+          Foo.propTypes = {};
+        `, Tsx: true},
+
+		// ---- Edge: arrow function component is tracked for the Foo.Prop path ----
+		{Code: `
+          const Foo = () => <div/>;
+          Foo.defaultProps = {};
+        `, Tsx: true},
+
+		// ---- Edge: parenthesized extends clause ----
+		{Code: `
+          class Hello extends (React.Component) {
+            componentDidMount() {}
+          }
+        `, Tsx: true},
+
+		// ---- Edge: deeply nested shape + oneOfType (all correct) ----
+		{Code: `
+          import PropTypes from 'prop-types';
+          class C extends React.Component {}
+          C.propTypes = {
+            x: PropTypes.shape({
+              y: PropTypes.oneOfType([
+                PropTypes.shape({
+                  z: PropTypes.number.isRequired,
+                }),
+                PropTypes.string,
+              ]).isRequired,
+            }).isRequired,
+          };
+        `, Tsx: true},
+
+		// ---- Edge: spread in propTypes object is tolerated ----
+		{Code: `
+          import PropTypes from 'prop-types';
+          const extra = { b: PropTypes.string };
+          class C extends React.Component {}
+          C.propTypes = {
+            a: PropTypes.number,
+            ...extra,
+          };
+        `, Tsx: true},
+
+		// ---- Edge: string key on a class method with correct casing ----
+		{Code: `
+          class Hello extends React.Component {
+            "componentWillMount"() {}
+          }
+        `, Tsx: true},
+
+		// ---- Edge: aliased named import of PropTypes from react ----
+		{Code: `
+          import { PropTypes as PT } from 'react';
+          class C extends React.Component {}
+          C.propTypes = {
+            a: PT.number.isRequired,
+          };
+        `, Tsx: true},
+
+		// ---- Edge: namespace import of prop-types ----
+		{Code: `
+          import * as PT from 'prop-types';
+          class C extends React.Component {}
+          C.propTypes = {
+            a: PT.string.isRequired,
+          };
+        `, Tsx: true},
+
+		// ---- Edge: numeric key should be ignored by lifecycle check ----
+		{Code: `
+          class Hello extends React.Component {
+            1() {}
+          }
+        `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: typoStaticClassProp — PropTypes variants ----
+		{Code: `
+        class Component extends React.Component {
+          static PropTypes = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.PropTypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.PropTypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {
+          static proptypes = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.proptypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.proptypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Upstream: typoStaticClassProp — ContextTypes variants ----
+		{Code: `
+        class Component extends React.Component {
+          static ContextTypes = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.ContextTypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.ContextTypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {
+          static contexttypes = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.contexttypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.contexttypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Upstream: typoStaticClassProp — ChildContextTypes variants ----
+		{Code: `
+        class Component extends React.Component {
+          static ChildContextTypes = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.ChildContextTypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.ChildContextTypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {
+          static childcontexttypes = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.childcontexttypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.childcontexttypes = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Upstream: typoStaticClassProp — DefaultProps variants ----
+		{Code: `
+        class Component extends React.Component {
+          static DefaultProps = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.DefaultProps = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.DefaultProps = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {
+          static defaultprops = {};
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        class Component extends React.Component {}
+        Component.defaultprops = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+		{Code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.defaultprops = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Upstream: typoStaticClassProp — assignment before class definition ----
+		{Code: `
+        Component.defaultprops = {}
+        class Component extends React.Component {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Upstream: @extends JSDoc tag ----
+		{Code: `
+        /** @extends React.Component */
+        class MyComponent extends BaseComponent {}
+        MyComponent.PROPTYPES = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Upstream: typoLifecycleMethod — PascalCase variant ----
+		{Code: `
+        class Hello extends React.Component {
+          static GetDerivedStateFromProps()  { }
+          ComponentWillMount() { }
+          UNSAFE_ComponentWillMount() { }
+          ComponentDidMount() { }
+          ComponentWillReceiveProps() { }
+          UNSAFE_ComponentWillReceiveProps() { }
+          ShouldComponentUpdate() { }
+          ComponentWillUpdate() { }
+          UNSAFE_ComponentWillUpdate() { }
+          GetSnapshotBeforeUpdate() { }
+          ComponentDidUpdate() { }
+          ComponentDidCatch() { }
+          ComponentWillUnmount() { }
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoLifecycleMethod", Line: 3},
+			{MessageId: "typoLifecycleMethod", Line: 4},
+			{MessageId: "typoLifecycleMethod", Line: 5},
+			{MessageId: "typoLifecycleMethod", Line: 6},
+			{MessageId: "typoLifecycleMethod", Line: 7},
+			{MessageId: "typoLifecycleMethod", Line: 8},
+			{MessageId: "typoLifecycleMethod", Line: 9},
+			{MessageId: "typoLifecycleMethod", Line: 10},
+			{MessageId: "typoLifecycleMethod", Line: 11},
+			{MessageId: "typoLifecycleMethod", Line: 12},
+			{MessageId: "typoLifecycleMethod", Line: 13},
+			{MessageId: "typoLifecycleMethod", Line: 14},
+			{MessageId: "typoLifecycleMethod", Line: 15},
+		}},
+
+		// ---- Upstream: typoLifecycleMethod — First-letter-uppercase variant ----
+		{Code: `
+        class Hello extends React.Component {
+          static Getderivedstatefromprops() { }
+          Componentwillmount() { }
+          UNSAFE_Componentwillmount() { }
+          Componentdidmount() { }
+          Componentwillreceiveprops() { }
+          UNSAFE_Componentwillreceiveprops() { }
+          Shouldcomponentupdate() { }
+          Componentwillupdate() { }
+          UNSAFE_Componentwillupdate() { }
+          Getsnapshotbeforeupdate() { }
+          Componentdidupdate() { }
+          Componentdidcatch() { }
+          Componentwillunmount() { }
+          Render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoLifecycleMethod", Line: 3},
+			{MessageId: "typoLifecycleMethod", Line: 4},
+			{MessageId: "typoLifecycleMethod", Line: 5},
+			{MessageId: "typoLifecycleMethod", Line: 6},
+			{MessageId: "typoLifecycleMethod", Line: 7},
+			{MessageId: "typoLifecycleMethod", Line: 8},
+			{MessageId: "typoLifecycleMethod", Line: 9},
+			{MessageId: "typoLifecycleMethod", Line: 10},
+			{MessageId: "typoLifecycleMethod", Line: 11},
+			{MessageId: "typoLifecycleMethod", Line: 12},
+			{MessageId: "typoLifecycleMethod", Line: 13},
+			{MessageId: "typoLifecycleMethod", Line: 14},
+			{MessageId: "typoLifecycleMethod", Line: 15},
+			{MessageId: "typoLifecycleMethod", Line: 16},
+		}},
+
+		// ---- Upstream: typoLifecycleMethod — lowercase variant ----
+		{Code: `
+        class Hello extends React.Component {
+          static getderivedstatefromprops() { }
+          componentwillmount() { }
+          unsafe_componentwillmount() { }
+          componentdidmount() { }
+          componentwillreceiveprops() { }
+          unsafe_componentwillreceiveprops() { }
+          shouldcomponentupdate() { }
+          componentwillupdate() { }
+          unsafe_componentwillupdate() { }
+          getsnapshotbeforeupdate() { }
+          componentdidupdate() { }
+          componentdidcatch() { }
+          componentwillunmount() { }
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+		}},
+
+		// ---- Upstream: typoPropType (single) ----
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+            a: PropTypes.Number.isRequired
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropType"}}},
+
+		// ---- Upstream: typoPropTypeChain (single) ----
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+            a: PropTypes.number.isrequired
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropTypeChain"}}},
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {
+          static propTypes = {
+            a: PropTypes.number.isrequired
+          }
+        };
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropTypeChain"}}},
+
+		// ---- Upstream: typoPropType — static field ----
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {
+          static propTypes = {
+            a: PropTypes.Number
+          }
+        };
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropType"}}},
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+            a: PropTypes.Number
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropType"}}},
+
+		// ---- Upstream: typoPropType — inside shape ----
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.shape({
+            b: PropTypes.String,
+            c: PropTypes.number.isRequired,
+          })
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropType"}}},
+
+		// ---- Upstream: typoPropType — inside oneOfType ----
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.oneOfType([
+            PropTypes.bools,
+            PropTypes.number,
+          ])
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropType"}}},
+
+		// ---- Upstream: typoPropType — multiple at top level ----
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+		{Code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+		{Code: `
+        import PropTypes from 'prop-types';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+
+		// ---- Upstream: typoPropTypeChain — multiple .isrequired ----
+		{Code: `
+        import PropTypes from 'prop-types';
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.string.isrequired,
+          b: PropTypes.shape({
+            c: PropTypes.number
+          }).isrequired
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropTypeChain"},
+			{MessageId: "typoPropTypeChain"},
+		}},
+
+		// ---- Upstream: typoPropType — aliased default import ----
+		{Code: `
+        import RealPropTypes from 'prop-types';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: RealPropTypes.bools,
+          b: RealPropTypes.Array,
+          c: RealPropTypes.function,
+          d: RealPropTypes.objectof,
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+
+		// ---- Upstream: typoPropTypeChain — React.PropTypes ----
+		{Code: `
+      import React from 'react';
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: React.PropTypes.string.isrequired,
+        b: React.PropTypes.shape({
+          c: React.PropTypes.number
+        }).isrequired
+      }
+    `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropTypeChain"},
+			{MessageId: "typoPropTypeChain"},
+		}},
+		{Code: `
+        import React from 'react';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: React.PropTypes.bools,
+          b: React.PropTypes.Array,
+          c: React.PropTypes.function,
+          d: React.PropTypes.objectof,
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+
+		// ---- Upstream: typoPropTypeChain — destructured { PropTypes } from react ----
+		{Code: `
+      import { PropTypes } from 'react';
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string.isrequired,
+        b: PropTypes.shape({
+          c: PropTypes.number
+        }).isrequired
+      }
+    `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropTypeChain"},
+			{MessageId: "typoPropTypeChain"},
+		}},
+
+		// ---- Upstream: noReactBinding ----
+		{Code: `
+      import 'react';
+      class Component extends React.Component {};
+    `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noReactBinding"}}},
+
+		// ---- Upstream: typoPropType — destructured from react ----
+		{Code: `
+        import { PropTypes } from 'react';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+
+		// ---- Upstream: typoPropTypeChain — leading whitespace variants ----
+		{Code: `
+      import PropTypes from 'prop-types';
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string.isrequired,
+        b: PropTypes.shape({
+          c: PropTypes.number
+        }).isrequired
+      }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropTypeChain"},
+			{MessageId: "typoPropTypeChain"},
+		}},
+
+		// ---- Upstream: typoPropTypeChain in createReactClass ----
+		{Code: `
+        import React from 'react';
+        import PropTypes from 'prop-types';
+        const Component = React.createReactClass({
+          propTypes: {
+            a: PropTypes.string.isrequired,
+            b: PropTypes.shape({
+              c: PropTypes.number
+            }).isrequired
+          }
+        });
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropTypeChain"},
+			{MessageId: "typoPropTypeChain"},
+		}},
+
+		// ---- Upstream: typoPropType in createReactClass childContextTypes ----
+		{Code: `
+        import React from 'react';
+        import PropTypes from 'prop-types';
+        const Component = React.createReactClass({
+          childContextTypes: {
+            a: PropTypes.bools,
+            b: PropTypes.Array,
+            c: PropTypes.function,
+            d: PropTypes.objectof,
+          }
+        });
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+			{MessageId: "typoPropType"},
+		}},
+
+		// ---- Upstream: createReactClass — prop declarations + lifecycle typos ----
+		{Code: `
+        import React from 'react';
+        const Component = React.createReactClass({
+          proptypes: {},
+          childcontexttypes: {},
+          contexttypes: {},
+          getdefaultProps() { },
+          getinitialState() { },
+          getChildcontext() { },
+          ComponentWillMount() { },
+          ComponentDidMount() { },
+          ComponentWillReceiveProps() { },
+          ShouldComponentUpdate() { },
+          ComponentWillUpdate() { },
+          ComponentDidUpdate() { },
+          ComponentWillUnmount() { },
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropDeclaration"},
+			{MessageId: "typoPropDeclaration"},
+			{MessageId: "typoPropDeclaration"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+		}},
+
+		// ---- Upstream: staticLifecycleMethod ----
+		{Code: `
+        class Hello extends React.Component {
+          getDerivedStateFromProps() { }
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "staticLifecycleMethod"}}},
+
+		// ---- Upstream: staticLifecycleMethod + typoLifecycleMethod combined ----
+		{Code: `
+        class Hello extends React.Component {
+          GetDerivedStateFromProps() { }
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "staticLifecycleMethod"},
+			{MessageId: "typoLifecycleMethod"},
+		}},
+
+		// ---- Upstream: noPropTypesBinding ----
+		{Code: `
+        import 'prop-types'
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPropTypesBinding"}}},
+
+		// ---- Contract: Line/Column + Message assertions (typoStaticClassProp) ----
+		{Code: "class C extends React.Component {\n  static ProPtYpEs = {};\n}",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "typoStaticClassProp",
+				Message:   "Typo in static class property declaration",
+				Line:      2, Column: 10, EndLine: 2, EndColumn: 19,
+			}}},
+		{Code: "class C extends React.Component {}\nC.DefaultProps = {};",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "typoStaticClassProp",
+				Message:   "Typo in static class property declaration",
+				Line:      2, Column: 3, EndLine: 2, EndColumn: 15,
+			}}},
+
+		// ---- Contract: Line/Column + Message assertions (typoPropType) ----
+		{Code: "import PropTypes from 'prop-types';\nclass C extends React.Component {}\nC.propTypes = { a: PropTypes.Number };",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "typoPropType",
+				Message:   "Typo in declared prop type: Number",
+				Line:      3, Column: 30, EndLine: 3, EndColumn: 36,
+			}}},
+
+		// ---- Contract: Line/Column + Message assertions (typoPropTypeChain) ----
+		{Code: "import PropTypes from 'prop-types';\nclass C extends React.Component {}\nC.propTypes = { a: PropTypes.number.isrequired };",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "typoPropTypeChain",
+				Message:   "Typo in prop type chain qualifier: isrequired",
+				Line:      3, Column: 37, EndLine: 3, EndColumn: 47,
+			}}},
+
+		// ---- Contract: Line/Column + Message assertions (typoLifecycleMethod) ----
+		{Code: "class C extends React.Component {\n  ComponentDidMount() {}\n}",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "typoLifecycleMethod",
+				Message:   "Typo in component lifecycle method declaration: ComponentDidMount should be componentDidMount",
+				Line:      2, Column: 3, EndLine: 2, EndColumn: 25,
+			}}},
+
+		// ---- Contract: Line/Column + Message assertions (staticLifecycleMethod) ----
+		{Code: "class C extends React.Component {\n  getDerivedStateFromProps() {}\n}",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "staticLifecycleMethod",
+				Message:   "Lifecycle method should be static: getDerivedStateFromProps",
+				Line:      2, Column: 3, EndLine: 2, EndColumn: 32,
+			}}},
+
+		// ---- Edge: typoStaticClassProp reported on the key, not the class ----
+		{Code: "class Hello extends React.Component {\n  static propTypes = {};\n  static proptypes = {};\n}",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp", Line: 3, Column: 10}}},
+
+		// ---- Edge: PureComponent variants are detected ----
+		{Code: "class C extends React.PureComponent {\n  ComponentDidMount() {}\n}",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoLifecycleMethod", Line: 2}}},
+		{Code: "class C extends PureComponent {}\nC.PropTypes = {};",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp", Line: 2}}},
+
+		// ---- Edge: ClassExpression assigned to variable ----
+		{Code: "const Foo = class extends React.Component {};\nFoo.PropTypes = {};",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp", Line: 2}}},
+
+		// ---- Edge: arrow function component is detected for Foo.Prop path ----
+		{Code: "const Foo = () => <div/>;\nFoo.DefaultProps = {};",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp", Line: 2}}},
+
+		// ---- Edge: deeply nested typo inside oneOfType inside shape ----
+		// Emission order follows the recursive descent: the `.isrequired`
+		// qualifier on the outer oneOfType is reported before descending
+		// into the oneOfType's element array.
+		{Code: `
+        import PropTypes from 'prop-types';
+        class C extends React.Component {}
+        C.propTypes = {
+          x: PropTypes.shape({
+            y: PropTypes.oneOfType([
+              PropTypes.Bool,
+              PropTypes.shape({ z: PropTypes.Number })
+            ]).isrequired
+          })
+        };
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{MessageId: "typoPropTypeChain"}, // .isrequired
+			{MessageId: "typoPropType"},      // PropTypes.Bool
+			{MessageId: "typoPropType"},      // PropTypes.Number inside nested shape
+		}},
+
+		// ---- Edge: parenthesized LHS target ----
+		{Code: "class C extends React.Component {}\n(C).PropTypes = {};",
+			Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Edge: @augments (alias of @extends) JSDoc tag ----
+		{Code: `
+        /** @augments React.PureComponent */
+        class MyComponent extends BaseComponent {}
+        MyComponent.PROPTYPES = {}
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoStaticClassProp"}}},
+
+		// ---- Edge: aliased React namespace — React.PropTypes still detected ----
+		{Code: `
+        import * as MyReact from 'react';
+        class C extends React.Component {}
+        C.propTypes = {
+          a: MyReact.PropTypes.string.isrequired,
+        };
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoPropTypeChain"}}},
+
+		// ---- Edge: string-literal lifecycle method key in class ----
+		{Code: `
+        class C extends React.Component {
+          "ComponentDidMount"() {}
+        }
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoLifecycleMethod"}}},
+
+		// ---- Edge: string-literal lifecycle method key in ES5 createReactClass ----
+		{Code: `
+        import React from 'react';
+        const C = React.createReactClass({
+          "ComponentDidMount": function() {},
+        });
+      `, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "typoLifecycleMethod"}}},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -104,6 +104,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
+    './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-typos.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-typos.test.ts
@@ -1,0 +1,1099 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-typos', {} as never, {
+  valid: [
+    // ---- Upstream: non-component classes / functions are ignored ----
+    {
+      code: `
+          import createReactClass from 'create-react-class'
+          function hello (extra = {}) {
+            return createReactClass({
+              noteType: 'hello',
+              renderItem () {
+                return null
+              },
+              ...extra
+            })
+          }
+        `,
+    },
+    {
+      code: `
+          class First {
+            static PropTypes = {key: "myValue"};
+            static ContextTypes = {key: "myValue"};
+            static ChildContextTypes = {key: "myValue"};
+            static DefaultProps = {key: "myValue"};
+          }
+        `,
+    },
+    {
+      code: `
+          class First {}
+          First.PropTypes = {key: "myValue"};
+          First.ContextTypes = {key: "myValue"};
+          First.ChildContextTypes = {key: "myValue"};
+          First.DefaultProps = {key: "myValue"};
+        `,
+    },
+    // ---- Upstream: exact casing on static class properties ----
+    {
+      code: `
+          class First extends React.Component {
+            static propTypes = {key: "myValue"};
+            static contextTypes = {key: "myValue"};
+            static childContextTypes = {key: "myValue"};
+            static defaultProps = {key: "myValue"};
+          }
+        `,
+    },
+    {
+      code: `
+          class First extends React.Component {}
+          First.propTypes = {key: "myValue"};
+          First.contextTypes = {key: "myValue"};
+          First.childContextTypes = {key: "myValue"};
+          First.defaultProps = {key: "myValue"};
+        `,
+    },
+    // ---- Upstream: non-static members of non-component class are fine ----
+    {
+      code: `
+          class MyClass {
+            propTypes = {key: "myValue"};
+            contextTypes = {key: "myValue"};
+            childContextTypes = {key: "myValue"};
+            defaultProps = {key: "myValue"};
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            PropTypes = {key: "myValue"};
+            ContextTypes = {key: "myValue"};
+            ChildContextTypes = {key: "myValue"};
+            DefaultProps = {key: "myValue"};
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            proptypes = {key: "myValue"};
+            contexttypes = {key: "myValue"};
+            childcontextypes = {key: "myValue"};
+            defaultprops = {key: "myValue"};
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            static PropTypes() {};
+            static ContextTypes() {};
+            static ChildContextTypes() {};
+            static DefaultProps() {};
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            static proptypes() {};
+            static contexttypes() {};
+            static childcontexttypes() {};
+            static defaultprops() {};
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {}
+          MyClass.prototype.PropTypes = function() {};
+          MyClass.prototype.ContextTypes = function() {};
+          MyClass.prototype.ChildContextTypes = function() {};
+          MyClass.prototype.DefaultProps = function() {};
+        `,
+    },
+    {
+      code: `
+          class MyClass {}
+          MyClass.PropTypes = function() {};
+          MyClass.ContextTypes = function() {};
+          MyClass.ChildContextTypes = function() {};
+          MyClass.DefaultProps = function() {};
+        `,
+    },
+    {
+      code: `
+          function MyRandomFunction() {}
+          MyRandomFunction.PropTypes = {};
+          MyRandomFunction.ContextTypes = {};
+          MyRandomFunction.ChildContextTypes = {};
+          MyRandomFunction.DefaultProps = {};
+        `,
+    },
+    // ---- Upstream: unsupported dynamic computed keys (bracket notation) ----
+    {
+      code: `
+          class First extends React.Component {}
+          First["prop" + "Types"] = {};
+          First["context" + "Types"] = {};
+          First["childContext" + "Types"] = {};
+          First["default" + "Props"] = {};
+        `,
+    },
+    {
+      code: `
+          class First extends React.Component {}
+          First["PROP" + "TYPES"] = {};
+          First["CONTEXT" + "TYPES"] = {};
+          First["CHILDCONTEXT" + "TYPES"] = {};
+          First["DEFAULT" + "PROPS"] = {};
+        `,
+    },
+    {
+      code: `
+          const propTypes = "PROPTYPES"
+          const contextTypes = "CONTEXTTYPES"
+          const childContextTypes = "CHILDCONTEXTTYPES"
+          const defaultProps = "DEFAULTPROPS"
+
+          class First extends React.Component {}
+          First[propTypes] = {};
+          First[contextTypes] = {};
+          First[childContextTypes] = {};
+          First[defaultProps] = {};
+        `,
+    },
+    // ---- Upstream: well-cased lifecycle methods ----
+    {
+      code: `
+          class Hello extends React.Component {
+            static getDerivedStateFromProps() { }
+            componentWillMount() { }
+            componentDidMount() { }
+            componentWillReceiveProps() { }
+            shouldComponentUpdate() { }
+            componentWillUpdate() { }
+            componentDidUpdate() { }
+            componentWillUnmount() { }
+            render() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          }
+        `,
+    },
+    {
+      code: `
+          class Hello extends React.Component {
+            "componentDidMount"() { }
+            "my-method"() { }
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            componentWillMount() { }
+            componentDidMount() { }
+            componentWillReceiveProps() { }
+            shouldComponentUpdate() { }
+            componentWillUpdate() { }
+            componentDidUpdate() { }
+            componentWillUnmount() { }
+            render() { }
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            componentwillmount() { }
+            componentdidmount() { }
+            componentwillreceiveprops() { }
+            shouldcomponentupdate() { }
+            componentwillupdate() { }
+            componentdidupdate() { }
+            componentwillUnmount() { }
+            render() { }
+          }
+        `,
+    },
+    {
+      code: `
+          class MyClass {
+            Componentwillmount() { }
+            Componentdidmount() { }
+            Componentwillreceiveprops() { }
+            Shouldcomponentupdate() { }
+            Componentwillupdate() { }
+            Componentdidupdate() { }
+            ComponentwillUnmount() { }
+            Render() { }
+          }
+        `,
+    },
+    // ---- Upstream: issue #1353 — unrelated .bind ----
+    {
+      code: `
+          function test(b) {
+            return a.bind(b);
+          }
+          function a() {}
+        `,
+    },
+    // ---- Upstream: well-formed PropTypes usage ----
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.number.isRequired
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            e: PropTypes.shape({
+              ea: PropTypes.string,
+            })
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.string,
+            b: PropTypes.string.isRequired,
+            c: PropTypes.shape({
+              d: PropTypes.string,
+              e: PropTypes.number.isRequired,
+            }).isRequired
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.oneOfType([
+              PropTypes.string,
+              PropTypes.number
+            ])
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.oneOf([
+              'hello',
+              'hi'
+            ])
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.childContextTypes = {
+            a: PropTypes.string,
+            b: PropTypes.string.isRequired,
+            c: PropTypes.shape({
+              d: PropTypes.string,
+              e: PropTypes.number.isRequired,
+            }).isRequired
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types";
+          class Component extends React.Component {};
+          Component.contextTypes = {
+            a: PropTypes.string,
+            b: PropTypes.string.isRequired,
+            c: PropTypes.shape({
+              d: PropTypes.string,
+              e: PropTypes.number.isRequired,
+            }).isRequired
+          }
+        `,
+    },
+    // ---- Upstream: external types alongside prop-types ----
+    {
+      code: `
+          import PropTypes from 'prop-types'
+          import * as MyPropTypes from 'lib/my-prop-types'
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.string,
+            b: MyPropTypes.MYSTRING,
+            c: MyPropTypes.MYSTRING.isRequired,
+          }
+        `,
+    },
+    {
+      code: `
+          import PropTypes from "prop-types"
+          import * as MyPropTypes from 'lib/my-prop-types'
+          class Component extends React.Component {};
+          Component.propTypes = {
+            b: PropTypes.string,
+            a: MyPropTypes.MYSTRING,
+          }
+        `,
+    },
+    {
+      code: `
+          import CustomReact from "react"
+          class Component extends React.Component {};
+          Component.propTypes = {
+            b: CustomReact.PropTypes.string,
+          }
+        `,
+    },
+    // ---- Upstream: absent arg to PropTypes.shape must not crash ----
+    {
+      code: `
+          class Component extends React.Component {};
+          Component.propTypes = {
+            a: PropTypes.shape(),
+          };
+          Component.contextTypes = {
+            a: PropTypes.shape(),
+          };
+        `,
+    },
+    // ---- Upstream: unrelated patterns ----
+    {
+      code: `
+          const fn = (err, res) => {
+            const { body: data = {} } = { ...res };
+            data.time = data.time || {};
+          };
+        `,
+    },
+    {
+      code: `
+          class Component extends React.Component {};
+          Component.propTypes = {
+            b: string.isRequired,
+            c: PropTypes.shape({
+              d: number.isRequired,
+            }).isRequired
+          }
+        `,
+    },
+    // ---- Upstream: createReactClass with PropTypes ----
+    {
+      code: `
+          import React from 'react';
+          import PropTypes from 'prop-types';
+          const Component = React.createReactClass({
+            propTypes: {
+              a: PropTypes.string.isRequired,
+              b: PropTypes.shape({
+                c: PropTypes.number
+              }).isRequired
+            }
+          });
+        `,
+    },
+    {
+      code: `
+          import React from 'react';
+          import PropTypes from 'prop-types';
+          const Component = React.createReactClass({
+            childContextTypes: {
+              a: PropTypes.bool,
+              b: PropTypes.array,
+              c: PropTypes.func,
+              d: PropTypes.object,
+            }
+          });
+        `,
+    },
+    {
+      code: `
+          import React from 'react';
+          const Component = React.createReactClass({
+            propTypes: {},
+            childContextTypes: {},
+            contextTypes: {},
+            componentWillMount() { },
+            componentDidMount() { },
+            componentWillReceiveProps() { },
+            shouldComponentUpdate() { },
+            componentWillUpdate() { },
+            componentDidUpdate() { },
+            componentWillUnmount() { },
+            render() {
+              return <div>Hello {this.props.name}</div>;
+            }
+          });
+        `,
+    },
+    // ---- Upstream: destructured named imports from prop-types ----
+    {
+      code: `
+          import { string, element } from "prop-types";
+
+          class Sample extends React.Component {
+            render() { return null; }
+          }
+
+          Sample.propTypes = {
+            title: string.isRequired,
+            body: element.isRequired
+          };
+        `,
+    },
+    // ---- Upstream: computed key with PropertyAccessExpression base ----
+    {
+      code: `
+          import React from 'react';
+
+          const A = { B: 'C' };
+
+          export default class MyComponent extends React.Component {
+            [A.B] () {
+              return null
+            }
+          }
+        `,
+    },
+    // ---- Upstream: React.forwardRef / styled-components escape hatches ----
+    {
+      code: `
+          const MyComponent = React.forwardRef((props, ref) => <div />);
+          MyComponent.defaultProps = { value: "" };
+        `,
+    },
+    {
+      code: `
+          import styled from "styled-components";
+
+          const MyComponent = styled.div;
+          MyComponent.defaultProps = { value: "" };
+        `,
+    },
+    // ---- Upstream: private method should not trigger lifecycle typo ----
+    {
+      code: `
+          class Editor extends React.Component {
+              #somethingPrivate() {
+                // ...
+              }
+
+              render() {
+              const { value = '' } = this.props;
+
+              return (
+                <textarea>
+                  {value}
+                </textarea>
+              );
+            }
+          }
+        `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream: typoStaticClassProp — PropTypes variants ----
+    {
+      code: `
+        class Component extends React.Component {
+          static PropTypes = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.PropTypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.PropTypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {
+          static proptypes = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.proptypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.proptypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    // ---- Upstream: typoStaticClassProp — ContextTypes variants ----
+    {
+      code: `
+        class Component extends React.Component {
+          static ContextTypes = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.ContextTypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.ContextTypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {
+          static contexttypes = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.contexttypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.contexttypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    // ---- Upstream: typoStaticClassProp — ChildContextTypes variants ----
+    {
+      code: `
+        class Component extends React.Component {
+          static ChildContextTypes = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.ChildContextTypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.ChildContextTypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {
+          static childcontexttypes = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.childcontexttypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.childcontexttypes = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    // ---- Upstream: typoStaticClassProp — DefaultProps variants ----
+    {
+      code: `
+        class Component extends React.Component {
+          static DefaultProps = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.DefaultProps = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.DefaultProps = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {
+          static defaultprops = {};
+        }
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        class Component extends React.Component {}
+        Component.defaultprops = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    {
+      code: `
+        function MyComponent() { return (<div>{this.props.myProp}</div>) }
+        MyComponent.defaultprops = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    // ---- Upstream: typoStaticClassProp — assignment before class definition ----
+    {
+      code: `
+        Component.defaultprops = {}
+        class Component extends React.Component {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    // ---- Upstream: @extends JSDoc tag ----
+    {
+      code: `
+        /** @extends React.Component */
+        class MyComponent extends BaseComponent {}
+        MyComponent.PROPTYPES = {}
+      `,
+      errors: [{ messageId: 'typoStaticClassProp' }],
+    },
+    // ---- Upstream: typoLifecycleMethod — PascalCase variant ----
+    {
+      code: `
+        class Hello extends React.Component {
+          static GetDerivedStateFromProps()  { }
+          ComponentWillMount() { }
+          UNSAFE_ComponentWillMount() { }
+          ComponentDidMount() { }
+          ComponentWillReceiveProps() { }
+          UNSAFE_ComponentWillReceiveProps() { }
+          ShouldComponentUpdate() { }
+          ComponentWillUpdate() { }
+          UNSAFE_ComponentWillUpdate() { }
+          GetSnapshotBeforeUpdate() { }
+          ComponentDidUpdate() { }
+          ComponentDidCatch() { }
+          ComponentWillUnmount() { }
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+      errors: Array(13).fill({ messageId: 'typoLifecycleMethod' }),
+    },
+    // ---- Upstream: typoLifecycleMethod — First-letter-uppercase variant ----
+    {
+      code: `
+        class Hello extends React.Component {
+          static Getderivedstatefromprops() { }
+          Componentwillmount() { }
+          UNSAFE_Componentwillmount() { }
+          Componentdidmount() { }
+          Componentwillreceiveprops() { }
+          UNSAFE_Componentwillreceiveprops() { }
+          Shouldcomponentupdate() { }
+          Componentwillupdate() { }
+          UNSAFE_Componentwillupdate() { }
+          Getsnapshotbeforeupdate() { }
+          Componentdidupdate() { }
+          Componentdidcatch() { }
+          Componentwillunmount() { }
+          Render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+      errors: Array(14).fill({ messageId: 'typoLifecycleMethod' }),
+    },
+    // ---- Upstream: typoLifecycleMethod — lowercase variant ----
+    {
+      code: `
+        class Hello extends React.Component {
+          static getderivedstatefromprops() { }
+          componentwillmount() { }
+          unsafe_componentwillmount() { }
+          componentdidmount() { }
+          componentwillreceiveprops() { }
+          unsafe_componentwillreceiveprops() { }
+          shouldcomponentupdate() { }
+          componentwillupdate() { }
+          unsafe_componentwillupdate() { }
+          getsnapshotbeforeupdate() { }
+          componentdidupdate() { }
+          componentdidcatch() { }
+          componentwillunmount() { }
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+      errors: Array(13).fill({ messageId: 'typoLifecycleMethod' }),
+    },
+    // ---- Upstream: typoPropType (single) ----
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+            a: PropTypes.Number.isRequired
+        }
+      `,
+      errors: [{ messageId: 'typoPropType' }],
+    },
+    // ---- Upstream: typoPropTypeChain (single) ----
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+            a: PropTypes.number.isrequired
+        }
+      `,
+      errors: [{ messageId: 'typoPropTypeChain' }],
+    },
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {
+          static propTypes = {
+            a: PropTypes.number.isrequired
+          }
+        };
+      `,
+      errors: [{ messageId: 'typoPropTypeChain' }],
+    },
+    // ---- Upstream: typoPropType — static field ----
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {
+          static propTypes = {
+            a: PropTypes.Number
+          }
+        };
+      `,
+      errors: [{ messageId: 'typoPropType' }],
+    },
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+            a: PropTypes.Number
+        }
+      `,
+      errors: [{ messageId: 'typoPropType' }],
+    },
+    // ---- Upstream: typoPropType — inside shape ----
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.shape({
+            b: PropTypes.String,
+            c: PropTypes.number.isRequired,
+          })
+        }
+      `,
+      errors: [{ messageId: 'typoPropType' }],
+    },
+    // ---- Upstream: typoPropType — inside oneOfType ----
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.oneOfType([
+            PropTypes.bools,
+            PropTypes.number,
+          ])
+        }
+      `,
+      errors: [{ messageId: 'typoPropType' }],
+    },
+    // ---- Upstream: typoPropType — multiple at top level ----
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    {
+      code: `
+        import PropTypes from "prop-types";
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    {
+      code: `
+        import PropTypes from 'prop-types';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    // ---- Upstream: typoPropTypeChain — multiple .isrequired ----
+    {
+      code: `
+        import PropTypes from 'prop-types';
+        class Component extends React.Component {};
+        Component.propTypes = {
+          a: PropTypes.string.isrequired,
+          b: PropTypes.shape({
+            c: PropTypes.number
+          }).isrequired
+        }
+      `,
+      errors: Array(2).fill({ messageId: 'typoPropTypeChain' }),
+    },
+    // ---- Upstream: typoPropType — aliased default import ----
+    {
+      code: `
+        import RealPropTypes from 'prop-types';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: RealPropTypes.bools,
+          b: RealPropTypes.Array,
+          c: RealPropTypes.function,
+          d: RealPropTypes.objectof,
+        }
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    // ---- Upstream: typoPropTypeChain — React.PropTypes ----
+    {
+      code: `
+      import React from 'react';
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: React.PropTypes.string.isrequired,
+        b: React.PropTypes.shape({
+          c: React.PropTypes.number
+        }).isrequired
+      }
+    `,
+      errors: Array(2).fill({ messageId: 'typoPropTypeChain' }),
+    },
+    {
+      code: `
+        import React from 'react';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: React.PropTypes.bools,
+          b: React.PropTypes.Array,
+          c: React.PropTypes.function,
+          d: React.PropTypes.objectof,
+        }
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    // ---- Upstream: typoPropTypeChain — destructured { PropTypes } from react ----
+    {
+      code: `
+      import { PropTypes } from 'react';
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string.isrequired,
+        b: PropTypes.shape({
+          c: PropTypes.number
+        }).isrequired
+      }
+    `,
+      errors: Array(2).fill({ messageId: 'typoPropTypeChain' }),
+    },
+    // ---- Upstream: noReactBinding ----
+    {
+      code: `
+      import 'react';
+      class Component extends React.Component {};
+    `,
+      errors: [{ messageId: 'noReactBinding' }],
+    },
+    // ---- Upstream: typoPropType — destructured from react ----
+    {
+      code: `
+        import { PropTypes } from 'react';
+        class Component extends React.Component {};
+        Component.childContextTypes = {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    // ---- Upstream: typoPropTypeChain in createReactClass ----
+    {
+      code: `
+        import React from 'react';
+        import PropTypes from 'prop-types';
+        const Component = React.createReactClass({
+          propTypes: {
+            a: PropTypes.string.isrequired,
+            b: PropTypes.shape({
+              c: PropTypes.number
+            }).isrequired
+          }
+        });
+      `,
+      errors: Array(2).fill({ messageId: 'typoPropTypeChain' }),
+    },
+    // ---- Upstream: typoPropType in createReactClass childContextTypes ----
+    {
+      code: `
+        import React from 'react';
+        import PropTypes from 'prop-types';
+        const Component = React.createReactClass({
+          childContextTypes: {
+            a: PropTypes.bools,
+            b: PropTypes.Array,
+            c: PropTypes.function,
+            d: PropTypes.objectof,
+          }
+        });
+      `,
+      errors: Array(4).fill({ messageId: 'typoPropType' }),
+    },
+    // ---- Upstream: createReactClass — prop declarations + lifecycle typos ----
+    {
+      code: `
+        import React from 'react';
+        const Component = React.createReactClass({
+          proptypes: {},
+          childcontexttypes: {},
+          contexttypes: {},
+          getdefaultProps() { },
+          getinitialState() { },
+          getChildcontext() { },
+          ComponentWillMount() { },
+          ComponentDidMount() { },
+          ComponentWillReceiveProps() { },
+          ShouldComponentUpdate() { },
+          ComponentWillUpdate() { },
+          ComponentDidUpdate() { },
+          ComponentWillUnmount() { },
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      errors: [
+        { messageId: 'typoPropDeclaration' },
+        { messageId: 'typoPropDeclaration' },
+        { messageId: 'typoPropDeclaration' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+      ],
+    },
+    // ---- Upstream: staticLifecycleMethod ----
+    {
+      code: `
+        class Hello extends React.Component {
+          getDerivedStateFromProps() { }
+        }
+      `,
+      errors: [{ messageId: 'staticLifecycleMethod' }],
+    },
+    // ---- Upstream: staticLifecycleMethod + typoLifecycleMethod combined ----
+    {
+      code: `
+        class Hello extends React.Component {
+          GetDerivedStateFromProps() { }
+        }
+      `,
+      errors: [
+        { messageId: 'staticLifecycleMethod' },
+        { messageId: 'typoLifecycleMethod' },
+      ],
+    },
+    // ---- Upstream: noPropTypesBinding ----
+    {
+      code: `
+        import 'prop-types'
+      `,
+      errors: [{ messageId: 'noPropTypesBinding' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-typos` rule from `eslint-plugin-react` to rslint.

Catches common casing typos in React components:

- **Static class properties** — `propTypes`, `contextTypes`, `childContextTypes`, `defaultProps` declared with wrong casing on a class extending `React.Component`/`PureComponent`, or assigned externally (`Component.PropTypes = {}`). Reports `typoStaticClassProp` / `typoPropDeclaration`.
- **Lifecycle methods** — any case variant of `componentWillMount` / `componentDidMount` / `shouldComponentUpdate` / `getSnapshotBeforeUpdate` / `render` / … declared on a class component or inside `createReactClass({ ... })`. Reports `typoLifecycleMethod`.
- **Static lifecycle declared non-static** — `getDerivedStateFromProps` declared as an instance method. Reports `staticLifecycleMethod`.
- **PropTypes usage** — when `prop-types` or `react` is imported, flags `PropTypes.<wrong>` (`typoPropType`) and `.isrequired` / other wrong chain qualifiers (`typoPropTypeChain`); `import 'react'` / `import 'prop-types'` with no binding emits `noReactBinding` / `noPropTypesBinding`.

Component detection recognizes ES6 classes extending `Component`/`PureComponent` (bare, pragma-qualified, or via `const Foo = class …`), functions/arrow functions returning JSX, and JSDoc `@extends`/`@augments React.Component` tags.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-typos.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-typos.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).