### PR TITLE
feat: port rule react/no-danger-with-children

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -20,6 +20,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger_with_children"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_did_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
@@ -57,6 +58,7 @@ func GetAllRules() []rule.Rule {
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
+		no_danger_with_children.NoDangerWithChildrenRule,
 		no_did_update_set_state.NoDidUpdateSetStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,

--- a/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.go
+++ b/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.go
@@ -1,0 +1,261 @@
+package no_danger_with_children
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// isCreateElementCallee reports whether a CallExpression callee is
+// `<anything>.createElement` — mirroring upstream's check:
+//
+//	node.callee.type === 'MemberExpression'
+//	  && 'name' in node.callee.property
+//	  && node.callee.property.name === 'createElement'
+//
+// Upstream deliberately does NOT restrict the object to `React` or the
+// configured pragma; any `x.createElement(...)` is inspected. We therefore
+// do NOT reuse `reactutil.IsCreateElementCall`, which enforces a pragma
+// match. Computed access (`x['createElement']`, modeled as
+// ElementAccessExpression) is excluded because upstream's
+// `'name' in property` guard skips computed keys.
+func isCreateElementCallee(callee *ast.Node) bool {
+	if callee == nil {
+		return false
+	}
+	callee = ast.SkipParentheses(callee)
+	if callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	name := callee.AsPropertyAccessExpression().Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return false
+	}
+	return name.AsIdentifier().Text == "createElement"
+}
+
+const dangerWithChildrenMessage = "Only set one of `children` or `props.dangerouslySetInnerHTML`"
+
+var NoDangerWithChildrenRule = rule.Rule{
+	Name: "react/no-danger-with-children",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// resolveObjectLiteralInit walks an Identifier back to its
+		// VariableDeclaration via the TypeChecker and returns the initializer
+		// when it is an object literal. Mirrors upstream's
+		// `variable.defs[0].node.init` lookup. Parentheses are transparent
+		// on the initializer (tsgo preserves them; ESTree flattens them).
+		resolveObjectLiteralInit := func(ident *ast.Node) *ast.ObjectLiteralExpression {
+			if ident == nil || ident.Kind != ast.KindIdentifier {
+				return nil
+			}
+			decl := utils.GetDeclaration(ctx.TypeChecker, ident)
+			if decl == nil || decl.Kind != ast.KindVariableDeclaration {
+				return nil
+			}
+			init := decl.AsVariableDeclaration().Initializer
+			if init == nil {
+				return nil
+			}
+			init = ast.SkipParentheses(init)
+			if init.Kind != ast.KindObjectLiteralExpression {
+				return nil
+			}
+			return init.AsObjectLiteralExpression()
+		}
+
+		// findObjectPropByName reports whether the object literal has a
+		// property with the given name — either directly (Identifier key, to
+		// match upstream's `prop.key.name === propName`) or via a spread whose
+		// initializer resolves to another object literal.
+		//
+		// `seen` tracks Identifier names already followed through a spread,
+		// so self-referencing initializers like `const props = { ...props }`
+		// terminate instead of looping.
+		//
+		// Upstream intentionally matches ONLY Identifier keys — a
+		// StringLiteral key (`"children": "x"`) has `.value` but no `.name`,
+		// so upstream's `prop.key.name === propName` is always false on it.
+		// We keep parity by not using `utils.GetStaticPropertyName` here.
+		var findObjectPropByName func(obj *ast.ObjectLiteralExpression, name string, seen map[string]bool) bool
+		findObjectPropByName = func(obj *ast.ObjectLiteralExpression, name string, seen map[string]bool) bool {
+			if obj == nil || obj.Properties == nil {
+				return false
+			}
+			for _, prop := range obj.Properties.Nodes {
+				switch prop.Kind {
+				case ast.KindPropertyAssignment:
+					keyNode := prop.AsPropertyAssignment().Name()
+					if keyNode != nil && keyNode.Kind == ast.KindIdentifier &&
+						keyNode.AsIdentifier().Text == name {
+						return true
+					}
+				case ast.KindShorthandPropertyAssignment:
+					keyNode := prop.AsShorthandPropertyAssignment().Name()
+					if keyNode != nil && keyNode.Kind == ast.KindIdentifier &&
+						keyNode.AsIdentifier().Text == name {
+						return true
+					}
+				case ast.KindSpreadAssignment:
+					expr := ast.SkipParentheses(prop.AsSpreadAssignment().Expression)
+					if expr.Kind != ast.KindIdentifier {
+						continue
+					}
+					spreadName := expr.AsIdentifier().Text
+					if seen[spreadName] {
+						continue
+					}
+					inner := resolveObjectLiteralInit(expr)
+					if inner == nil {
+						continue
+					}
+					nextSeen := make(map[string]bool, len(seen)+1)
+					for k, v := range seen {
+						nextSeen[k] = v
+					}
+					nextSeen[spreadName] = true
+					if findObjectPropByName(inner, name, nextSeen) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		// asPropsObject returns the ObjectLiteralExpression to inspect for a
+		// given props node, together with a `seen` set pre-populated with the
+		// identifier name (if any) that was just resolved. Callers should use
+		// the returned `seen` for their first recursive lookup so a
+		// self-referencing initializer (`const props = { ...props, ... }`)
+		// terminates on the first recursion.
+		asPropsObject := func(node *ast.Node) (*ast.ObjectLiteralExpression, map[string]bool) {
+			node = ast.SkipParentheses(node)
+			if node.Kind == ast.KindObjectLiteralExpression {
+				return node.AsObjectLiteralExpression(), map[string]bool{}
+			}
+			if node.Kind == ast.KindIdentifier {
+				if obj := resolveObjectLiteralInit(node); obj != nil {
+					return obj, map[string]bool{node.AsIdentifier().Text: true}
+				}
+			}
+			return nil, nil
+		}
+
+		// findJsxAttr reports whether a JSX opening / self-closing element
+		// carries an attribute with the given name, either as a plain
+		// JsxAttribute (Identifier name) or via a JsxSpreadAttribute whose
+		// *Identifier* argument resolves to an object literal containing that
+		// name (transitively through further spreads).
+		//
+		// NOTE: Upstream's `findSpreadVariable` reads `attribute.argument.name`,
+		// which only exists when the argument is an Identifier. Inline object
+		// spreads (`{...{ ... }}`) are therefore opaque to upstream — we keep
+		// parity here by requiring Identifier too, rather than inspecting the
+		// inline object directly.
+		findJsxAttr := func(element *ast.Node, name string) bool {
+			for _, attr := range reactutil.GetJsxElementAttributes(element) {
+				switch attr.Kind {
+				case ast.KindJsxAttribute:
+					nameNode := attr.AsJsxAttribute().Name()
+					if nameNode != nil && nameNode.Kind == ast.KindIdentifier &&
+						nameNode.AsIdentifier().Text == name {
+						return true
+					}
+				case ast.KindJsxSpreadAttribute:
+					expr := ast.SkipParentheses(attr.AsJsxSpreadAttribute().Expression)
+					if expr.Kind != ast.KindIdentifier {
+						continue
+					}
+					inner := resolveObjectLiteralInit(expr)
+					if inner == nil {
+						continue
+					}
+					seen := map[string]bool{expr.AsIdentifier().Text: true}
+					if findObjectPropByName(inner, name, seen) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		// isLineBreak mirrors ESLint's isLineBreak helper: a JsxText that
+		// spans more than one line AND contains only whitespace. A single-line
+		// whitespace JsxText (e.g. `<div> </div>`) counts as meaningful
+		// children and is NOT a line break — matches upstream.
+		isLineBreak := func(child *ast.Node) bool {
+			if child == nil || child.Kind != ast.KindJsxText {
+				return false
+			}
+			text := child.AsJsxText().Text
+			if strings.TrimSpace(text) != "" {
+				return false
+			}
+			return strings.Contains(text, "\n")
+		}
+
+		// checkJsx is shared between JsxElement and JsxSelfClosingElement.
+		// elementForAttrs carries the attributes (opening element or the
+		// self-closing element itself); reportNode is the node the diagnostic
+		// is attached to (the full JsxElement / JsxSelfClosingElement).
+		checkJsx := func(elementForAttrs, reportNode *ast.Node, firstChild *ast.Node) {
+			hasChildren := false
+			if firstChild != nil && !isLineBreak(firstChild) {
+				hasChildren = true
+			} else if findJsxAttr(elementForAttrs, "children") {
+				hasChildren = true
+			}
+			if !hasChildren {
+				return
+			}
+			if findJsxAttr(elementForAttrs, "dangerouslySetInnerHTML") {
+				ctx.ReportNode(reportNode, rule.RuleMessage{
+					Id:          "dangerWithChildren",
+					Description: dangerWithChildrenMessage,
+				})
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindJsxElement: func(node *ast.Node) {
+				jsx := node.AsJsxElement()
+				var firstChild *ast.Node
+				if jsx.Children != nil && len(jsx.Children.Nodes) > 0 {
+					firstChild = jsx.Children.Nodes[0]
+				}
+				checkJsx(jsx.OpeningElement, node, firstChild)
+			},
+			ast.KindJsxSelfClosingElement: func(node *ast.Node) {
+				checkJsx(node, node, nil)
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !isCreateElementCallee(call.Expression) {
+					return
+				}
+				if call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+					return
+				}
+				obj, seen := asPropsObject(call.Arguments.Nodes[1])
+				if obj == nil {
+					return
+				}
+				if !findObjectPropByName(obj, "dangerouslySetInnerHTML", seen) {
+					return
+				}
+				hasChildren := len(call.Arguments.Nodes) > 2
+				if !hasChildren {
+					hasChildren = findObjectPropByName(obj, "children", seen)
+				}
+				if hasChildren {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "dangerWithChildren",
+						Description: dangerWithChildrenMessage,
+					})
+				}
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.md
+++ b/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.md
@@ -1,0 +1,46 @@
+# no-danger-with-children
+
+Disallow when a DOM element is using both `children` and `dangerouslySetInnerHTML`.
+
+## Rule Details
+
+This rule helps prevent problems caused by using `children` and
+`dangerouslySetInnerHTML` at the same time. React will throw a warning if this
+rule is ignored.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+<div dangerouslySetInnerHTML={{ __html: "HTML" }}>Children</div>;
+
+<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>Children</Hello>;
+
+<div dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />;
+
+React.createElement(
+  "div",
+  { dangerouslySetInnerHTML: { __html: "HTML" } },
+  "Children"
+);
+
+React.createElement("div", {
+  dangerouslySetInnerHTML: { __html: "HTML" },
+  children: "Children",
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+<div>Children</div>;
+
+<div dangerouslySetInnerHTML={{ __html: "HTML" }} />;
+
+React.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } });
+
+React.createElement("div", {}, "Children");
+```
+
+## Original Documentation
+
+- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md

--- a/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children_test.go
+++ b/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children_test.go
@@ -1,0 +1,424 @@
+package no_danger_with_children
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoDangerWithChildrenRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDangerWithChildrenRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<div>Children</div>;`, Tsx: true},
+		{Code: `const props: any = {}; <div {...props} />;`, Tsx: true},
+		{Code: `<div dangerouslySetInnerHTML={{ __html: "HTML" }} />;`, Tsx: true},
+		{Code: `<div children="Children" />;`, Tsx: true},
+		{
+			Code: `
+				const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+				const x = <div {...props} />;
+			`,
+			Tsx: true,
+		},
+		{
+			Code: `
+				const moreProps = { className: "eslint" };
+				const props = { children: "Children", ...moreProps };
+				const x = <div {...props} />;
+			`,
+			Tsx: true,
+		},
+		{
+			Code: `
+				const otherProps = { children: "Children" };
+				const { a, b, ...props } = otherProps as any;
+				const x = <div {...props} />;
+			`,
+			Tsx: true,
+		},
+		{Code: `<Hello>Children</Hello>;`, Tsx: true},
+		{Code: `<Hello dangerouslySetInnerHTML={{ __html: "HTML" }} />;`, Tsx: true},
+		{
+			Code: `
+				<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>
+				</Hello>;
+			`,
+			Tsx: true,
+		},
+		{Code: `React.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } });`, Tsx: true},
+		{Code: `React.createElement("div", {}, "Children");`, Tsx: true},
+		{Code: `React.createElement("Hello", { dangerouslySetInnerHTML: { __html: "HTML" } });`, Tsx: true},
+		{Code: `React.createElement("Hello", {}, "Children");`, Tsx: true},
+		{Code: `<Hello {...undefined}>Children</Hello>;`, Tsx: true},
+		{Code: `React.createElement("Hello", undefined, "Children");`, Tsx: true},
+		{
+			Code: `
+				declare const shallow: any;
+				declare const TaskEditableTitle: any;
+				const props = { ...props, scratch: { mode: 'edit' } } as any;
+				const component = shallow(<TaskEditableTitle {...props} />);
+			`,
+			Tsx: true,
+		},
+
+		// ---- Additional edge cases ----
+		// Empty element, no props, no children.
+		{Code: `<div />;`, Tsx: true},
+		// Whitespace-only multi-line children with only dangerouslySetInnerHTML — not reported
+		// because upstream treats a newline-only first child as a line break.
+		{
+			Code: `
+				<div dangerouslySetInnerHTML={{ __html: "HTML" }}>
+				</div>;
+			`,
+			Tsx: true,
+		},
+		// dangerouslySetInnerHTML is case-sensitive (lowercase h doesn't trigger).
+		{Code: `<div dangerouslySetInnerHtml={{ __html: "HTML" }}>Children</div>;`, Tsx: true},
+		// Bare createElement (destructured import) — upstream only inspects
+		// `x.createElement(...)` member calls, so the bare form is not checked.
+		{Code: `createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`, Tsx: true},
+		// Computed createElement access — upstream's `'name' in property`
+		// guard skips computed keys, so `x["createElement"](...)` is ignored.
+		{Code: `React["createElement"]("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`, Tsx: true},
+		// Call with fewer than 2 args.
+		{Code: `React.createElement("div");`, Tsx: true},
+		// Children-only prop, no dangerous — valid.
+		{Code: `<div children="x">also</div>;`, Tsx: true},
+		// Empty JSX text between tags (only whitespace on same line) counts as empty.
+		{
+			Code: `
+				<div dangerouslySetInnerHTML={{ __html: "HTML" }}>
+
+				</div>;
+			`,
+			Tsx: true,
+		},
+		// String-literal key (`"children": "x"`) matches neither upstream's
+		// `prop.key.name === propName` nor our Identifier-only check — so a
+		// spread of an object that carries a string-literal children key
+		// is NOT treated as children. Locks parity with upstream.
+		{
+			Code: `
+				const props = { "children": "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+				const x = <div {...props} />;
+			`,
+			Tsx: true,
+		},
+		// Inline object spread (`{...{...}}`) isn't followed by upstream
+		// (upstream checks `attribute.argument.name`, which only exists on
+		// Identifier arguments). We intentionally keep parity — treated as
+		// opaque, so nothing fires.
+		{
+			Code: `<div {...{ dangerouslySetInnerHTML: { __html: "HTML" }, children: "x" }} />;`,
+			Tsx:  true,
+		},
+		// Self-closing JSX with dangerouslySetInnerHTML alone and no children attribute.
+		{Code: `<Foo dangerouslySetInnerHTML={{ __html: "HTML" }} />;`, Tsx: true},
+		// createElement with props as a parenthesized object literal — the
+		// paren wrapper must be transparent.
+		{Code: `React.createElement("div", ({ dangerouslySetInnerHTML: { __html: "HTML" } }));`, Tsx: true},
+		// createElement where the 2nd arg is an Identifier that does NOT
+		// resolve to an object literal (e.g. declared but never initialized).
+		{
+			Code: `
+				let props: any;
+				React.createElement("div", props, "Children");
+			`,
+			Tsx: true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		{
+			Code: `
+				<div dangerouslySetInnerHTML={{ __html: "HTML" }}>
+					Children
+				</div>;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerWithChildren",
+					Message:   "Only set one of `children` or `props.dangerouslySetInnerHTML`",
+					Line:      2,
+					Column:    5,
+				},
+			},
+		},
+		{
+			Code: `<div dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `
+				const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+				const x = <div {...props}>Children</div>;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+		{
+			Code: `
+				const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+				const x = <div {...props} />;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+		{
+			Code: `
+				<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>
+					Children
+				</Hello>;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 2, Column: 5},
+			},
+		},
+		{
+			Code: `<Hello dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}> </Hello>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 1, Column: 1},
+			},
+		},
+		{
+			Code: `
+				React.createElement(
+					"div",
+					{ dangerouslySetInnerHTML: { __html: "HTML" } },
+					"Children"
+				);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 2},
+			},
+		},
+		{
+			Code: `
+				React.createElement(
+					"div",
+					{
+						dangerouslySetInnerHTML: { __html: "HTML" },
+						children: "Children",
+					}
+				);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 2},
+			},
+		},
+		{
+			Code: `
+				React.createElement(
+					"Hello",
+					{ dangerouslySetInnerHTML: { __html: "HTML" } },
+					"Children"
+				);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 2},
+			},
+		},
+		{
+			Code: `
+				React.createElement(
+					"Hello",
+					{
+						dangerouslySetInnerHTML: { __html: "HTML" },
+						children: "Children",
+					}
+				);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 2},
+			},
+		},
+		{
+			Code: `
+				const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+				React.createElement("div", props, "Children");
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+		{
+			Code: `
+				const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+				React.createElement("div", props);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+		{
+			Code: `
+				const moreProps = { children: "Children" };
+				const otherProps = { ...moreProps };
+				const props = { ...otherProps, dangerouslySetInnerHTML: { __html: "HTML" } };
+				React.createElement("div", props);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 5},
+			},
+		},
+
+		// ---- Additional edge cases ----
+		// JSX expression container as children (not a JsxText) — counts as children.
+		{
+			Code: `const x = <div dangerouslySetInnerHTML={{ __html: "HTML" }}>{children}</div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 1, Column: 11},
+			},
+		},
+		// Any `x.createElement(...)` member call is inspected — upstream
+		// doesn't restrict to the React pragma, so non-React objects must
+		// also trigger.
+		{
+			Code: `declare const createFoo: any; createFoo.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 1, Column: 31},
+			},
+		},
+		// Nested-member callee object (Preact-style `h.createElement` via
+		// alias) — still a MemberExpression with property name `createElement`,
+		// so upstream flags it.
+		{
+			Code: `declare const lib: { h: { createElement: (...a: any[]) => any } }; lib.h.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren"},
+			},
+		},
+		// Full range assertion on self-closing — covers the entire element.
+		{
+			Code: `<div dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dangerWithChildren",
+					Line:      1,
+					Column:    1,
+					EndLine:   1,
+					EndColumn: 73,
+				},
+			},
+		},
+		// Shorthand property in the resolved spread target: the upstream
+		// `prop.key.name === propName` check matches shorthand bindings just
+		// like regular Identifier keys.
+		{
+			Code: `
+				const dangerouslySetInnerHTML = { __html: "HTML" };
+				const children = "Children";
+				const props = { dangerouslySetInnerHTML, children };
+				const x = <div {...props} />;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 5},
+			},
+		},
+		// Three-level spread chain resolved through the TypeChecker.
+		{
+			Code: `
+				const a = { dangerouslySetInnerHTML: { __html: "HTML" } };
+				const b = { ...a };
+				const c = { ...b };
+				React.createElement("div", c, "Children");
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 5},
+			},
+		},
+		// Parenthesized initializer must be transparent on the spread target.
+		{
+			Code: `
+				const props = ({ dangerouslySetInnerHTML: { __html: "HTML" } });
+				const x = <div {...props}>Children</div>;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+		// Self-closing JSX with children attr via spread + direct dangerously prop.
+		{
+			Code: `
+				const extras = { children: "Children" };
+				const x = <div dangerouslySetInnerHTML={{ __html: "HTML" }} {...extras} />;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+		// createElement where props is a parenthesized inline object.
+		{
+			Code: `
+				React.createElement(
+					"div",
+					({ dangerouslySetInnerHTML: { __html: "HTML" }, children: "Children" })
+				);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 2},
+			},
+		},
+		// Nested JSX: outer element has neither prop, inner element has both.
+		// Only the inner should report.
+		{
+			Code: `
+				const x = (
+					<div>
+						<span dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />
+					</div>
+				);
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 4},
+			},
+		},
+		// Direct dangerously prop co-located with a spread whose target has
+		// children — both paths must be inspected.
+		{
+			Code: `
+				const extras = { children: "Children" };
+				const x = <div {...extras} dangerouslySetInnerHTML={{ __html: "HTML" }} />;
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dangerWithChildren", Line: 3},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -102,6 +102,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
+    './tests/eslint-plugin-react/rules/no-danger-with-children.test.ts',
     './tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-danger-with-children.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-danger-with-children.test.ts
@@ -1,0 +1,298 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-danger-with-children', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    { code: `<div>Children</div>;` },
+    { code: `const props: any = {}; <div {...props} />;` },
+    { code: `<div dangerouslySetInnerHTML={{ __html: "HTML" }} />;` },
+    { code: `<div children="Children" />;` },
+    {
+      code: `
+        const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+        const x = <div {...props} />;
+      `,
+    },
+    {
+      code: `
+        const moreProps = { className: "eslint" };
+        const props = { children: "Children", ...moreProps };
+        const x = <div {...props} />;
+      `,
+    },
+    {
+      code: `
+        const otherProps = { children: "Children" };
+        const { a, b, ...props } = otherProps as any;
+        const x = <div {...props} />;
+      `,
+    },
+    { code: `<Hello>Children</Hello>;` },
+    { code: `<Hello dangerouslySetInnerHTML={{ __html: "HTML" }} />;` },
+    {
+      code: `
+        <Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>
+        </Hello>;
+      `,
+    },
+    {
+      code: `React.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } });`,
+    },
+    { code: `React.createElement("div", {}, "Children");` },
+    {
+      code: `React.createElement("Hello", { dangerouslySetInnerHTML: { __html: "HTML" } });`,
+    },
+    { code: `React.createElement("Hello", {}, "Children");` },
+    { code: `<Hello {...undefined}>Children</Hello>;` },
+    { code: `React.createElement("Hello", undefined, "Children");` },
+    {
+      code: `
+        declare const shallow: any;
+        declare const TaskEditableTitle: any;
+        const props = { ...props, scratch: { mode: 'edit' } } as any;
+        const component = shallow(<TaskEditableTitle {...props} />);
+      `,
+    },
+
+    // ---- Additional edge cases ----
+    // Empty element, no props, no children.
+    { code: `<div />;` },
+    // dangerouslySetInnerHTML is case-sensitive.
+    {
+      code: `<div dangerouslySetInnerHtml={{ __html: "HTML" }}>Children</div>;`,
+    },
+    // Bare createElement — upstream only matches `x.createElement(...)`.
+    {
+      code: `createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`,
+    },
+    // Computed createElement access — upstream skips via `'name' in property`.
+    {
+      code: `React["createElement"]("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`,
+    },
+    // Single argument createElement — nothing to check.
+    { code: `React.createElement("div");` },
+    // Whitespace-only multi-line children — treated as empty.
+    {
+      code: `
+        <div dangerouslySetInnerHTML={{ __html: "HTML" }}>
+        </div>;
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `
+        <div dangerouslySetInnerHTML={{ __html: "HTML" }}>
+          Children
+        </div>;
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `<div dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />;`,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+        const x = <div {...props}>Children</div>;
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+        const x = <div {...props} />;
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        <Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>
+          Children
+        </Hello>;
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `<Hello dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />;`,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}> </Hello>;`,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        React.createElement(
+          "div",
+          { dangerouslySetInnerHTML: { __html: "HTML" } },
+          "Children"
+        );
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        React.createElement(
+          "div",
+          {
+            dangerouslySetInnerHTML: { __html: "HTML" },
+            children: "Children",
+          }
+        );
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        React.createElement(
+          "Hello",
+          { dangerouslySetInnerHTML: { __html: "HTML" } },
+          "Children"
+        );
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        React.createElement(
+          "Hello",
+          {
+            dangerouslySetInnerHTML: { __html: "HTML" },
+            children: "Children",
+          }
+        );
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+        React.createElement("div", props, "Children");
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+        React.createElement("div", props);
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    {
+      code: `
+        const moreProps = { children: "Children" };
+        const otherProps = { ...moreProps };
+        const props = { ...otherProps, dangerouslySetInnerHTML: { __html: "HTML" } };
+        React.createElement("div", props);
+      `,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+
+    // ---- Additional edge cases ----
+    // JSX expression container child — counts as meaningful children.
+    {
+      code: `const children: any = "x"; const x = <div dangerouslySetInnerHTML={{ __html: "HTML" }}>{children}</div>;`,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    // Any `x.createElement(...)` member call, pragma-agnostic.
+    {
+      code: `declare const createFoo: any; createFoo.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+    // Nested member callee (`lib.h.createElement(...)`).
+    {
+      code: `declare const lib: { h: { createElement: (...a: any[]) => any } }; lib.h.createElement("div", { dangerouslySetInnerHTML: { __html: "HTML" } }, "Children");`,
+      errors: [
+        {
+          message:
+            'Only set one of `children` or `props.dangerouslySetInnerHTML`',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-danger-with-children` rule from `eslint-plugin-react` to rslint.

The rule disallows a DOM element from using both `children` and `dangerouslySetInnerHTML` at the same time — they are mutually exclusive in React and trigger a runtime warning if combined.

Covers both:
- JSX form: `<div dangerouslySetInnerHTML={...}>Children</div>` / `<div dangerouslySetInnerHTML={...} children="..." />`.
- `x.createElement(...)` form (pragma-agnostic, matching upstream): flags any member-call whose property name is `createElement` with a dangerous props object plus children (either as a 3rd arg or as an inline `children` key).

Spread attributes / spread object properties are resolved through the TypeChecker when the argument is an Identifier; self-referencing initializers (`const props = { ...props, ... }`) terminate via a `seen` set.

## Related Links

- ESLint rule doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-danger-with-children.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-danger-with-children.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).