### PR TITLE
feat: port rule react/no-render-return-value

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -25,6 +25,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
@@ -65,6 +66,7 @@ func GetAllRules() []rule.Rule {
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
+		no_render_return_value.NoRenderReturnValueRule,
 		no_string_refs.NoStringRefsRule,
 		no_typos.NoTyposRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value.go
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value.go
@@ -1,0 +1,185 @@
+package no_render_return_value
+
+import (
+	"regexp"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// calleeObjectRe selects the acceptable callee-object names by React version.
+// Mirrors upstream's if/else-if chain:
+//
+//	default / >= 15.0.0 → ReactDOM
+//	^0.14.0             → React or ReactDOM
+//	^0.13.0             → React
+//
+// Anything else (e.g. 0.0.1) falls back to the default ReactDOM, matching
+// upstream's uninitialized-branch behavior.
+var (
+	reReactDOM   = regexp.MustCompile(`^ReactDOM$`)
+	reReactOrDOM = regexp.MustCompile(`^React(DOM)?$`)
+	reReact      = regexp.MustCompile(`^React$`)
+)
+
+func calleeObjectRe(settings map[string]interface{}) *regexp.Regexp {
+	// >= 15.0.0 — the default branch when version is unset (ParseReactVersion
+	// returns 999,999,999) and therefore ≥ 15.
+	if !reactutil.ReactVersionLessThan(settings, 15, 0, 0) {
+		return reReactDOM
+	}
+	// ^0.14.0 → [0.14.0, 0.15.0)
+	if !reactutil.ReactVersionLessThan(settings, 0, 14, 0) &&
+		reactutil.ReactVersionLessThan(settings, 0, 15, 0) {
+		return reReactOrDOM
+	}
+	// ^0.13.0 → [0.13.0, 0.14.0)
+	if !reactutil.ReactVersionLessThan(settings, 0, 13, 0) &&
+		reactutil.ReactVersionLessThan(settings, 0, 14, 0) {
+		return reReact
+	}
+	return reReactDOM
+}
+
+// matchedObjectName reports the Identifier text of the call's callee object
+// when the callee shape is `<Identifier>.render` (or `<Identifier>[render]`
+// where `render` is an Identifier reference literally named "render") AND the
+// identifier matches the version-selected pattern. Returns "" otherwise.
+//
+// Two bracket-access sub-cases mirror upstream's `'name' in callee.property`
+// guard exactly:
+//
+//   - `ReactDOM['render']()` — property is a StringLiteral; ESTree Literal
+//     has no `.name`, so `'name' in property` is false → upstream skips. We
+//     skip too.
+//   - `ReactDOM[render]()` — property is an Identifier reference literally
+//     named "render"; ESTree Identifier has `.name === 'render'` → upstream
+//     triggers. We trigger too.
+//
+// Parentheses on the callee, the pragma identifier, and the bracket argument
+// are transparently skipped.
+func matchedObjectName(call *ast.CallExpression, pattern *regexp.Regexp) string {
+	callee := ast.SkipParentheses(call.Expression)
+	switch callee.Kind {
+	case ast.KindPropertyAccessExpression:
+		prop := callee.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(prop.Expression)
+		if obj.Kind != ast.KindIdentifier {
+			return ""
+		}
+		name := obj.AsIdentifier().Text
+		if !pattern.MatchString(name) {
+			return ""
+		}
+		nameNode := prop.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return ""
+		}
+		if nameNode.AsIdentifier().Text != "render" {
+			return ""
+		}
+		return name
+	case ast.KindElementAccessExpression:
+		ea := callee.AsElementAccessExpression()
+		obj := ast.SkipParentheses(ea.Expression)
+		if obj.Kind != ast.KindIdentifier {
+			return ""
+		}
+		name := obj.AsIdentifier().Text
+		if !pattern.MatchString(name) {
+			return ""
+		}
+		// ESTree's `'name' in callee.property` test: only Identifier nodes
+		// have `.name`. Literal (StringLiteral / NumericLiteral) and
+		// computed key expressions do not, so upstream silently skips them.
+		// Mirror by accepting ONLY Identifier here — even if its referent
+		// happens to evaluate to "render" at runtime, upstream doesn't see
+		// that, and neither do we.
+		arg := ast.SkipParentheses(ea.ArgumentExpression)
+		if arg == nil || arg.Kind != ast.KindIdentifier {
+			return ""
+		}
+		if arg.AsIdentifier().Text != "render" {
+			return ""
+		}
+		return name
+	}
+	return ""
+}
+
+// NoRenderReturnValueRule flags uses of the return value of `ReactDOM.render`
+// (or `React.render` on legacy 0.13/0.14 React). The rule fires only when the
+// call sits in a position that consumes the return value — `var x = ...`,
+// `{ k: ... }`, `return ...`, an arrow expression body, or the RHS of an
+// assignment — matching upstream exactly.
+var NoRenderReturnValueRule = rule.Rule{
+	Name: "react/no-render-return-value",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pattern := calleeObjectRe(ctx.Settings)
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				objName := matchedObjectName(call, pattern)
+				if objName == "" {
+					return
+				}
+				// Walk up ParenthesizedExpression wrappers transparently —
+				// ESTree flattens parens, so upstream's `parent.type` check
+				// already sees the non-paren ancestor. Equivalent to
+				// upstream's implicit flattening.
+				parent := ast.WalkUpParenthesizedExpressions(node.Parent)
+				if parent == nil {
+					return
+				}
+				if !consumesReturnValue(parent, node) {
+					return
+				}
+				ctx.ReportNode(ast.SkipParentheses(call.Expression), rule.RuleMessage{
+					Id:          "noReturnValue",
+					Description: "Do not depend on the return value from " + objName + ".render",
+				})
+			},
+		}
+	},
+}
+
+// consumesReturnValue mirrors upstream's parent-type allow-list, mapped onto
+// tsgo's AST:
+//
+//	ESTree                     | tsgo
+//	---------------------------|-----
+//	VariableDeclarator         | VariableDeclaration
+//	Property                   | PropertyAssignment
+//	ReturnStatement            | ReturnStatement (same)
+//	ArrowFunctionExpression    | ArrowFunction, only when `call` is the body
+//	AssignmentExpression       | BinaryExpression with an assignment operator
+//	                           |   (covers compound / logical assignment too,
+//	                           |   matching ESTree's single AssignmentExpression
+//	                           |   type)
+//
+// `call` is the original CallExpression (before the caller's paren-walk); for
+// the arrow-body case, ParenthesizedExpression wrappers around the body are
+// skipped so `(a) => (call())` reaches the same ArrowFunction.
+func consumesReturnValue(parent *ast.Node, call *ast.Node) bool {
+	switch parent.Kind {
+	case ast.KindVariableDeclaration,
+		ast.KindPropertyAssignment,
+		ast.KindReturnStatement:
+		return true
+	case ast.KindArrowFunction:
+		af := parent.AsArrowFunction()
+		if af.Body == nil {
+			return false
+		}
+		return ast.SkipParentheses(af.Body) == call
+	case ast.KindBinaryExpression:
+		// `ast.IsAssignmentExpression(parent, false)` covers `=`, `+=`, `-=`,
+		// `*=`, `/=`, `%=`, `**=`, `<<=`, `>>=`, `>>>=`, `&=`, `|=`, `^=`,
+		// `&&=`, `||=`, `??=` — matching ESTree's single AssignmentExpression
+		// type. `false` means "include compound assignments".
+		return ast.IsAssignmentExpression(parent, false)
+	}
+	return false
+}

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value.md
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value.md
@@ -1,0 +1,56 @@
+# no-render-return-value
+
+Disallow usage of the return value of `ReactDOM.render`.
+
+`ReactDOM.render()` currently returns a reference to the root `ReactComponent`
+instance. However, using this return value is legacy and should be avoided
+because future versions of React may render components asynchronously in some
+cases. If you need a reference to the root `ReactComponent` instance, the
+preferred solution is to attach a
+[callback ref](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs)
+to the root element.
+
+## Rule Details
+
+The rule flags `ReactDOM.render` calls whose return value is consumed — i.e.
+when the call sits in one of these positions:
+
+- Variable initializer (`var x = ReactDOM.render(...)`)
+- Object property value (`{ k: ReactDOM.render(...) }`)
+- `return` argument (`return ReactDOM.render(...)`)
+- Arrow function expression body (`(a, b) => ReactDOM.render(a, b)`)
+- Right-hand side of an assignment (`x = ReactDOM.render(...)`)
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+const inst = ReactDOM.render(<App />, document.body);
+doSomethingWithInst(inst);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+ReactDOM.render(<App ref={(inst) => doSomethingWithInst(inst)} />, document.body);
+
+ReactDOM.render(<App />, document.body, () => {
+  // the render has finished
+});
+```
+
+## React Version
+
+The callee object pattern depends on `settings.react.version`:
+
+| Version range | Matched object(s) |
+| ------------- | ----------------- |
+| `>= 15.0.0` (default) | `ReactDOM` |
+| `^0.14.0` | `React` or `ReactDOM` |
+| `^0.13.0` | `React` |
+
+Any other version (e.g. `0.0.1`) falls back to `ReactDOM`-only, matching
+upstream's default branch.
+
+## Original Documentation
+
+- [eslint-plugin-react / no-render-return-value](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md)

--- a/internal/plugins/react/rules/no_render_return_value/no_render_return_value_test.go
+++ b/internal/plugins/react/rules/no_render_return_value/no_render_return_value_test.go
@@ -1,0 +1,350 @@
+// cspell:ignore renderder
+
+package no_render_return_value
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRenderReturnValueRule(t *testing.T) {
+	// Shared settings fixtures mirroring upstream's `settings: { react: { version: '…' } }`.
+	react0140 := map[string]interface{}{"react": map[string]interface{}{"version": "0.14.0"}}
+	react0130 := map[string]interface{}{"react": map[string]interface{}{"version": "0.13.0"}}
+	react0001 := map[string]interface{}{"react": map[string]interface{}{"version": "0.0.1"}}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRenderReturnValueRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: render with no return-value consumption ----
+		{Code: `ReactDOM.render(<div />, document.body);`, Tsx: true},
+		{Code: `
+        let node;
+        ReactDOM.render(<div ref={ref => node = ref}/>, document.body);
+      `, Tsx: true},
+
+		// ---- Upstream: version-gated callee-object matching ----
+		{Code: `ReactDOM.render(<div ref={ref => this.node = ref}/>, document.body);`, Tsx: true, Settings: react0140},
+		{Code: `React.render(<div ref={ref => this.node = ref}/>, document.body);`, Tsx: true, Settings: react0140},
+		{Code: `React.render(<div ref={ref => this.node = ref}/>, document.body);`, Tsx: true, Settings: react0130},
+
+		// ---- Upstream: version 0.0.1 falls back to default (ReactDOM-only) — React doesn't match ----
+		{Code: `var foo = React.render(<div />, root);`, Tsx: true, Settings: react0001},
+
+		// ---- Upstream: bare `render(...)` — callee not a MemberExpression ----
+		{Code: `var foo = render(<div />, root)`, Tsx: true},
+
+		// ---- Upstream: lowercase `ReactDom.renderder` — regex is case-sensitive, neither name nor property match ----
+		{Code: `var foo = ReactDom.renderder(<div />, root)`, Tsx: true},
+
+		// ---- Edge: bracket access with a string-literal key — upstream's `'name' in property` guard is false for Literal nodes (no `.name`), so no fire ----
+		{Code: `var x = ReactDOM['render'](<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: bracket access with a numeric-literal key — same as above ----
+		{Code: `var x = ReactDOM[0](<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: bracket access with an Identifier named NOT "render" — `property.name !== 'render'` → no fire ----
+		{Code: `var renderFn; var x = ReactDOM[renderFn](<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: bracket access with a template-literal / computed expression — not an Identifier, no `.name`, no fire ----
+		{Code: "var x = ReactDOM[`render`](<div />, document.body);", Tsx: true},
+
+		// ---- Edge: `React.render` at default version (>= 15.0.0) — object must be `ReactDOM`, not `React` ----
+		{Code: `var x = React.render(<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: call as a non-return-consuming argument position ----
+		{Code: `doSomething(ReactDOM.render(<div />, document.body));`, Tsx: true},
+
+		// ---- Edge: conditional expression — not in the allow-list ----
+		{Code: `var x = cond ? ReactDOM.render(<div />, document.body) : null;`, Tsx: true},
+
+		// ---- Edge: logical-operand position — not in the allow-list ----
+		{Code: `var x = y || ReactDOM.render(<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: nullish-coalesce operand ----
+		{Code: `var x = y ?? ReactDOM.render(<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: chained member access — callee.object is a MemberExpression, not an Identifier ----
+		{Code: `var x = obj.ReactDOM.render(<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: `new ReactDOM.render()` — a NewExpression, not a CallExpression — listener doesn't fire ----
+		{Code: `var x = new ReactDOM.render(<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: `await` / `yield` / `throw` / `typeof` — none of them are in the allow-list ----
+		{Code: `async function f() { await ReactDOM.render(<div />, document.body); }`, Tsx: true},
+		{Code: `function* g() { yield ReactDOM.render(<div />, document.body); }`, Tsx: true},
+		{Code: `function h() { throw ReactDOM.render(<div />, document.body); }`, Tsx: true},
+		{Code: `var x = typeof ReactDOM.render(<div />, document.body);`, Tsx: true},
+
+		// ---- Edge: array / spread / template — consumed into a container, not via the allow-list ----
+		{Code: `var xs = [ReactDOM.render(<div />, document.body)];`, Tsx: true},
+		{Code: `var o = { ...ReactDOM.render(<div />, document.body) };`, Tsx: true},
+		{Code: `var s = ` + "`${ReactDOM.render(<div />, document.body)}`" + `;`, Tsx: true},
+
+		// ---- Edge: method-chained from the call — `.then` / `.foo` parent is a PropertyAccess ----
+		{Code: `ReactDOM.render(<div />, document.body).then(inst => inst);`, Tsx: true},
+		{Code: `var x = ReactDOM.render(<div />, document.body).foo;`, Tsx: true},
+
+		// ---- Edge: SequenceExpression (comma) — only the last operand is consumed by its parent ----
+		{Code: `var x = (foo(), ReactDOM.render(<div />, document.body), 1);`, Tsx: true},
+
+		// ---- Edge: TS type assertion / non-null — wrapped in AsExpression / NonNullExpression; matches upstream's parent-type guard miss ----
+		{Code: `var x = ReactDOM.render(<div />, document.body) as any;`, Tsx: true},
+		{Code: `var x = ReactDOM.render(<div />, document.body)!;`, Tsx: true},
+
+		// ---- Edge: shadowed `ReactDOM` identifier still matches — rule is name-based, not scope-aware (matches upstream) ----
+		// Sibling valid: a top-level call with no consumption still doesn't fire.
+		{Code: `{ let ReactDOM; ReactDOM.render(<div />, document.body); }`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: VariableDeclarator (default version → ReactDOM) ----
+		{
+			Code: `var Hello = ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noReturnValue",
+					Message:   "Do not depend on the return value from ReactDOM.render",
+					Line:      1, Column: 13, EndLine: 1, EndColumn: 28,
+				},
+			},
+		},
+
+		// ---- Upstream: Object property value ----
+		{
+			Code: `
+        var o = {
+          inst: ReactDOM.render(<div />, document.body)
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 3, Column: 17},
+			},
+		},
+
+		// ---- Upstream: ReturnStatement ----
+		{
+			Code: `
+        function render () {
+          return ReactDOM.render(<div />, document.body)
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Upstream: ArrowFunctionExpression body ----
+		{
+			Code: `var render = (a, b) => ReactDOM.render(a, b)`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 24, EndLine: 1, EndColumn: 39},
+			},
+		},
+
+		// ---- Upstream: AssignmentExpression (member-expression LHS) ----
+		{
+			Code: `this.o = ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 10},
+			},
+		},
+
+		// ---- Upstream: AssignmentExpression (identifier LHS) ----
+		{
+			Code: `var v; v = ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 12},
+			},
+		},
+
+		// ---- Upstream: React matches at ^0.14.0 ----
+		{
+			Code:     `var inst = React.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: react0140,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noReturnValue",
+					Message:   "Do not depend on the return value from React.render",
+					Line:      1, Column: 12,
+				},
+			},
+		},
+
+		// ---- Upstream: ReactDOM matches at ^0.14.0 ----
+		{
+			Code:     `var inst = ReactDOM.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: react0140,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noReturnValue",
+					Message:   "Do not depend on the return value from ReactDOM.render",
+					Line:      1, Column: 12,
+				},
+			},
+		},
+
+		// ---- Upstream: React matches at ^0.13.0 ----
+		{
+			Code:     `var inst = React.render(<div />, document.body);`,
+			Tsx:      true,
+			Settings: react0130,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noReturnValue",
+					Message:   "Do not depend on the return value from React.render",
+					Line:      1, Column: 12,
+				},
+			},
+		},
+
+		// ---- Edge: parens around the init — ESTree flattens, tsgo preserves; walk transparently ----
+		{
+			Code: `var x = (ReactDOM.render(<div />, document.body));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 10},
+			},
+		},
+
+		// ---- Edge: double parens ----
+		{
+			Code: `var x = ((ReactDOM.render(<div />, document.body)));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 11},
+			},
+		},
+
+		// ---- Edge: parens around the arrow body ----
+		{
+			Code: `var f = () => (ReactDOM.render(<div />, document.body))`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 16},
+			},
+		},
+
+		// ---- Edge: nested arrow — inner arrow's body is the call ----
+		{
+			Code: `var f = () => () => ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 21},
+			},
+		},
+
+		// ---- Edge: compound assignment (`+=`) — upstream's `parent.type === 'AssignmentExpression'` matches all operators ----
+		{
+			Code: `var v = 0; v += ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 17},
+			},
+		},
+
+		// ---- Edge: logical assignment (`??=`) — also an AssignmentExpression ----
+		{
+			Code: `var v; v ??= ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 14},
+			},
+		},
+
+		// ---- Edge: chained assignment — inner `=` fires too ----
+		{
+			Code: `var a, b; a = b = ReactDOM.render(<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 19},
+			},
+		},
+
+		// ---- Edge: destructuring-assignment RHS — still an AssignmentExpression ----
+		{
+			Code: `var o; ({ a: o } = ReactDOM.render(<div />, document.body));`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 20},
+			},
+		},
+
+		// ---- Edge: shorthand property value ----
+		{
+			Code: `var o = { inst: ReactDOM.render(<div />, document.body) };`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 17},
+			},
+		},
+
+		// ---- Edge: class-method return ----
+		{
+			Code: `
+        class App {
+          foo() {
+            return ReactDOM.render(<div />, document.body);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Edge: class-field initializer arrow — body is the call ----
+		{
+			Code: `
+        class App {
+          cb = () => ReactDOM.render(<div />, document.body);
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 3, Column: 22},
+			},
+		},
+
+		// ---- Edge: nested inside IIFE returning the render — the return itself consumes ----
+		{
+			Code: `var x = (() => { return ReactDOM.render(<div />, document.body); })();`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 25},
+			},
+		},
+
+		// ---- Edge: TSX function-component return ----
+		{
+			Code: `
+        function App() {
+          return ReactDOM.render(<div />, document.body);
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 3, Column: 18},
+			},
+		},
+
+		// ---- Edge: bracket access with an Identifier literally named `render` —
+		// upstream's `'name' in callee.property && property.name === 'render'`
+		// is true for Identifier(render), regardless of what the variable
+		// actually references at runtime. Matches upstream exactly.
+		{
+			Code: `var render; var x = ReactDOM[render](<div />, document.body);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noReturnValue", Line: 1, Column: 21},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -107,6 +107,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-direct-mutation-state.test.ts',
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
+    './tests/eslint-plugin-react/rules/no-render-return-value.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-render-return-value.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-render-return-value.test.ts
@@ -1,0 +1,170 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-render-return-value', {} as never, {
+  valid: [
+    // ---- Upstream: render with no return-value consumption ----
+    { code: `ReactDOM.render(<div />, document.body);` },
+    {
+      code: `
+        let node;
+        ReactDOM.render(<div ref={ref => node = ref}/>, document.body);
+      `,
+    },
+    { code: `var foo = render(<div />, root)` },
+    { code: `var foo = ReactDom.renderder(<div />, root)` },
+
+    // ---- Edge: bracket access with string / numeric / template / other-identifier key — upstream's `'name' in property && property.name === 'render'` guard fails ----
+    { code: `var x = ReactDOM['render'](<div />, document.body);` },
+    { code: `var x = ReactDOM[0](<div />, document.body);` },
+    {
+      code: `var renderFn; var x = ReactDOM[renderFn](<div />, document.body);`,
+    },
+    { code: 'var x = ReactDOM[`render`](<div />, document.body);' },
+
+    // ---- Edge: React at default version (>= 15.0.0) — must be ReactDOM ----
+    { code: `var x = React.render(<div />, document.body);` },
+
+    // ---- Non-consuming positions ----
+    { code: `doSomething(ReactDOM.render(<div />, document.body));` },
+    { code: `var x = cond ? ReactDOM.render(<div />, document.body) : null;` },
+    { code: `var x = y || ReactDOM.render(<div />, document.body);` },
+    { code: `var x = y ?? ReactDOM.render(<div />, document.body);` },
+    { code: `var x = obj.ReactDOM.render(<div />, document.body);` },
+    { code: `var x = new ReactDOM.render(<div />, document.body);` },
+    {
+      code: `async function f() { await ReactDOM.render(<div />, document.body); }`,
+    },
+    {
+      code: `function* g() { yield ReactDOM.render(<div />, document.body); }`,
+    },
+    { code: `function h() { throw ReactDOM.render(<div />, document.body); }` },
+    { code: `var x = typeof ReactDOM.render(<div />, document.body);` },
+    { code: `var xs = [ReactDOM.render(<div />, document.body)];` },
+    { code: `var o = { ...ReactDOM.render(<div />, document.body) };` },
+    { code: `ReactDOM.render(<div />, document.body).then(inst => inst);` },
+    { code: `var x = ReactDOM.render(<div />, document.body).foo;` },
+    {
+      code: `var x = (foo(), ReactDOM.render(<div />, document.body), 1);`,
+    },
+
+    // ---- TS wrappers (AsExpression / NonNullExpression) — upstream skips, we match ----
+    { code: `var x = ReactDOM.render(<div />, document.body) as any;` },
+    { code: `var x = ReactDOM.render(<div />, document.body)!;` },
+  ],
+  invalid: [
+    // ---- Upstream: VariableDeclarator ----
+    {
+      code: `var Hello = ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    // ---- Upstream: Object property value ----
+    {
+      code: `
+        var o = {
+          inst: ReactDOM.render(<div />, document.body)
+        };
+      `,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    // ---- Upstream: ReturnStatement ----
+    {
+      code: `
+        function render () {
+          return ReactDOM.render(<div />, document.body)
+        }
+      `,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    // ---- Upstream: ArrowFunctionExpression body ----
+    {
+      code: `var render = (a, b) => ReactDOM.render(a, b)`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    // ---- Upstream: AssignmentExpression (member-expression LHS) ----
+    {
+      code: `this.o = ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    // ---- Upstream: AssignmentExpression (identifier LHS) ----
+    {
+      code: `var v; v = ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- Parens transparent ----
+    {
+      code: `var x = (ReactDOM.render(<div />, document.body));`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    {
+      code: `var x = ((ReactDOM.render(<div />, document.body)));`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    {
+      code: `var f = () => (ReactDOM.render(<div />, document.body))`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- Nested arrow — inner body is the call ----
+    {
+      code: `var f = () => () => ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- Compound / logical / chained / destructuring assignment ----
+    {
+      code: `var v = 0; v += ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    {
+      code: `var v; v ??= ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    {
+      code: `var a, b; a = b = ReactDOM.render(<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    {
+      code: `var o; ({ a: o } = ReactDOM.render(<div />, document.body));`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- Class-method return + class-field arrow body ----
+    {
+      code: `
+        class App {
+          foo() {
+            return ReactDOM.render(<div />, document.body);
+          }
+        }
+      `,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+    {
+      code: `
+        class App {
+          cb = () => ReactDOM.render(<div />, document.body);
+        }
+      `,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- TSX function-component return ----
+    {
+      code: `
+        function App() {
+          return ReactDOM.render(<div />, document.body);
+        }
+      `,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+
+    // ---- Bracket access with an Identifier literally named `render` — upstream's `property.name === 'render'` matches ----
+    {
+      code: `var render; var x = ReactDOM[render](<div />, document.body);`,
+      errors: [{ messageId: 'noReturnValue' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-render-return-value` rule from `eslint-plugin-react` to rslint.

The rule flags uses of the return value of `ReactDOM.render` (or legacy `React.render` on old React versions). It triggers only when the call sits in a position that consumes the return value — variable initializer, object property value, `return` argument, arrow expression body, or the RHS of an assignment — matching upstream exactly.

Key behaviors:

- Version-gated callee-object matching via `settings.react.version`:
  - `>= 15.0.0` (default) → `ReactDOM`
  - `^0.14.0` → `React` or `ReactDOM`
  - `^0.13.0` → `React`
- Supports both dotted access (`ReactDOM.render()`) and computed bracket access with an `Identifier` literally named `render` (`ReactDOM[render]()`), mirroring upstream's `'name' in callee.property && callee.property.name === 'render'` guard.
- String-literal / numeric-literal / template-literal / other-identifier bracket keys do NOT trigger, matching upstream.
- Paren-transparent on callee, callee object, arrow body, and parent ancestor walk — compensates for tsgo preserving `ParenthesizedExpression` while ESTree flattens.
- Covers all assignment operators (`=`, `+=`, `??=`, destructuring, etc.) via `ast.IsAssignmentExpression`.

Verified on real codebases (rsbuild, rspack): no false positives on modern `ReactDOM.createRoot(root).render(<App />)` patterns (callee.object is a CallExpression, not an Identifier).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-render-return-value.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-render-return-value.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).