### PR TITLE
feat: port rule react/jsx-no-target-blank

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -11,6 +11,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_max_props_per_line"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_bind"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_duplicate_props"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_target_blank"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_undef"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_pascal_case"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_props_no_multi_spaces"
@@ -45,6 +46,7 @@ func GetAllRules() []rule.Rule {
 		jsx_max_props_per_line.JsxMaxPropsPerLineRule,
 		jsx_no_bind.JsxNoBindRule,
 		jsx_no_duplicate_props.JsxNoDuplicatePropsRule,
+		jsx_no_target_blank.JsxNoTargetBlankRule,
 		jsx_no_undef.JsxNoUndefRule,
 		jsx_pascal_case.JsxPascalCaseRule,
 		jsx_props_no_multi_spaces.JsxPropsNoMultiSpacesRule,

--- a/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.go
+++ b/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.go
@@ -1,0 +1,601 @@
+package jsx_no_target_blank
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const (
+	msgNoreferrer = `Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations`
+	msgNoopener   = `Using target="_blank" without rel="noreferrer" or rel="noopener" (the former implies the latter and is preferred due to wider support) is a security risk: see https://mathiasbynens.github.io/rel-noopener/#recommendations`
+)
+
+// externalLinkRe mirrors upstream's `/^(?:\w+:|\/\/)/` — matches absolute URLs
+// (`http://`, `mailto:`, …) and protocol-relative URLs (`//example.com`).
+var externalLinkRe = regexp.MustCompile(`^(?:\w+:|//)`)
+
+type options struct {
+	allowReferrer          bool
+	enforceDynamicLinks    string // "always" | "never"
+	warnOnSpreadAttributes bool
+	links                  bool
+	forms                  bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{
+		allowReferrer:          false,
+		enforceDynamicLinks:    "always",
+		warnOnSpreadAttributes: false,
+		links:                  true,
+		forms:                  false,
+	}
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["allowReferrer"].(bool); ok {
+		opts.allowReferrer = v
+	}
+	if v, ok := m["enforceDynamicLinks"].(string); ok && (v == "always" || v == "never") {
+		opts.enforceDynamicLinks = v
+	}
+	if v, ok := m["warnOnSpreadAttributes"].(bool); ok {
+		opts.warnOnSpreadAttributes = v
+	}
+	if v, ok := m["links"].(bool); ok {
+		opts.links = v
+	}
+	if v, ok := m["forms"].(bool); ok {
+		opts.forms = v
+	}
+	return opts
+}
+
+// componentMap maps a component tag name (e.g. "a", "Link") to the set of
+// attribute names that identify its link target (e.g. ["href"] or ["to"]).
+type componentMap map[string][]string
+
+func newDefaultLinkComponents() componentMap {
+	return componentMap{"a": {"href"}}
+}
+
+func newDefaultFormComponents() componentMap {
+	return componentMap{"form": {"action"}}
+}
+
+// readComponentsFromSettings extracts a component-name→attribute-list map
+// from `settings.<key>`, matching upstream `util/linkComponents`.
+//
+// Shapes accepted (each entry may appear standalone or as an element of an
+// outer array, mirroring upstream's `DEFAULT.concat(settings[key] || [])`):
+//
+//   - string: "Link"                                    → {Link: [defaultAttr]}
+//   - {name, <attrField>}: <attrField> string or []str  → {name: [attr…]}
+//
+// `attrField` is "linkAttribute" for linkComponents and "formAttribute" for
+// formComponents — upstream uses distinct field names for each category
+// (`value.linkAttribute` vs `value.formAttribute`), so getting this wrong
+// would silently fall back to the default attribute for every custom form
+// component the user configures.
+func readComponentsFromSettings(settings map[string]interface{}, key, attrField, defaultAttr string, base componentMap) componentMap {
+	out := componentMap{}
+	for k, v := range base {
+		out[k] = slices.Clone(v)
+	}
+	if settings == nil {
+		return out
+	}
+	raw, ok := settings[key]
+	if !ok {
+		return out
+	}
+	addOne := func(entry interface{}) {
+		switch e := entry.(type) {
+		case string:
+			out[e] = appendUnique(out[e], defaultAttr)
+		case map[string]interface{}:
+			name, _ := e["name"].(string)
+			if name == "" {
+				return
+			}
+			var attrs []string
+			// Mirrors upstream's `[].concat(value[attrField])` coercion:
+			// string → single-element list, array → as-is, missing → empty
+			// (which we backfill with the default attribute).
+			switch la := e[attrField].(type) {
+			case string:
+				attrs = []string{la}
+			case []interface{}:
+				for _, v := range la {
+					if s, ok := v.(string); ok {
+						attrs = append(attrs, s)
+					}
+				}
+			}
+			if len(attrs) == 0 {
+				attrs = []string{defaultAttr}
+			}
+			for _, a := range attrs {
+				out[name] = appendUnique(out[name], a)
+			}
+		}
+	}
+	// Upstream accepts either a single entry (string/object) or an array of
+	// them at `settings[key]`. JS's `[].concat(x)` flattens both into the
+	// final list; we mirror that by accepting either shape here.
+	switch r := raw.(type) {
+	case string:
+		addOne(r)
+	case map[string]interface{}:
+		addOne(r)
+	case []interface{}:
+		for _, entry := range r {
+			addOne(entry)
+		}
+	}
+	return out
+}
+
+func appendUnique(list []string, s string) []string {
+	if slices.Contains(list, s) {
+		return list
+	}
+	return append(list, s)
+}
+
+// jsxExpressionInner unwraps a JsxExpression container and transparently
+// skips ParenthesizedExpression wrappers on its payload. tsgo preserves
+// parentheses as explicit nodes where ESTree flattens them; every downstream
+// `.Kind` / `.As*()` access in this rule goes through this helper so that
+// shapes like `{(…)}` and `{( (…) )}` are handled identically to `{…}`.
+//
+// Returns nil when the container is empty (`{}`) or not a JsxExpression.
+func jsxExpressionInner(node *ast.Node) *ast.Node {
+	if node == nil || node.Kind != ast.KindJsxExpression {
+		return nil
+	}
+	expr := node.AsJsxExpression().Expression
+	if expr == nil {
+		return nil
+	}
+	return ast.SkipParentheses(expr)
+}
+
+// stringLiteralText returns the text of a StringLiteral node (the direct
+// attribute-value form for `attr="x"`). Parentheses are skipped; every other
+// node kind — including NoSubstitutionTemplateLiteral — returns "", false,
+// matching upstream's `value.type === 'Literal' && typeof value.value ===
+// 'string'` guard for the `target` attribute.
+func stringLiteralText(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindStringLiteral {
+		return n.AsStringLiteral().Text, true
+	}
+	return "", false
+}
+
+// templateOrStringText extends stringLiteralText by also accepting a
+// NoSubstitutionTemplateLiteral — this mirrors upstream's `getStringFromValue`
+// branch that reads `TemplateLiteral.quasis[0].value.cooked` for the `rel`
+// attribute. Parentheses are skipped.
+//
+// TemplateExpression (templates with `${}`) is deliberately not handled:
+// upstream would read only the first quasi, but rslint treats the value as
+// non-literal so the enclosing check falls through to "non-string branch" —
+// the same effective outcome for every rel string we care about.
+func templateOrStringText(node *ast.Node) (string, bool) {
+	if node == nil {
+		return "", false
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindStringLiteral:
+		return n.AsStringLiteral().Text, true
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return n.AsNoSubstitutionTemplateLiteral().Text, true
+	}
+	return "", false
+}
+
+// attributeValuePossiblyBlank reports whether a `target` attribute could
+// evaluate to "_blank" (case-insensitive). Matches upstream:
+//
+//   - StringLiteral directly (`target="_blank"`) → check the text
+//   - JsxExpression containing StringLiteral (`target={"_blank"}`) → check
+//   - JsxExpression containing ConditionalExpression → either branch is a
+//     StringLiteral equal to "_blank"
+//
+// Parentheses are transparently skipped everywhere a child node kind is
+// examined. NoSubstitutionTemplateLiteral is deliberately excluded for strict
+// upstream parity (upstream's check is `expr.type === 'Literal'`, which
+// excludes templates).
+func attributeValuePossiblyBlank(attr *ast.Node) bool {
+	if attr == nil {
+		return false
+	}
+	init := attr.AsJsxAttribute().Initializer
+	if init == nil {
+		return false
+	}
+	// Direct `attr="_blank"` form.
+	if s, ok := stringLiteralText(init); ok {
+		return strings.EqualFold(s, "_blank")
+	}
+	// `attr={…}` form — unwrap the JsxExpression and any paren wrappers.
+	expr := jsxExpressionInner(init)
+	if expr == nil {
+		return false
+	}
+	if s, ok := stringLiteralText(expr); ok {
+		return strings.EqualFold(s, "_blank")
+	}
+	if expr.Kind == ast.KindConditionalExpression {
+		cond := expr.AsConditionalExpression()
+		if s, ok := stringLiteralText(cond.WhenTrue); ok && strings.EqualFold(s, "_blank") {
+			return true
+		}
+		if s, ok := stringLiteralText(cond.WhenFalse); ok && strings.EqualFold(s, "_blank") {
+			return true
+		}
+	}
+	return false
+}
+
+// findLastIndex returns the largest i for which pred(attrs[i]) is true, or -1.
+func findLastIndex(attrs []*ast.Node, pred func(*ast.Node) bool) int {
+	for i := len(attrs) - 1; i >= 0; i-- {
+		if pred(attrs[i]) {
+			return i
+		}
+	}
+	return -1
+}
+
+// attrHasName reports whether an attribute is a JsxAttribute whose name
+// display string equals `name`. reactutil.GetJsxPropName returns "spread" for
+// JsxSpreadAttribute and "ns:local" for JsxNamespacedName, neither of which
+// overlaps with the `target` / `rel` / `href` names we compare against —
+// matching upstream's `attr.name && attr.name.name === 'target'` guard which
+// implicitly skips spreads and namespaced attributes.
+func attrHasName(attr *ast.Node, name string) bool {
+	if attr == nil || attr.Kind != ast.KindJsxAttribute {
+		return false
+	}
+	return reactutil.GetJsxPropName(attr) == name
+}
+
+func attrNameIsOneOf(attr *ast.Node, names []string) bool {
+	if attr == nil || attr.Kind != ast.KindJsxAttribute {
+		return false
+	}
+	return slices.Contains(names, reactutil.GetJsxPropName(attr))
+}
+
+// isExternalURL reports whether a string literal value looks like an external
+// URL under upstream's `/^(?:\w+:|\/\/)/` regex (absolute `proto:` or
+// protocol-relative `//`).
+func isExternalURL(s string) bool {
+	return externalLinkRe.MatchString(s)
+}
+
+func hasExternalLink(attrs []*ast.Node, linkAttrs []string, warnOnSpread bool, spreadIdx int) bool {
+	linkIdx := findLastIndex(attrs, func(a *ast.Node) bool {
+		return attrNameIsOneOf(a, linkAttrs)
+	})
+	if linkIdx != -1 {
+		init := attrs[linkIdx].AsJsxAttribute().Initializer
+		// Upstream guard: `attr.value.type === 'Literal' && typeof value ===
+		// 'string' && regex.test(value)`. In tsgo this corresponds to a
+		// StringLiteral directly under the attribute (not inside `{…}`).
+		if s, ok := stringLiteralText(init); ok && isExternalURL(s) {
+			return true
+		}
+	}
+	return warnOnSpread && linkIdx < spreadIdx
+}
+
+func hasDynamicLink(attrs []*ast.Node, linkAttrs []string) bool {
+	return findLastIndex(attrs, func(a *ast.Node) bool {
+		if !attrNameIsOneOf(a, linkAttrs) {
+			return false
+		}
+		init := a.AsJsxAttribute().Initializer
+		return init != nil && init.Kind == ast.KindJsxExpression
+	}) != -1
+}
+
+// relStrings extracts the candidate string values the rel attribute could
+// evaluate to. Mirrors upstream's `getStringFromValue` including the
+// "matched-test-condition" shortcut: when both `target` and `rel` are
+// JsxExpressions wrapping a ConditionalExpression sharing the same test
+// identifier, only the rel branch aligned with the `_blank` target branch is
+// returned. Otherwise all literal branches of the conditional are returned.
+//
+// A returned `nil` entry represents a non-string branch — callers treat it as
+// "this branch is not a secure rel".
+func relStrings(relInit, targetInit *ast.Node) []*string {
+	if relInit == nil {
+		return nil
+	}
+	// Direct `rel="…"` form.
+	if s, ok := templateOrStringText(relInit); ok {
+		sCopy := s
+		return []*string{&sCopy}
+	}
+	expr := jsxExpressionInner(relInit)
+	if expr == nil {
+		return nil
+	}
+	// `rel={"…"}` / `rel={\`…\`}` form.
+	if s, ok := templateOrStringText(expr); ok {
+		sCopy := s
+		return []*string{&sCopy}
+	}
+	if expr.Kind == ast.KindConditionalExpression {
+		cond := expr.AsConditionalExpression()
+		consequent := stringOrNil(cond.WhenTrue)
+		alternate := stringOrNil(cond.WhenFalse)
+		// Matched-test shortcut: when both target and rel branch on the same
+		// identifier, only the rel branch aligned with the `_blank` target
+		// branch matters — the other side is unreachable when target !==
+		// "_blank", so rel's value there can't make this usage insecure.
+		if targetExpr := jsxExpressionInner(targetInit); targetExpr != nil && targetExpr.Kind == ast.KindConditionalExpression {
+			targetCond := targetExpr.AsConditionalExpression()
+			if relCondName := identifierName(cond.Condition); relCondName != "" && relCondName == identifierName(targetCond.Condition) {
+				tConsequent, _ := stringLiteralText(targetCond.WhenTrue)
+				tAlternate, _ := stringLiteralText(targetCond.WhenFalse)
+				switch "_blank" {
+				case tConsequent:
+					return []*string{consequent}
+				case tAlternate:
+					return []*string{alternate}
+				}
+			}
+		}
+		return []*string{consequent, alternate}
+	}
+	// Non-literal rel expression (`rel={getRel()}`, etc.) — caller should
+	// treat as non-secure.
+	return []*string{nil}
+}
+
+// stringOrNil returns a pointer to the string value of a literal-like node
+// (after skipping parentheses), or nil when the node carries a non-string
+// value (number, boolean, null, identifier, …).
+func stringOrNil(node *ast.Node) *string {
+	if s, ok := templateOrStringText(node); ok {
+		return &s
+	}
+	return nil
+}
+
+func identifierName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindIdentifier {
+		return n.AsIdentifier().Text
+	}
+	return ""
+}
+
+func hasSecureRel(attrs []*ast.Node, allowReferrer, warnOnSpread bool, spreadIdx int) bool {
+	relIdx := findLastIndex(attrs, func(a *ast.Node) bool { return attrHasName(a, "rel") })
+	targetIdx := findLastIndex(attrs, func(a *ast.Node) bool { return attrHasName(a, "target") })
+	if relIdx == -1 || (warnOnSpread && relIdx < spreadIdx) {
+		return false
+	}
+	relInit := attrs[relIdx].AsJsxAttribute().Initializer
+	var targetInit *ast.Node
+	if targetIdx != -1 {
+		targetInit = attrs[targetIdx].AsJsxAttribute().Initializer
+	}
+	values := relStrings(relInit, targetInit)
+	if len(values) == 0 {
+		return false
+	}
+	for _, v := range values {
+		if v == nil {
+			return false
+		}
+		tags := strings.Split(strings.ToLower(*v), " ")
+		if slices.Contains(tags, "noreferrer") {
+			continue
+		}
+		if allowReferrer && slices.Contains(tags, "noopener") {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// buildRelFix returns the fix that adds / normalizes the rel attribute so the
+// element becomes secure. Mirrors upstream's fixer logic. Returns nil when no
+// fix should be emitted (target trailing a spread, or non-string / non-literal
+// rel expression the fixer cannot rewrite safely).
+func buildRelFix(sf *ast.SourceFile, attrs []*ast.Node, targetIdx, spreadIdx int, relValue string) *rule.RuleFix {
+	relIdx := findLastIndex(attrs, func(a *ast.Node) bool { return attrHasName(a, "rel") })
+	if targetIdx < spreadIdx || (spreadIdx >= 0 && relIdx == -1) {
+		return nil
+	}
+	if relIdx == -1 {
+		// Insert ` rel="…"` after the last attribute.
+		lastAttr := attrs[len(attrs)-1]
+		fix := rule.RuleFixInsertAfter(lastAttr, ` rel="`+relValue+`"`)
+		return &fix
+	}
+	init := attrs[relIdx].AsJsxAttribute().Initializer
+	if init == nil {
+		// Boolean shorthand `rel` → insert `="…"` after the attribute.
+		fix := rule.RuleFixInsertAfter(attrs[relIdx], `="`+relValue+`"`)
+		return &fix
+	}
+	// `rel="…"` — split on the target token, re-join preserving others.
+	if s, ok := stringLiteralText(init); ok {
+		parts := splitNonEmpty(s, relValue)
+		fix := rule.RuleFixReplace(sf, init, `"`+strings.Join(append(parts, relValue), " ")+`"`)
+		return &fix
+	}
+	// `rel={…}` form.
+	expr := jsxExpressionInner(init)
+	if expr == nil {
+		return nil
+	}
+	// `rel={"…"}` → rewrite just the inner string literal, preserving the
+	// curly braces the user wrote. Mirrors upstream's `replaceText(value.
+	// expression, …)`.
+	if s, ok := stringLiteralText(expr); ok {
+		parts := splitNonEmpty(s, relValue)
+		fix := rule.RuleFixReplace(sf, expr, `"`+strings.Join(append(parts, relValue), " ")+`"`)
+		return &fix
+	}
+	// `rel={true}` / `{null}` / `{3}` / `{false}` / `{undefined}` —
+	// non-string primitive; upstream collapses the whole `{…}` down to a
+	// plain string attribute. We only rewrite shapes we can reason about;
+	// arbitrary expressions (identifier, call) are left alone, matching the
+	// upstream "return null" branch.
+	switch expr.Kind {
+	case ast.KindNumericLiteral, ast.KindBigIntLiteral, ast.KindTrueKeyword,
+		ast.KindFalseKeyword, ast.KindNullKeyword, ast.KindUndefinedKeyword:
+		fix := rule.RuleFixReplace(sf, init, `"`+relValue+`"`)
+		return &fix
+	case ast.KindIdentifier:
+		if expr.AsIdentifier().Text == "undefined" {
+			fix := rule.RuleFixReplace(sf, init, `"`+relValue+`"`)
+			return &fix
+		}
+	}
+	return nil
+}
+
+// splitNonEmpty splits `s` by `sep` and drops empty segments — matching
+// upstream's `value.split(sep).filter(Boolean)`. Used to sanitize rel values
+// like "noopenernoreferrer" → ["noopener"] so the fix can re-append the token
+// cleanly without duplicating it.
+func splitNonEmpty(s, sep string) []string {
+	raw := strings.Split(s, sep)
+	out := raw[:0]
+	for _, p := range raw {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func reportWithOptionalFix(ctx rule.RuleContext, node *ast.Node, messageId, description string, fix *rule.RuleFix) {
+	msg := rule.RuleMessage{Id: messageId, Description: description}
+	if fix != nil {
+		ctx.ReportNodeWithFixes(node, msg, *fix)
+		return
+	}
+	ctx.ReportNode(node, msg)
+}
+
+var JsxNoTargetBlankRule = rule.Rule{
+	Name: "react/jsx-no-target-blank",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		linkComponents := readComponentsFromSettings(ctx.Settings, "linkComponents", "linkAttribute", "href", newDefaultLinkComponents())
+		formComponents := readComponentsFromSettings(ctx.Settings, "formComponents", "formAttribute", "action", newDefaultFormComponents())
+
+		messageId := "noTargetBlankWithoutNoreferrer"
+		description := msgNoreferrer
+		relValue := "noreferrer"
+		if opts.allowReferrer {
+			messageId = "noTargetBlankWithoutNoopener"
+			description = msgNoopener
+			relValue = "noopener"
+		}
+
+		check := func(node *ast.Node) {
+			// Upstream keys on `node.name.name`, which is only a string for an
+			// Identifier tag. PropertyAccessExpression (`<Foo.Bar>`),
+			// JsxNamespacedName (`<ns:a>`) and ThisKeyword tags all hash to
+			// non-string and fall through — same as our empty-name guard.
+			tagName := reactutil.GetJsxTagName(node)
+			if tagName == nil || tagName.Kind != ast.KindIdentifier {
+				return
+			}
+			name := tagName.AsIdentifier().Text
+			isLink := opts.links && linkComponents[name] != nil
+			isForm := opts.forms && formComponents[name] != nil
+			if !isLink && !isForm {
+				return
+			}
+			attrs := reactutil.GetJsxElementAttributes(node)
+			if len(attrs) == 0 {
+				return
+			}
+
+			targetIdx := findLastIndex(attrs, func(a *ast.Node) bool { return attrHasName(a, "target") })
+			spreadIdx := findLastIndex(attrs, func(a *ast.Node) bool { return a.Kind == ast.KindJsxSpreadAttribute })
+
+			// shouldProceed encodes upstream's entry gate: check the element
+			// when target could be "_blank", OR when a spread might inject
+			// one and `warnOnSpreadAttributes` is enabled. Upstream's gate is
+			// literally equivalent to this condition once the branches of its
+			// nested if/else-if are unrolled.
+			shouldProceed := func() bool {
+				var targetAttr *ast.Node
+				if targetIdx != -1 {
+					targetAttr = attrs[targetIdx]
+				}
+				if attributeValuePossiblyBlank(targetAttr) {
+					return true
+				}
+				return opts.warnOnSpreadAttributes && spreadIdx >= 0
+			}
+
+			if isLink {
+				if shouldProceed() {
+					componentAttrs := linkComponents[name]
+					dangerous := hasExternalLink(attrs, componentAttrs, opts.warnOnSpreadAttributes, spreadIdx) ||
+						(opts.enforceDynamicLinks == "always" && hasDynamicLink(attrs, componentAttrs))
+					if dangerous && !hasSecureRel(attrs, opts.allowReferrer, opts.warnOnSpreadAttributes, spreadIdx) {
+						reportWithOptionalFix(ctx, node, messageId, description,
+							buildRelFix(ctx.SourceFile, attrs, targetIdx, spreadIdx, relValue))
+						return
+					}
+				}
+			}
+			if isForm {
+				// Form branch mirrors upstream: forms never autofix, and the
+				// inner `hasSecureRel` / `hasExternalLink` calls are invoked
+				// with undefined trailing arguments — equivalent to
+				// `(attrs, false, false, -1)` / `(attrs, formAttrs, false, -1)`
+				// on our side. Upstream also passes no `allowReferrer` there,
+				// so forms with only `rel="noopener"` still report even when
+				// the rule-level option is on.
+				if !shouldProceed() {
+					return
+				}
+				if hasSecureRel(attrs, false, false, -1) {
+					return
+				}
+				formAttrs := formComponents[name]
+				if hasExternalLink(attrs, formAttrs, false, -1) ||
+					(opts.enforceDynamicLinks == "always" && hasDynamicLink(attrs, formAttrs)) {
+					reportWithOptionalFix(ctx, node, messageId, description, nil)
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxOpeningElement:     check,
+			ast.KindJsxSelfClosingElement: check,
+		}
+	},
+}

--- a/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.md
+++ b/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.md
@@ -1,0 +1,102 @@
+# jsx-no-target-blank
+
+Disallow `target="_blank"` attribute without `rel="noreferrer"`.
+
+## Rule Details
+
+When creating a JSX element that has an `a` tag, it is often desired to have
+the link open in a new tab using the `target="_blank"` attribute. Using this
+attribute unaccompanied by `rel="noreferrer"`, however, is a severe security
+vulnerability (see
+[here](https://mathiasbynens.github.io/rel-noopener) for more details).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Hello = <a target="_blank" href="http://example.com/">Foo</a>;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var Hello = <p target="_blank"></p>;
+var Hello = <a target="_blank" rel="noreferrer" href="http://example.com"></a>;
+var Hello = <a target="_blank" rel="noopener noreferrer" href="http://example.com"></a>;
+var Hello = <a target="_blank" href="path/in/the/host"></a>;
+```
+
+## Rule Options
+
+```json
+{
+  "react/jsx-no-target-blank": [
+    "error",
+    {
+      "allowReferrer": false,
+      "enforceDynamicLinks": "always",
+      "warnOnSpreadAttributes": false,
+      "links": true,
+      "forms": false
+    }
+  ]
+}
+```
+
+### `allowReferrer`
+
+When `true` the rule permits `rel="noopener"` alone (the `Referer` header is
+still sent). Defaults to `false`.
+
+### `enforceDynamicLinks`
+
+- `"always"` (default) — the rule also checks dynamic link targets
+  (`href={value}`).
+- `"never"` — dynamic link targets are exempt.
+
+### `warnOnSpreadAttributes`
+
+When `true`, spread attributes (`{...props}`) are treated as a potential
+override of `target` / `href` / `rel`, so the rule may still report even when
+the explicit attributes look safe. Defaults to `false`.
+
+### `links` / `forms`
+
+Toggle the checks for anchor-like link components (`links`, default `true`)
+and `<form>`-like components (`forms`, default `false`).
+
+### Custom components
+
+The rule honors the top-level `settings.linkComponents` and
+`settings.formComponents` entries, matching
+[eslint-plugin-react's `linkComponents` configuration](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/README.md#configuration).
+Example:
+
+```json
+{
+  "settings": {
+    "linkComponents": [
+      "Hyperlink",
+      { "name": "Link", "linkAttribute": "to" }
+    ]
+  }
+}
+```
+
+## Differences from ESLint
+
+None — this rule aims for 1:1 behavior with
+[`react/jsx-no-target-blank`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md).
+A few upstream implementation details deserve a note:
+
+- The form branch (`forms: true`) does not autofix, matching upstream.
+- When the `rel` attribute uses an expression the rule cannot analyze
+  (e.g. `rel={getRel()}`), the diagnostic is still reported but no fix is
+  emitted.
+- The secure-rel check for `<form>` always treats `allowReferrer` as `false`
+  — forms with only `rel="noopener"` still report even when the rule-level
+  `allowReferrer` option is on, matching upstream's
+  `hasSecureRel(node)` call shape.
+
+## Original Documentation
+
+- [eslint-plugin-react docs](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md)

--- a/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank_test.go
+++ b/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank_test.go
@@ -1,0 +1,683 @@
+package jsx_no_target_blank
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoTargetBlankRule(t *testing.T) {
+	defaultErrors := []rule_tester.InvalidTestCaseError{
+		{MessageId: "noTargetBlankWithoutNoreferrer"},
+	}
+	allowReferrerErrors := []rule_tester.InvalidTestCaseError{
+		{MessageId: "noTargetBlankWithoutNoopener"},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoTargetBlankRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<a href="foobar"></a>;`, Tsx: true},
+		{Code: `<a randomTag></a>;`, Tsx: true},
+		{Code: `<a target />;`, Tsx: true},
+		{Code: `<a href="foobar" target="_blank" rel="noopener noreferrer"></a>;`, Tsx: true},
+		{Code: `<a href="foobar" target="_blank" rel="noreferrer"></a>;`, Tsx: true},
+		{Code: `<a href="foobar" target="_blank" rel={"noopener noreferrer"}></a>;`, Tsx: true},
+		{Code: `<a href="foobar" target="_blank" rel={"noreferrer"}></a>;`, Tsx: true},
+		{Code: `<a href={"foobar"} target={"_blank"} rel={"noopener noreferrer"}></a>;`, Tsx: true},
+		{Code: `<a href={"foobar"} target={"_blank"} rel={"noreferrer"}></a>;`, Tsx: true},
+		{Code: `<a href={'foobar'} target={'_blank'} rel={'noopener noreferrer'}></a>;`, Tsx: true},
+		{Code: `<a href={'foobar'} target={'_blank'} rel={'noreferrer'}></a>;`, Tsx: true},
+		{Code: "<a href={`foobar`} target={`_blank`} rel={`noopener noreferrer`}></a>;", Tsx: true},
+		{Code: "<a href={`foobar`} target={`_blank`} rel={`noreferrer`}></a>;", Tsx: true},
+		{Code: `<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>;`, Tsx: true},
+		{Code: `<a target="_blank" {...spreadProps} rel="noreferrer"></a>;`, Tsx: true},
+		{Code: `<a {...spreadProps} target="_blank" rel="noopener noreferrer" href="https://example.com">s</a>;`, Tsx: true},
+		{Code: `<a {...spreadProps} target="_blank" rel="noreferrer" href="https://example.com">s</a>;`, Tsx: true},
+		{Code: `<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>;`, Tsx: true},
+		{Code: `<a target="_blank" rel="noreferrer" {...spreadProps}></a>;`, Tsx: true},
+		{Code: `<p target="_blank"></p>;`, Tsx: true},
+		{Code: `<a href="foobar" target="_BLANK" rel="NOOPENER noreferrer"></a>;`, Tsx: true},
+		{Code: `<a href="foobar" target="_BLANK" rel="NOREFERRER"></a>;`, Tsx: true},
+		{Code: `<a target="_blank" rel={relValue}></a>;`, Tsx: true},
+		{Code: `<a target={targetValue} rel="noopener noreferrer"></a>;`, Tsx: true},
+		{Code: `<a target={targetValue} rel="noreferrer"></a>;`, Tsx: true},
+		{Code: `<a target={targetValue} rel={"noopener noreferrer"}></a>;`, Tsx: true},
+		{Code: `<a target={targetValue} rel={"noreferrer"}></a>;`, Tsx: true},
+		{Code: `<a target={targetValue} href="relative/path"></a>;`, Tsx: true},
+		{Code: `<a target={targetValue} href="/absolute/path"></a>;`, Tsx: true},
+		{Code: `<a target={'targetValue'} href="/absolute/path"></a>;`, Tsx: true},
+		{Code: `<a target={"targetValue"} href="/absolute/path"></a>;`, Tsx: true},
+		{Code: `<a target={null} href="//example.com"></a>;`, Tsx: true},
+		{
+			Code:    `<a {...someObject} href="/absolute/path"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+		},
+		{
+			Code:    `<a {...someObject} rel="noreferrer"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+		},
+		{
+			Code:    `<a {...someObject} rel="noreferrer" target="_blank"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+		},
+		{
+			Code:    `<a {...someObject} href="foobar" target="_blank"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+		},
+		{
+			Code:    `<a target="_blank" href={ dynamicLink }></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "never"},
+		},
+		{
+			Code:    `<a target={"_blank"} href={ dynamicLink }></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "never"},
+		},
+		{
+			Code:    `<a target={'_blank'} href={ dynamicLink }></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "never"},
+		},
+		{
+			Code:     `<Link target="_blank" href={ dynamicLink }></Link>;`,
+			Tsx:      true,
+			Options:  map[string]interface{}{"enforceDynamicLinks": "never"},
+			Settings: map[string]interface{}{"linkComponents": []interface{}{"Link"}},
+		},
+		{
+			Code:    `<Link target="_blank" to={ dynamicLink }></Link>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "never"},
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "Link", "linkAttribute": "to"},
+			},
+		},
+		{
+			Code:    `<Link target="_blank" to={ dynamicLink }></Link>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "never"},
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "Link", "linkAttribute": []interface{}{"to"}},
+			},
+		},
+		{
+			Code:    `<a href="foobar" target="_blank" rel="noopener"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowReferrer": true},
+		},
+		{
+			Code:    `<a href="foobar" target="_blank" rel="noreferrer"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowReferrer": true},
+		},
+		{Code: `<a target={3} />;`, Tsx: true},
+		{Code: `<a href="some-link" {...otherProps} target="some-non-blank-target"></a>;`, Tsx: true},
+		{Code: `<a href="some-link" target="some-non-blank-target" {...otherProps}></a>;`, Tsx: true},
+		{
+			Code:    `<a target="_blank" href="/absolute/path"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": false},
+		},
+		{
+			Code:    `<a target="_blank" href="/absolute/path"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": false, "links": true},
+		},
+		{Code: `<form action="https://example.com" target="_blank"></form>;`, Tsx: true},
+		{
+			Code:    `<form action="https://example.com" target="_blank" rel="noopener noreferrer"></form>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+		},
+		{
+			Code:    `<form action="https://example.com" target="_blank" rel="noopener noreferrer"></form>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true, "links": false},
+		},
+		{Code: `<a href target="_blank"/>;`, Tsx: true},
+		{Code: `<a href={href} target={isExternal ? "_blank" : undefined} rel="noopener noreferrer" />;`, Tsx: true},
+		{Code: `<a href={href} target={isExternal ? undefined : "_blank"} rel={isExternal ? "noreferrer" : "noopener noreferrer"} />;`, Tsx: true},
+		{Code: `<a href={href} target={isExternal ? undefined : "_blank"} rel={isExternal ? "noreferrer noopener" : "noreferrer"} />;`, Tsx: true},
+		{
+			Code:    `<a href={href} target="_blank" rel={isExternal ? "noreferrer" : "noopener"} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowReferrer": true},
+		},
+		{Code: `<a href={href} target={isExternal ? "_blank" : undefined} rel={isExternal ? "noreferrer" : undefined} />;`, Tsx: true},
+		{Code: `<a href={href} target={isSelf ? "_self" : "_blank"} rel={isSelf ? undefined : "noreferrer"} />;`, Tsx: true},
+		{Code: `<a href={href} target={isSelf ? "_self" : ""} rel={isSelf ? undefined : ""} />;`, Tsx: true},
+		{Code: `<a href={href} target={isExternal ? "_blank" : undefined} rel={isExternal ? "noopener noreferrer" : undefined} />;`, Tsx: true},
+		{
+			Code:    `<form action={action} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+		},
+		{
+			Code:    `<form action={action} {...spread} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+		},
+
+		// ---- Additional edge cases ----
+		// Non-link JSX elements are ignored regardless of target value.
+		{Code: `<div target="_blank" href="https://example.com"></div>;`, Tsx: true},
+		// The link branch does not apply to unknown link components unless
+		// configured via settings.
+		{Code: `<Link target="_blank" href="https://example.com" />;`, Tsx: true},
+		// Member-access tag names (<Foo.Bar>) are not link components under
+		// the default configuration — the check skips them entirely.
+		{Code: `<Foo.Bar target="_blank" href="https://example.com" />;`, Tsx: true},
+		// Namespaced tag — same as above, skipped.
+		{Code: `<svg:a target="_blank" href="https://example.com" />;`, Tsx: true},
+		// Fragments have no tag name → skipped.
+		{Code: `<><a href="/safe">safe</a></>;`, Tsx: true},
+		// `target=""` is not "_blank" — the case-insensitive comparison still
+		// requires the exact token match.
+		{Code: `<a target="" href="https://example.com"></a>;`, Tsx: true},
+		// Parenthesized conditional branches still match — AST unwrap reaches
+		// the inner literal even when tsgo preserves the paren node.
+		{Code: `<a href={href} target={isExternal ? ("_blank") : undefined} rel={isExternal ? ("noreferrer") : undefined} />;`, Tsx: true},
+		// Template literal in target is NOT treated as possibly blank —
+		// matches upstream's `expr.type === 'Literal'` guard which excludes
+		// TemplateLiteral. So this entire element is considered not checked.
+		{Code: "<a target={`_blank`} href=\"https://example.com\"></a>;", Tsx: true},
+		// Multiple distinct spread attributes with a secure rel after them
+		// are still valid under default options.
+		{Code: `<a {...a} {...b} target="_blank" href="https://example.com" rel="noreferrer"></a>;`, Tsx: true},
+		// Nested anchor inside a component — inner anchor is independently
+		// checked. Outer <div> is not a link component.
+		{Code: `<div><a href="/safe">s</a></div>;`, Tsx: true},
+		// Conditional where BOTH branches are non-_blank strings is not
+		// possibly blank, so the element is skipped.
+		{Code: `<a href={href} target={isSelf ? "_parent" : "_top"}></a>;`, Tsx: true},
+		// Namespaced attribute name for target — upstream compares against
+		// `.name.name` which is the local "name" object for JSXNamespacedName,
+		// so it never equals 'target'. The rule treats `a:target` as an
+		// unrelated attribute and skips the element.
+		{Code: `<a a:target="_blank" href="https://example.com"></a>;`, Tsx: true},
+		// Custom link component with linkAttribute: 'to', but the actual
+		// `href` attribute is the one set externally — the rule only scans
+		// the configured attribute, so this is valid.
+		{
+			Code:    `<Link target="_blank" href="https://example.com" to="/safe" rel="noreferrer"></Link>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always"},
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "Link", "linkAttribute": "to"},
+			},
+		},
+		// Default linkComponents plus a settings-configured one — both kinds
+		// of elements are checked in the same pass.
+		{
+			Code:     `<a href="/safe" target="_blank" rel="noreferrer"></a>;`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"linkComponents": []interface{}{"Link"}},
+		},
+		// Custom form component with `formAttribute` (NOT `linkAttribute`) —
+		// regression for a field-name mismatch that silently fell back to
+		// the default "action". Here the configured attribute `endpoint`
+		// carries the external URL so the form must be checked; with a
+		// secure rel it stays valid.
+		{
+			Code:    `<MyForm target="_blank" endpoint="https://example.com" rel="noopener noreferrer"></MyForm>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+			Settings: map[string]interface{}{
+				"formComponents": map[string]interface{}{"name": "MyForm", "formAttribute": "endpoint"},
+			},
+		},
+		// Custom component configured via `settings.linkComponents` with
+		// multiple link attributes — `linkAttribute: ['to', 'href']`. The
+		// rule scans both; here neither carries an external URL and href is
+		// absent, so the element is valid.
+		{
+			Code: `<MultiLink target="_blank" to="/internal" rel="noreferrer"></MultiLink>;`,
+			Tsx:  true,
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "MultiLink", "linkAttribute": []interface{}{"to", "href"}},
+			},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code:   `<a target="_blank" href="https://example.com/1"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="https://example.com/1" rel="noreferrer"></a>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noTargetBlankWithoutNoreferrer", Line: 1, Column: 1, EndLine: 1, EndColumn: 49},
+			},
+		},
+		{
+			Code:   `<a target="_blank" rel="" href="https://example.com/2"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="noreferrer" href="https://example.com/2"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" rel={0} href="https://example.com/3"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="noreferrer" href="https://example.com/3"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" rel={1} href="https://example.com/3"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="noreferrer" href="https://example.com/3"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" rel={false} href="https://example.com/4"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="noreferrer" href="https://example.com/4"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" rel={null} href="https://example.com/5"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="noreferrer" href="https://example.com/5"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" rel="noopenernoreferrer" href="https://example.com/6"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="noopener noreferrer" href="https://example.com/6"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" rel="no referrer" href="https://example.com/7"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" rel="no referrer noreferrer" href="https://example.com/7"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_BLANK" href="https://example.com/8"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_BLANK" href="https://example.com/8" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href="//example.com/9"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="//example.com/9" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href="//example.com/10" rel={true}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="//example.com/10" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href="//example.com/11" rel={3}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="//example.com/11" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href="//example.com/12" rel={null}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="//example.com/12" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		// Non-literal rel expression — no autofix (same as upstream: fix
+		// returns null, diagnostic still reports).
+		{
+			Code:   `<a target="_blank" href="//example.com/13" rel={getRel()}></a>;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href="//example.com/14" rel={"noopenernoreferrer"}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="//example.com/14" rel={"noopener noreferrer"}></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target={"_blank"} href={"//example.com/15"} rel={"noopenernoreferrer"}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target={"_blank"} href={"//example.com/15"} rel={"noopener noreferrer"}></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			// cspell:disable-next-line
+			Code:   `<a target={"_blank"} href={"//example.com/16"} rel={"noopenernoreferrernoreferrernoreferrernoreferrernoreferrer"}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target={"_blank"} href={"//example.com/16"} rel={"noopener noreferrer"}></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href="//example.com/17" rel></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="//example.com/17" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target="_blank" href={ dynamicLink }></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href={ dynamicLink } rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target={'_blank'} href="//example.com/18"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target={'_blank'} href="//example.com/18" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a target={"_blank"} href="//example.com/19"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target={"_blank"} href="//example.com/19" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		{
+			Code:    `<a href="https://example.com/20" target="_blank" rel></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a href="https://example.com/20" target="_blank" rel="noopener"></a>;`},
+			Options: map[string]interface{}{"allowReferrer": true},
+			Errors:  allowReferrerErrors,
+		},
+		{
+			Code:    `<a href="https://example.com/20" target="_blank"></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a href="https://example.com/20" target="_blank" rel="noopener"></a>;`},
+			Options: map[string]interface{}{"allowReferrer": true},
+			Errors:  allowReferrerErrors,
+		},
+		{
+			Code:    `<a target="_blank" href={ dynamicLink }></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a target="_blank" href={ dynamicLink } rel="noreferrer"></a>;`},
+			Options: map[string]interface{}{"enforceDynamicLinks": "always"},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a {...someObject}></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a {...someObject} target="_blank"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a href="foobar" {...someObject} target="_blank"></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a href="foobar" target="_blank" rel="noreferrer" {...someObject}></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a href="foobar" target="_blank" {...someObject}></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"enforceDynamicLinks": "always", "warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:     `<Link target="_blank" href={ dynamicLink }></Link>;`,
+			Tsx:      true,
+			Output:   []string{`<Link target="_blank" href={ dynamicLink } rel="noreferrer"></Link>;`},
+			Options:  map[string]interface{}{"enforceDynamicLinks": "always"},
+			Settings: map[string]interface{}{"linkComponents": []interface{}{"Link"}},
+			Errors:   defaultErrors,
+		},
+		{
+			Code:    `<Link target="_blank" to={ dynamicLink }></Link>;`,
+			Tsx:     true,
+			Output:  []string{`<Link target="_blank" to={ dynamicLink } rel="noreferrer"></Link>;`},
+			Options: map[string]interface{}{"enforceDynamicLinks": "always"},
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "Link", "linkAttribute": "to"},
+			},
+			Errors: defaultErrors,
+		},
+		{
+			Code:    `<a href="some-link" {...otherProps} target="some-non-blank-target"></a>;`,
+			Tsx:     true,
+			Errors:  defaultErrors,
+			Options: map[string]interface{}{"warnOnSpreadAttributes": true},
+		},
+		{
+			Code:    `<a href="some-link" target="some-non-blank-target" {...otherProps}></a>;`,
+			Tsx:     true,
+			Errors:  defaultErrors,
+			Options: map[string]interface{}{"warnOnSpreadAttributes": true},
+		},
+		{
+			Code:    `<a target="_blank" href="//example.com" rel></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a target="_blank" href="//example.com" rel="noreferrer"></a>;`},
+			Options: map[string]interface{}{"links": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a target="_blank" href="//example.com" rel></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a target="_blank" href="//example.com" rel="noreferrer"></a>;`},
+			Options: map[string]interface{}{"links": true, "forms": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<a target="_blank" href="//example.com" rel></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a target="_blank" href="//example.com" rel="noreferrer"></a>;`},
+			Options: map[string]interface{}{"links": true, "forms": false},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<form method="POST" action="https://example.com" target="_blank"></form>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<form method="POST" action="https://example.com" rel="" target="_blank"></form>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<form method="POST" action="https://example.com" rel="noopenernoreferrer" target="_blank"></form>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<form method="POST" action="https://example.com" rel="noopenernoreferrer" target="_blank"></form>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true, "links": false},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:   `<a href={href} target="_blank" rel={isExternal ? "undefined" : "undefined"} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a href={href} target="_blank" rel={isExternal ? "noopener" : undefined} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a href={href} target="_blank" rel={isExternal ? "undefined" : "noopener"} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a href={href} target={isExternal ? "_blank" : undefined} rel={isExternal ? undefined : "noopener noreferrer"} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a href={href} target="_blank" rel={isExternal ? 3 : "noopener noreferrer"} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:   `<a href={href} target="_blank" rel={isExternal ? "noopener noreferrer" : "3"} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		{
+			Code:    `<a href={href} target="_blank" rel={isExternal ? "noopener" : "2"} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowReferrer": true},
+			Errors:  allowReferrerErrors,
+		},
+		{
+			Code:    `<form action={action} target="_blank" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowReferrer": true, "forms": true},
+			Errors:  allowReferrerErrors,
+		},
+		{
+			Code:    `<form action={action} target="_blank" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+			Errors:  defaultErrors,
+		},
+		{
+			Code:    `<form action={action} {...spread} />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true, "warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+
+		// ---- Additional edge cases ----
+		// Multi-line attributes — the reported range still covers the full
+		// opening element across lines.
+		{
+			Code: "<a\n  target=\"_blank\"\n  href=\"https://example.com/ml\"\n></a>;",
+			Tsx:  true,
+			Output: []string{
+				"<a\n  target=\"_blank\"\n  href=\"https://example.com/ml\" rel=\"noreferrer\"\n></a>;",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noTargetBlankWithoutNoreferrer", Line: 1, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// Self-closing anchor form — same semantics as non-self-closing for
+		// the diagnostic; the reported range ends after the `/>`.
+		{
+			Code:   `<a target="_blank" href="https://example.com/sc" />;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="https://example.com/sc" rel="noreferrer" />;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noTargetBlankWithoutNoreferrer", Line: 1, Column: 1, EndLine: 1, EndColumn: 52},
+			},
+		},
+		// Regression: parens around the whole conditional target expression
+		// must not hide the `_blank` branch from detection. Before the
+		// SkipParentheses fix, this was a silent false-negative.
+		{
+			Code:   `<a href="https://example.com/paren" target={(isExternal ? "_blank" : undefined)}></a>;`,
+			Tsx:    true,
+			Output: []string{`<a href="https://example.com/paren" target={(isExternal ? "_blank" : undefined)} rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		// Regression: parens around a direct string literal inside the JSX
+		// expression container. Same failure mode as above.
+		{
+			Code:   `<a target={("_blank")} href="https://example.com/paren2"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target={("_blank")} href="https://example.com/paren2" rel="noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		// Regression: parens around the rel conditional — secure-rel
+		// extraction must unwrap parens on both target and rel to find the
+		// matched-test shortcut, otherwise the conditional was treated as
+		// non-literal and wrongly reported.
+		{
+			Code:   `<a href="https://example.com/relp" target="_blank" rel={(getRel())}></a>;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		// Case-insensitive rel token matching: the rule splits on whitespace
+		// and compares case-insensitively, so the single-word joined form
+		// "NOOPENERNOREFERRER" does NOT contain "noreferrer" as a token and
+		// is reported. Matches upstream.
+		{
+			Code:   `<a target="_blank" href="https://example.com/ci" rel="NOOPENERNOREFERRER"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="https://example.com/ci" rel="NOOPENERNOREFERRER noreferrer"></a>;`},
+			Errors: defaultErrors,
+		},
+		// Three-way conditional where the _blank branch is unguarded by the
+		// rel's matched test — we fall back to examining every rel branch
+		// and report when any branch is non-secure.
+		{
+			Code:   `<a href={href} target="_blank" rel={isExternal ? "noreferrer" : isInternal ? "noreferrer" : "nothing"} />;`,
+			Tsx:    true,
+			Errors: defaultErrors,
+		},
+		// Custom link component whose configured linkAttribute also happens
+		// to be set to an external URL — still reported.
+		{
+			Code:     `<Link target="_blank" to="https://example.com/link"></Link>;`,
+			Tsx:      true,
+			Output:   []string{`<Link target="_blank" to="https://example.com/link" rel="noreferrer"></Link>;`},
+			Options:  map[string]interface{}{"enforceDynamicLinks": "always"},
+			Settings: map[string]interface{}{"linkComponents": map[string]interface{}{"name": "Link", "linkAttribute": "to"}},
+			Errors:   defaultErrors,
+		},
+		// Two spreads, target/rel around them — spread position still
+		// matters: rel BEFORE a spread with warnOnSpread true is not trusted.
+		{
+			Code:    `<a {...a} target="_blank" rel="noreferrer" {...b}></a>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"warnOnSpreadAttributes": true},
+			Errors:  defaultErrors,
+		},
+		// Regression: custom form component using `formAttribute` with a
+		// dynamic URL — forms don't autofix; the report still fires.
+		{
+			Code:    `<MyForm target="_blank" endpoint={url}></MyForm>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"forms": true},
+			Settings: map[string]interface{}{
+				"formComponents": map[string]interface{}{"name": "MyForm", "formAttribute": "endpoint"},
+			},
+			Errors: defaultErrors,
+		},
+		// Message text assertion — locks in the exact diagnostic string for
+		// the default (noreferrer) message, matching upstream verbatim.
+		{
+			Code:   `<a target="_blank" href="https://example.com/msg"></a>;`,
+			Tsx:    true,
+			Output: []string{`<a target="_blank" href="https://example.com/msg" rel="noreferrer"></a>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noTargetBlankWithoutNoreferrer",
+					Message:   `Using target="_blank" without rel="noreferrer" (which implies rel="noopener") is a security risk in older browsers: see https://mathiasbynens.github.io/rel-noopener/#recommendations`,
+				},
+			},
+		},
+		// Message text assertion — locks in the exact diagnostic string for
+		// the allowReferrer (noopener) message.
+		{
+			Code:    `<a target="_blank" href="https://example.com/msg2"></a>;`,
+			Tsx:     true,
+			Output:  []string{`<a target="_blank" href="https://example.com/msg2" rel="noopener"></a>;`},
+			Options: map[string]interface{}{"allowReferrer": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noTargetBlankWithoutNoopener",
+					Message:   `Using target="_blank" without rel="noreferrer" or rel="noopener" (the former implies the latter and is preferred due to wider support) is a security risk: see https://mathiasbynens.github.io/rel-noopener/#recommendations`,
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -94,6 +94,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',
     './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts
@@ -1,0 +1,307 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-target-blank', {} as never, {
+  valid: [
+    { code: `<a href="foobar"></a>;` },
+    { code: `<a randomTag></a>;` },
+    { code: `<a target />;` },
+    {
+      code: `<a href="foobar" target="_blank" rel="noopener noreferrer"></a>;`,
+    },
+    { code: `<a href="foobar" target="_blank" rel="noreferrer"></a>;` },
+    {
+      code: `<a href="foobar" target="_blank" rel={"noopener noreferrer"}></a>;`,
+    },
+    { code: `<a href="foobar" target="_blank" rel={"noreferrer"}></a>;` },
+    {
+      code: `<a href={"foobar"} target={"_blank"} rel={"noopener noreferrer"}></a>;`,
+    },
+    { code: `<a href={"foobar"} target={"_blank"} rel={"noreferrer"}></a>;` },
+    {
+      code: `<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>;`,
+    },
+    { code: `<a target="_blank" {...spreadProps} rel="noreferrer"></a>;` },
+    {
+      code: `<a {...spreadProps} target="_blank" rel="noopener noreferrer" href="https://example.com">s</a>;`,
+    },
+    {
+      code: `<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>;`,
+    },
+    { code: `<a target="_blank" rel="noreferrer" {...spreadProps}></a>;` },
+    { code: `<p target="_blank"></p>;` },
+    {
+      code: `<a href="foobar" target="_BLANK" rel="NOOPENER noreferrer"></a>;`,
+    },
+    { code: `<a href="foobar" target="_BLANK" rel="NOREFERRER"></a>;` },
+    { code: `<a target="_blank" rel={relValue}></a>;` },
+    { code: `<a target={targetValue} rel="noopener noreferrer"></a>;` },
+    { code: `<a target={targetValue} rel="noreferrer"></a>;` },
+    { code: `<a target={targetValue} rel={"noopener noreferrer"}></a>;` },
+    { code: `<a target={targetValue} rel={"noreferrer"}></a>;` },
+    { code: `<a target={targetValue} href="relative/path"></a>;` },
+    { code: `<a target={targetValue} href="/absolute/path"></a>;` },
+    { code: `<a target={'targetValue'} href="/absolute/path"></a>;` },
+    { code: `<a target={"targetValue"} href="/absolute/path"></a>;` },
+    { code: `<a target={null} href="//example.com"></a>;` },
+    {
+      code: `<a {...someObject} href="/absolute/path"></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+    },
+    {
+      code: `<a {...someObject} rel="noreferrer"></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+    },
+    {
+      code: `<a {...someObject} rel="noreferrer" target="_blank"></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+    },
+    {
+      code: `<a {...someObject} href="foobar" target="_blank"></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+    },
+    {
+      code: `<a target="_blank" href={ dynamicLink }></a>;`,
+      options: [{ enforceDynamicLinks: 'never' }],
+    },
+    {
+      code: `<a target={"_blank"} href={ dynamicLink }></a>;`,
+      options: [{ enforceDynamicLinks: 'never' }],
+    },
+    {
+      code: `<a target={'_blank'} href={ dynamicLink }></a>;`,
+      options: [{ enforceDynamicLinks: 'never' }],
+    },
+    {
+      code: `<a href="foobar" target="_blank" rel="noopener"></a>;`,
+      options: [{ allowReferrer: true }],
+    },
+    {
+      code: `<a href="foobar" target="_blank" rel="noreferrer"></a>;`,
+      options: [{ allowReferrer: true }],
+    },
+    { code: `<a target={3} />;` },
+    {
+      code: `<a href="some-link" {...otherProps} target="some-non-blank-target"></a>;`,
+    },
+    {
+      code: `<a href="some-link" target="some-non-blank-target" {...otherProps}></a>;`,
+    },
+    {
+      code: `<a target="_blank" href="/absolute/path"></a>;`,
+      options: [{ forms: false }],
+    },
+    {
+      code: `<a target="_blank" href="/absolute/path"></a>;`,
+      options: [{ forms: false, links: true }],
+    },
+    { code: `<form action="https://example.com" target="_blank"></form>;` },
+    {
+      code: `<form action="https://example.com" target="_blank" rel="noopener noreferrer"></form>;`,
+      options: [{ forms: true }],
+    },
+    {
+      code: `<form action="https://example.com" target="_blank" rel="noopener noreferrer"></form>;`,
+      options: [{ forms: true, links: false }],
+    },
+    { code: `<a href target="_blank"/>;` },
+    {
+      code: `<a href={href} target={isExternal ? "_blank" : undefined} rel="noopener noreferrer" />;`,
+    },
+    {
+      code: `<a href={href} target={isExternal ? undefined : "_blank"} rel={isExternal ? "noreferrer" : "noopener noreferrer"} />;`,
+    },
+    {
+      code: `<a href={href} target="_blank" rel={isExternal ? "noreferrer" : "noopener"} />;`,
+      options: [{ allowReferrer: true }],
+    },
+    {
+      code: `<a href={href} target={isExternal ? "_blank" : undefined} rel={isExternal ? "noreferrer" : undefined} />;`,
+    },
+    {
+      code: `<a href={href} target={isSelf ? "_self" : "_blank"} rel={isSelf ? undefined : "noreferrer"} />;`,
+    },
+    {
+      code: `<form action={action} />;`,
+      options: [{ forms: true }],
+    },
+    {
+      code: `<form action={action} {...spread} />;`,
+      options: [{ forms: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: `<a target="_blank" href="https://example.com/1"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" rel="" href="https://example.com/2"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" rel={0} href="https://example.com/3"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" rel={false} href="https://example.com/4"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" rel={null} href="https://example.com/5"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" rel="noopenernoreferrer" href="https://example.com/6"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" rel="no referrer" href="https://example.com/7"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_BLANK" href="https://example.com/8"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href="//example.com/9"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href="//example.com/10" rel={true}></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href="//example.com/13" rel={getRel()}></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href="//example.com/14" rel={"noopenernoreferrer"}></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href="//example.com/17" rel></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href={ dynamicLink }></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target={'_blank'} href="//example.com/18"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target={"_blank"} href="//example.com/19"></a>;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href="https://example.com/20" target="_blank"></a>;`,
+      options: [{ allowReferrer: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoopener' }],
+    },
+    {
+      code: `<a target="_blank" href={ dynamicLink }></a>;`,
+      options: [{ enforceDynamicLinks: 'always' }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a {...someObject}></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a {...someObject} target="_blank"></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href="foobar" {...someObject} target="_blank"></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href="foobar" target="_blank" rel="noreferrer" {...someObject}></a>;`,
+      options: [
+        { enforceDynamicLinks: 'always', warnOnSpreadAttributes: true },
+      ],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href="some-link" {...otherProps} target="some-non-blank-target"></a>;`,
+      options: [{ warnOnSpreadAttributes: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a target="_blank" href="//example.com" rel></a>;`,
+      options: [{ links: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<form method="POST" action="https://example.com" target="_blank"></form>;`,
+      options: [{ forms: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<form method="POST" action="https://example.com" rel="" target="_blank"></form>;`,
+      options: [{ forms: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<form method="POST" action="https://example.com" rel="noopenernoreferrer" target="_blank"></form>;`,
+      options: [{ forms: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href={href} target="_blank" rel={isExternal ? "undefined" : "undefined"} />;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href={href} target="_blank" rel={isExternal ? "noopener" : undefined} />;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href={href} target="_blank" rel={isExternal ? 3 : "noopener noreferrer"} />;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href={href} target="_blank" rel={isExternal ? "noopener noreferrer" : "3"} />;`,
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<a href={href} target="_blank" rel={isExternal ? "noopener" : "2"} />;`,
+      options: [{ allowReferrer: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoopener' }],
+    },
+    {
+      code: `<form action={action} target="_blank" />;`,
+      options: [{ allowReferrer: true, forms: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoopener' }],
+    },
+    {
+      code: `<form action={action} target="_blank" />;`,
+      options: [{ forms: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+    {
+      code: `<form action={action} {...spread} />;`,
+      options: [{ forms: true, warnOnSpreadAttributes: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoreferrer' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -110,6 +110,9 @@ nodesep
 nolint
 nonconstructor
 nonoctal
+noopener
+noopenernoreferrer
+noreferrer
 noregabi
 notcool
 notunique
@@ -126,6 +129,7 @@ Prag
 Prettier
 propertyassignment
 Ptrs
+quasis
 quxx
 qwer
 rankdir
@@ -137,6 +141,7 @@ Readonlys
 realpath
 recurser
 reducable
+Referer
 relint
 relinting
 relints


### PR DESCRIPTION
## Summary

Port the [\`react/jsx-no-target-blank\`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) rule from \`eslint-plugin-react\` to rslint.

The rule disallows using \`target=\"_blank\"\` on anchor / link components (and, opt-in, form components) without a secure \`rel\` attribute. It covers static string attributes, JSX expression containers, conditional expressions (including the matched-test-condition shortcut across \`target\` / \`rel\`), spread attributes, custom link / form components configured via \`settings.linkComponents\` / \`settings.formComponents\`, and provides autofix for the link branch (forms never autofix, matching upstream).

## Related Links

- ESLint rule docs: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-target-blank.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/jsx-no-target-blank.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).