### PR TITLE
feat: port rule react/no-will-update-set-state

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -26,6 +26,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_will_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
@@ -63,6 +64,7 @@ func GetAllRules() []rule.Rule {
 		no_string_refs.NoStringRefsRule,
 		no_typos.NoTyposRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
+		no_will_update_set_state.NoWillUpdateSetStateRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		require_render_return.RequireRenderReturnRule,
 		self_closing_comp.SelfClosingCompRule,

--- a/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state.go
+++ b/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state.go
@@ -1,0 +1,175 @@
+package no_will_update_set_state
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// methodName is the single lifecycle hook this rule targets. Upstream's
+// makeNoMethodSetStateRule factory is parameterized; since
+// no-will-update-set-state always passes 'componentWillUpdate', we hardcode it.
+// Upstream additionally accepts the `UNSAFE_componentWillUpdate` alias once
+// `testReactVersion(ctx, '>= 16.3.0')` passes — see checkUnsafe below.
+const methodName = "componentWillUpdate"
+
+// unsafeMethodName is the React 16.3+ renamed alias. Upstream matches it via
+// `shouldCheckUnsafeCb` which is wired to `testReactVersion(ctx, '>= 16.3.0')`
+// in `no-will-update-set-state.js`.
+const unsafeMethodName = "UNSAFE_componentWillUpdate"
+
+// isStopper mirrors ESLint's ancestor.type check for containers whose `key`
+// can identify the target method: Property, MethodDefinition, ClassProperty,
+// PropertyDefinition. In tsgo these collapse into PropertyAssignment (object
+// `name: fn`), MethodDeclaration (class methods + object shorthand),
+// GetAccessor / SetAccessor / Constructor, and PropertyDeclaration (class
+// field). ShorthandPropertyAssignment is omitted — it has no function body,
+// so setState could never appear beneath it.
+//
+// Decomposed as `IsMethodOrAccessor || Kind in {Constructor, PropertyAssignment,
+// PropertyDeclaration}`: IsMethodOrAccessor covers MethodDeclaration /
+// GetAccessor / SetAccessor, and the remaining three are the non-function
+// key-bearing containers.
+func isStopper(node *ast.Node) bool {
+	if ast.IsMethodOrAccessor(node) {
+		return true
+	}
+	switch node.Kind {
+	case ast.KindConstructor,
+		ast.KindPropertyAssignment,
+		ast.KindPropertyDeclaration:
+		return true
+	}
+	return false
+}
+
+// esTreeNameOf returns the string an ESTree consumer would read from
+// `node.name` for an Identifier / PrivateIdentifier. PrivateIdentifier
+// strips the leading `#` per spec (tsgo retains it, so we trim). Any other
+// node kind — ComputedPropertyName, StringLiteral, NumericLiteral, etc. —
+// has no `.name` in ESTree and yields "". Callers that compare against a
+// known identifier string therefore get the correct "never equal" answer
+// without extra guards.
+//
+// Used in both contexts the rule cares about: the member-expression
+// property (`callee.property.name`) and the container key
+// (`ancestor.key.name`). Neither is a true "static property name" in the
+// wider sense — e.g. `this['setState']()` must NOT match (upstream:
+// `'name' in callee.property` is false), so reusing
+// `utils.GetStaticPropertyName` here would be incorrect (it resolves
+// string literals as static names).
+func esTreeNameOf(nameNode *ast.Node) string {
+	if nameNode == nil {
+		return ""
+	}
+	switch nameNode.Kind {
+	case ast.KindIdentifier:
+		return nameNode.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(nameNode.AsPrivateIdentifier().Text, "#")
+	}
+	return ""
+}
+
+// stopperName returns the ESTree-visible name of a stopper node's key.
+// See [esTreeNameOf] for the aliasing rationale.
+func stopperName(node *ast.Node) string {
+	return esTreeNameOf(node.Name())
+}
+
+func parseDisallowInFunc(options any) bool {
+	switch v := options.(type) {
+	case string:
+		return v == "disallow-in-func"
+	case []interface{}:
+		if len(v) > 0 {
+			if s, ok := v[0].(string); ok {
+				return s == "disallow-in-func"
+			}
+		}
+	}
+	return false
+}
+
+// shouldCheckUnsafe mirrors upstream's `testReactVersion(context, '>= 16.3.0')`
+// callback wired as `shouldCheckUnsafeCb`. When it returns true, upstream's
+// `nameMatches` also accepts `UNSAFE_componentWillUpdate`.
+//
+// Note: `no-will-update-set-state` is NOT in upstream's `methodNoopsAsOf` map,
+// so `shouldBeNoop` always returns false — the rule stays active regardless of
+// React version. The version check is used ONLY to decide whether to also
+// match the UNSAFE_ alias, not to disable the rule.
+func shouldCheckUnsafe(settings map[string]interface{}) bool {
+	return !reactutil.ReactVersionLessThan(settings, 16, 3, 0)
+}
+
+var NoWillUpdateSetStateRule = rule.Rule{
+	Name: "react/no-will-update-set-state",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		disallowInFunc := parseDisallowInFunc(options)
+		checkUnsafe := shouldCheckUnsafe(ctx.Settings)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				callee := ast.SkipParentheses(call.Expression)
+				if callee.Kind != ast.KindPropertyAccessExpression {
+					return
+				}
+				prop := callee.AsPropertyAccessExpression()
+				if ast.SkipParentheses(prop.Expression).Kind != ast.KindThisKeyword {
+					return
+				}
+				// Upstream: `'name' in callee.property && callee.property.name
+				// === 'setState'`. esTreeNameOf yields "" for shapes ESTree's
+				// `.name` lookup would miss (string/numeric/computed keys),
+				// so the equality check below correctly rejects them.
+				if esTreeNameOf(prop.Name()) != "setState" {
+					return
+				}
+
+				// Walk ancestors innermost-to-outermost, mirroring ESLint's
+				// `findLast(ancestors, cb)`. Depth counts function-like
+				// wrappers crossed before the first matching stopper; in
+				// default mode a match at depth > 1 is skipped (setState in a
+				// nested callback), while `disallow-in-func` reports at any
+				// depth.
+				//
+				// `ast.IsFunctionLikeDeclaration` returns true for
+				// FunctionDeclaration / FunctionExpression / ArrowFunction /
+				// MethodDeclaration / Constructor / GetAccessor / SetAccessor —
+				// exactly the set ESLint's /Function(Expression|Declaration)$/
+				// regex matches, extended to the method/accessor/constructor
+				// nodes that tsgo exposes directly (ESTree wraps those in a
+				// FunctionExpression child that the regex also matches).
+				// Excludes signature kinds (MethodSignature, CallSignature,
+				// etc.) and ClassStaticBlockDeclaration — none of which can
+				// host a runtime `this.setState()` under `componentWillUpdate`.
+				depth := 0
+				for p := node.Parent; p != nil; p = p.Parent {
+					if ast.IsFunctionLikeDeclaration(p) {
+						depth++
+					}
+					if !isStopper(p) {
+						continue
+					}
+					sn := stopperName(p)
+					// nameMatches: methodName, or (when checkUnsafe) the UNSAFE_ alias.
+					if sn != methodName && (!checkUnsafe || sn != unsafeMethodName) {
+						continue
+					}
+					if !disallowInFunc && depth > 1 {
+						continue
+					}
+					ctx.ReportNode(callee, rule.RuleMessage{
+						Id:          "noSetState",
+						Description: "Do not use setState in " + sn,
+					})
+					return
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state.md
+++ b/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state.md
@@ -1,0 +1,96 @@
+# no-will-update-set-state
+
+Disallow `this.setState` inside `componentWillUpdate`.
+
+Updating the state during a component update (before render) is a no-op — the
+update is already in flight, so calling `setState` here either triggers an
+infinite loop or is silently dropped.
+
+## Rule Details
+
+This rule flags any `this.setState` call whose enclosing class method, class
+field initializer, or object-literal property is keyed `componentWillUpdate`.
+When `settings.react.version` is `>= 16.3.0` (or unset — treated as latest),
+the rule additionally flags the same pattern keyed `UNSAFE_componentWillUpdate`,
+matching the renamed alias shipped in React 16.3.
+
+By default, calls inside a nested function (regular or arrow) are allowed —
+enable `disallow-in-func` to forbid them too.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  componentWillUpdate: function () {
+    this.setState({
+      name: this.props.name.toUpperCase(),
+    });
+  },
+});
+```
+
+```javascript
+class Hello extends React.Component {
+  componentWillUpdate() {
+    this.setState({
+      name: this.props.name.toUpperCase(),
+    });
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var Hello = createReactClass({
+  componentWillUpdate: function () {
+    someNonMemberFunction(arg);
+    this.someHandler = this.setState;
+  },
+});
+```
+
+```javascript
+var Hello = createReactClass({
+  componentWillUpdate: function () {
+    someClass.onSomeEvent(function (data) {
+      this.setState({
+        data: data,
+      });
+    });
+  },
+});
+```
+
+## Rule Options
+
+```json
+{ "react/no-will-update-set-state": ["error", "disallow-in-func"] }
+```
+
+With `disallow-in-func` set, the rule also flags `this.setState` calls inside
+nested functions:
+
+```javascript
+var Hello = createReactClass({
+  componentWillUpdate: function () {
+    someClass.onSomeEvent(function (data) {
+      this.setState({
+        data: data,
+      });
+    });
+  },
+});
+```
+
+## React Version
+
+Unlike `no-did-update-set-state` / `no-did-mount-set-state`, this rule is not a
+no-op at any React version — `componentWillUpdate` is unsafe on every release.
+The React version only controls whether `UNSAFE_componentWillUpdate` (the 16.3+
+renamed alias) is also flagged, matching `eslint-plugin-react`'s
+`shouldCheckUnsafeCb`.
+
+## Original Documentation
+
+- [eslint-plugin-react / no-will-update-set-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md)

--- a/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state_test.go
+++ b/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state_test.go
@@ -1,0 +1,825 @@
+package no_will_update_set_state
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoWillUpdateSetStateRule(t *testing.T) {
+	react162 := map[string]interface{}{"react": map[string]interface{}{"version": "16.2.0"}}
+	react163 := map[string]interface{}{"react": map[string]interface{}{"version": "16.3.0"}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoWillUpdateSetStateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: createReactClass render only, no componentWillUpdate ----
+		{Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: empty componentWillUpdate body ----
+		{Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {}
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: componentWillUpdate with non-member call and property assignment ----
+		{Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someHandler = this.setState;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState inside a nested regular function (default mode) ----
+		{Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState inside a nested named function declaration (default mode) ----
+		{Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            function handleEvent(data) {
+              this.setState({
+                data: data
+              });
+            }
+            someClass.onSomeEvent(handleEvent)
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: UNSAFE_componentWillUpdate is NOT matched when react < 16.3.0 ----
+		{Code: `
+        class Hello extends React.Component {
+          UNSAFE_componentWillUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `, Tsx: true, Settings: react162},
+
+		// ---- Default-mode: setState inside nested arrow (depth > 1) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setState receiver is not `this` ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            other.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: method name mismatch (componentDidUpdate, not componentWillUpdate) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentDidUpdate() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: computed key `[`componentWillUpdate`]()` — non-Identifier key never matches ----
+		{Code: "\n        class Hello extends React.Component {\n          [`componentWillUpdate`]() {\n            this.setState({});\n          }\n        }\n      ", Tsx: true},
+
+		// ---- Edge: string-literal key in object literal — non-Identifier key never matches ----
+		{Code: `
+        var Hello = createReactClass({
+          "componentWillUpdate": function() {
+            this.setState({});
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: bracketed setState access ('name' in property guard) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this['setState']({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: top-level call outside any method/class/object ----
+		{Code: `this.setState({});`, Tsx: true},
+
+		// ---- Edge: setState in a sibling render() stays untouched — rule is method-scoped ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {}
+          render() {
+            this.setState({});
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setState inside JSX callback within componentWillUpdate — default mode allows (depth > 1) ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            return <button onClick={() => this.setState({})}/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: TS non-null / as expressions break the ThisKeyword match, so no report ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            (this as any).setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: aliased setState via destructuring — receiver is not a MemberExpression ----
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            const { setState } = this;
+            setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: outer componentWillUpdate, setState inside an inner class's constructor (default mode) ----
+		// Walk: Constructor (depth 1, stopper name="constructor" — no match), ClassDeclaration,
+		// outer MethodDeclaration (depth 2, stopper match — skipped because depth > 1).
+		{Code: `
+        class Outer extends React.Component {
+          componentWillUpdate() {
+            class Inner { constructor() { this.setState({}); } }
+            new Inner();
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: UNSAFE_ alias NOT matched when version explicitly pinned below 16.3.0 ----
+		// Upstream's `shouldCheckUnsafeCb` returns false for < 16.3.0.
+		{Code: `
+        var Hello = createReactClass({
+          UNSAFE_componentWillUpdate: function() {
+            this.setState({});
+          }
+        });
+      `, Tsx: true, Settings: react162},
+
+		// ---- Edge: TS non-null assertion `this!.setState()` breaks ThisKeyword match ----
+		// The NonNullExpression wraps `this`, not a ParenthesizedExpression, so
+		// SkipParentheses leaves it intact. Matches upstream (TSNonNullExpression
+		// is not a ThisExpression).
+		{Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this!.setState({});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: UNSAFE_ alias NOT matched even under default mode when
+		// called from a non-matching sibling method ----
+		{Code: `
+        class Hello extends React.Component {
+          someOtherMethod() {
+            this.setState({});
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream #1: createReactClass componentWillUpdate → setState ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in componentWillUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Upstream #2: ES6 class method componentWillUpdate → setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in componentWillUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Upstream #3: disallow-in-func + createReactClass (direct call) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #4: disallow-in-func + ES6 class (direct call) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream #5: disallow-in-func + setState in nested function (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #6: disallow-in-func + setState in nested function (ES6 class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({
+                data: data
+              });
+            })
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #7: setState inside if-block (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            if (true) {
+              this.setState({
+                data: data
+              });
+            }
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #8: setState inside if-block (ES6 class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            if (true) {
+              this.setState({
+                data: data
+              });
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream #9: disallow-in-func + arrow callback (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 45},
+			},
+		},
+
+		// ---- Upstream #10: disallow-in-func + arrow callback (ES6 class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent((data) => this.setState({data: data}));
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 45},
+			},
+		},
+
+		// ---- Upstream #11: UNSAFE_componentWillUpdate matched when react >= 16.3.0 (class) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          UNSAFE_componentWillUpdate() {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: react163,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in UNSAFE_componentWillUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Upstream #12: UNSAFE_componentWillUpdate matched when react >= 16.3.0 (createReactClass) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          UNSAFE_componentWillUpdate: function() {
+            this.setState({
+              data: data
+            });
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: react163,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in UNSAFE_componentWillUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Edge: parenthesized `(this).setState(...)` receiver ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            (this).setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-chain on `this` — `this?.setState()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this?.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: optional-call `this.setState?.()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.setState?.({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: object-literal shorthand method (tsgo: MethodDeclaration with no PropertyAssignment wrapper) ----
+		{
+			Code: `
+        var Hello = {
+          componentWillUpdate() {
+            this.setState({});
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class field with arrow initializer ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate = () => {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: class field with function expression initializer ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate = function() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setState under explicit React version < 16.3 — rule active, UNSAFE_ NOT matched ----
+		// This case targets the non-UNSAFE name, so it fires regardless of version.
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: react162,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: multiple setState calls in same componentWillUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.setState({});
+            if (x) { this.setState({}); }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+				{MessageId: "noSetState", Line: 5, Column: 22},
+			},
+		},
+
+		// ---- Edge: async componentWillUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          async componentWillUpdate() {
+            await Promise.resolve();
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 13},
+			},
+		},
+
+		// ---- Edge: generator componentWillUpdate ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          *componentWillUpdate() {
+            yield this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: class expression (not ClassDeclaration) ----
+		{
+			Code: `
+        const Hello = class extends React.Component {
+          componentWillUpdate() {
+            this.setState({});
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: arrow-function value in object literal (createReactClass-style) ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          componentWillUpdate: () => {
+            this.setState({});
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: JSX callback + disallow-in-func (symmetric pair to the default-mode valid case above) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            return <button onClick={() => this.setState({})}/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 43},
+			},
+		},
+
+		// ---- Edge: nested class whose inner method is also componentWillUpdate — inner takes precedence ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          componentWillUpdate() {
+            class Inner extends React.Component {
+              componentWillUpdate() {
+                this.setState({});
+              }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Edge: disallow-in-func — setState inside a nested arrow inside a nested function ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent(function() {
+              Promise.resolve().then(() => this.setState({}));
+            });
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 5, Column: 44},
+			},
+		},
+
+		// ---- Edge: getter named `componentWillUpdate` — stopper via IsMethodOrAccessor, depth 1 from the getter itself ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          get componentWillUpdate() {
+            this.setState({});
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier stopper `#componentWillUpdate` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          #componentWillUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier callee `this.#setState()` ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.#setState({});
+          }
+          #setState(_x: unknown) {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: static componentWillUpdate (upstream doesn't discriminate static) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          static componentWillUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: setter named `componentWillUpdate` — stopper via IsMethodOrAccessor ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          set componentWillUpdate(v: unknown) {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noSetState", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: UNSAFE_ alias as object-literal shorthand method (default version) ----
+		{
+			Code: `
+        var Hello = {
+          UNSAFE_componentWillUpdate() {
+            this.setState({});
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in UNSAFE_componentWillUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+
+		// ---- Edge: UNSAFE_ nested inside componentWillUpdate — innermost stopper wins ----
+		// Walk: inner MethodDeclaration UNSAFE_componentWillUpdate (depth 1, stopper match)
+		// → reported against the inner alias, not the outer name.
+		{
+			Code: `
+        class Outer extends React.Component {
+          componentWillUpdate() {
+            class Inner extends React.Component {
+              UNSAFE_componentWillUpdate() {
+                this.setState({});
+              }
+            }
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in UNSAFE_componentWillUpdate",
+					Line:      6, Column: 17,
+				},
+			},
+		},
+
+		// ---- Edge: React version absent (defaults to 999.999.999 ≥ 16.3.0) — UNSAFE_ alias IS matched ----
+		// Upstream's `testReactVersion` treats missing version as latest, so the
+		// UNSAFE_ callback returns true and the alias fires.
+		{
+			Code: `
+        class Hello extends React.Component {
+          UNSAFE_componentWillUpdate() {
+            this.setState({});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in UNSAFE_componentWillUpdate",
+					Line:      4, Column: 13,
+				},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state_test.go
+++ b/internal/plugins/react/rules/no_will_update_set_state/no_will_update_set_state_test.go
@@ -662,6 +662,35 @@ func TestNoWillUpdateSetStateRule(t *testing.T) {
 			},
 		},
 
+		// ---- Regression: disallow-in-func — setState in inner class's non-matching
+		// method must still report at OUTER componentWillUpdate ----
+		// Upstream's findLast returns false on a non-matching stopper (`render`)
+		// and keeps walking outward; reaches `componentWillUpdate` with depth=2,
+		// disallow-in-func bypasses the depth>1 gate, and reports on the outer
+		// method. Locks in the `continue`-past-non-matching-stopper behavior so
+		// a future "just return on first stopper" refactor can't silently flip it.
+		{
+			Code: `
+        class Outer extends React.Component {
+          componentWillUpdate() {
+            class Inner {
+              render() { this.setState({}); }
+            }
+            new Inner();
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []interface{}{"disallow-in-func"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noSetState",
+					Message:   "Do not use setState in componentWillUpdate",
+					Line:      5, Column: 26,
+				},
+			},
+		},
+
 		// ---- Edge: disallow-in-func — setState inside a nested arrow inside a nested function ----
 		{
 			Code: `

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -108,6 +108,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
+    './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts
@@ -1,0 +1,127 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-will-update-set-state', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {}
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            someNonMemberFunction(arg);
+            this.someHandler = this.setState;
+          }
+        });
+      `,
+    },
+    // ---- Default mode allows setState in nested callbacks ----
+    {
+      code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({ data: data });
+            });
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent((data) => this.setState({ data: data }));
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        var Hello = createReactClass({
+          componentWillUpdate: function() {
+            this.setState({ data: data });
+          }
+        });
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            this.setState({ data: data });
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- disallow-in-func flags setState in nested callbacks ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent(function(data) {
+              this.setState({ data: data });
+            });
+          }
+        }
+      `,
+      options: ['disallow-in-func'],
+      errors: [{ messageId: 'noSetState' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            someClass.onSomeEvent((data) => this.setState({ data: data }));
+          }
+        }
+      `,
+      options: ['disallow-in-func'],
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- setState inside if-block ----
+    {
+      code: `
+        class Hello extends React.Component {
+          componentWillUpdate() {
+            if (true) {
+              this.setState({ data: data });
+            }
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+    // ---- UNSAFE_ alias flagged when react version unset (defaults to latest) ----
+    {
+      code: `
+        class Hello extends React.Component {
+          UNSAFE_componentWillUpdate() {
+            this.setState({ data: data });
+          }
+        }
+      `,
+      errors: [{ messageId: 'noSetState' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-will-update-set-state` rule from `eslint-plugin-react` to rslint.

The rule disallows `this.setState` inside `componentWillUpdate`. When `settings.react.version >= 16.3.0` (including the default "unset = latest"), it additionally flags the `UNSAFE_componentWillUpdate` alias — mirroring upstream's `shouldCheckUnsafeCb`. Unlike its `componentDidUpdate` / `componentDidMount` siblings, this rule is **not** gated to be a no-op at any React version (it is not in upstream's \`methodNoopsAsOf\` map).

Supports the single `disallow-in-func` option: when enabled, also flags \`this.setState\` calls inside functions nested within the lifecycle method.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-will-update-set-state.js
- Shared factory: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/util/makeNoMethodSetStateRule.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).