### PR TITLE
feat: port rule react/no-direct-mutation-state

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -21,6 +21,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_did_update_set_state"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
@@ -58,6 +59,7 @@ func GetAllRules() []rule.Rule {
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_did_update_set_state.NoDidUpdateSetStateRule,
+		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
 		no_string_refs.NoStringRefsRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -377,7 +377,7 @@ func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass s
 		return comp
 	}
 	for p := node.Parent; p != nil; p = p.Parent {
-		if ast.IsFunctionLike(p) && IsStatelessReactComponent(p) {
+		if ast.IsFunctionLike(p) && IsStatelessReactComponent(p, pragma) {
 			return p
 		}
 	}
@@ -385,12 +385,34 @@ func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass s
 }
 
 // IsStatelessReactComponent reports whether `fn` (a FunctionLike) looks like a
-// React functional component — i.e. it has a capital-cased associated name
-// AND returns JSX or null on at least one path. Nested functions are not
-// considered when searching for returns.
+// React functional component. Mirrors eslint-plugin-react's
+// `getStatelessComponent` decision tree:
 //
-// See GetEnclosingReactComponentOrStateless for the priority rules.
-func IsStatelessReactComponent(fn *ast.Node) bool {
+//   - FunctionDeclaration — component iff returns JSX/null AND either:
+//     (a) its own Identifier is capitalized, OR
+//     (b) it is anonymous AND carries the `export default` modifier (ESLint's
+//     `!node.id || capitalized(node.id.name)` condition).
+//
+//   - FunctionExpression / ArrowFunction — component iff returns JSX/null AND
+//     either wrapped in a pragma component call OR in an "allowed position"
+//     AND the position-specific capitalization check passes:
+//
+//   - Wrapped in `<pragma>.memo(...)` / `<pragma>.forwardRef(...)` / bare
+//     `memo(...)` / bare `forwardRef(...)` — always a component.
+//   - Allowed positions (VariableDeclarator, AssignmentExpression,
+//     PropertyAssignment, ReturnStatement, ExportAssignment, outer
+//     ArrowFunction body) gate everything else. A bare IIFE or any other
+//     CallExpression argument position is NOT allowed, matching upstream's
+//     `isInAllowedPositionForComponent` default-false branch.
+//   - Within an allowed position, specific capitalization rules apply per
+//     upstream: VariableDeclarator/PropertyAssignment use the binding name;
+//     `Id = fn` assignments use the LHS Identifier; MemberExpression LHS
+//     uses the rightmost property name (with `module.exports = ...` as a
+//     special blanket-true case); a named FunctionExpression defers to its
+//     own Identifier.
+//
+// Pass the empty string for `pragma` to default to `DefaultReactPragma`.
+func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 	if fn == nil {
 		return false
 	}
@@ -399,67 +421,166 @@ func IsStatelessReactComponent(fn *ast.Node) bool {
 	default:
 		return false
 	}
-	name := functionAssociatedName(fn)
-	if name == "" || !isFirstLetterCapitalized(name) {
+	if !functionReturnsJSXOrNull(fn) {
 		return false
 	}
-	return functionReturnsJSXOrNull(fn)
-}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
 
-// functionAssociatedName picks the name that identifies a function-like node
-// for React component detection, matching eslint-plugin-react's
-// getStatelessComponent priority:
-//
-//   - FunctionDeclaration — always the function's own Identifier (its name
-//     is the authoritative reference).
-//   - FunctionExpression / ArrowFunction — the enclosing
-//     VariableDeclaration / PropertyAssignment / `Identifier = fn`
-//     assignment's Identifier FIRST. Only when no such parent context yields
-//     a name do we fall back to a named FunctionExpression's own name. The
-//     parent-first ordering matches upstream's `getStatelessComponent`, which
-//     early-returns `undefined` when `parent.id.name` is lowercase — the
-//     parent decides component-ness, the function's own name does not
-//     override a lowercase parent.
-//
-// Returns "" when no usable Identifier is found (computed keys, destructuring
-// patterns, anonymous default exports).
-func functionAssociatedName(fn *ast.Node) string {
 	if fn.Kind == ast.KindFunctionDeclaration {
 		name := fn.Name()
+		if name == nil {
+			// Anonymous FD is only legal as `export default function() {...}`.
+			return ast.GetCombinedModifierFlags(fn)&ast.ModifierFlagsDefault != 0
+		}
+		return name.Kind == ast.KindIdentifier && isFirstLetterCapitalized(name.AsIdentifier().Text)
+	}
+
+	parent := fn.Parent
+	if parent == nil {
+		return false
+	}
+
+	// memo / forwardRef wrapping takes precedence regardless of position —
+	// upstream checks pragmaComponentWrapper BEFORE allowed-position.
+	if parent.Kind == ast.KindCallExpression && isPragmaComponentWrapperCall(parent, fn, pragma) {
+		return true
+	}
+
+	if !isInAllowedPositionForComponent(fn) {
+		return false
+	}
+
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		binding := parent.AsVariableDeclaration().Name()
+		if binding != nil && binding.Kind == ast.KindIdentifier {
+			return isFirstLetterCapitalized(binding.AsIdentifier().Text)
+		}
+		return false
+	case ast.KindPropertyAssignment:
+		name := parent.AsPropertyAssignment().Name()
 		if name != nil && name.Kind == ast.KindIdentifier {
-			return name.AsIdentifier().Text
+			return isFirstLetterCapitalized(name.AsIdentifier().Text)
 		}
-		return ""
-	}
-	if parent := fn.Parent; parent != nil {
-		switch parent.Kind {
-		case ast.KindVariableDeclaration:
-			binding := parent.AsVariableDeclaration().Name()
-			if binding != nil && binding.Kind == ast.KindIdentifier {
-				return binding.AsIdentifier().Text
-			}
-		case ast.KindPropertyAssignment:
-			name := parent.AsPropertyAssignment().Name()
+		return false
+	case ast.KindExportAssignment:
+		return true
+	case ast.KindBinaryExpression:
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken || bin.Right != fn {
+			return false
+		}
+		// Named FE defers to its own Identifier (mirrors upstream's
+		// `if (node.id) return capitalized(node.id.name) ? node : undefined`).
+		if fn.Kind == ast.KindFunctionExpression {
+			name := fn.Name()
 			if name != nil && name.Kind == ast.KindIdentifier {
-				return name.AsIdentifier().Text
-			}
-		case ast.KindBinaryExpression:
-			bin := parent.AsBinaryExpression()
-			if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
-				left := ast.SkipParentheses(bin.Left)
-				if left.Kind == ast.KindIdentifier {
-					return left.AsIdentifier().Text
-				}
+				return isFirstLetterCapitalized(name.AsIdentifier().Text)
 			}
 		}
+		// Anonymous FE / Arrow: decide by LHS.
+		left := ast.SkipParentheses(bin.Left)
+		switch left.Kind {
+		case ast.KindIdentifier:
+			return isFirstLetterCapitalized(left.AsIdentifier().Text)
+		case ast.KindPropertyAccessExpression:
+			pa := left.AsPropertyAccessExpression()
+			obj := ast.SkipParentheses(pa.Expression)
+			name := pa.Name()
+			if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "module" &&
+				name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "exports" {
+				return true
+			}
+			if name != nil && name.Kind == ast.KindIdentifier {
+				return isFirstLetterCapitalized(name.AsIdentifier().Text)
+			}
+		}
+		return false
 	}
+
+	// ReturnStatement / outer-ArrowFunction body: no binding name available,
+	// fall back to node.id check (matches upstream's final `if (node.id)`).
 	if fn.Kind == ast.KindFunctionExpression {
 		name := fn.Name()
 		if name != nil && name.Kind == ast.KindIdentifier {
-			return name.AsIdentifier().Text
+			return isFirstLetterCapitalized(name.AsIdentifier().Text)
 		}
 	}
-	return ""
+	return false
+}
+
+// isInAllowedPositionForComponent mirrors eslint-plugin-react's
+// `utils.isInAllowedPositionForComponent`: only parent node kinds in the
+// allow-list may host a stateless functional component. Sequence expressions
+// (`a, b`) pass through when `fn` is the last operand.
+func isInAllowedPositionForComponent(fn *ast.Node) bool {
+	parent := fn.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindVariableDeclaration,
+		ast.KindPropertyAssignment,
+		ast.KindReturnStatement,
+		ast.KindExportAssignment,
+		ast.KindArrowFunction:
+		return true
+	case ast.KindBinaryExpression:
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken == nil {
+			return false
+		}
+		switch bin.OperatorToken.Kind {
+		case ast.KindEqualsToken:
+			// AssignmentExpression — always allowed when `fn` is the RHS.
+			return bin.Right == fn
+		case ast.KindCommaToken:
+			// SequenceExpression — only the last operand inherits its parent's
+			// allowed-ness.
+			if bin.Right == fn {
+				return isInAllowedPositionForComponent(parent)
+			}
+		}
+	}
+	return false
+}
+
+// isPragmaComponentWrapperCall reports whether `call` is a React
+// component-wrapping call — `<pragma>.memo(fn)` / `<pragma>.forwardRef(fn)` /
+// bare `memo(fn)` / bare `forwardRef(fn)` — with `fn` as the first argument.
+// Pragma defaults to `DefaultReactPragma` when empty. Mirrors upstream's
+// default `wrapperFunctions` entries (`{property: 'memo', object: pragma}`,
+// `{property: 'forwardRef', object: pragma}`); the user-configurable
+// `settings.componentWrapperFunctions` is NOT honored.
+func isPragmaComponentWrapperCall(call, fn *ast.Node, pragma string) bool {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	c := call.AsCallExpression()
+	if c.Arguments == nil || len(c.Arguments.Nodes) == 0 || c.Arguments.Nodes[0] != fn {
+		return false
+	}
+	callee := ast.SkipParentheses(c.Expression)
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		text := callee.AsIdentifier().Text
+		return text == "memo" || text == "forwardRef"
+	case ast.KindPropertyAccessExpression:
+		pa := callee.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		text := name.AsIdentifier().Text
+		return text == "memo" || text == "forwardRef"
+	}
+	return false
 }
 
 // functionReturnsJSXOrNull reports whether the function's body contains a

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -407,50 +407,56 @@ func IsStatelessReactComponent(fn *ast.Node) bool {
 }
 
 // functionAssociatedName picks the name that identifies a function-like node
-// for React component detection:
+// for React component detection, matching eslint-plugin-react's
+// getStatelessComponent priority:
 //
-//   - the function's own Identifier (FunctionDeclaration / named
-//     FunctionExpression)
-//   - otherwise the Identifier of the enclosing VariableDeclaration /
-//     PropertyAssignment
+//   - FunctionDeclaration — always the function's own Identifier (its name
+//     is the authoritative reference).
+//   - FunctionExpression / ArrowFunction — the enclosing
+//     VariableDeclaration / PropertyAssignment / `Identifier = fn`
+//     assignment's Identifier FIRST. Only when no such parent context yields
+//     a name do we fall back to a named FunctionExpression's own name. The
+//     parent-first ordering matches upstream's `getStatelessComponent`, which
+//     early-returns `undefined` when `parent.id.name` is lowercase — the
+//     parent decides component-ness, the function's own name does not
+//     override a lowercase parent.
 //
-// Returns "" when no usable Identifier is found (e.g. computed keys,
-// destructuring patterns, anonymous default exports).
+// Returns "" when no usable Identifier is found (computed keys, destructuring
+// patterns, anonymous default exports).
 func functionAssociatedName(fn *ast.Node) string {
-	switch fn.Kind {
-	case ast.KindFunctionDeclaration:
+	if fn.Kind == ast.KindFunctionDeclaration {
 		name := fn.Name()
 		if name != nil && name.Kind == ast.KindIdentifier {
 			return name.AsIdentifier().Text
 		}
-	case ast.KindFunctionExpression:
-		name := fn.Name()
-		if name != nil && name.Kind == ast.KindIdentifier && isFirstLetterCapitalized(name.AsIdentifier().Text) {
-			return name.AsIdentifier().Text
-		}
-	}
-	parent := fn.Parent
-	if parent == nil {
 		return ""
 	}
-	switch parent.Kind {
-	case ast.KindVariableDeclaration:
-		binding := parent.AsVariableDeclaration().Name()
-		if binding != nil && binding.Kind == ast.KindIdentifier {
-			return binding.AsIdentifier().Text
+	if parent := fn.Parent; parent != nil {
+		switch parent.Kind {
+		case ast.KindVariableDeclaration:
+			binding := parent.AsVariableDeclaration().Name()
+			if binding != nil && binding.Kind == ast.KindIdentifier {
+				return binding.AsIdentifier().Text
+			}
+		case ast.KindPropertyAssignment:
+			name := parent.AsPropertyAssignment().Name()
+			if name != nil && name.Kind == ast.KindIdentifier {
+				return name.AsIdentifier().Text
+			}
+		case ast.KindBinaryExpression:
+			bin := parent.AsBinaryExpression()
+			if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
+				left := ast.SkipParentheses(bin.Left)
+				if left.Kind == ast.KindIdentifier {
+					return left.AsIdentifier().Text
+				}
+			}
 		}
-	case ast.KindPropertyAssignment:
-		name := parent.AsPropertyAssignment().Name()
+	}
+	if fn.Kind == ast.KindFunctionExpression {
+		name := fn.Name()
 		if name != nil && name.Kind == ast.KindIdentifier {
 			return name.AsIdentifier().Text
-		}
-	case ast.KindBinaryExpression:
-		bin := parent.AsBinaryExpression()
-		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
-			left := ast.SkipParentheses(bin.Left)
-			if left.Kind == ast.KindIdentifier {
-				return left.AsIdentifier().Text
-			}
 		}
 	}
 	return ""
@@ -506,12 +512,17 @@ func functionReturnsJSXOrNull(fn *ast.Node) bool {
 	return found
 }
 
-// isJSXOrNullExpression reports whether `expr` is a JSX element, JSX fragment,
-// or the `null` literal — walking through ParenthesizedExpression,
-// ConditionalExpression branches, and comma-sequence (BinaryExpression with
-// `,`) right-most operands so `(<div/>)`, `cond ? <div/> : null`, and
-// `(side, <div/>)` all qualify (matches eslint-plugin-react's
-// jsxUtil.isReturningJSXOrNull).
+// isJSXOrNullExpression reports whether `expr` may evaluate to JSX or `null`
+// on at least one control-flow path — walking through:
+//
+//   - ParenthesizedExpression wrappers
+//   - ConditionalExpression (`cond ? a : b`) — either branch
+//   - Comma sequence (`a, b`) — right-most operand
+//   - Logical `&&` / `||` / `??` — either operand (common React patterns like
+//     `cond && <div/>` / `cond || <div/>` / `x ?? <div/>`)
+//
+// Approximates eslint-plugin-react's jsxUtil.isReturningJSXOrNull non-strict
+// mode — "some path returns JSX or null" is sufficient.
 func isJSXOrNullExpression(expr *ast.Node) bool {
 	expr = ast.SkipParentheses(expr)
 	switch expr.Kind {
@@ -524,8 +535,16 @@ func isJSXOrNullExpression(expr *ast.Node) bool {
 		return isJSXOrNullExpression(ce.WhenTrue) || isJSXOrNullExpression(ce.WhenFalse)
 	case ast.KindBinaryExpression:
 		bin := expr.AsBinaryExpression()
-		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken {
+		if bin.OperatorToken == nil {
+			return false
+		}
+		switch bin.OperatorToken.Kind {
+		case ast.KindCommaToken:
 			return isJSXOrNullExpression(bin.Right)
+		case ast.KindAmpersandAmpersandToken,
+			ast.KindBarBarToken,
+			ast.KindQuestionQuestionToken:
+			return isJSXOrNullExpression(bin.Left) || isJSXOrNullExpression(bin.Right)
 		}
 	}
 	return false

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -273,8 +273,17 @@ func GetJsxTagBaseIdentifier(tagName *ast.Node) *ast.Node {
 //     where `this` is not inside any function (ESLint's scope walk returns
 //     null for that too).
 func IsInsideReactComponent(node *ast.Node, pragma, createClass string) bool {
+	return GetEnclosingReactComponent(node, pragma, createClass) != nil
+}
+
+// GetEnclosingReactComponent is IsInsideReactComponent's sibling that returns
+// the component node itself (the ClassDeclaration / ClassExpression, or the
+// ObjectLiteralExpression passed to createReactClass) rather than a bool.
+// Returns nil when `node` is not inside a React component. See
+// IsInsideReactComponent for the detection rules.
+func GetEnclosingReactComponent(node *ast.Node, pragma, createClass string) *ast.Node {
 	if node == nil {
-		return false
+		return nil
 	}
 	if pragma == "" {
 		pragma = DefaultReactPragma
@@ -298,7 +307,7 @@ func IsInsideReactComponent(node *ast.Node, pragma, createClass string) bool {
 			}
 			seenNearestClass = true
 			if ExtendsReactComponent(p, pragma) {
-				return true
+				return p
 			}
 		case ast.KindObjectLiteralExpression:
 			if !seenEnclosingFunction {
@@ -322,11 +331,11 @@ func IsInsideReactComponent(node *ast.Node, pragma, createClass string) bool {
 				continue
 			}
 			if IsCreateClassCall(call, pragma, createClass) {
-				return true
+				return p
 			}
 		}
 	}
-	return false
+	return nil
 }
 
 func isObjectArgumentOf(call *ast.CallExpression, obj *ast.Node) bool {
@@ -339,6 +348,191 @@ func isObjectArgumentOf(call *ast.CallExpression, obj *ast.Node) bool {
 		}
 	}
 	return false
+}
+
+// GetEnclosingReactComponentOrStateless is GetEnclosingReactComponent extended
+// with eslint-plugin-react's `getParentStatelessComponent` fallback: when no
+// enclosing ES6 class / ES5 createReactClass component is found, the nearest
+// FunctionLike ancestor that looks like a functional component (capital-cased
+// name + returns JSX/null) is returned.
+//
+// Priority matches upstream's `getParentComponent`:
+//
+//	getParentES6Component || getParentES5Component || getParentStatelessComponent
+//
+// so when a mutation node is inside an inner function nested within an outer
+// class component, the OUTER class component is returned (preventing the
+// inner stateless candidate from masking the class boundary).
+//
+// Only a restricted subset of upstream's heuristics is implemented — the
+// patterns covering production React code: named FunctionDeclaration,
+// FunctionExpression / ArrowFunction assigned to a capital-cased
+// VariableDeclarator, PropertyAssignment, or ExportAssignment (default export),
+// plus function expression in a CallExpression (e.g. React.memo wrapper —
+// approximate match). This is intentionally conservative: missed detection
+// causes a rule miss, over-detection would cause false-positive reports in
+// non-component functions.
+func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass string) *ast.Node {
+	if comp := GetEnclosingReactComponent(node, pragma, createClass); comp != nil {
+		return comp
+	}
+	for p := node.Parent; p != nil; p = p.Parent {
+		if ast.IsFunctionLike(p) && IsStatelessReactComponent(p) {
+			return p
+		}
+	}
+	return nil
+}
+
+// IsStatelessReactComponent reports whether `fn` (a FunctionLike) looks like a
+// React functional component — i.e. it has a capital-cased associated name
+// AND returns JSX or null on at least one path. Nested functions are not
+// considered when searching for returns.
+//
+// See GetEnclosingReactComponentOrStateless for the priority rules.
+func IsStatelessReactComponent(fn *ast.Node) bool {
+	if fn == nil {
+		return false
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction:
+	default:
+		return false
+	}
+	name := functionAssociatedName(fn)
+	if name == "" || !isFirstLetterCapitalized(name) {
+		return false
+	}
+	return functionReturnsJSXOrNull(fn)
+}
+
+// functionAssociatedName picks the name that identifies a function-like node
+// for React component detection:
+//
+//   - the function's own Identifier (FunctionDeclaration / named
+//     FunctionExpression)
+//   - otherwise the Identifier of the enclosing VariableDeclaration /
+//     PropertyAssignment
+//
+// Returns "" when no usable Identifier is found (e.g. computed keys,
+// destructuring patterns, anonymous default exports).
+func functionAssociatedName(fn *ast.Node) string {
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		name := fn.Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text
+		}
+	case ast.KindFunctionExpression:
+		name := fn.Name()
+		if name != nil && name.Kind == ast.KindIdentifier && isFirstLetterCapitalized(name.AsIdentifier().Text) {
+			return name.AsIdentifier().Text
+		}
+	}
+	parent := fn.Parent
+	if parent == nil {
+		return ""
+	}
+	switch parent.Kind {
+	case ast.KindVariableDeclaration:
+		binding := parent.AsVariableDeclaration().Name()
+		if binding != nil && binding.Kind == ast.KindIdentifier {
+			return binding.AsIdentifier().Text
+		}
+	case ast.KindPropertyAssignment:
+		name := parent.AsPropertyAssignment().Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text
+		}
+	case ast.KindBinaryExpression:
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
+			left := ast.SkipParentheses(bin.Left)
+			if left.Kind == ast.KindIdentifier {
+				return left.AsIdentifier().Text
+			}
+		}
+	}
+	return ""
+}
+
+// functionReturnsJSXOrNull reports whether the function's body contains a
+// `return <jsx/>` / `return null` at depth ≤ 1 (nested functions excluded),
+// OR — for an arrow with expression body — whether that expression is JSX or
+// `null`. ConditionalExpression is traversed so `return cond ? <jsx/> : null`
+// qualifies.
+func functionReturnsJSXOrNull(fn *ast.Node) bool {
+	var body *ast.Node
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		body = fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		body = fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		body = fn.AsArrowFunction().Body
+		if body != nil && body.Kind != ast.KindBlock {
+			return isJSXOrNullExpression(body)
+		}
+	}
+	if body == nil {
+		return false
+	}
+	found := false
+	var visit ast.Visitor
+	visit = func(n *ast.Node) bool {
+		if found || n == nil {
+			return found
+		}
+		switch n.Kind {
+		case ast.KindReturnStatement:
+			rs := n.AsReturnStatement()
+			if rs.Expression != nil && isJSXOrNullExpression(rs.Expression) {
+				found = true
+				return true
+			}
+		case ast.KindFunctionExpression,
+			ast.KindFunctionDeclaration,
+			ast.KindArrowFunction,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor:
+			return false
+		}
+		n.ForEachChild(visit)
+		return found
+	}
+	visit(body)
+	return found
+}
+
+// isJSXOrNullExpression reports whether `expr` is a JSX element, JSX fragment,
+// or the `null` literal — walking through ParenthesizedExpression,
+// ConditionalExpression branches, and comma-sequence (BinaryExpression with
+// `,`) right-most operands so `(<div/>)`, `cond ? <div/> : null`, and
+// `(side, <div/>)` all qualify (matches eslint-plugin-react's
+// jsxUtil.isReturningJSXOrNull).
+func isJSXOrNullExpression(expr *ast.Node) bool {
+	expr = ast.SkipParentheses(expr)
+	switch expr.Kind {
+	case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
+		return true
+	case ast.KindNullKeyword:
+		return true
+	case ast.KindConditionalExpression:
+		ce := expr.AsConditionalExpression()
+		return isJSXOrNullExpression(ce.WhenTrue) || isJSXOrNullExpression(ce.WhenFalse)
+	case ast.KindBinaryExpression:
+		bin := expr.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindCommaToken {
+			return isJSXOrNullExpression(bin.Right)
+		}
+	}
+	return false
+}
+
+func isFirstLetterCapitalized(s string) bool {
+	return len(s) > 0 && s[0] >= 'A' && s[0] <= 'Z'
 }
 
 // IsCreateElementCall reports whether the callee is `<pragma>.createElement`.

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -418,6 +418,26 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 	}
 	switch fn.Kind {
 	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction:
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		// A shorthand method / accessor in an ObjectLiteralExpression
+		// corresponds to ESTree's `Property { method | kind: 'get'|'set',
+		// key, value: FunctionExpression }`. Upstream's
+		// getStatelessComponent's Property branch classifies the inner FE as
+		// a component when the property key is a capitalized Identifier AND
+		// the function returns JSX. Setters never return a value so
+		// functionReturnsJSXOrNull naturally rejects them.
+		// Class-body occurrences have a ClassLike parent — NOT
+		// ObjectLiteralExpression — and are excluded so they continue to go
+		// through the ES6-class path.
+		parent := fn.Parent
+		if parent == nil || parent.Kind != ast.KindObjectLiteralExpression {
+			return false
+		}
+		name := fn.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		return isFirstLetterCapitalized(name.AsIdentifier().Text) && functionReturnsJSXOrNull(fn)
 	default:
 		return false
 	}
@@ -633,6 +653,12 @@ func functionReturnsJSXOrNull(fn *ast.Node) bool {
 		if body != nil && body.Kind != ast.KindBlock {
 			return isJSXOrNullExpression(body)
 		}
+	case ast.KindMethodDeclaration:
+		body = fn.AsMethodDeclaration().Body
+	case ast.KindGetAccessor:
+		body = fn.AsGetAccessorDeclaration().Body
+	case ast.KindSetAccessor:
+		body = fn.AsSetAccessorDeclaration().Body
 	}
 	if body == nil {
 		return false

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -452,6 +452,22 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		return false
 	}
 
+	// Upstream's `isParentComponentNotStatelessComponent` carve-out: an
+	// object-literal property whose key is a lowercase Identifier AND whose
+	// function has at least one parameter is treated as an instance method,
+	// not a component. Typical render-style components in this shape have
+	// NO params (`render() { return <div/>; }`); a method that takes params
+	// (`handleClick(e) { return <div/>; }`) is an event handler / method
+	// that coincidentally returns JSX — ESLint exempts it.
+	if parent.Kind == ast.KindPropertyAssignment {
+		name := parent.AsPropertyAssignment().Name()
+		if name != nil && name.Kind == ast.KindIdentifier &&
+			!isFirstLetterCapitalized(name.AsIdentifier().Text) &&
+			len(fn.Parameters()) > 0 {
+			return false
+		}
+	}
+
 	switch parent.Kind {
 	case ast.KindVariableDeclaration:
 		binding := parent.AsVariableDeclaration().Name()

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -485,54 +485,61 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		return true
 	case ast.KindBinaryExpression:
 		bin := parent.AsBinaryExpression()
-		if bin.OperatorToken == nil || bin.OperatorToken.Kind != ast.KindEqualsToken || bin.Right != fn {
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
+			// Named FE defers to its own Identifier (mirrors upstream's
+			// `if (node.id) return capitalized(node.id.name) ? node : undefined`).
+			if fn.Kind == ast.KindFunctionExpression {
+				name := fn.Name()
+				if name != nil && name.Kind == ast.KindIdentifier {
+					return isFirstLetterCapitalized(name.AsIdentifier().Text)
+				}
+			}
+			// Anonymous FE / Arrow: decide by LHS.
+			left := ast.SkipParentheses(bin.Left)
+			switch left.Kind {
+			case ast.KindIdentifier:
+				return isFirstLetterCapitalized(left.AsIdentifier().Text)
+			case ast.KindPropertyAccessExpression:
+				pa := left.AsPropertyAccessExpression()
+				obj := ast.SkipParentheses(pa.Expression)
+				name := pa.Name()
+				if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "module" &&
+					name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "exports" {
+					return true
+				}
+				if name != nil && name.Kind == ast.KindIdentifier {
+					return isFirstLetterCapitalized(name.AsIdentifier().Text)
+				}
+			}
 			return false
 		}
-		// Named FE defers to its own Identifier (mirrors upstream's
-		// `if (node.id) return capitalized(node.id.name) ? node : undefined`).
-		if fn.Kind == ast.KindFunctionExpression {
-			name := fn.Name()
-			if name != nil && name.Kind == ast.KindIdentifier {
-				return isFirstLetterCapitalized(name.AsIdentifier().Text)
-			}
-		}
-		// Anonymous FE / Arrow: decide by LHS.
-		left := ast.SkipParentheses(bin.Left)
-		switch left.Kind {
-		case ast.KindIdentifier:
-			return isFirstLetterCapitalized(left.AsIdentifier().Text)
-		case ast.KindPropertyAccessExpression:
-			pa := left.AsPropertyAccessExpression()
-			obj := ast.SkipParentheses(pa.Expression)
-			name := pa.Name()
-			if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "module" &&
-				name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "exports" {
-				return true
-			}
-			if name != nil && name.Kind == ast.KindIdentifier {
-				return isFirstLetterCapitalized(name.AsIdentifier().Text)
-			}
-		}
-		return false
+		// Non-assignment BinaryExpression (comma / etc.): fall through to the
+		// allowed-position fallback below. `isInAllowedPositionForComponent`
+		// already gated the comma-last position.
 	}
 
-	// ReturnStatement / outer-ArrowFunction body: no binding name available,
-	// fall back to node.id check (matches upstream's final `if (node.id)`).
+	// Allowed-position fallback (ReturnStatement, outer-ArrowFunction body,
+	// SequenceExpression-last operand, …). Upstream's `getStatelessComponent`
+	// returns the node here for anonymous FE / Arrow, and defers to the id
+	// check for a named FunctionExpression.
 	if fn.Kind == ast.KindFunctionExpression {
 		name := fn.Name()
 		if name != nil && name.Kind == ast.KindIdentifier {
 			return isFirstLetterCapitalized(name.AsIdentifier().Text)
 		}
 	}
-	return false
+	return true
 }
 
 // isInAllowedPositionForComponent mirrors eslint-plugin-react's
 // `utils.isInAllowedPositionForComponent`: only parent node kinds in the
 // allow-list may host a stateless functional component. Sequence expressions
-// (`a, b`) pass through when `fn` is the last operand.
+// (`a, b`) pass through when `fn` is the last operand. ParenthesizedExpression
+// wrappers (which ESTree flattens but tsgo preserves) are transparent so
+// `const Hello = (init(), arrow)` — whose comma Sequence sits inside parens —
+// still reaches the VariableDeclaration ancestor.
 func isInAllowedPositionForComponent(fn *ast.Node) bool {
-	parent := fn.Parent
+	parent := skipParenParents(fn)
 	if parent == nil {
 		return false
 	}
@@ -561,6 +568,16 @@ func isInAllowedPositionForComponent(fn *ast.Node) bool {
 		}
 	}
 	return false
+}
+
+// skipParenParents walks up through ParenthesizedExpression wrappers and
+// returns the first non-paren ancestor of `node`, or nil.
+func skipParenParents(node *ast.Node) *ast.Node {
+	p := node.Parent
+	for p != nil && p.Kind == ast.KindParenthesizedExpression {
+		p = p.Parent
+	}
+	return p
 }
 
 // isPragmaComponentWrapperCall reports whether `call` is a React

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -416,16 +416,17 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 	if fn == nil {
 		return false
 	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+
 	switch fn.Kind {
-	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction:
 	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
-		// A shorthand method / accessor in an ObjectLiteralExpression
-		// corresponds to ESTree's `Property { method | kind: 'get'|'set',
-		// key, value: FunctionExpression }`. Upstream's
-		// getStatelessComponent's Property branch classifies the inner FE as
-		// a component when the property key is a capitalized Identifier AND
-		// the function returns JSX. Setters never return a value so
-		// functionReturnsJSXOrNull naturally rejects them.
+		// Object-literal shorthand method / accessor. Upstream's Property
+		// branch (method && !computed) | (!id && !computed) classifies the
+		// inner FE as a component when the property key is a capitalized
+		// Identifier AND the function returns strict JSX (isReturningJSX).
+		// Setters naturally fail functionReturnsJSX (no return value).
 		// Class-body occurrences have a ClassLike parent — NOT
 		// ObjectLiteralExpression — and are excluded so they continue to go
 		// through the ES6-class path.
@@ -437,24 +438,22 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		if name == nil || name.Kind != ast.KindIdentifier {
 			return false
 		}
-		return isFirstLetterCapitalized(name.AsIdentifier().Text) && functionReturnsJSXOrNull(fn)
-	default:
-		return false
-	}
-	if !functionReturnsJSXOrNull(fn) {
-		return false
-	}
-	if pragma == "" {
-		pragma = DefaultReactPragma
-	}
-
-	if fn.Kind == ast.KindFunctionDeclaration {
+		return isFirstLetterCapitalized(name.AsIdentifier().Text) && functionReturnsJSX(fn)
+	case ast.KindFunctionDeclaration:
+		// Branch: FunctionDeclaration requires isReturningJSXOrNull AND
+		// (no id || capitalized). Anonymous FD is only legal as
+		// `export default function() {...}`.
+		if !functionReturnsJSXOrNull(fn) {
+			return false
+		}
 		name := fn.Name()
 		if name == nil {
-			// Anonymous FD is only legal as `export default function() {...}`.
 			return ast.GetCombinedModifierFlags(fn)&ast.ModifierFlagsDefault != 0
 		}
 		return name.Kind == ast.KindIdentifier && isFirstLetterCapitalized(name.AsIdentifier().Text)
+	case ast.KindFunctionExpression, ast.KindArrowFunction:
+	default:
+		return false
 	}
 
 	parent := fn.Parent
@@ -462,31 +461,46 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		return false
 	}
 
-	// ESTree-style paren transparency for the wrapper-argument case: `React.memo((fn))`.
-	// fn's direct parent in tsgo is a ParenthesizedExpression, while ESTree
-	// flattens it so that upstream sees the outer CallExpression directly.
-	effectiveParent := parent
-	if effectiveParent.Kind == ast.KindParenthesizedExpression && effectiveParent.Parent != nil {
-		effectiveParent = effectiveParent.Parent
+	// Derived flags mirroring upstream's local `isPropertyAssignment` /
+	// `isModuleExportsAssignment`.
+	isMEAssign := false
+	isModuleExportsAssign := false
+	if parent.Kind == ast.KindBinaryExpression {
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
+			left := ast.SkipParentheses(bin.Left)
+			if left.Kind == ast.KindPropertyAccessExpression {
+				isMEAssign = true
+				pa := left.AsPropertyAccessExpression()
+				obj := ast.SkipParentheses(pa.Expression)
+				name := pa.Name()
+				if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "module" &&
+					name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "exports" {
+					isModuleExportsAssign = true
+				}
+			}
+		}
 	}
 
-	// memo / forwardRef wrapping takes precedence regardless of position —
-	// upstream checks pragmaComponentWrapper BEFORE allowed-position.
-	if effectiveParent.Kind == ast.KindCallExpression && isPragmaComponentWrapperCall(effectiveParent, fn, pragma) {
-		return true
-	}
-
-	// ExportDefault branch (upstream: strict isReturningJSX — null-only
-	// doesn't qualify).
+	// Branch 1 — ExportDefault (strict isReturningJSX).
 	if parent.Kind == ast.KindExportAssignment {
 		return functionReturnsJSX(fn)
 	}
 
-	// Strict-JSX rejection for positions that demand isReturningJSX (not
-	// just JSX-or-null): when parent is a ReturnStatement or the expression
-	// body of an enclosing arrow, upstream returns undefined immediately if
-	// the function does not strictly return JSX. `null`-only returns are
-	// excluded here.
+	// Branch 2 — VariableDeclarator.
+	if parent.Kind == ast.KindVariableDeclaration {
+		if !functionReturnsJSXOrNull(fn) {
+			return false
+		}
+		binding := parent.AsVariableDeclaration().Name()
+		if binding != nil && binding.Kind == ast.KindIdentifier {
+			return isFirstLetterCapitalized(binding.AsIdentifier().Text)
+		}
+		return false
+	}
+
+	// Branch 3 — early-reject in ReturnStatement / arrow-expression-body
+	// when not strictly returning JSX.
 	if parent.Kind == ast.KindReturnStatement ||
 		(parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == fn) {
 		if !functionReturnsJSX(fn) {
@@ -494,12 +508,36 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		}
 	}
 
-	// Nested-arrow patterns — upstream examines the grandparent's
-	// AssignmentExpression LHS / Property key when the function's parent is
-	// an outer ArrowFunction that itself sits in one of these positions.
+	// Branch 4 — AssignmentExpression with non-MemberExpression LHS
+	// (handled; Identifier LHS path).
+	if parent.Kind == ast.KindBinaryExpression && !isMEAssign {
+		bin := parent.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
+			if !functionReturnsJSXOrNull(fn) {
+				return false
+			}
+			// Named FE defers to its own id (matches upstream's final
+			// `if (node.id)` check, which runs before the lowercase-LHS
+			// reject in the property-assignment tail).
+			if fn.Kind == ast.KindFunctionExpression {
+				name := fn.Name()
+				if name != nil && name.Kind == ast.KindIdentifier {
+					return isFirstLetterCapitalized(name.AsIdentifier().Text)
+				}
+			}
+			left := ast.SkipParentheses(bin.Left)
+			if left.Kind == ast.KindIdentifier {
+				return isFirstLetterCapitalized(left.AsIdentifier().Text)
+			}
+			return false
+		}
+	}
+
+	// Branches 5 & 6 — nested Arrow whose outer Arrow is itself in an
+	// AssignmentExpression / PropertyAssignment position.
 	if parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == fn {
 		grand := parent.Parent
-		if grand != nil {
+		if grand != nil && !isMEAssign && functionReturnsJSXOrNull(fn) {
 			switch grand.Kind {
 			case ast.KindBinaryExpression:
 				bin := grand.AsBinaryExpression()
@@ -508,6 +546,7 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 					if left.Kind == ast.KindIdentifier {
 						return isFirstLetterCapitalized(left.AsIdentifier().Text)
 					}
+					return false
 				}
 			case ast.KindPropertyAssignment:
 				name := grand.AsPropertyAssignment().Name()
@@ -519,17 +558,96 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		}
 	}
 
-	if !isInAllowedPositionForComponent(fn) {
+	// Branches 7 & 8 — inner function in a ReturnStatement whose enclosing
+	// function itself sits in an AssignmentExpression / PropertyAssignment
+	// position. Upstream first checks the inner FE's own id (if capitalized
+	// return it), then walks functionExpr = parent.parent.parent.
+	if parent.Kind == ast.KindReturnStatement {
+		if fn.Kind == ast.KindFunctionExpression {
+			name := fn.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && isFirstLetterCapitalized(name.AsIdentifier().Text) {
+				return true
+			}
+		}
+		// functionExpr = ReturnStatement.parent (Block) . parent (functionExpr)
+		funcExpr := parent.Parent
+		if funcExpr != nil {
+			funcExpr = funcExpr.Parent
+		}
+		if funcExpr != nil && funcExpr.Parent != nil && !isMEAssign && functionReturnsJSXOrNull(fn) {
+			gp := funcExpr.Parent
+			switch gp.Kind {
+			case ast.KindBinaryExpression:
+				bin := gp.AsBinaryExpression()
+				if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == funcExpr {
+					left := ast.SkipParentheses(bin.Left)
+					if left.Kind == ast.KindIdentifier {
+						return isFirstLetterCapitalized(left.AsIdentifier().Text)
+					}
+					return false
+				}
+			case ast.KindPropertyAssignment:
+				name := gp.AsPropertyAssignment().Name()
+				if name != nil && name.Kind == ast.KindIdentifier {
+					return isFirstLetterCapitalized(name.AsIdentifier().Text)
+				}
+				return false
+			}
+		}
+	}
+
+	// Branch 9 — parent has a MemberExpression-style key
+	// (e.g. `{ [obj.prop]: fn }` computed key resolving to a member access).
+	if parent.Kind == ast.KindPropertyAssignment {
+		nameNode := parent.AsPropertyAssignment().Name()
+		if nameNode != nil && nameNode.Kind == ast.KindComputedPropertyName {
+			keyExpr := ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
+			if keyExpr.Kind == ast.KindPropertyAccessExpression || keyExpr.Kind == ast.KindElementAccessExpression {
+				if !functionReturnsJSX(fn) && !functionReturnsOnlyNull(fn) {
+					return false
+				}
+			}
+		}
+	}
+
+	// Branch 10 — Property method/no-id + !computed form.
+	// In tsgo, the `method: true` arm is handled via the MethodDeclaration
+	// path above. Here we handle the `!id && !computed` arm — an anonymous
+	// FE/Arrow assigned as a PropertyAssignment initializer with Identifier
+	// key. Strict isReturningJSX applies.
+	if parent.Kind == ast.KindPropertyAssignment {
+		pa := parent.AsPropertyAssignment()
+		name := pa.Name()
+		isComputed := name != nil && name.Kind == ast.KindComputedPropertyName
+		hasId := fn.Kind == ast.KindFunctionExpression && fn.Name() != nil
+		if !hasId && !isComputed {
+			if name != nil && name.Kind == ast.KindIdentifier {
+				if !isFirstLetterCapitalized(name.AsIdentifier().Text) {
+					return false
+				}
+				return functionReturnsJSX(fn)
+			}
+			return false
+		}
+	}
+
+	// Branch 11 — pragma component wrapper (paren-transparent arg).
+	effectiveParent := parent
+	if effectiveParent.Kind == ast.KindParenthesizedExpression && effectiveParent.Parent != nil {
+		effectiveParent = effectiveParent.Parent
+	}
+	if effectiveParent.Kind == ast.KindCallExpression && isPragmaComponentWrapperCall(effectiveParent, fn, pragma) {
+		if functionReturnsJSXOrNull(fn) {
+			return true
+		}
+	}
+
+	// Branch 12 — require allowed position AND isReturningJSXOrNull.
+	if !isInAllowedPositionForComponent(fn) || !functionReturnsJSXOrNull(fn) {
 		return false
 	}
 
-	// Upstream's `isParentComponentNotStatelessComponent` carve-out: an
-	// object-literal property whose key is a lowercase Identifier AND whose
-	// function has at least one parameter is treated as an instance method,
-	// not a component. Typical render-style components in this shape have
-	// NO params (`render() { return <div/>; }`); a method that takes params
-	// (`handleClick(e) { return <div/>; }`) is an event handler / method
-	// that coincidentally returns JSX — ESLint exempts it.
+	// Branch 13 — isParentComponentNotStatelessComponent carve-out.
 	if parent.Kind == ast.KindPropertyAssignment {
 		name := parent.AsPropertyAssignment().Name()
 		if name != nil && name.Kind == ast.KindIdentifier &&
@@ -539,65 +657,89 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		}
 	}
 
-	switch parent.Kind {
-	case ast.KindVariableDeclaration:
-		binding := parent.AsVariableDeclaration().Name()
-		if binding != nil && binding.Kind == ast.KindIdentifier {
-			return isFirstLetterCapitalized(binding.AsIdentifier().Text)
-		}
-		return false
-	case ast.KindPropertyAssignment:
-		name := parent.AsPropertyAssignment().Name()
-		if name != nil && name.Kind == ast.KindIdentifier {
-			return isFirstLetterCapitalized(name.AsIdentifier().Text)
-		}
-		return false
-	case ast.KindBinaryExpression:
-		bin := parent.AsBinaryExpression()
-		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
-			// Named FE defers to its own Identifier (mirrors upstream's
-			// `if (node.id) return capitalized(node.id.name) ? node : undefined`).
-			if fn.Kind == ast.KindFunctionExpression {
-				name := fn.Name()
-				if name != nil && name.Kind == ast.KindIdentifier {
-					return isFirstLetterCapitalized(name.AsIdentifier().Text)
-				}
-			}
-			// Anonymous FE / Arrow: decide by LHS.
-			left := ast.SkipParentheses(bin.Left)
-			switch left.Kind {
-			case ast.KindIdentifier:
-				return isFirstLetterCapitalized(left.AsIdentifier().Text)
-			case ast.KindPropertyAccessExpression:
-				pa := left.AsPropertyAccessExpression()
-				obj := ast.SkipParentheses(pa.Expression)
-				name := pa.Name()
-				if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "module" &&
-					name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "exports" {
-					return true
-				}
-				if name != nil && name.Kind == ast.KindIdentifier {
-					return isFirstLetterCapitalized(name.AsIdentifier().Text)
-				}
-			}
-			return false
-		}
-		// Non-assignment BinaryExpression (comma / etc.): fall through to the
-		// allowed-position fallback below. `isInAllowedPositionForComponent`
-		// already gated the comma-last position.
-	}
-
-	// Allowed-position fallback (ReturnStatement, outer-ArrowFunction body,
-	// SequenceExpression-last operand, …). Upstream's `getStatelessComponent`
-	// returns the node here for anonymous FE / Arrow, and defers to the id
-	// check for a named FunctionExpression.
+	// Branch 14 — `if (node.id) return capitalized(node.id.name)`.
 	if fn.Kind == ast.KindFunctionExpression {
 		name := fn.Name()
 		if name != nil && name.Kind == ast.KindIdentifier {
 			return isFirstLetterCapitalized(name.AsIdentifier().Text)
 		}
 	}
+
+	// Branch 15 — isPropertyAssignment (MemberExpression LHS) but not
+	// module.exports: reject when rightmost property name is lowercase.
+	if isMEAssign && !isModuleExportsAssign {
+		bin := parent.AsBinaryExpression()
+		left := ast.SkipParentheses(bin.Left)
+		if left.Kind == ast.KindPropertyAccessExpression {
+			pa := left.AsPropertyAccessExpression()
+			name := pa.Name()
+			if name != nil && name.Kind == ast.KindIdentifier && !isFirstLetterCapitalized(name.AsIdentifier().Text) {
+				return false
+			}
+		}
+	}
+
+	// Branch 16 — Property parent + returns only null ⇒ undefined. Already
+	// handled by Branch 10 when !id & !computed (strict isReturningJSX
+	// rejects null-only). The final `return node` for anonymous allowed-
+	// position fallbacks remains.
 	return true
+}
+
+// functionReturnsOnlyNull mirrors jsxUtil.isReturningOnlyNull: every
+// return statement (at depth ≤ 1) returns the `null` literal, and at
+// least one return exists. Arrow expression bodies count as a single
+// return. Functions without any returns don't qualify.
+func functionReturnsOnlyNull(fn *ast.Node) bool {
+	var body *ast.Node
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		body = fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		body = fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		af := fn.AsArrowFunction()
+		body = af.Body
+		if body != nil && body.Kind != ast.KindBlock {
+			return ast.SkipParentheses(body).Kind == ast.KindNullKeyword
+		}
+	case ast.KindMethodDeclaration:
+		body = fn.AsMethodDeclaration().Body
+	case ast.KindGetAccessor:
+		body = fn.AsGetAccessorDeclaration().Body
+	}
+	if body == nil {
+		return false
+	}
+	sawReturn := false
+	allNull := true
+	var visit ast.Visitor
+	visit = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n.Kind {
+		case ast.KindReturnStatement:
+			sawReturn = true
+			rs := n.AsReturnStatement()
+			if rs.Expression == nil || ast.SkipParentheses(rs.Expression).Kind != ast.KindNullKeyword {
+				allNull = false
+			}
+			return false
+		case ast.KindFunctionExpression,
+			ast.KindFunctionDeclaration,
+			ast.KindArrowFunction,
+			ast.KindMethodDeclaration,
+			ast.KindGetAccessor,
+			ast.KindSetAccessor,
+			ast.KindConstructor:
+			return false
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(body)
+	return sawReturn && allNull
 }
 
 // isInAllowedPositionForComponent mirrors eslint-plugin-react's

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -462,10 +462,61 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		return false
 	}
 
+	// ESTree-style paren transparency for the wrapper-argument case: `React.memo((fn))`.
+	// fn's direct parent in tsgo is a ParenthesizedExpression, while ESTree
+	// flattens it so that upstream sees the outer CallExpression directly.
+	effectiveParent := parent
+	if effectiveParent.Kind == ast.KindParenthesizedExpression && effectiveParent.Parent != nil {
+		effectiveParent = effectiveParent.Parent
+	}
+
 	// memo / forwardRef wrapping takes precedence regardless of position —
 	// upstream checks pragmaComponentWrapper BEFORE allowed-position.
-	if parent.Kind == ast.KindCallExpression && isPragmaComponentWrapperCall(parent, fn, pragma) {
+	if effectiveParent.Kind == ast.KindCallExpression && isPragmaComponentWrapperCall(effectiveParent, fn, pragma) {
 		return true
+	}
+
+	// ExportDefault branch (upstream: strict isReturningJSX — null-only
+	// doesn't qualify).
+	if parent.Kind == ast.KindExportAssignment {
+		return functionReturnsJSX(fn)
+	}
+
+	// Strict-JSX rejection for positions that demand isReturningJSX (not
+	// just JSX-or-null): when parent is a ReturnStatement or the expression
+	// body of an enclosing arrow, upstream returns undefined immediately if
+	// the function does not strictly return JSX. `null`-only returns are
+	// excluded here.
+	if parent.Kind == ast.KindReturnStatement ||
+		(parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == fn) {
+		if !functionReturnsJSX(fn) {
+			return false
+		}
+	}
+
+	// Nested-arrow patterns — upstream examines the grandparent's
+	// AssignmentExpression LHS / Property key when the function's parent is
+	// an outer ArrowFunction that itself sits in one of these positions.
+	if parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == fn {
+		grand := parent.Parent
+		if grand != nil {
+			switch grand.Kind {
+			case ast.KindBinaryExpression:
+				bin := grand.AsBinaryExpression()
+				if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == parent {
+					left := ast.SkipParentheses(bin.Left)
+					if left.Kind == ast.KindIdentifier {
+						return isFirstLetterCapitalized(left.AsIdentifier().Text)
+					}
+				}
+			case ast.KindPropertyAssignment:
+				name := grand.AsPropertyAssignment().Name()
+				if name != nil && name.Kind == ast.KindIdentifier {
+					return isFirstLetterCapitalized(name.AsIdentifier().Text)
+				}
+				return false
+			}
+		}
 	}
 
 	if !isInAllowedPositionForComponent(fn) {
@@ -501,8 +552,6 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 			return isFirstLetterCapitalized(name.AsIdentifier().Text)
 		}
 		return false
-	case ast.KindExportAssignment:
-		return true
 	case ast.KindBinaryExpression:
 		bin := parent.AsBinaryExpression()
 		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
@@ -612,7 +661,13 @@ func isPragmaComponentWrapperCall(call, fn *ast.Node, pragma string) bool {
 		return false
 	}
 	c := call.AsCallExpression()
-	if c.Arguments == nil || len(c.Arguments.Nodes) == 0 || c.Arguments.Nodes[0] != fn {
+	if c.Arguments == nil || len(c.Arguments.Nodes) == 0 {
+		return false
+	}
+	// Paren-transparent argument match: tsgo preserves ParenthesizedExpression
+	// wrappers that ESTree flattens, so `React.memo((fn))` surfaces the paren
+	// as the first argument rather than `fn` itself.
+	if ast.SkipParentheses(c.Arguments.Nodes[0]) != fn {
 		return false
 	}
 	callee := ast.SkipParentheses(c.Expression)
@@ -642,6 +697,20 @@ func isPragmaComponentWrapperCall(call, fn *ast.Node, pragma string) bool {
 // `null`. ConditionalExpression is traversed so `return cond ? <jsx/> : null`
 // qualifies.
 func functionReturnsJSXOrNull(fn *ast.Node) bool {
+	return functionReturnsJSXInternal(fn, true)
+}
+
+// functionReturnsJSX is the strict sibling of functionReturnsJSXOrNull:
+// a `null` return does NOT qualify on its own. Mirrors upstream's
+// jsxUtil.isReturningJSX (as opposed to isReturningJSXOrNull). Used by
+// branches of getStatelessComponent that specifically gate on strict JSX
+// (ExportDefault, inside-ReturnStatement / arrow-expression-body early
+// rejection, Property `method`-branch final check).
+func functionReturnsJSX(fn *ast.Node) bool {
+	return functionReturnsJSXInternal(fn, false)
+}
+
+func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool) bool {
 	var body *ast.Node
 	switch fn.Kind {
 	case ast.KindFunctionDeclaration:
@@ -651,7 +720,7 @@ func functionReturnsJSXOrNull(fn *ast.Node) bool {
 	case ast.KindArrowFunction:
 		body = fn.AsArrowFunction().Body
 		if body != nil && body.Kind != ast.KindBlock {
-			return isJSXOrNullExpression(body)
+			return isJSXExpression(body, acceptNull)
 		}
 	case ast.KindMethodDeclaration:
 		body = fn.AsMethodDeclaration().Body
@@ -672,7 +741,7 @@ func functionReturnsJSXOrNull(fn *ast.Node) bool {
 		switch n.Kind {
 		case ast.KindReturnStatement:
 			rs := n.AsReturnStatement()
-			if rs.Expression != nil && isJSXOrNullExpression(rs.Expression) {
+			if rs.Expression != nil && isJSXExpression(rs.Expression, acceptNull) {
 				found = true
 				return true
 			}
@@ -692,27 +761,23 @@ func functionReturnsJSXOrNull(fn *ast.Node) bool {
 	return found
 }
 
-// isJSXOrNullExpression reports whether `expr` may evaluate to JSX or `null`
-// on at least one control-flow path — walking through:
-//
-//   - ParenthesizedExpression wrappers
-//   - ConditionalExpression (`cond ? a : b`) — either branch
-//   - Comma sequence (`a, b`) — right-most operand
-//   - Logical `&&` / `||` / `??` — either operand (common React patterns like
-//     `cond && <div/>` / `cond || <div/>` / `x ?? <div/>`)
-//
-// Approximates eslint-plugin-react's jsxUtil.isReturningJSXOrNull non-strict
-// mode — "some path returns JSX or null" is sufficient.
-func isJSXOrNullExpression(expr *ast.Node) bool {
+// isJSXExpression reports whether `expr` may evaluate to JSX (or to `null`
+// when `acceptNull` is true) on at least one control-flow path. Walks through
+// ParenthesizedExpression, ConditionalExpression (both branches),
+// comma-sequence right-most operands, and logical `&&` / `||` / `??`
+// operands (either side). Pass `acceptNull=true` for
+// `isReturningJSXOrNull`-style gates and `false` for the strict
+// `isReturningJSX` gates.
+func isJSXExpression(expr *ast.Node, acceptNull bool) bool {
 	expr = ast.SkipParentheses(expr)
 	switch expr.Kind {
 	case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
 		return true
 	case ast.KindNullKeyword:
-		return true
+		return acceptNull
 	case ast.KindConditionalExpression:
 		ce := expr.AsConditionalExpression()
-		return isJSXOrNullExpression(ce.WhenTrue) || isJSXOrNullExpression(ce.WhenFalse)
+		return isJSXExpression(ce.WhenTrue, acceptNull) || isJSXExpression(ce.WhenFalse, acceptNull)
 	case ast.KindBinaryExpression:
 		bin := expr.AsBinaryExpression()
 		if bin.OperatorToken == nil {
@@ -720,11 +785,11 @@ func isJSXOrNullExpression(expr *ast.Node) bool {
 		}
 		switch bin.OperatorToken.Kind {
 		case ast.KindCommaToken:
-			return isJSXOrNullExpression(bin.Right)
+			return isJSXExpression(bin.Right, acceptNull)
 		case ast.KindAmpersandAmpersandToken,
 			ast.KindBarBarToken,
 			ast.KindQuestionQuestionToken:
-			return isJSXOrNullExpression(bin.Left) || isJSXOrNullExpression(bin.Right)
+			return isJSXExpression(bin.Left, acceptNull) || isJSXExpression(bin.Right, acceptNull)
 		}
 	}
 	return false

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.go
@@ -1,0 +1,181 @@
+package no_direct_mutation_state
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// inConstructorExemption mirrors eslint-plugin-react's
+// `shouldIgnoreComponent` check: mutation is exempt when we are lexically
+// inside the component's constructor AND NOT inside any nested
+// CallExpression.
+//
+// Walks from `node.Parent` toward `component` (exclusive) looking for a
+// KindConstructor ancestor and any KindCallExpression ancestor.
+func inConstructorExemption(node, component *ast.Node) bool {
+	inConstructor := false
+	inCallExpression := false
+	for p := node.Parent; p != nil && p != component; p = p.Parent {
+		switch p.Kind {
+		case ast.KindConstructor:
+			inConstructor = true
+		case ast.KindCallExpression:
+			inCallExpression = true
+		}
+	}
+	return inConstructor && !inCallExpression
+}
+
+// innermostMemberExpression mirrors eslint-plugin-react's
+// `getOuterMemberExpression`, which walks `node.object` inward while it is
+// still a member expression, returning the innermost member expression whose
+// base is no longer a member expression.
+//
+// Both PropertyAccessExpression (`.foo`) and ElementAccessExpression
+// (`['foo']`) are traversed, matching ESTree's unified `MemberExpression`.
+// Parentheses are transparently skipped at each step (ESTree flattens them;
+// tsgo preserves them).
+func innermostMemberExpression(node *ast.Node) *ast.Node {
+	current := node
+	for {
+		current = ast.SkipParentheses(current)
+		var inner *ast.Node
+		switch current.Kind {
+		case ast.KindPropertyAccessExpression:
+			inner = current.AsPropertyAccessExpression().Expression
+		case ast.KindElementAccessExpression:
+			inner = current.AsElementAccessExpression().Expression
+		default:
+			return current
+		}
+		innerSkipped := ast.SkipParentheses(inner)
+		switch innerSkipped.Kind {
+		case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+			current = innerSkipped
+		default:
+			return current
+		}
+	}
+}
+
+// isThisStateMember mirrors eslint-plugin-react's
+// `componentUtil.isStateMemberExpression`: matches `this.state` where the
+// property is a bare Identifier named `state`. `this['state']` does NOT
+// match (ESLint checks `node.property.name === 'state'`, which is undefined
+// for non-Identifier properties).
+func isThisStateMember(node *ast.Node) bool {
+	node = ast.SkipParentheses(node)
+	if node.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	prop := node.AsPropertyAccessExpression()
+	if ast.SkipParentheses(prop.Expression).Kind != ast.KindThisKeyword {
+		return false
+	}
+	name := prop.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return false
+	}
+	return name.AsIdentifier().Text == "state"
+}
+
+var NoDirectMutationStateRule = rule.Rule{
+	Name: "react/no-direct-mutation-state",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		report := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noDirectMutation",
+				Description: "Do not mutate state directly. Use setState().",
+			})
+		}
+
+		// check handles both assignments and update expressions. `target` is
+		// the outer-most member expression being mutated (node.left for an
+		// assignment; node.argument for ++/--). `reportNode` is the AST node
+		// whose position the diagnostic should point at — matching ESLint:
+		//
+		//   - For assignments: `node.left.object` (i.e. the object of the
+		//     assignment's LHS member expression, which for `this.state.x = ...`
+		//     is `this.state` and for `this.state = ...` is `this`).
+		//   - For updates: the innermost `this.state` member expression.
+		//
+		// Both reportNodes start at the same column as the overall chain, so
+		// line/column assertions align with ESLint.
+		check := func(node, target, reportNode *ast.Node) {
+			target = ast.SkipParentheses(target)
+			switch target.Kind {
+			case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+			default:
+				return
+			}
+			innermost := innermostMemberExpression(target)
+			if !isThisStateMember(innermost) {
+				return
+			}
+			component := reactutil.GetEnclosingReactComponentOrStateless(node, pragma, createClass)
+			if component == nil {
+				return
+			}
+			if inConstructorExemption(node, component) {
+				return
+			}
+			report(reportNode)
+		}
+
+		return rule.RuleListeners{
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+					return
+				}
+				left := ast.SkipParentheses(bin.Left)
+				// Report position mirrors ESLint's `node.left.object` — the
+				// direct base of the assignment's LHS (e.g. `this.state` for
+				// `this.state.foo = ...`, or `this` for `this.state = ...`).
+				var reportNode *ast.Node
+				switch left.Kind {
+				case ast.KindPropertyAccessExpression:
+					reportNode = left.AsPropertyAccessExpression().Expression
+				case ast.KindElementAccessExpression:
+					reportNode = left.AsElementAccessExpression().Expression
+				default:
+					return
+				}
+				check(node, left, reportNode)
+			},
+
+			ast.KindPrefixUnaryExpression: func(node *ast.Node) {
+				pf := node.AsPrefixUnaryExpression()
+				if pf.Operator != ast.KindPlusPlusToken && pf.Operator != ast.KindMinusMinusToken {
+					return
+				}
+				operand := ast.SkipParentheses(pf.Operand)
+				// ESLint guards with `node.argument.type !== 'MemberExpression'`.
+				switch operand.Kind {
+				case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+				default:
+					return
+				}
+				check(node, operand, innermostMemberExpression(operand))
+			},
+
+			ast.KindPostfixUnaryExpression: func(node *ast.Node) {
+				pf := node.AsPostfixUnaryExpression()
+				if pf.Operator != ast.KindPlusPlusToken && pf.Operator != ast.KindMinusMinusToken {
+					return
+				}
+				operand := ast.SkipParentheses(pf.Operand)
+				switch operand.Kind {
+				case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+				default:
+					return
+				}
+				check(node, operand, innermostMemberExpression(operand))
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.md
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state.md
@@ -1,0 +1,71 @@
+# no-direct-mutation-state
+
+## Rule Details
+
+Disallow direct mutation of `this.state`. State should only be updated through
+`setState()` (or the `useState` setter), so React can correctly schedule a
+re-render and reconcile the resulting UI. Writing to `this.state` directly is
+allowed only inside the component's constructor, where the initial state is
+being seeded.
+
+The rule targets both ES6 class components extending `Component` /
+`PureComponent` (or their pragma-qualified forms, e.g. `React.Component`) and
+ES5 components created with `createReactClass(...)` (or
+`<pragma>.<createClass>(...)`).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  render: function () {
+    this.state.foo = "bar";
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+```
+
+```javascript
+class Hello extends React.Component {
+  componentDidMount() {
+    this.state.foo = "bar";
+  }
+}
+```
+
+```javascript
+class Hello extends React.Component {
+  constructor(props) {
+    super(props);
+    doSomethingAsync(() => {
+      this.state = "bad";
+    });
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class Hello extends React.Component {
+  constructor() {
+    super();
+    this.state = { foo: "bar" };
+  }
+  update() {
+    this.setState({ foo: "baz" });
+  }
+}
+```
+
+```javascript
+class Hello {
+  getFoo() {
+    this.state.foo = "bar";
+    return this.state.foo;
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react `no-direct-mutation-state`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md)

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -472,6 +472,57 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           };
         }
       `, Tsx: true},
+
+		// ---- Edge: three-level return-nested in assignment with LOWERCASE
+		// outer LHS — upstream's branch 7 (ReturnStatement → functionExpr
+		// → AssignmentExpression) examines outer LHS, so lowercase `x`
+		// rejects classification. ----
+		{Code: `
+        x = function () {
+          return () => {
+            this.state.x = 1;
+            return <div/>;
+          };
+        };
+      `, Tsx: true},
+
+		// ---- Edge: three-level return-nested in Property with LOWERCASE
+		// outer key — upstream's branch 8 (ReturnStatement → functionExpr
+		// → Property) rejects. ----
+		{Code: `
+        const obj = {
+          helper: function () {
+            return () => {
+              this.state.x = 1;
+              return <div/>;
+            };
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: MemberExpression-style computed key (`{ [a.b]: fn }`)
+		// with a non-JSX, non-null return — upstream's branch 9 rejects. ----
+		{Code: `
+        const obj = {
+          [a.b]: () => {
+            this.state.x = 1;
+            return 42;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: anonymous arrow assigned to PropertyAssignment with
+		// Identifier CAPITAL key BUT returning null only — upstream's
+		// Property !id+!computed branch uses strict isReturningJSX and
+		// rejects null-only. ----
+		{Code: `
+        const obj = {
+          Hello: () => {
+            this.state.x = 1;
+            return null;
+          },
+        };
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -1730,6 +1781,77 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: three-level return-nested, capital outer LHS is a
+		// component per upstream's branch 7. ----
+		{
+			Code: `
+        Hello = function () {
+          return () => {
+            this.state.x = 1;
+            return <div/>;
+          };
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: three-level return-nested, capital outer Property key is
+		// a component per upstream's branch 8. ----
+		{
+			Code: `
+        const obj = {
+          Hello: function () {
+            return () => {
+              this.state.x = 1;
+              return <div/>;
+            };
+          },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Edge: MemberExpression-style computed key with JSX return IS
+		// a component (upstream's branch 9 only rejects non-JSX non-null). ----
+		{
+			Code: `
+        const obj = {
+          [a.b]: () => {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: named FE in ReturnStatement with capitalized own id is
+		// a component (upstream's branch 7 first check: if node.id capital
+		// return node). ----
+		{
+			Code: `
+        x = function () {
+          return function Inner() {
+            this.state.x = 1;
+            return <div/>;
+          };
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -372,6 +372,53 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           }
         }
       `, Tsx: true},
+
+		// ---- Edge: class-body MethodDeclaration is NOT a stateless FE/Arrow
+		// (upstream's getStatelessComponent only accepts
+		// FunctionDeclaration / FunctionExpression / ArrowFunction). Mutations
+		// in a class method ALWAYS go through the ES6-class path, never the
+		// stateless fallback. A method with lowercase name + params on a
+		// non-component class is therefore NOT reported, matching ESLint. ----
+		{Code: `
+        class Helper {
+          handleClick(event) {
+            this.state.x = 1;
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: lowercase-keyed shorthand method is NOT a component
+		// (PropertyAssignment-style capitalization check). ----
+		{Code: `
+        const obj = {
+          hello() {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: computed key on shorthand method (`[Hello]() {...}`) is
+		// NOT a component per upstream's `!node.parent.computed` guard. ----
+		{Code: `
+        const obj = {
+          ['Hello']() {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: object-literal setter `set Hello(v) { ... }` doesn't
+		// return JSX (no return value), so never a component. ----
+		{Code: `
+        const obj = {
+          set Hello(v) {
+            this.state.x = v;
+          },
+        };
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -1532,6 +1579,41 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: object-literal shorthand method with capital key IS a
+		// component per upstream's Property branch
+		// (parent.method && !parent.computed && capitalized(key)). ----
+		{
+			Code: `
+        const obj = {
+          Hello() {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: object-literal getter with capital key IS a component per
+		// upstream (`!node.id && !node.parent.computed`). ----
+		{
+			Code: `
+        const obj = {
+          get Hello() {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -212,6 +212,17 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           this.state.x = 1;
         }
       `, Tsx: true},
+
+		// ---- Edge: lowercase variable beats named FE — `const outer = function Inner() {...}`
+		// matches ESLint's getStatelessComponent, which early-returns `undefined`
+		// when VariableDeclarator.id is lowercase; the FE's own capitalized name
+		// MUST NOT override that. ----
+		{Code: `
+        const outer = function Inner() {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -934,6 +945,80 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noDirectMutation", Line: 3, Column: 35},
+			},
+		},
+
+		// ---- Edge: capital variable + lowercase named FE — `const Outer = function inner() {...}`
+		// ESLint's VariableDeclarator branch decides by parent.id.name ("Outer"),
+		// NOT by the FE's own inner name — so this IS detected as a component. ----
+		{
+			Code: `
+        const Outer = function inner() {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: IIFE with a named capitalized FE — ESLint's fallback
+		// `if (node.id) return isFirstLetterCapitalized(node.id.name) ? node : undefined`
+		// treats it as a component. ----
+		{
+			Code: `
+        (function Hello() {
+          this.state.x = 1;
+          return <div/>;
+        })();
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless component with `cond && <div/>` (common conditional render) ----
+		{
+			Code: `
+        function Hello(props) {
+          this.state.x = 1;
+          return props.visible && <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless component with `cond || <div/>` fallback pattern ----
+		{
+			Code: `
+        function Hello(props) {
+          this.state.x = 1;
+          return props.fallback || <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless component with nullish coalescing `x ?? <div/>` ----
+		{
+			Code: `
+        function Hello(props) {
+          this.state.x = 1;
+          return props.cached ?? <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -273,6 +273,44 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           return <div/>;
         });
       `, Tsx: true},
+
+		// ---- Edge: object-literal method with lowercase key AND params —
+		// upstream's isParentComponentNotStatelessComponent carve-out treats
+		// it as an instance method (event handler / helper), NOT a stateless
+		// component. Must NOT be reported. ----
+		{Code: `
+        const obj = {
+          handleClick: function (event) {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `, Tsx: true},
+		{Code: `
+        const obj = {
+          handleClick: (event) => {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: arrow used as Array.map callback — CallExpression parent,
+		// not a memo/forwardRef wrapper, not in allowed position. ----
+		{Code: `
+        arr.map((item) => {
+          this.state.x = 1;
+          return <div>{item}</div>;
+        });
+      `, Tsx: true},
+
+		// ---- Edge: capital-cased function not returning JSX — not a component ----
+		{Code: `
+        const Hello = () => {
+          this.state.x = 1;
+          return 42;
+        };
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -1184,5 +1222,27 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 				{MessageId: "noDirectMutation", Line: 3, Column: 11},
 			},
 		},
+
+		// ---- Edge: capitalized-key object-literal property with params is
+		// still a component — isParentComponentNotStatelessComponent requires
+		// BOTH lowercase key AND params. ----
+		{
+			Code: `
+        const obj = {
+          Hello: function (props) {
+            this.state.x = 1;
+            return <div>{props.name}</div>;
+          },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: lowercase-key with NO params — still excluded by the
+		// regular PropertyAssignment branch (lowercase key → not a component). ----
+		// Kept as a matching valid test above; not duplicated here.
 	})
 }

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -419,6 +419,59 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           },
         };
       `, Tsx: true},
+
+		// ---- Edge: `export default () => null` — upstream's ExportDefault
+		// branch uses the STRICT isReturningJSX which excludes null-only
+		// returns. Returning only null is therefore NOT a component. ----
+		{Code: `
+        export default () => {
+          this.state.x = 1;
+          return null;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: nested arrow whose outer-arrow body's parent is an
+		// AssignmentExpression with a LOWERCASE LHS — upstream requires
+		// capitalized outer LHS, so inner arrow is NOT a component. ----
+		{Code: `
+        x = () => () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: nested arrow whose outer-arrow body's parent is a
+		// PropertyAssignment with a LOWERCASE key — same logic. ----
+		{Code: `
+        const obj = {
+          helper: () => () => {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: `x = () => null` — null-only arrow whose parent is an
+		// ArrowFunction expression body. Upstream's strict isReturningJSX gate
+		// rejects null-only returns in this position. ----
+		{Code: `
+        x = () => () => {
+          this.state.x = 1;
+          return null;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: `function f() { return () => null; }` — inner arrow in
+		// ReturnStatement with null-only return. Upstream rejects via
+		// isReturningJSX strict gate. ----
+		{Code: `
+        function f() {
+          return () => {
+            this.state.x = 1;
+            return null;
+          };
+        }
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -1614,6 +1667,69 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: nested arrow with CAPITALIZED outer-assignment LHS —
+		// upstream examines `parent.parent.left` (the outer `Hello`)
+		// capitalization, not the inner arrow's. ----
+		{
+			Code: `
+        Hello = () => () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: nested arrow under a CAPITAL-keyed PropertyAssignment. ----
+		{
+			Code: `
+        const obj = {
+          Hello: () => () => {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: paren-wrapped fn argument `React.memo((fn))` — tsgo keeps
+		// the ParenthesizedExpression; the wrapper detection must be
+		// paren-transparent to match ESTree behavior. ----
+		{
+			Code: `
+        const Hello = React.memo((() => {
+          this.state.x = 1;
+          return <div/>;
+        }));
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: `export default () => <div/>` strict gate still passes
+		// when the body returns real JSX (not just null). ----
+		{
+			Code: `
+        export default () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
 			},
 		},
 	})

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -1,0 +1,940 @@
+package no_direct_mutation_state
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDirectMutationStateRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDirectMutationStateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: createReactClass with no mutation ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: local object shaped like { state: {} } is not this.state ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            var obj = {state: {}};
+            obj.state.name = "foo";
+            return <div>Hello {obj.state.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: not a component at all ----
+		{Code: `
+        var Hello = "foo";
+        module.exports = {};
+      `, Tsx: true},
+
+		// ---- Upstream: non-component class (no extends) — mutation allowed ----
+		{Code: `
+        class Hello {
+          getFoo() {
+            this.state.foo = 'bar'
+            return this.state.foo;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: mutation inside constructor is exempt ----
+		{Code: `
+        class Hello extends React.Component {
+          constructor() {
+            this.state.foo = "bar"
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: numeric literal assignment in constructor is still exempt ----
+		{Code: `
+        class Hello extends React.Component {
+          constructor() {
+            this.state.foo = 1;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: nested non-mutating class inside a component constructor ----
+		{Code: `
+        class OneComponent extends Component {
+          constructor() {
+            super();
+            class AnotherComponent extends Component {
+              constructor() {
+                super();
+              }
+            }
+            this.state = {};
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bracket access `this['state']` is not matched (ESLint checks Identifier .name only) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this['state'].foo = 'bar';
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: receiver is not `this` ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            that.state.foo = 'bar';
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: a class that doesn't extend Component/PureComponent ----
+		{Code: `
+        class Hello extends SomethingElse {
+          componentDidMount() {
+            this.state.foo = 'bar';
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: destructuring assignment whose LHS is a pattern, not a member ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            const {x} = this.state;
+            ({x} = this.state);
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: inside constructor, outside any call: compound assignment is still exempt ----
+		{Code: `
+        class Hello extends React.Component {
+          constructor() {
+            this.state.count += 1;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: mutation sits in a non-function position of createReactClass — no component ----
+		{Code: `
+        var Hello = createReactClass({
+          foo: (this.state.bar = 1)
+        });
+      `, Tsx: true},
+
+		// ---- Edge: `super.state.foo = ...` — not `this`, not reported (matches ESLint `object.type === 'ThisExpression'`) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            super.state.foo = "bar";
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: receiver is an identifier coincidentally named `state` ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            const state = { foo: 0 };
+            state.foo = 1;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `this['state'].foo = x` — computed outer, not flagged (matches ESLint) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this['state'].nested.foo = 1;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: React.PureComponent subclass is still a component ----
+		{Code: `
+        class Hello extends React.PureComponent {
+          constructor() {
+            super();
+            this.state = { foo: 'bar' };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: pragma-qualified createClass via React settings ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass"}},
+		},
+
+		// ---- Edge: lowercase-named function is NOT a component (no capital letter) ----
+		{Code: `
+        function hello() {
+          this.state.x = 1;
+          return <div/>;
+        }
+      `, Tsx: true},
+
+		// ---- Edge: capital-named function that doesn't return JSX/null is NOT a component ----
+		{Code: `
+        function Hello() {
+          this.state.x = 1;
+          return "hi";
+        }
+      `, Tsx: true},
+
+		// ---- Edge: arrow with lowercase VariableDeclarator name is NOT a component ----
+		{Code: `
+        const hello = () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: bare function body (no enclosing component) ----
+		{Code: `
+        function foo() {
+          this.state.x = 1;
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: createReactClass — simple mutation ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.foo = "bar"
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: createReactClass — update expression ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.foo++;
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: createReactClass — nested property assignment ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.person.name= "bar"
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: createReactClass — deeper nested assignment ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.person.name.first = "bar"
+            return <div>Hello</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: two mutations in the same render body ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.person.name.first = "bar"
+            this.state.person.name.last = "baz"
+            return <div>Hello</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noDirectMutation",
+					Message:   "Do not mutate state directly. Use setState().",
+					Line:      4, Column: 13,
+				},
+				{
+					MessageId: "noDirectMutation",
+					Message:   "Do not mutate state directly. Use setState().",
+					Line:      5, Column: 13,
+				},
+			},
+		},
+
+		// ---- Upstream: mutation in a class method called from the constructor ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor() {
+            someFn()
+          }
+          someFn() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 7, Column: 13},
+			},
+		},
+
+		// ---- Upstream: constructor body but wrapped in a nested CallExpression (arrow in async helper) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props)
+            doSomethingAsync(() => {
+              this.state = "bad";
+            });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 6, Column: 15},
+			},
+		},
+
+		// ---- Upstream: componentWillMount ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillMount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: componentDidMount ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: componentWillReceiveProps ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillReceiveProps() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: shouldComponentUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          shouldComponentUpdate() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: componentWillUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: componentDidUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: componentWillUnmount ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUnmount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: bare `class Hello extends Component` (unqualified) ----
+		{
+			Code: `
+        class Hello extends Component {
+          componentDidMount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: compound assignment is still a mutation ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.count += 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: prefix decrement ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            --this.state.count;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 15},
+			},
+		},
+
+		// ---- Edge: mutation inside an ArrowFunction callback inside a class method is NOT in the constructor ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            setTimeout(() => { this.state.x = 1; });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 32},
+			},
+		},
+
+		// ---- Edge: parenthesized LHS is unwrapped ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (this.state.foo) = "bar";
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 14},
+			},
+		},
+
+		// ---- Edge: bracket access within the chain still traverses inward ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state['foo'] = "bar";
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: static method — ESLint flags (does not special-case `this` binding) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          static foo() {
+            this.state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class getter body ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          get foo() {
+            this.state.x = 1;
+            return 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class setter body ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          set foo(_v) {
+            this.state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: arrow-function class property body (fires outside the constructor) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          handleClick = () => {
+            this.state.x = 1;
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class field initializer (PropertyDeclaration, not a Constructor) ----
+		// The mutation runs during construction semantically, but syntactically
+		// it is NOT inside a constructor MethodDefinition, so ESLint flags it
+		// (`inConstructor` never becomes true).
+		{
+			Code: `
+        class Hello extends React.Component {
+          foo = (this.state.x = 1);
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Edge: anonymous class expression component ----
+		{
+			Code: `
+        var Hello = class extends React.Component {
+          componentDidMount() {
+            this.state.x = 1;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: IIFE inside constructor — nested CallExpression voids the exemption ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor() {
+            super();
+            (() => { this.state.x = 1; })();
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- Edge: object-literal method named `constructor` inside createReactClass
+		// is NOT the ES6 constructor — mutation is flagged. ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          constructor: function() {
+            this.state.x = 1;
+          },
+          render: function() {
+            return <div/>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: mutation deep inside nested CallExpressions inside a method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            foo(bar(baz(() => { this.state.x = 1; })));
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 33},
+			},
+		},
+
+		// ---- Edge: logical assignment ||= on this.state ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.x ||= 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: mutation inside a generator method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          *step() {
+            this.state.x = 1;
+            yield 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: mutation inside async method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          async load() {
+            await Promise.resolve();
+            this.state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: computed-name class method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          ['foo']() {
+            this.state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: private method ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          #foo() {
+            this.state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: pragma-qualified createReactClass via settings: `React.createClass({...})` ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          render: function() {
+            this.state.x = 1;
+            return <div/>;
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: React.PureComponent — a component, should be flagged ----
+		{
+			Code: `
+        class Hello extends React.PureComponent {
+          componentDidMount() {
+            this.state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: nested React component inside a non-component class method ----
+		{
+			Code: `
+        class Outer {
+          method() {
+            class Inner extends React.Component {
+              componentDidMount() {
+                this.state.x = 1;
+              }
+            }
+            return Inner;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Edge: two mutations across different lifecycle methods on same class ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.a = 1;
+          }
+          componentWillUnmount() {
+            this.state.b = 2;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+				{MessageId: "noDirectMutation", Line: 7, Column: 13},
+			},
+		},
+
+		// ---- Edge: mutation inside constructor wrapped in a PostfixUnary call — still flagged ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor() {
+            super();
+            someHelper(() => { this.state.x++; });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 5, Column: 32},
+			},
+		},
+
+		// ---- Edge: stateless FunctionDeclaration component (capital name + JSX return) ----
+		{
+			Code: `
+        function Hello() {
+          this.state.x = 1;
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless arrow assigned to capital-cased VariableDeclarator ----
+		{
+			Code: `
+        const Hello = () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless FunctionExpression assigned to capital-cased VariableDeclarator ----
+		{
+			Code: `
+        const Hello = function() {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless arrow with implicit JSX return body ----
+		{
+			Code: `
+        const Hello = () => (this.state.x = 1, <div/>);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 2, Column: 30},
+			},
+		},
+
+		// ---- Edge: stateless component returning `null` on some branch ----
+		{
+			Code: `
+        function Hello() {
+          this.state.x = 1;
+          if (cond) return null;
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless component with ternary returning JSX-or-null ----
+		{
+			Code: `
+        function Hello(props) {
+          this.state.x = 1;
+          return props.show ? <div/> : null;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: stateless component's inner arrow does NOT shadow — outer stateless wins ----
+		{
+			Code: `
+        function Hello() {
+          const onClick = () => { this.state.x = 1; };
+          onClick();
+          return <div onClick={onClick}/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 35},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -311,6 +311,67 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           return 42;
         };
       `, Tsx: true},
+
+		// ---- Edge: `delete this.state.x` — rule only fires on assignment /
+		// update expressions, not DeleteExpression (matches ESLint). ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            delete this.state.x;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: anonymous FE assigned to lowercase `obj.foo = ...` ----
+		{Code: `
+        obj.foo = function () {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: returning an arrow (not JSX) — not a component ----
+		{Code: `
+        const Hello = () => {
+          this.state.x = 1;
+          return () => <div/>;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: assignment default in destructuring params (BinaryExpression
+		// shape is a BindingElement, not a real assignment) — not a mutation. ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount({ key = this.state.fallback } = {}) {
+            return key;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: `for (key in this.state) {...}` — reads, not a mutation ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            for (const k in this.state) { console.log(k); }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: Inner component class's constructor mutation is exempt on
+		// Inner; outer Outer.foo() never sees the mutation on the walk path. ----
+		{Code: `
+        class Outer extends React.Component {
+          foo() {
+            class Inner extends React.Component {
+              constructor() {
+                super();
+                this.state = { inner: true };
+              }
+            }
+            return Inner;
+          }
+        }
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -1244,5 +1305,234 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 		// ---- Edge: lowercase-key with NO params — still excluded by the
 		// regular PropertyAssignment branch (lowercase key → not a component). ----
 		// Kept as a matching valid test above; not duplicated here.
+
+		// ---- Edge: 5-level deep chain `this.state.a.b.c.d = 1` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.a.b.c.d = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: prefix increment `++this.state.x` (mirror of prefix decrement) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            ++this.state.counter;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 15},
+			},
+		},
+
+		// ---- Edge: postfix decrement `this.state.x--` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.counter--;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: bitwise compound assignment `|=` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.flags |= 0x1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: nullish coalescing assignment `??=` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.value ??= 0;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: exponentiation compound assignment `**=` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.power **= 2;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: chained assignment `this.state.a = this.state.b = 1` —
+		// two separate mutations, both should report. ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.a = this.state.b = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+				{MessageId: "noDirectMutation", Line: 4, Column: 28},
+			},
+		},
+
+		// ---- Edge: parenthesized `this` inside the chain: `(this).state.x = 1` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            (this).state.x = 1;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: mutation inside an arrow JSX-attribute callback ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            return <button onClick={() => { this.state.x = 1; }}/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 45},
+			},
+		},
+
+		// ---- Edge: mutation inside a template-literal expression position ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            tag` + "`${this.state.x = 1}`" + `;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: JSX Fragment `<></>` as return — `isJSXOrNullExpression`
+		// must recognize KindJsxFragment. ----
+		{
+			Code: `
+        const Hello = () => {
+          this.state.x = 1;
+          return <></>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: named default-exported FD — `export default function Hello() {...}` ----
+		{
+			Code: `
+        export default function Hello() {
+          this.state.x = 1;
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: named `export const Hello = () => ...` ----
+		{
+			Code: `
+        export const Hello = () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: mutation in a stateless component nested inside another
+		// stateless component — the INNER one is the nearest component. ----
+		{
+			Code: `
+        function Outer() {
+          const Inner = () => {
+            this.state.x = 1;
+            return <span/>;
+          };
+          return <Inner/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: SequenceExpression-last stateless component —
+		// `const Hello = (init(), () => <div/>)` forms a SequenceExpression,
+		// the last operand is the arrow; allowed-position must pass through. ----
+		{
+			Code: `
+        const Hello = (init(), (props) => {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
 	})
 }

--- a/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
+++ b/internal/plugins/react/rules/no_direct_mutation_state/no_direct_mutation_state_test.go
@@ -223,6 +223,56 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           return <div/>;
         };
       `, Tsx: true},
+
+		// ---- Edge: non-wrapper CallExpression parent (e.g. plain helper) — not a component ----
+		{Code: `
+        helper(function () {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `, Tsx: true},
+
+		// ---- Edge: lowercase property name in object literal — not a component ----
+		{Code: `
+        const obj = {
+          render: () => {
+            this.state.x = 1;
+            return <div/>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: IIFE (any name) is NOT in an allowed position for component
+		// per ESLint's isInAllowedPositionForComponent — CallExpression parent is
+		// rejected, so these must NOT be reported. ----
+		{Code: `
+        (function Hello() {
+          this.state.x = 1;
+          return <div/>;
+        })();
+      `, Tsx: true},
+		{Code: `
+        (() => {
+          this.state.x = 1;
+          return <div/>;
+        })();
+      `, Tsx: true},
+
+		// ---- Edge: obj.lowercase = fn — lowercase property name is NOT a component ----
+		{Code: `
+        obj.foo = function () {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `, Tsx: true},
+
+		// ---- Edge: plain helper callback (not memo/forwardRef) — not a component ----
+		{Code: `
+        setTimeout(() => {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: createReactClass — simple mutation ----
 		{
@@ -964,22 +1014,6 @@ func TestNoDirectMutationStateRule(t *testing.T) {
 			},
 		},
 
-		// ---- Edge: IIFE with a named capitalized FE — ESLint's fallback
-		// `if (node.id) return isFirstLetterCapitalized(node.id.name) ? node : undefined`
-		// treats it as a component. ----
-		{
-			Code: `
-        (function Hello() {
-          this.state.x = 1;
-          return <div/>;
-        })();
-      `,
-			Tsx: true,
-			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "noDirectMutation", Line: 3, Column: 11},
-			},
-		},
-
 		// ---- Edge: stateless component with `cond && <div/>` (common conditional render) ----
 		{
 			Code: `
@@ -1015,6 +1049,135 @@ func TestNoDirectMutationStateRule(t *testing.T) {
           this.state.x = 1;
           return props.cached ?? <div/>;
         }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: React.memo wrapping an anonymous arrow ----
+		{
+			Code: `
+        const Hello = React.memo(() => {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: bare `memo(...)` (destructured from React) ----
+		{
+			Code: `
+        export default memo(() => {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: React.forwardRef wrapping an anonymous arrow ----
+		{
+			Code: `
+        const Hello = React.forwardRef((props, ref) => {
+          this.state.x = 1;
+          return <div ref={ref}/>;
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: bare `forwardRef(...)` ----
+		{
+			Code: `
+        const Hello = forwardRef((props, ref) => {
+          this.state.x = 1;
+          return <div ref={ref}/>;
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: pragma-qualified memo under `settings.react.pragma = "Preact"` ----
+		{
+			Code: `
+        const Hello = Preact.memo(() => {
+          this.state.x = 1;
+          return <div/>;
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: `export default function() {...}` (anonymous default-export FD) ----
+		{
+			Code: `
+        export default function () {
+          this.state.x = 1;
+          return <div/>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: `export default () => ...` (arrow default export) ----
+		{
+			Code: `
+        export default () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: `module.exports = function() {...}` — blanket true per ESLint's
+		// isModuleExportsAssignment carve-out. ----
+		{
+			Code: `
+        module.exports = function () {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noDirectMutation", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: `obj.Hello = function() {...}` — capitalized property name
+		// assignment on an arbitrary MemberExpression LHS is a component. ----
+		{
+			Code: `
+        obj.Hello = function () {
+          this.state.x = 1;
+          return <div/>;
+        };
       `,
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -103,6 +103,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts',
+    './tests/eslint-plugin-react/rules/no-direct-mutation-state.test.ts',
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-direct-mutation-state.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-direct-mutation-state.test.ts
@@ -1,0 +1,294 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-direct-mutation-state', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            var obj = {state: {}};
+            obj.state.name = "foo";
+            return <div>Hello {obj.state.name}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = "foo";
+        module.exports = {};
+      `,
+    },
+    {
+      code: `
+        class Hello {
+          getFoo() {
+            this.state.foo = 'bar'
+            return this.state.foo;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          constructor() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          constructor() {
+            this.state.foo = 1;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class OneComponent extends Component {
+          constructor() {
+            super();
+            class AnotherComponent extends Component {
+              constructor() {
+                super();
+              }
+            }
+            this.state = {};
+          }
+        }
+      `,
+    },
+    // ---- Edge: bracket access `this['state']` is not matched ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this['state'].foo = 'bar';
+          }
+        }
+      `,
+    },
+    // ---- Edge: lowercase function — not a stateless component ----
+    {
+      code: `
+        function hello() {
+          this.state.x = 1;
+          return <div/>;
+        }
+      `,
+    },
+    // ---- Edge: Capital fn not returning JSX — not a component ----
+    {
+      code: `
+        function Hello() {
+          this.state.x = 1;
+          return 42;
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.foo = "bar"
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.foo++;
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.person.name= "bar"
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.person.name.first = "bar"
+            return <div>Hello</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            this.state.person.name.first = "bar"
+            this.state.person.name.last = "baz"
+            return <div>Hello</div>;
+          }
+        });
+      `,
+      errors: [
+        { messageId: 'noDirectMutation' },
+        { messageId: 'noDirectMutation' },
+      ],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          constructor() {
+            someFn()
+          }
+          someFn() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props)
+            doSomethingAsync(() => {
+              this.state = "bad";
+            });
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillMount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillReceiveProps() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          shouldComponentUpdate() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUnmount() {
+            this.state.foo = "bar"
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    // ---- Edge: compound assignment is still a mutation ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentDidMount() {
+            this.state.count += 1;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    // ---- Edge: stateless FunctionDeclaration component ----
+    {
+      code: `
+        function Hello() {
+          this.state.x = 1;
+          return <div/>;
+        }
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+    // ---- Edge: stateless arrow assigned to capital-cased variable ----
+    {
+      code: `
+        const Hello = () => {
+          this.state.x = 1;
+          return <div/>;
+        };
+      `,
+      errors: [{ messageId: 'noDirectMutation' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-direct-mutation-state` rule from eslint-plugin-react to rslint.

The rule disallows direct mutation of `this.state` (e.g. `this.state.foo = 'bar'`, `this.state.foo++`, compound assignments), which bypasses React's scheduler. Initial state assignment inside the ES6 constructor is exempted. Covers ES6 class components, ES5 \`createReactClass\` components, and functional components.

Coverage details:

- **Component detection** — new \`reactutil.GetEnclosingReactComponentOrStateless\` mirrors upstream's \`getParentES6Component || getParentES5Component || getParentStatelessComponent\` priority so \`this.state = x\` inside an inner arrow nested within an outer class constructor correctly inherits the outer class's constructor exemption.
- **Assignment / update forms** — all assignment operators (\`=\`, \`+=\`, \`||=\`, \`&&=\`, \`??=\`, etc.) via \`KindBinaryExpression\`, plus prefix / postfix \`++\` / \`--\` via \`KindPrefixUnaryExpression\` / \`KindPostfixUnaryExpression\`.
- **Constructor exemption** — ancestor walk bounded by the component node, checking for \`KindConstructor\` ancestor and any \`KindCallExpression\` ancestor (nested call voids the exemption), equivalent to upstream's dynamic \`inConstructor && !inCallExpression\` state machine.
- **Member chain walk** — follows both \`PropertyAccessExpression\` and \`ElementAccessExpression\` inward through parentheses; matches only when the innermost receiver is \`this\` with Identifier \`state\` (aligned with upstream's \`isStateMemberExpression\`).

Tests:

- Go: 22 valid + 46 invalid cases. All upstream valid (7) / invalid (14) cases migrated 1:1. Extra coverage added for tsgo-vs-ESTree edges (explicit paren nodes, \`ElementAccessExpression\` in chain), for the full assignment-operator matrix, and for class-member variants (static / getter / setter / async / generator / computed / private / class-field initializer / arrow class property), class expression, IIFE in constructor, deep nested calls, pragma-qualified \`React.createClass\` via settings, and functional component shapes (\`FunctionDeclaration\`, \`const X = () => ...\`, \`const X = function() {...}\`, implicit JSX return, ternary JSX/null).
- JS (rstest): upstream cases plus functional component and compound-assignment cases.

Differential validation:

- Built the binary and ran against \`web-infra-dev/rsbuild\` (279 files) and \`web-infra-dev/rspack\` (401 files). Zero \`react/no-direct-mutation-state\` reports, confirmed as true negatives by an independent grep — neither codebase contains an assignment to \`this.state.*\`.
- A canary file with both a class-component mutation and a functional-component mutation reports both errors as expected.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-direct-mutation-state.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-direct-mutation-state.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).