### PR TITLE
feat: port rule react/no-deprecated

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -21,6 +21,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger_with_children"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_deprecated"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_did_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
@@ -61,6 +62,7 @@ func GetAllRules() []rule.Rule {
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_danger_with_children.NoDangerWithChildrenRule,
+		no_deprecated.NoDeprecatedRule,
 		no_did_update_set_state.NoDidUpdateSetStateRule,
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -350,6 +350,35 @@ func isObjectArgumentOf(call *ast.CallExpression, obj *ast.Node) bool {
 	return false
 }
 
+// IsCreateReactClassObjectArg reports whether `obj` (an ObjectLiteralExpression)
+// is the FIRST argument of a `<createClass>(...)` / `<pragma>.<createClass>(...)`
+// call. Parens wrapping `obj` before it reaches the call argument position are
+// transparent — tsgo preserves them while ESTree flattens — so
+// `createReactClass(({...}))` still matches.
+//
+// Pass the empty string for pragma / createClass to fall back to
+// `DefaultReactPragma` / `DefaultReactCreateClass`. Returns false for any
+// non-ObjectLiteralExpression input, for objects in non-argument positions,
+// and for calls whose callee is not the configured createClass name.
+func IsCreateReactClassObjectArg(obj *ast.Node, pragma, createClass string) bool {
+	if obj == nil || obj.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	cur := obj
+	for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
+		cur = cur.Parent
+	}
+	parent := cur.Parent
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := parent.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 || call.Arguments.Nodes[0] != cur {
+		return false
+	}
+	return IsCreateClassCall(call, pragma, createClass)
+}
+
 // GetEnclosingReactComponentOrStateless is GetEnclosingReactComponent extended
 // with eslint-plugin-react's `getParentStatelessComponent` fallback: when no
 // enclosing ES6 class / ES5 createReactClass component is found, the nearest
@@ -399,11 +428,13 @@ func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass s
 //
 //   - Wrapped in `<pragma>.memo(...)` / `<pragma>.forwardRef(...)` / bare
 //     `memo(...)` / bare `forwardRef(...)` — always a component.
+//
 //   - Allowed positions (VariableDeclarator, AssignmentExpression,
 //     PropertyAssignment, ReturnStatement, ExportAssignment, outer
 //     ArrowFunction body) gate everything else. A bare IIFE or any other
 //     CallExpression argument position is NOT allowed, matching upstream's
 //     `isInAllowedPositionForComponent` default-false branch.
+//
 //   - Within an allowed position, specific capitalization rules apply per
 //     upstream: VariableDeclarator/PropertyAssignment use the binding name;
 //     `Id = fn` assignments use the LHS Identifier; MemberExpression LHS

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated.go
@@ -1,0 +1,448 @@
+package no_deprecated
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// deprecationInfo holds the triple upstream's `deprecated[method]` returns:
+// the React version in which the method was deprecated, the replacement
+// (`, use X instead` — empty when no replacement is suggested), and an
+// optional external reference URL/notes (`, see Y`).
+type deprecationInfo struct {
+	version   string
+	newMethod string
+	refs      string
+}
+
+// modulesList mirrors upstream's MODULES map — maps each npm package source
+// to the canonical binding name(s) that users typically give to it in a
+// destructuring / import. The FIRST entry of `names` is the canonical name
+// used to synthesize deprecation keys (e.g. `React.X`, `ReactDOM.X`).
+var modulesList = []struct {
+	source string
+	names  []string
+}{
+	{"react", []string{"React"}},
+	{"react-addons-perf", []string{"ReactPerf", "Perf"}},
+	{"react-dom", []string{"ReactDOM"}},
+	{"react-dom/server", []string{"ReactDOMServer"}},
+}
+
+// canonicalForModuleSource returns the canonical binding name (MODULES[key][0])
+// for a module string like "react-dom", or "" when the module isn't a React
+// npm package we track.
+func canonicalForModuleSource(source string) string {
+	for _, m := range modulesList {
+		if m.source == source {
+			return m.names[0]
+		}
+	}
+	return ""
+}
+
+// canonicalForModuleIdentifier returns the canonical binding name for an
+// Identifier whose text equals any known module's alias (e.g. `Perf` →
+// `Perf`, since `ReactPerf` / `Perf` are both aliases of the
+// `react-addons-perf` module). Mirrors upstream's second-arm match in
+// `getReactModuleName` — the matched name itself becomes the module binding.
+func canonicalForModuleIdentifier(name string) string {
+	for _, m := range modulesList {
+		for _, n := range m.names {
+			if n == name {
+				return n
+			}
+		}
+	}
+	return ""
+}
+
+// buildDeprecated returns the deprecation table for a given pragma. The
+// pragma is substituted into every `<pragma>.X` key — so `settings.react.pragma`
+// or a `@jsx` directive changes which bare-member accesses are flagged.
+// Non-pragma keys (ReactDOM.*, ReactPerf.*, Perf.*, ReactDOMServer.*,
+// this.transferPropsTo, lifecycle-method names) use literal binding names
+// and are unaffected by pragma. Mirrors upstream's `getDeprecated(pragma)`.
+func buildDeprecated(pragma string) map[string]deprecationInfo {
+	m := make(map[string]deprecationInfo, 40)
+	// 0.12.0
+	m[pragma+".renderComponent"] = deprecationInfo{"0.12.0", pragma + ".render", ""}
+	m[pragma+".renderComponentToString"] = deprecationInfo{"0.12.0", pragma + ".renderToString", ""}
+	m[pragma+".renderComponentToStaticMarkup"] = deprecationInfo{"0.12.0", pragma + ".renderToStaticMarkup", ""}
+	m[pragma+".isValidComponent"] = deprecationInfo{"0.12.0", pragma + ".isValidElement", ""}
+	m[pragma+".PropTypes.component"] = deprecationInfo{"0.12.0", pragma + ".PropTypes.element", ""}
+	m[pragma+".PropTypes.renderable"] = deprecationInfo{"0.12.0", pragma + ".PropTypes.node", ""}
+	m[pragma+".isValidClass"] = deprecationInfo{"0.12.0", "", ""}
+	m["this.transferPropsTo"] = deprecationInfo{"0.12.0", "spread operator ({...})", ""}
+	// 0.13.0
+	m[pragma+".addons.classSet"] = deprecationInfo{"0.13.0", "the npm module classnames", ""}
+	m[pragma+".addons.cloneWithProps"] = deprecationInfo{"0.13.0", pragma + ".cloneElement", ""}
+	// 0.14.0
+	m[pragma+".render"] = deprecationInfo{"0.14.0", "ReactDOM.render", ""}
+	m[pragma+".unmountComponentAtNode"] = deprecationInfo{"0.14.0", "ReactDOM.unmountComponentAtNode", ""}
+	m[pragma+".findDOMNode"] = deprecationInfo{"0.14.0", "ReactDOM.findDOMNode", ""}
+	m[pragma+".renderToString"] = deprecationInfo{"0.14.0", "ReactDOMServer.renderToString", ""}
+	m[pragma+".renderToStaticMarkup"] = deprecationInfo{"0.14.0", "ReactDOMServer.renderToStaticMarkup", ""}
+	// 15.0.0
+	m[pragma+".addons.LinkedStateMixin"] = deprecationInfo{"15.0.0", "", ""}
+	m["ReactPerf.printDOM"] = deprecationInfo{"15.0.0", "ReactPerf.printOperations", ""}
+	m["Perf.printDOM"] = deprecationInfo{"15.0.0", "Perf.printOperations", ""}
+	m["ReactPerf.getMeasurementsSummaryMap"] = deprecationInfo{"15.0.0", "ReactPerf.getWasted", ""}
+	m["Perf.getMeasurementsSummaryMap"] = deprecationInfo{"15.0.0", "Perf.getWasted", ""}
+	// 15.5.0
+	m[pragma+".createClass"] = deprecationInfo{"15.5.0", "the npm module create-react-class", ""}
+	m[pragma+".addons.TestUtils"] = deprecationInfo{"15.5.0", "ReactDOM.TestUtils", ""}
+	m[pragma+".PropTypes"] = deprecationInfo{"15.5.0", "the npm module prop-types", ""}
+	// 15.6.0
+	m[pragma+".DOM"] = deprecationInfo{"15.6.0", "the npm module react-dom-factories", ""}
+	// 16.9.0 — lifecycle methods (keys without pragma prefix; matched by bare member name).
+	lifecycleRef := "https://reactjs.org/docs/react-component.html#"
+	lifecycleTail := ". Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components."
+	m["componentWillMount"] = deprecationInfo{"16.9.0", "UNSAFE_componentWillMount", lifecycleRef + "unsafe_componentwillmount" + lifecycleTail}
+	m["componentWillReceiveProps"] = deprecationInfo{"16.9.0", "UNSAFE_componentWillReceiveProps", lifecycleRef + "unsafe_componentwillreceiveprops" + lifecycleTail}
+	m["componentWillUpdate"] = deprecationInfo{"16.9.0", "UNSAFE_componentWillUpdate", lifecycleRef + "unsafe_componentwillupdate" + lifecycleTail}
+	// 18.0.0 — react-dom / react-dom/server deprecations (literal ReactDOM/ReactDOMServer, pragma-independent).
+	m["ReactDOM.render"] = deprecationInfo{"18.0.0", "createRoot", "https://reactjs.org/link/switch-to-createroot"}
+	m["ReactDOM.hydrate"] = deprecationInfo{"18.0.0", "hydrateRoot", "https://reactjs.org/link/switch-to-createroot"}
+	m["ReactDOM.unmountComponentAtNode"] = deprecationInfo{"18.0.0", "root.unmount", "https://reactjs.org/link/switch-to-createroot"}
+	m["ReactDOMServer.renderToNodeStream"] = deprecationInfo{"18.0.0", "renderToPipeableStream", "https://reactjs.org/docs/react-dom-server.html#rendertonodestream"}
+	return m
+}
+
+// jsxPragmaRe matches a `@jsx Foo` directive anywhere in source text. The
+// comment form (block vs. line) isn't constrained — upstream's pragmaUtil
+// accepts the pragma from any comment, so we scan the raw source.
+var jsxPragmaRe = regexp.MustCompile(`@jsx\s+([A-Za-z_$][\w$.]*)`)
+
+// detectJsxPragma returns the identifier following the first `@jsx` directive
+// in the source, or "" when no directive is present.
+func detectJsxPragma(sourceText string) string {
+	m := jsxPragmaRe.FindStringSubmatch(sourceText)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// parseVersion parses a leading "major[.minor[.patch]]" numeric triple and
+// returns (M, m, p). Unparseable components become 0. Prerelease / build
+// metadata tails are ignored — matches the lenient comparison used by
+// eslint-plugin-react's version util for simple `>= X` checks.
+func parseVersion(s string) (int, int, int) {
+	var parts [3]int
+	i := 0
+	for _, seg := range strings.Split(s, ".") {
+		if i >= 3 {
+			break
+		}
+		// Strip a trailing non-digit tail (e.g. "-rc.1", "+build").
+		cut := len(seg)
+		for j, c := range seg {
+			if c < '0' || c > '9' {
+				cut = j
+				break
+			}
+		}
+		n, err := strconv.Atoi(seg[:cut])
+		if err == nil {
+			parts[i] = n
+		}
+		i++
+	}
+	return parts[0], parts[1], parts[2]
+}
+
+// versionActive reports whether the configured React version is greater-or-
+// equal to `deprecVersion` — i.e. whether the deprecation is "in effect" for
+// this project. An absent `settings.react.version` defaults to 999.999.999
+// (matching upstream's "latest"), so every deprecation fires by default.
+func versionActive(settings map[string]interface{}, deprecVersion string) bool {
+	major, minor, patch := parseVersion(deprecVersion)
+	return !reactutil.ReactVersionLessThan(settings, major, minor, patch)
+}
+
+// buildDottedPath walks down the Expression chain of a PropertyAccessExpression
+// and returns the dotted path "base.seg1.seg2…" when every segment is a
+// bare-identifier member access through either an Identifier or `this` base.
+// Returns "" for element-access (`foo['bar']`), computed bases, or any
+// non-identifier reachable component — such shapes can't match an upstream
+// deprecation key derived from source text.
+//
+// NOTE: Parentheses are transparently skipped at every step via
+// `ast.SkipParentheses`. ESTree would preserve source-level parens when
+// `getText(node)` reads the range, so `(React).createClass` would miss there.
+// We flag it — a more permissive, rule-catches-more-cases divergence that
+// we lock in via a dedicated test. See the rule's `.md` for details.
+func buildDottedPath(node *ast.Node) string {
+	var segs []string
+	cur := node
+	for {
+		cur = ast.SkipParentheses(cur)
+		if cur.Kind != ast.KindPropertyAccessExpression {
+			break
+		}
+		pa := cur.AsPropertyAccessExpression()
+		nameNode := pa.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return ""
+		}
+		segs = append(segs, nameNode.AsIdentifier().Text)
+		cur = pa.Expression
+	}
+	cur = ast.SkipParentheses(cur)
+	var base string
+	switch cur.Kind {
+	case ast.KindIdentifier:
+		base = cur.AsIdentifier().Text
+	case ast.KindThisKeyword:
+		base = "this"
+	default:
+		return ""
+	}
+	// segs was collected outer → inner (leaf first). Write base, then
+	// append segments in reverse (inner first) to form "base.inner…leaf".
+	var b strings.Builder
+	b.WriteString(base)
+	for i := len(segs) - 1; i >= 0; i-- {
+		b.WriteByte('.')
+		b.WriteString(segs[i])
+	}
+	return b.String()
+}
+
+// formatMessage builds the deprecation diagnostic string. Mirrors upstream's
+// message template:
+//
+//	{{oldMethod}} is deprecated since React {{version}}{{newMethod}}{{refs}}
+//
+// where newMethod is `", use X instead"` when set, and refs is `", see Y"`
+// when set — both empty otherwise.
+func formatMessage(methodName string, d deprecationInfo) string {
+	var b strings.Builder
+	b.WriteString(methodName)
+	b.WriteString(" is deprecated since React ")
+	b.WriteString(d.version)
+	if d.newMethod != "" {
+		b.WriteString(", use ")
+		b.WriteString(d.newMethod)
+		b.WriteString(" instead")
+	}
+	if d.refs != "" {
+		b.WriteString(", see ")
+		b.WriteString(d.refs)
+	}
+	return b.String()
+}
+
+var NoDeprecatedRule = rule.Rule{
+	Name: "react/no-deprecated",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		// Determine pragma: `@jsx` directive in source wins over
+		// `settings.react.pragma`, matching upstream's `pragmaUtil.getFromContext`.
+		pragma := detectJsxPragma(ctx.SourceFile.Text())
+		if pragma == "" {
+			pragma = reactutil.GetReactPragma(ctx.Settings)
+		}
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+		deprecated := buildDeprecated(pragma)
+
+		report := func(node *ast.Node, methodName string, d deprecationInfo) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "deprecated",
+				Description: formatMessage(methodName, d),
+			})
+		}
+
+		// check is the common gate — present only when the key is both in the
+		// table and active for the configured React version.
+		check := func(node *ast.Node, methodName string) {
+			d, ok := deprecated[methodName]
+			if !ok {
+				return
+			}
+			if !versionActive(ctx.Settings, d.version) {
+				return
+			}
+			report(node, methodName, d)
+		}
+
+		// checkComponentMembers inspects lifecycle-method keys on a class or
+		// createReactClass object literal. Each member whose Identifier key is
+		// a deprecated lifecycle name (`componentWillMount`, etc.) yields a
+		// report at the key node — matching upstream's
+		// `astUtil.getPropertyNameNode(property)` report target.
+		checkComponentMembers := func(members []*ast.Node) {
+			for _, m := range members {
+				if m == nil {
+					continue
+				}
+				// Skip SpreadAssignment / SemicolonClassElement / etc. that
+				// don't carry a named key.
+				key := m.Name()
+				if key == nil || key.Kind != ast.KindIdentifier {
+					continue
+				}
+				name := key.AsIdentifier().Text
+				check(key, name)
+			}
+		}
+
+		return rule.RuleListeners{
+			// `React.createClass`, `React.addons.TestUtils`,
+			// `this.transferPropsTo`, `ReactDOM.render`, … Each
+			// PropertyAccessExpression level is checked independently;
+			// `React.DOM.div` ⇒ inner `React.DOM` matches, outer doesn't.
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				path := buildDottedPath(node)
+				if path == "" {
+					return
+				}
+				check(node, path)
+			},
+
+			// `import { createClass, PropTypes } from 'react'` → check each
+			// named specifier as `<canonical>.<imported-name>`.
+			ast.KindImportDeclaration: func(node *ast.Node) {
+				decl := node.AsImportDeclaration()
+				if decl == nil || decl.ModuleSpecifier == nil || decl.ModuleSpecifier.Kind != ast.KindStringLiteral {
+					return
+				}
+				canonical := canonicalForModuleSource(decl.ModuleSpecifier.AsStringLiteral().Text)
+				if canonical == "" {
+					return
+				}
+				if decl.ImportClause == nil {
+					return
+				}
+				clause := decl.ImportClause.AsImportClause()
+				// ESLint's filter `'imported' in s && s.imported` excludes
+				// default / namespace specifiers — only NamedImports carry
+				// an `imported` identifier.
+				if clause == nil || clause.NamedBindings == nil || clause.NamedBindings.Kind != ast.KindNamedImports {
+					return
+				}
+				named := clause.NamedBindings.AsNamedImports()
+				if named == nil || named.Elements == nil {
+					return
+				}
+				for _, elem := range named.Elements.Nodes {
+					spec := elem.AsImportSpecifier()
+					if spec == nil {
+						continue
+					}
+					// `PropertyName` holds the imported name when aliased
+					// (`{ X as Y }`); otherwise `Name()` is the imported name.
+					importedNode := spec.PropertyName
+					if importedNode == nil {
+						importedNode = spec.Name()
+					}
+					if importedNode == nil || importedNode.Kind != ast.KindIdentifier {
+						continue
+					}
+					check(elem, canonical+"."+importedNode.AsIdentifier().Text)
+				}
+			},
+
+			// Destructuring from a React-module call (`require('react')`,
+			// `import('react-dom')`, etc.) or from an identifier whose name is
+			// a module alias (`ReactPerf`). Mirrors upstream's
+			// `VariableDeclarator` branch.
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				vd := node.AsVariableDeclaration()
+				if vd == nil || vd.Initializer == nil {
+					return
+				}
+				bindingName := vd.Name()
+				if bindingName == nil || bindingName.Kind != ast.KindObjectBindingPattern {
+					return
+				}
+				init := ast.SkipParentheses(vd.Initializer)
+
+				// Arm 1 of `getReactModuleName`: init is a CallExpression and
+				// the first argument is a string literal matching a module
+				// source — `key === node.init.arguments[0].value`. Upstream
+				// does not actually require the callee to be `require`, so
+				// neither do we. (The proceed-condition's second arm
+				// specifically checks `require`, but it's redundant: arm 1 of
+				// getReactModuleName subsumes the require case.)
+				canonical := ""
+				if init.Kind == ast.KindCallExpression {
+					call := init.AsCallExpression()
+					if call.Arguments != nil && len(call.Arguments.Nodes) > 0 {
+						arg0 := ast.SkipParentheses(call.Arguments.Nodes[0])
+						if arg0.Kind == ast.KindStringLiteral {
+							canonical = canonicalForModuleSource(arg0.AsStringLiteral().Text)
+						}
+					}
+				}
+				// Arm 2: init is a bare Identifier whose text matches one of
+				// a module's alias names (e.g. `ReactPerf` / `Perf`).
+				if canonical == "" && init.Kind == ast.KindIdentifier {
+					canonical = canonicalForModuleIdentifier(init.AsIdentifier().Text)
+				}
+				if canonical == "" {
+					return
+				}
+
+				obp := bindingName.AsBindingPattern()
+				if obp == nil || obp.Elements == nil {
+					return
+				}
+				for _, elem := range obp.Elements.Nodes {
+					if elem == nil {
+						continue
+					}
+					be := elem.AsBindingElement()
+					if be == nil {
+						continue
+					}
+					// `...rest` has no property-name; upstream filters it out
+					// via `p.type !== 'RestElement' && p.key`.
+					if be.DotDotDotToken != nil {
+						continue
+					}
+					// ESLint's `property.key.name` is the imported/from-source
+					// name. For an aliased binding `{ X: Y }` tsgo exposes
+					// `PropertyName` (= X). For a shorthand `{ X }` the
+					// `Name()` itself is the key.
+					keyNode := be.PropertyName
+					if keyNode == nil {
+						keyNode = be.Name()
+					}
+					if keyNode == nil || keyNode.Kind != ast.KindIdentifier {
+						continue
+					}
+					check(keyNode, canonical+"."+keyNode.AsIdentifier().Text)
+				}
+			},
+
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				checkComponentMembers(node.Members())
+			},
+			ast.KindClassExpression: func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				checkComponentMembers(node.Members())
+			},
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				if !reactutil.IsCreateReactClassObjectArg(node, pragma, createClass) {
+					return
+				}
+				ol := node.AsObjectLiteralExpression()
+				if ol == nil || ol.Properties == nil {
+					return
+				}
+				checkComponentMembers(ol.Properties.Nodes)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated.md
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated.md
@@ -1,0 +1,97 @@
+# react/no-deprecated
+
+## Rule Details
+
+Several methods are deprecated between React versions. This rule warns about usage of methods that have been deprecated in the React version configured via `settings.react.version`. When no version is configured, the rule treats the project as "latest" and flags every known deprecation.
+
+The rule detects deprecated APIs through member access, named imports, destructuring from `require()` / module bindings, and lifecycle methods declared inside React components (ES5 `createReactClass` objects and ES6 classes extending `Component` / `PureComponent`).
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+React.render(<MyComponent />, root);
+
+React.unmountComponentAtNode(root);
+
+React.findDOMNode(this.refs.foo);
+
+React.renderToString(<MyComponent />);
+
+React.renderToStaticMarkup(<MyComponent />);
+
+React.createClass({ /* Class object */ });
+
+const propTypes = {
+  foo: PropTypes.bar,
+};
+
+// Any factories under React.DOM
+React.DOM.div();
+
+import React, { PropTypes } from 'react';
+
+// old lifecycles (since React 16.9)
+class Foo extends React.Component {
+  componentWillMount() {}
+  componentWillReceiveProps() {}
+  componentWillUpdate() {}
+}
+
+// React 18 deprecations
+import { render } from 'react-dom';
+ReactDOM.render(<div></div>, container);
+
+import { hydrate } from 'react-dom';
+ReactDOM.hydrate(<div></div>, container);
+
+import { unmountComponentAtNode } from 'react-dom';
+ReactDOM.unmountComponentAtNode(container);
+
+import { renderToNodeStream } from 'react-dom/server';
+ReactDOMServer.renderToNodeStream(element);
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+// when React < 18
+ReactDOM.render(<MyComponent />, root);
+
+// when React is < 0.14
+ReactDOM.findDOMNode(this.refs.foo);
+
+import { PropTypes } from 'prop-types';
+
+class Foo extends React.Component {
+  UNSAFE_componentWillMount() {}
+  UNSAFE_componentWillReceiveProps() {}
+  UNSAFE_componentWillUpdate() {}
+}
+
+ReactDOM.createPortal(child, container);
+
+import { createRoot } from 'react-dom/client';
+const root = createRoot(container);
+root.unmount();
+
+import { hydrateRoot } from 'react-dom/client';
+const root = hydrateRoot(container, <App/>);
+```
+
+## Settings
+
+This rule is influenced by the shared React settings:
+
+- `settings.react.version` — determines which deprecations are active (default: latest).
+- `settings.react.pragma` — the `React` object name used for `<pragma>.X` deprecations (default: `"React"`). An inline `@jsx` comment overrides this setting for the file.
+
+## Differences from ESLint
+
+rslint flags these forms; ESLint does not:
+
+- `(React).createClass` and any other parenthesized wrap around the receiver.
+- `React?.createClass()` and optional-chain forms like `React?.addons?.TestUtils`.
+
+## Original Documentation
+
+- https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
@@ -808,5 +808,20 @@ func TestNoDeprecatedRule(t *testing.T) {
 				Line:      1, Column: 1,
 			}},
 		},
+
+		// ---- Edge: destructuring from a non-`require` call whose first argument
+		// is a React module string — upstream `getReactModuleName` arm 1 matches
+		// any CallExpression (not just `require`) whose first arg equals a
+		// module key, so `var {createClass} = myFunc('react')` is reported too.
+		// Locks in ESLint parity against a tempting "require-only" narrowing. ----
+		{
+			Code: `var {createClass} = myFunc('react');`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 6,
+			}},
+		},
 	})
 }

--- a/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
+++ b/internal/plugins/react/rules/no_deprecated/no_deprecated_test.go
@@ -1,0 +1,812 @@
+package no_deprecated
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Common message builders (mirror upstream's errorMessage helper).
+func msg(oldMethod, version, newMethod, refs string) string {
+	out := oldMethod + " is deprecated since React " + version
+	if newMethod != "" {
+		out += ", use " + newMethod + " instead"
+	}
+	if refs != "" {
+		out += ", see " + refs
+	}
+	return out
+}
+
+const lifecycleRefsTail = ". Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components."
+const lifecycleRefsHead = "https://reactjs.org/docs/react-component.html#"
+
+func TestNoDeprecatedRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoDeprecatedRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid: not deprecated APIs ----
+		{Code: `var element = React.createElement('p', {}, null);`, Tsx: true},
+		{Code: `var clone = React.cloneElement(element);`, Tsx: true},
+		{Code: `ReactDOM.cloneElement(child, container);`, Tsx: true},
+		{Code: `ReactDOM.findDOMNode(instance);`, Tsx: true},
+		{Code: `ReactDOM.createPortal(child, container);`, Tsx: true},
+		{Code: `ReactDOMServer.renderToString(element);`, Tsx: true},
+		{Code: `ReactDOMServer.renderToStaticMarkup(element);`, Tsx: true},
+
+		// ---- Upstream valid: createReactClass with only render ----
+		{Code: `
+        var Foo = createReactClass({
+          render: function() {}
+        })
+      `, Tsx: true},
+
+		// ---- Upstream valid: Non-React patterns (not createReactClass) ----
+		{Code: `
+        var Foo = createReactClassNonReact({
+          componentWillMount: function() {},
+          componentWillReceiveProps: function() {},
+          componentWillUpdate: function() {}
+        });
+      `, Tsx: true},
+		{Code: `
+        var Foo = {
+          componentWillMount: function() {},
+          componentWillReceiveProps: function() {},
+          componentWillUpdate: function() {}
+        };
+      `, Tsx: true},
+		{Code: `
+        class Foo {
+          constructor() {}
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: deprecated in a later React version than settings ----
+		{Code: `React.renderComponent()`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "0.11.0"}}},
+		{Code: `React.createClass()`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "15.4.0"}}},
+		{Code: `PropTypes`, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "15.4.0"}}},
+		{Code: `
+        class Foo extends React.Component {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.8.0"}}},
+
+		// ---- Upstream valid: destructuring rest / default — no flagged name ----
+		{Code: `
+        import React from "react";
+
+        let { default: defaultReactExport, ...allReactExports } = React;
+      `, Tsx: true},
+
+		// ---- Upstream valid: React < 18 (react-dom / react-dom/server pre-18 API is fine) ----
+		{Code: `
+        import { render, hydrate } from 'react-dom';
+        import { renderToNodeStream } from 'react-dom/server';
+        ReactDOM.render(element, container);
+        ReactDOM.unmountComponentAtNode(container);
+        ReactDOMServer.renderToNodeStream(element);
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "17.999.999"}}},
+
+		// ---- Upstream valid: React 18 replacements are fine ----
+		{Code: `
+        import ReactDOM, { createRoot } from 'react-dom/client';
+        ReactDOM.createRoot(container);
+        const root = createRoot(container);
+        root.unmount();
+      `, Tsx: true},
+		{Code: `
+        import ReactDOM, { hydrateRoot } from 'react-dom/client';
+        ReactDOM.hydrateRoot(container, <App/>);
+        hydrateRoot(container, <App/>);
+      `, Tsx: true},
+		{Code: `
+        import ReactDOMServer, { renderToPipeableStream } from 'react-dom/server';
+        ReactDOMServer.renderToPipeableStream(<App />, {});
+        renderToPipeableStream(<App />, {});
+      `, Tsx: true},
+
+		// ---- Upstream valid: renderToString stays on ReactDOMServer, not deprecated ----
+		{Code: `
+        import { renderToString } from 'react-dom/server';
+      `, Tsx: true},
+		{Code: `
+        const { renderToString } = require('react-dom/server');
+      `, Tsx: true},
+
+		// ---- Edge: element access doesn't match (dotted-path only) ----
+		{Code: `React['createClass']({})`, Tsx: true},
+
+		// ---- Edge: non-React destructuring isn't flagged ----
+		{Code: `var { createClass } = something();`, Tsx: true},
+		{Code: `var { createClass } = require('not-react');`, Tsx: true},
+
+		// ---- Edge: lifecycle inside nested non-component class is ignored ----
+		// Only the nearest class decides ES6-component status, so an Inner
+		// non-React class with componentWillMount does NOT inherit Outer's
+		// component-ness.
+		{Code: `
+        class Outer extends React.Component {
+          render() {
+            class Inner {
+              componentWillMount() {}
+            }
+            return null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: non-null assertion `React!.createClass` — chain breaks, not flagged ----
+		// ESLint runs on JS and never sees this; rslint conservatively doesn't
+		// traverse through TS-only NonNullExpression either, matching "upstream
+		// has no opinion" semantics.
+		{Code: `React!.createClass({})`, Tsx: true},
+
+		// ---- Edge: `as any` cast breaks the dotted chain similarly ----
+		{Code: `(React as any).createClass({})`, Tsx: true},
+
+		// ---- Edge: renderToString from react-dom/server — canonical is
+		// ReactDOMServer.renderToString, which is NOT in the deprecation map. ----
+		{Code: `import { renderToString } from 'react-dom/server';`, Tsx: true},
+		{Code: `ReactDOMServer.renderToString(element);`, Tsx: true},
+
+		// ---- Edge: namespace import isn't a named specifier, so nothing flagged ----
+		{Code: `import * as React from 'react';`, Tsx: true},
+
+		// ---- Edge: default import alone — no named specifiers, nothing flagged ----
+		{Code: `import React from 'react';`, Tsx: true},
+
+		// ---- Edge: static lifecycle method on React class — same name matches map ----
+		// Note: upstream also flags this (getComponentProperties returns all members,
+		// the deprecation map key is just the bare name). Locked in for parity.
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream #1: React.renderComponent() ----
+		{
+			Code: `React.renderComponent()`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.renderComponent", "0.12.0", "React.render", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Upstream #2: custom pragma via settings ----
+		{
+			Code:     `Foo.renderComponent()`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Foo"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("Foo.renderComponent", "0.12.0", "Foo.render", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Upstream #3: `@jsx Foo` comment overrides pragma ----
+		{
+			Code: `/** @jsx Foo */ Foo.renderComponent()`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("Foo.renderComponent", "0.12.0", "Foo.render", ""),
+				Line:      1, Column: 17,
+			}},
+		},
+
+		// ---- Upstream #4: `this.transferPropsTo()` ----
+		{
+			Code: `this.transferPropsTo()`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("this.transferPropsTo", "0.12.0", "spread operator ({...})", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Upstream #5: nested member access — inner path matches ----
+		{
+			Code: `React.addons.TestUtils`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.addons.TestUtils", "15.5.0", "ReactDOM.TestUtils", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.addons.classSet()`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.addons.classSet", "0.13.0", "the npm module classnames", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Upstream #6: 0.14.0 migrations ----
+		{
+			Code: `React.render(element, container);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.render", "0.14.0", "ReactDOM.render", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.unmountComponentAtNode(container);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.unmountComponentAtNode", "0.14.0", "ReactDOM.unmountComponentAtNode", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.findDOMNode(instance);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.findDOMNode", "0.14.0", "ReactDOM.findDOMNode", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.renderToString(element);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.renderToString", "0.14.0", "ReactDOMServer.renderToString", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.renderToStaticMarkup(element);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.renderToStaticMarkup", "0.14.0", "ReactDOMServer.renderToStaticMarkup", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Upstream #7: React.createClass / React.PropTypes / React.DOM ----
+		{
+			Code: `React.createClass({});`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code:     `Foo.createClass({});`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Foo"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("Foo.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.PropTypes`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.PropTypes", "15.5.0", "the npm module prop-types", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React.DOM.div`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.DOM", "15.6.0", "the npm module react-dom-factories", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Upstream #8: require() destructuring ----
+		{
+			Code: `var {createClass} = require('react');`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 6,
+			}},
+		},
+		{
+			Code: `var {createClass, PropTypes} = require('react');`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+					Line:      1, Column: 6,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("React.PropTypes", "15.5.0", "the npm module prop-types", ""),
+					Line:      1, Column: 19,
+				},
+			},
+		},
+
+		// ---- Upstream #9: named imports ----
+		{
+			Code: `import {createClass} from 'react';`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 9,
+			}},
+		},
+		{
+			Code: `import {createClass, PropTypes} from 'react';`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+					Line:      1, Column: 9,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("React.PropTypes", "15.5.0", "the npm module prop-types", ""),
+					Line:      1, Column: 22,
+				},
+			},
+		},
+
+		// ---- Upstream #10: default import + destructure of the namespace ----
+		{
+			Code: `
+      import React from 'react';
+      const {createClass, PropTypes} = React;
+    `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+					Line:      3, Column: 14,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("React.PropTypes", "15.5.0", "the npm module prop-types", ""),
+					Line:      3, Column: 27,
+				},
+			},
+		},
+
+		// ---- Upstream #11: react-addons-perf ----
+		{
+			Code: `import {printDOM} from 'react-addons-perf';`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("ReactPerf.printDOM", "15.0.0", "ReactPerf.printOperations", ""),
+				Line:      1, Column: 9,
+			}},
+		},
+		{
+			Code: `
+        import ReactPerf from 'react-addons-perf';
+        const {printDOM} = ReactPerf;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("ReactPerf.printDOM", "15.0.0", "ReactPerf.printOperations", ""),
+				Line:      3, Column: 16,
+			}},
+		},
+
+		// ---- Upstream #12: lifecycle methods (ES6 class extending React.PureComponent) ----
+		{
+			Code: `
+        class Bar extends React.PureComponent {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("componentWillMount", "16.9.0", "UNSAFE_componentWillMount", lifecycleRefsHead+"unsafe_componentwillmount"+lifecycleRefsTail),
+					Line:      3, Column: 11,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("componentWillReceiveProps", "16.9.0", "UNSAFE_componentWillReceiveProps", lifecycleRefsHead+"unsafe_componentwillreceiveprops"+lifecycleRefsTail),
+					Line:      4, Column: 11,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("componentWillUpdate", "16.9.0", "UNSAFE_componentWillUpdate", lifecycleRefsHead+"unsafe_componentwillupdate"+lifecycleRefsTail),
+					Line:      5, Column: 11,
+				},
+			},
+		},
+
+		// ---- Upstream #13: class expression (extends React.PureComponent) ----
+		{
+			Code: `
+        function Foo() {
+          return class Bar extends React.PureComponent {
+            componentWillMount() {}
+            componentWillReceiveProps() {}
+            componentWillUpdate() {}
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 4, Column: 13},
+				{MessageId: "deprecated", Line: 5, Column: 13},
+				{MessageId: "deprecated", Line: 6, Column: 13},
+			},
+		},
+
+		// ---- Upstream #14: bare PureComponent (unqualified) ----
+		{
+			Code: `
+        class Bar extends PureComponent {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+				{MessageId: "deprecated", Line: 4, Column: 11},
+				{MessageId: "deprecated", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Upstream #15: React.Component ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+				{MessageId: "deprecated", Line: 4, Column: 11},
+				{MessageId: "deprecated", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Upstream #16: bare Component ----
+		{
+			Code: `
+        class Foo extends Component {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+				{MessageId: "deprecated", Line: 4, Column: 11},
+				{MessageId: "deprecated", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Upstream #17: createReactClass lifecycle methods ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          componentWillMount: function() {},
+          componentWillReceiveProps: function() {},
+          componentWillUpdate: function() {}
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+				{MessageId: "deprecated", Line: 4, Column: 11},
+				{MessageId: "deprecated", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Upstream #18: with constructor (not reported) ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          constructor() {}
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 4, Column: 11},
+				{MessageId: "deprecated", Line: 5, Column: 11},
+				{MessageId: "deprecated", Line: 6, Column: 11},
+			},
+		},
+
+		// ---- Upstream #19–22: React 18 react-dom / react-dom-server deprecations ----
+		{
+			Code: `
+        import { render } from 'react-dom';
+        ReactDOM.render(<div></div>, container);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOM.render", "18.0.0", "createRoot", "https://reactjs.org/link/switch-to-createroot"),
+					Line:      2, Column: 18,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOM.render", "18.0.0", "createRoot", "https://reactjs.org/link/switch-to-createroot"),
+					Line:      3, Column: 9,
+				},
+			},
+		},
+		{
+			Code: `
+        import { hydrate } from 'react-dom';
+        ReactDOM.hydrate(<div></div>, container);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOM.hydrate", "18.0.0", "hydrateRoot", "https://reactjs.org/link/switch-to-createroot"),
+					Line:      2, Column: 18,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOM.hydrate", "18.0.0", "hydrateRoot", "https://reactjs.org/link/switch-to-createroot"),
+					Line:      3, Column: 9,
+				},
+			},
+		},
+		{
+			Code: `
+        import { unmountComponentAtNode } from 'react-dom';
+        ReactDOM.unmountComponentAtNode(container);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOM.unmountComponentAtNode", "18.0.0", "root.unmount", "https://reactjs.org/link/switch-to-createroot"),
+					Line:      2, Column: 18,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOM.unmountComponentAtNode", "18.0.0", "root.unmount", "https://reactjs.org/link/switch-to-createroot"),
+					Line:      3, Column: 9,
+				},
+			},
+		},
+		{
+			Code: `
+        import { renderToNodeStream } from 'react-dom/server';
+        ReactDOMServer.renderToNodeStream(element);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOMServer.renderToNodeStream", "18.0.0", "renderToPipeableStream", "https://reactjs.org/docs/react-dom-server.html#rendertonodestream"),
+					Line:      2, Column: 18,
+				},
+				{
+					MessageId: "deprecated",
+					Message:   msg("ReactDOMServer.renderToNodeStream", "18.0.0", "renderToPipeableStream", "https://reactjs.org/docs/react-dom-server.html#rendertonodestream"),
+					Line:      3, Column: 9,
+				},
+			},
+		},
+
+		// ---- Edge: parenthesized `(React).createClass` — rslint flags, ESLint would not ----
+		// Locks in the Phase 1 Step 5.B divergence documented in the `.md`.
+		{
+			Code: `(React).createClass({})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Edge: version exactly at deprecation boundary is reported ----
+		{
+			Code:     `React.createClass({})`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "15.5.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Edge: async / generator / async-generator lifecycle variants ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          async componentWillMount() {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 17},
+			},
+		},
+
+		// ---- Edge: class field arrow lifecycle ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          componentWillMount = () => {}
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: aliased destructuring `{createClass: fn}` — key name is from-module ----
+		{
+			Code: `const {createClass: fn} = require('react');`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 8,
+			}},
+		},
+
+		// ---- Edge: optional chain `React?.createClass()` — tsgo PropertyAccess
+		// with OptionalChain flag is still KindPropertyAccessExpression, so the
+		// dotted-path builder handles it transparently. ----
+		{
+			Code: `React?.createClass({})`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+		{
+			Code: `React?.addons?.TestUtils`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("React.addons.TestUtils", "15.5.0", "ReactDOM.TestUtils", ""),
+				Line:      1, Column: 1,
+			}},
+		},
+
+		// ---- Edge: createReactClass with multi-layer parens around the object argument ----
+		{
+			Code: `
+        createReactClass(((({
+          componentWillMount: function() {}
+        }))));
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: `<pragma>.createClass` ≠ configured createClass (default
+		// `createReactClass`), so the inner object is NOT recognized as an ES5
+		// component and its lifecycle keys are NOT examined. Only the outer
+		// `React.createClass` itself is flagged (as a deprecated member access).
+		// Matches upstream: upstream's `componentUtil.isES5Component` also
+		// compares against `settings.react.createClass` literally. ----
+		{
+			Code: `
+        React.createClass({
+          componentWillMount: function() {}
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: same shape but with `settings.react.createClass` set to
+		// `"createClass"` — now the inner object IS an ES5 component and its
+		// lifecycle prop is additionally flagged. ----
+		{
+			Code: `
+        React.createClass({
+          componentWillMount: function() {}
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{"createClass": "createClass"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 2, Column: 9},
+				{MessageId: "deprecated", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: @jsx wins over settings.react.pragma when both are present ----
+		{
+			Code:     `/** @jsx Bar */ Bar.createClass({})`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Foo"}},
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("Bar.createClass", "15.5.0", "the npm module create-react-class", ""),
+				Line:      1, Column: 17,
+			}},
+		},
+
+		// ---- Edge: class expression assigned to const — lifecycle still detected ----
+		{
+			Code: `
+        const Hello = class extends React.Component {
+          componentWillMount() {}
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Edge: SpreadAssignment in createReactClass doesn't crash and doesn't mask siblings ----
+		{
+			Code: `
+        const mixin = {};
+        var Hello = createReactClass({
+          ...mixin,
+          componentWillUpdate: function() {}
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "deprecated", Line: 5, Column: 11},
+			},
+		},
+
+		// ---- Edge: ReactDOMServer.renderToNodeStream without any import (direct member access). ----
+		{
+			Code: `ReactDOMServer.renderToNodeStream(element);`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "deprecated",
+				Message:   msg("ReactDOMServer.renderToNodeStream", "18.0.0", "renderToPipeableStream", "https://reactjs.org/docs/react-dom-server.html#rendertonodestream"),
+				Line:      1, Column: 1,
+			}},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_typos/no_typos.go
+++ b/internal/plugins/react/rules/no_typos/no_typos.go
@@ -462,7 +462,7 @@ func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
 		ast.KindObjectLiteralExpression: func(node *ast.Node) {
 			// Component defined via createReactClass({...}): inspect top-level
 			// properties for prop-declaration typos and lifecycle typos.
-			if !isCreateClassObjectArg(node, pragma, createClass) {
+			if !reactutil.IsCreateReactClassObjectArg(node, pragma, createClass) {
 				return
 			}
 			for _, prop := range node.AsObjectLiteralExpression().Properties.Nodes {
@@ -646,30 +646,6 @@ func enclosingClass(node *ast.Node) *ast.Node {
 		}
 	}
 	return nil
-}
-
-// isCreateClassObjectArg reports whether `obj` is the first argument of a
-// `<createClass>(...)` / `<pragma>.<createClass>(...)` call. ES5 component
-// detection hinges on this shape.
-func isCreateClassObjectArg(obj *ast.Node, pragma, createClass string) bool {
-	if obj == nil || obj.Kind != ast.KindObjectLiteralExpression {
-		return false
-	}
-	// Walk up through any parenthesized wrappers to find the call argument
-	// position — tsgo preserves parens that ESTree would flatten.
-	cur := obj
-	for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
-		cur = cur.Parent
-	}
-	parent := cur.Parent
-	if parent == nil || parent.Kind != ast.KindCallExpression {
-		return false
-	}
-	call := parent.AsCallExpression()
-	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 || call.Arguments.Nodes[0] != cur {
-		return false
-	}
-	return reactutil.IsCreateClassCall(call, pragma, createClass)
 }
 
 // functionReturnsJSX reports whether the given function-like node contains a

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -103,6 +103,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-danger-with-children.test.ts',
+    './tests/eslint-plugin-react/rules/no-deprecated.test.ts',
     './tests/eslint-plugin-react/rules/no-did-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/no-direct-mutation-state.test.ts',
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-deprecated.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-deprecated.test.ts
@@ -1,0 +1,152 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-deprecated', {} as never, {
+  valid: [
+    // ---- Not deprecated ----
+    { code: `var element = React.createElement('p', {}, null);` },
+    { code: `var clone = React.cloneElement(element);` },
+    { code: `ReactDOM.cloneElement(child, container);` },
+    { code: `ReactDOM.findDOMNode(instance);` },
+    { code: `ReactDOM.createPortal(child, container);` },
+    { code: `ReactDOMServer.renderToString(element);` },
+    { code: `ReactDOMServer.renderToStaticMarkup(element);` },
+
+    // ---- createReactClass with only render ----
+    {
+      code: `
+        var Foo = createReactClass({
+          render: function() {}
+        })
+      `,
+    },
+
+    // ---- Non-React patterns ----
+    {
+      code: `
+        var Foo = createReactClassNonReact({
+          componentWillMount: function() {}
+        });
+      `,
+    },
+    {
+      code: `
+        var Foo = { componentWillMount: function() {} };
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          componentWillMount() {}
+        }
+      `,
+    },
+
+    // ---- React 18 replacements ----
+    {
+      code: `
+        import ReactDOM, { createRoot } from 'react-dom/client';
+        ReactDOM.createRoot(container);
+        const root = createRoot(container);
+        root.unmount();
+      `,
+    },
+    {
+      code: `
+        import { renderToString } from 'react-dom/server';
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Member access ----
+    {
+      code: `React.renderComponent()`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `this.transferPropsTo()`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `React.addons.TestUtils`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `React.render(element, container);`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `React.createClass({});`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `React.PropTypes`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `React.DOM.div`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+
+    // ---- Destructuring ----
+    {
+      code: `var {createClass} = require('react');`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `var {createClass, PropTypes} = require('react');`,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+
+    // ---- Imports ----
+    {
+      code: `import {createClass} from 'react';`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+    {
+      code: `import {printDOM} from 'react-addons-perf';`,
+      errors: [{ messageId: 'deprecated' }],
+    },
+
+    // ---- Lifecycle methods ----
+    {
+      code: `
+        class Foo extends React.Component {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `,
+      errors: [
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+        { messageId: 'deprecated' },
+      ],
+    },
+    {
+      code: `
+        var Foo = createReactClass({
+          componentWillMount: function() {}
+        })
+      `,
+      errors: [{ messageId: 'deprecated' }],
+    },
+
+    // ---- React 18 deprecations ----
+    {
+      code: `
+        import { render } from 'react-dom';
+        ReactDOM.render(<div></div>, container);
+      `,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+    {
+      code: `
+        import { renderToNodeStream } from 'react-dom/server';
+        ReactDOMServer.renderToNodeStream(element);
+      `,
+      errors: [{ messageId: 'deprecated' }, { messageId: 'deprecated' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -235,3 +235,12 @@ Nent
 Søknad
 codepoint
 misalign
+Pipeable
+classnames
+componentwillmount
+componentwillreceiveprops
+componentwillupdate
+renderable
+Unparseable
+deprec
+segs


### PR DESCRIPTION
## Summary

Port the `react/no-deprecated` rule from `eslint-plugin-react` to rslint.

The rule warns about usage of React APIs that are deprecated at the configured `settings.react.version`. Detection covers:

- Member access: `React.createClass`, `React.PropTypes`, `React.DOM`, `React.addons.*`, `this.transferPropsTo`, `ReactDOM.render` (React 18), `ReactDOMServer.renderToNodeStream` (React 18), etc.
- Named imports from `react` / `react-dom` / `react-dom/server` / `react-addons-perf`.
- Destructuring from `require('<react-module>')` or from the module-binding identifier.
- Deprecated lifecycle methods (`componentWillMount` / `componentWillReceiveProps` / `componentWillUpdate` ≥ 16.9.0) in ES5 `createReactClass` objects and ES6 classes extending `Component` / `PureComponent`.

Configuration respected: `settings.react.version`, `settings.react.pragma`, `settings.react.createClass`, and inline `@jsx` comments (override pragma).

All 24 upstream `invalid` and 22 upstream `valid` test cases are migrated 1:1, plus Go-implementation-specific edge cases (optional chain, parenthesized receiver, multi-paren createReactClass argument, class-field arrow lifecycle, aliased destructuring, TS non-null/as-cast chain break, etc.).

Two known user-visible divergences (rslint more permissive, documented in the rule's `.md` and locked in by tests):

- `(React).createClass` — flagged by rslint, missed by ESLint.
- `React?.createClass()` — flagged by rslint, missed by ESLint.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-deprecated.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-deprecated.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).