### PR TITLE
fix: api.go files filter handling

### DIFF
--- a/cmd/rslint/api.go
+++ b/cmd/rslint/api.go
@@ -62,14 +62,41 @@ func (h *IPCHandler) HandleLint(req api.LintRequest) (*api.LintResponse, error) 
 
 	// Create filesystem
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
-	allowedFiles := []string{}
+	var allowedFiles []string
+	seenAllowedFiles := make(map[string]struct{})
+
+	resolveRequestPath := func(filePath string) string {
+		if tspath.PathIsAbsolute(filePath) {
+			return tspath.NormalizePath(filePath)
+		}
+		return tspath.ResolvePath(currentDirectory, filePath)
+	}
+
+	addAllowedFile := func(filePath string) string {
+		normalizedPath := resolveRequestPath(filePath)
+		if _, exists := seenAllowedFiles[normalizedPath]; exists {
+			return normalizedPath
+		}
+		seenAllowedFiles[normalizedPath] = struct{}{}
+		allowedFiles = append(allowedFiles, normalizedPath)
+		return normalizedPath
+	}
+
+	if req.Files != nil {
+		allowedFiles = make([]string, 0, len(req.Files)+len(req.FileContents))
+		for _, filePath := range req.Files {
+			addAllowedFile(filePath)
+		}
+	}
 	// Apply file contents if provided
 	if len(req.FileContents) > 0 {
+		if allowedFiles == nil {
+			allowedFiles = make([]string, 0, len(req.FileContents))
+		}
 		fileContents := make(map[string]string, len(req.FileContents))
 		for k, v := range req.FileContents {
-			normalizePath := tspath.NormalizePath(k)
-			fileContents[normalizePath] = v
-			allowedFiles = append(allowedFiles, normalizePath)
+			normalizedPath := addAllowedFile(k)
+			fileContents[normalizedPath] = v
 		}
 		fs = utils.NewOverlayVFS(fs, fileContents)
 

--- a/cmd/rslint/api_test.go
+++ b/cmd/rslint/api_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	api "github.com/web-infra-dev/rslint/internal/api"
+)
+
+func preserveWorkingDirectory(t *testing.T) {
+	t.Helper()
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	// HandleLint mutates the process CWD when WorkingDirectory is set.
+	// Register testing's built-in cleanup to restore the original directory.
+	t.Chdir(oldWD)
+}
+
+func TestHandleLint_DefaultsToLintAllFiles(t *testing.T) {
+	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
+	if err != nil {
+		t.Fatalf("resolve fixtures dir: %v", err)
+	}
+	configPath := filepath.Join(fixturesDir, "rslint.json")
+
+	preserveWorkingDirectory(t)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           configPath,
+		WorkingDirectory: fixturesDir,
+		RuleOptions: map[string]interface{}{
+			"@typescript-eslint/no-unsafe-member-access": "error",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+
+	if response.FileCount <= 0 {
+		t.Fatalf("expected lint to process at least one file, got %d", response.FileCount)
+	}
+	if len(response.Diagnostics) == 0 {
+		t.Fatal("expected lint to report diagnostics when no explicit files filter is provided")
+	}
+}
+
+func TestHandleLint_ExplicitFilesRestrictsScope(t *testing.T) {
+	fixturesDir, err := filepath.Abs(filepath.Join("..", "..", "packages", "rslint", "fixtures"))
+	if err != nil {
+		t.Fatalf("resolve fixtures dir: %v", err)
+	}
+	configPath := filepath.Join(fixturesDir, "rslint.json")
+	targetFile := filepath.Join(fixturesDir, "src", "index.ts")
+
+	preserveWorkingDirectory(t)
+
+	handler := &IPCHandler{}
+	response, err := handler.HandleLint(api.LintRequest{
+		Config:           configPath,
+		Files:            []string{targetFile},
+		WorkingDirectory: fixturesDir,
+		RuleOptions: map[string]interface{}{
+			"@typescript-eslint/no-unsafe-member-access": "error",
+		},
+	})
+	if err != nil {
+		t.Fatalf("HandleLint returned error: %v", err)
+	}
+
+	if response.FileCount != 1 {
+		t.Fatalf("expected lint to process exactly one file, got %d", response.FileCount)
+	}
+	if len(response.Diagnostics) == 0 {
+		t.Fatal("expected lint to report diagnostics for the explicitly requested file")
+	}
+	for _, diagnostic := range response.Diagnostics {
+		if diagnostic.FilePath != "src/index.ts" {
+			t.Fatalf("expected diagnostics to be limited to src/index.ts, got %q", diagnostic.FilePath)
+		}
+	}
+}

--- a/packages/rslint/tests/__snapshots__/api.test.mjs.snap
+++ b/packages/rslint/tests/__snapshots__/api.test.mjs.snap
@@ -13,9 +13,90 @@ const y = x;",
 
 exports[`lint api > diag snapshot 1`] = `
 {
-  "diagnostics": [],
-  "errorCount": 0,
-  "fileCount": 0,
+  "diagnostics": [
+    {
+      "filePath": "src/close-test.ts",
+      "message": "Unsafe member access .prop on an \`any\` value.",
+      "messageId": "unsafeMemberExpression",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 3,
+        },
+        "start": {
+          "column": 11,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-member-access",
+    },
+    {
+      "filePath": "src/disable-file.ts",
+      "message": "Unsafe member access .someProperty on an \`any\` value.",
+      "messageId": "unsafeMemberExpression",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-member-access",
+    },
+    {
+      "filePath": "src/disable.ts",
+      "message": "Unsafe member access .someProperty on an \`any\` value.",
+      "messageId": "unsafeMemberExpression",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 5,
+        },
+        "start": {
+          "column": 19,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-member-access",
+    },
+    {
+      "filePath": "src/index.ts",
+      "message": "Unsafe member access .b on an \`any\` value.",
+      "messageId": "unsafeMemberExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 2,
+        },
+        "start": {
+          "column": 3,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-member-access",
+    },
+    {
+      "filePath": "src/index.ts",
+      "message": "Unsafe member access .c on an \`any\` value.",
+      "messageId": "unsafeMemberExpression",
+      "range": {
+        "end": {
+          "column": 4,
+          "line": 5,
+        },
+        "start": {
+          "column": 3,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unsafe-member-access",
+    },
+  ],
+  "errorCount": 5,
+  "fileCount": 8,
   "ruleCount": 1,
 }
 `;


### PR DESCRIPTION
## Summary
This change fixes the files filtering behavior in the IPC lint API.

In cmd/rslint/api.go (line 65), allowedFiles now defaults to nil instead of an empty slice. That matters because omitting files should mean “lint everything”, while an empty allow-list effectively filters out all files. The patch also normalizes and resolves paths from both files and fileContents against workingDirectory, then deduplicates them before passing them into the linter. That makes explicit file filtering and virtual-file overlays behave consistently for relative and absolute paths.

The branch also adds Go coverage in cmd/rslint/api_test.go (line 11) for the two key cases: linting all files when no files filter is provided, and restricting linting to a single requested file when files is set. Finally, the snapshot in packages/rslint/tests/snapshots/api.test.mjs.snap (line 13) was updated to reflect the corrected behavior: the API now returns real diagnostics for the fixture set instead of an empty result.
## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
