### PR TITLE
feat: port rule react/no-access-state-in-setstate

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -18,6 +18,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_react"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_uses_vars"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_wrap_multilines"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_access_state_in_setstate"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_children_prop"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_danger_with_children"
@@ -60,6 +61,7 @@ func GetAllRules() []rule.Rule {
 		jsx_uses_react.JsxUsesReactRule,
 		jsx_uses_vars.JsxUsesVarsRule,
 		jsx_wrap_multilines.JsxWrapMultilinesRule,
+		no_access_state_in_setstate.NoAccessStateInSetstateRule,
 		no_children_prop.NoChildrenPropRule,
 		no_danger.NoDangerRule,
 		no_danger_with_children.NoDangerWithChildrenRule,

--- a/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.go
+++ b/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.go
@@ -1,0 +1,559 @@
+package no_access_state_in_setstate
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// memberPropertyName returns the property-side name of a PropertyAccessExpression
+// the way ESLint sees it via `property.name`: an Identifier's text, or a
+// PrivateIdentifier's text with the leading `#` stripped (per ESTree spec).
+// Any other shape (e.g. ElementAccessExpression caller, null name) yields ""
+// so callers can compare against a literal name without false matches.
+func memberPropertyName(pa *ast.PropertyAccessExpression) string {
+	if pa == nil {
+		return ""
+	}
+	name := pa.Name()
+	if name == nil {
+		return ""
+	}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		return name.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(name.AsPrivateIdentifier().Text, "#")
+	}
+	return ""
+}
+
+// isThisReceiver reports whether `expr` — with any ParenthesizedExpression
+// wrappers skipped — is the `this` keyword. Mirrors ESTree's post-paren-strip
+// `object.type === 'ThisExpression'` check.
+func isThisReceiver(expr *ast.Node) bool {
+	return expr != nil && ast.SkipParentheses(expr).Kind == ast.KindThisKeyword
+}
+
+// isSetStateCall matches `this.setState(...)` (and `this.#setState(...)`),
+// replicating upstream's `callee.property.name === 'setState' &&
+// callee.object.type === 'ThisExpression'`. Bracket-access
+// (`this['setState']`) is excluded: upstream's `property.name` check has no
+// analog for Literal keys. Parentheses around `this` are stripped to emulate
+// ESTree's paren-stripping.
+func isSetStateCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := node.AsCallExpression()
+	callee := ast.SkipParentheses(call.Expression)
+	if callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pa := callee.AsPropertyAccessExpression()
+	if !isThisReceiver(pa.Expression) {
+		return false
+	}
+	return memberPropertyName(pa) == "setState"
+}
+
+// isThisStateMember matches the `this.state` AST pattern ESLint detects via
+// `property.name === 'state' && object.type === 'ThisExpression'`. Bracket
+// access (`this['state']`) is excluded for the same reason as isSetStateCall.
+func isThisStateMember(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pa := node.AsPropertyAccessExpression()
+	if !isThisReceiver(pa.Expression) {
+		return false
+	}
+	return memberPropertyName(pa) == "state"
+}
+
+// isFirstArgumentInSetStateCall mirrors upstream's helper of the same name.
+// Returns true when `current` is a setState call AND the ancestor chain from
+// `node` reaches `current.arguments[0]`.
+func isFirstArgumentInSetStateCall(current, node *ast.Node) bool {
+	if !isSetStateCall(current) {
+		return false
+	}
+	for node != nil && node.Parent != current {
+		node = node.Parent
+	}
+	if node == nil {
+		return false
+	}
+	call := current.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return false
+	}
+	return call.Arguments.Nodes[0] == node
+}
+
+// containerKind captures which upstream branch a "walk stopper" corresponds to.
+// Both branches populate the `methods` array, but only classMethod propagates
+// transitively through the CallExpression listener — upstream's propagation
+// loop is gated on `current.type === 'MethodDefinition'`, which is the ESTree
+// class-body form only.
+type containerKind int
+
+const (
+	containerNone      containerKind = iota
+	containerClass                   // ESTree MethodDefinition (class-body method/accessor/constructor)
+	containerObjectLit               // ESTree Property with FunctionExpression value (object-literal method or `foo: function(){}` form)
+)
+
+// methodContainerKind reports which "function body attached to a named key"
+// shape `node` represents — the generalized form of upstream's MemberExpression
+// walk stoppers. We purposefully cover every tsgo shape that maps onto ESTree's
+// MethodDefinition or Property-with-FE-value so new AST forms (object-literal
+// getter / setter, shorthand method, arrow in property value — see below) are
+// tracked consistently instead of case-by-case.
+//
+// Classification:
+//
+//   - classMethod: function-like node whose direct parent is a ClassLike node
+//     (ClassDeclaration / ClassExpression). Includes MethodDeclaration,
+//     GetAccessor, SetAccessor, Constructor — all four ESTree MethodDefinition
+//     kinds. PropertyDeclaration (class field, including arrow-function fields)
+//     is NOT included: ESTree renders it as PropertyDefinition, which upstream's
+//     walk does not stop at.
+//
+//   - objectLit: function-like value attached to an object-literal key.
+//     Covers three tsgo shapes, all of which ESTree flattens into
+//     Property-with-FE-value:
+//     1. MethodDeclaration / GetAccessor / SetAccessor whose parent is
+//     ObjectLiteralExpression (shorthand: `{ foo() {...} }`, `{ get foo() {...} }`).
+//     2. FunctionExpression whose parent is PropertyAssignment
+//     (`{ foo: function() {...} }`).
+//     Arrow functions as property values (`{ foo: () => {...} }`) are
+//     intentionally NOT tracked — upstream gates on `FunctionExpression`,
+//     which excludes ArrowFunctionExpression.
+func methodContainerKind(node *ast.Node) containerKind {
+	if node == nil || node.Parent == nil {
+		return containerNone
+	}
+	parent := node.Parent
+	// Class-body member — ESTree MethodDefinition.
+	if ast.IsClassLike(parent) {
+		switch node.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+			return containerClass
+		}
+		return containerNone
+	}
+	// Object-literal shorthand method / accessor.
+	if parent.Kind == ast.KindObjectLiteralExpression && ast.IsMethodOrAccessor(node) {
+		return containerObjectLit
+	}
+	// Object-literal `foo: function() {...}` form.
+	if parent.Kind == ast.KindPropertyAssignment && node.Kind == ast.KindFunctionExpression {
+		if parent.AsPropertyAssignment().Initializer == node {
+			return containerObjectLit
+		}
+	}
+	return containerNone
+}
+
+// containerKeyName returns the method-container's key as a string — the
+// value ESLint would read via `'name' in current.key ? current.key.name :
+// undefined`. Only Identifier and PrivateIdentifier populate `.name` in
+// ESTree (the latter without the leading `#` per spec); StringLiteral,
+// NumericLiteral, and ComputedPropertyName all yield `undefined` and never
+// match a real callee name. We mirror that strictly — any non-Identifier /
+// non-PrivateIdentifier key yields "" so propagation stays upstream-aligned
+// even for e.g. `['nextState']() {...}` or `"nextState"() {...}`.
+//
+// For class-body members the key lives on the node itself (`node.Name()`);
+// for object-literal property values it lives on the PropertyAssignment
+// parent.
+func containerKeyName(node *ast.Node, kind containerKind) string {
+	switch kind {
+	case containerClass:
+		if node.Kind == ast.KindConstructor {
+			// ESTree's constructor key is Identifier('constructor') — keep
+			// parity even though no real code calls `constructor` by name.
+			return "constructor"
+		}
+		return keyIdentifierText(node.Name())
+	case containerObjectLit:
+		keyHost := node
+		if node.Parent.Kind == ast.KindPropertyAssignment {
+			keyHost = node.Parent
+		}
+		return keyIdentifierText(keyHost.Name())
+	}
+	return ""
+}
+
+// keyIdentifierText extracts the string value ESLint would see via
+// `'name' in node.key`. Returns the raw Identifier text, or a
+// PrivateIdentifier's text with the leading `#` stripped. Any other key
+// shape (StringLiteral, NumericLiteral, ComputedPropertyName, nil) yields
+// "" — upstream's `'name' in key` evaluates to false for those.
+func keyIdentifierText(n *ast.Node) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return n.AsIdentifier().Text
+	case ast.KindPrivateIdentifier:
+		return strings.TrimPrefix(n.AsPrivateIdentifier().Text, "#")
+	}
+	return ""
+}
+
+// isValueOrObjectPosition mirrors upstream's Identifier-listener guard:
+//
+//	while (current.parent.type === 'BinaryExpression') current = current.parent;
+//	if (('value' in current.parent && current.parent.value === current)
+//	    || ('object' in current.parent && current.parent.object === current))
+//
+// Mapping to tsgo:
+//
+//   - PropertyAssignment.Initializer  — ESTree Property.value (`{ foo: x }`)
+//   - ShorthandPropertyAssignment.Name — ESTree Property where key === value
+//     (`{ x }`); upstream's property.value still refers to the Identifier.
+//   - PropertyAccessExpression.Expression — ESTree MemberExpression.object
+//     for `x.foo`.
+//   - ElementAccessExpression.Expression — ESTree MemberExpression.object
+//     for `x[foo]`. The computed-key ArgumentExpression is NOT an "object"
+//     position — it corresponds to ESTree's `property`, not `object`.
+//
+// The BinaryExpression walk is restricted to non-assignment operators because
+// tsgo collapses ESTree's BinaryExpression + AssignmentExpression into one
+// Kind; upstream's check only targets non-assignment binary wrappers like
+// `a + b`.
+func isValueOrObjectPosition(id *ast.Node) bool {
+	p := walkUpBinary(id).Parent
+	if p == nil {
+		return false
+	}
+	cur := walkUpBinary(id)
+	switch p.Kind {
+	case ast.KindPropertyAssignment:
+		return p.AsPropertyAssignment().Initializer == cur
+	case ast.KindShorthandPropertyAssignment:
+		return p.AsShorthandPropertyAssignment().Name() == cur
+	case ast.KindPropertyAccessExpression:
+		return p.AsPropertyAccessExpression().Expression == cur
+	case ast.KindElementAccessExpression:
+		return p.AsElementAccessExpression().Expression == cur
+	}
+	return false
+}
+
+// walkUpBinary returns the outermost node reached by following non-assignment
+// BinaryExpression parents. Equivalent to the first loop in upstream's
+// Identifier listener — used so the caller can continue walking for the
+// setState-first-arg check from the post-binary-wrapper position.
+func walkUpBinary(node *ast.Node) *ast.Node {
+	cur := node
+	for cur.Parent != nil && cur.Parent.Kind == ast.KindBinaryExpression {
+		bin := cur.Parent.AsBinaryExpression()
+		if bin.OperatorToken == nil || ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+			break
+		}
+		cur = cur.Parent
+	}
+	return cur
+}
+
+// objectBindingPatternPropertyName extracts the "property-side name" of a
+// BindingElement — matching ESLint's `'name' in property.key && property.key.name`
+// lookup. Only Identifier keys (explicit or shorthand) participate; computed
+// keys, string-literal keys, and rest elements yield "".
+func objectBindingPatternPropertyName(be *ast.Node) string {
+	if be == nil || be.Kind != ast.KindBindingElement {
+		return ""
+	}
+	bindingElem := be.AsBindingElement()
+	if bindingElem.DotDotDotToken != nil {
+		return ""
+	}
+	if bindingElem.PropertyName != nil {
+		if bindingElem.PropertyName.Kind == ast.KindIdentifier {
+			return bindingElem.PropertyName.AsIdentifier().Text
+		}
+		return ""
+	}
+	// Shorthand: `{ state }` — the local Name doubles as the property key.
+	n := bindingElem.Name()
+	if n != nil && n.Kind == ast.KindIdentifier {
+		return n.AsIdentifier().Text
+	}
+	return ""
+}
+
+// findEnclosingClassMethod returns the nearest ancestor that is an ESTree
+// MethodDefinition (class-body member). Used by the CallExpression listener's
+// propagation loop.
+func findEnclosingClassMethod(node *ast.Node) *ast.Node {
+	return ast.FindAncestor(node, func(n *ast.Node) bool {
+		return methodContainerKind(n) == containerClass
+	})
+}
+
+var NoAccessStateInSetstateRule = rule.Rule{
+	Name: "react/no-access-state-in-setstate",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		isClassComponent := func(node *ast.Node) bool {
+			return reactutil.GetEnclosingReactComponent(node, pragma, createClass) != nil
+		}
+
+		report := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "useCallback",
+				Description: "Use callback in setState when referencing the previous state.",
+			})
+		}
+
+		type methodEntry struct {
+			methodName string
+			node       *ast.Node
+		}
+		// varEntry stores one tracked binding.
+		//
+		//   - symbol: non-nil when the binding was resolved through the type
+		//     checker. Use-site matching then compares symbol identity, which
+		//     correctly distinguishes `let`/`const` bindings declared in
+		//     sibling blocks of the same function (ESLint's block-scope
+		//     semantics — a strict upstream match).
+		//   - scope / variableName: fallback match used when either the
+		//     binding or the use site couldn't be resolved to a symbol
+		//     (e.g. plain-JS files with no TypeChecker available). Coarser
+		//     than block-scope resolution; preserves the previous function-
+		//     granular behavior rather than silently under-reporting.
+		type varEntry struct {
+			node         *ast.Node
+			symbol       *ast.Symbol
+			scope        *ast.Node
+			variableName string
+		}
+		// methods accumulates function containers whose body reads `this.state`
+		// (directly, or transitively via another tracked method). vars
+		// accumulates local bindings initialized with / destructured from
+		// `this.state` / `this`. Both persist across the whole file walk,
+		// matching upstream's closure variables.
+		var methods []methodEntry
+		var vars []varEntry
+
+		// symbolAt returns the symbol at `node` when the TypeChecker is
+		// available, or nil otherwise. Centralized so every call site
+		// consistently nil-guards on `ctx.TypeChecker`.
+		symbolAt := func(node *ast.Node) *ast.Symbol {
+			if ctx.TypeChecker == nil || node == nil {
+				return nil
+			}
+			return ctx.TypeChecker.GetSymbolAtLocation(node)
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				if !isThisStateMember(node) {
+					return
+				}
+				if !isClassComponent(node) {
+					return
+				}
+				for current := node; current != nil; current = current.Parent {
+					if isFirstArgumentInSetStateCall(current, node) {
+						report(node)
+						return
+					}
+					if kind := methodContainerKind(current); kind != containerNone {
+						methods = append(methods, methodEntry{
+							methodName: containerKeyName(current, kind),
+							node:       node,
+						})
+						return
+					}
+					if current.Kind == ast.KindVariableDeclaration {
+						declName := current.AsVariableDeclaration().Name()
+						vars = append(vars, varEntry{
+							node:         node,
+							symbol:       symbolAt(declName),
+							scope:        utils.FindEnclosingScope(node),
+							variableName: identifierOrEmpty(declName),
+						})
+						return
+					}
+				}
+			},
+
+			ast.KindCallExpression: func(node *ast.Node) {
+				if !isClassComponent(node) {
+					return
+				}
+				call := node.AsCallExpression()
+				// Upstream's `'name' in node.callee` admits both Identifier and
+				// PrivateIdentifier callees (the latter's `.name` excludes the
+				// leading `#` per ESTree spec). MemberExpression callees are
+				// excluded — propagation only triggers through bare-identifier
+				// calls. We mirror this and only compute a name for Identifier
+				// / PrivateIdentifier callees.
+				calleeName := ""
+				switch call.Expression.Kind {
+				case ast.KindIdentifier:
+					calleeName = call.Expression.AsIdentifier().Text
+				case ast.KindPrivateIdentifier:
+					calleeName = strings.TrimPrefix(call.Expression.AsPrivateIdentifier().Text, "#")
+				}
+
+				// Propagate tracked methods up one class-body frame: if this
+				// call invokes a tracked method by bare identifier, find the
+				// enclosing MethodDefinition and register it too so later
+				// `this.setState(outerMethod())` reports.
+				if calleeName != "" {
+					// Snapshot length so appends during iteration don't feed
+					// back into the same loop — mirrors upstream's single
+					// forEach pass.
+					n := len(methods)
+					for i := range n {
+						method := methods[i]
+						if method.methodName != calleeName {
+							continue
+						}
+						if enclosing := findEnclosingClassMethod(node.Parent); enclosing != nil {
+							methods = append(methods, methodEntry{
+								methodName: containerKeyName(enclosing, containerClass),
+								node:       method.node,
+							})
+						}
+					}
+				}
+
+				// If this call sits inside the first argument of a setState
+				// call, report once for every tracked method whose name
+				// matches the callee — each tracked method stores the
+				// original `this.state` node as the report position, per
+				// upstream.
+				for current := node.Parent; current != nil; current = current.Parent {
+					if !isFirstArgumentInSetStateCall(current, node) {
+						continue
+					}
+					if calleeName != "" {
+						for _, method := range methods {
+							if method.methodName == calleeName {
+								report(method.node)
+							}
+						}
+					}
+					return
+				}
+			},
+
+			ast.KindIdentifier: func(node *ast.Node) {
+				if !isValueOrObjectPosition(node) {
+					return
+				}
+				// Walk up through non-assignment BinaryExpression wrappers
+				// first — upstream's inner `while` — so the outer walk starts
+				// from the same position ESLint sees.
+				start := walkUpBinary(node)
+				useName := node.AsIdentifier().Text
+				// Prefer symbol-identity matching (aligns with ESLint's
+				// block-scope manager); fall back to function-scope + name
+				// when either side lacks a symbol (no TypeChecker, or the
+				// use site doesn't resolve — e.g. undeclared identifier).
+				useSymbol := utils.GetReferenceSymbol(node, ctx.TypeChecker)
+				var useScope *ast.Node // lazily computed for fallback
+				for current := start; current != nil; current = current.Parent {
+					if !isFirstArgumentInSetStateCall(current, node) {
+						continue
+					}
+					for _, v := range vars {
+						var matched bool
+						if v.symbol != nil && useSymbol != nil {
+							matched = v.symbol == useSymbol
+						} else {
+							if useScope == nil {
+								useScope = utils.FindEnclosingScope(node)
+							}
+							matched = v.scope == useScope && v.variableName == useName
+						}
+						if matched {
+							report(v.node)
+						}
+					}
+					// Upstream does NOT break here — it keeps walking up,
+					// potentially matching a second, outer setState call.
+				}
+			},
+
+			ast.KindObjectBindingPattern: func(node *ast.Node) {
+				// Upstream's `'init' in node.parent && node.parent.init &&
+				// node.parent.init.type === 'ThisExpression'`. Only
+				// VariableDeclarator parents carry an `.init`; Parameter and
+				// nested BindingElement parents do not, so they are skipped.
+				// Parentheses around `this` are skipped to emulate ESTree's
+				// paren-stripping.
+				parent := node.Parent
+				if parent == nil || parent.Kind != ast.KindVariableDeclaration {
+					return
+				}
+				init := parent.AsVariableDeclaration().Initializer
+				if init == nil || !isThisReceiver(init) {
+					return
+				}
+				scope := utils.FindEnclosingScope(node)
+				pat := node.AsBindingPattern()
+				if pat == nil || pat.Elements == nil {
+					return
+				}
+				for _, elem := range pat.Elements.Nodes {
+					if elem.Kind != ast.KindBindingElement {
+						continue
+					}
+					if objectBindingPatternPropertyName(elem) != "state" {
+						continue
+					}
+					be := elem.AsBindingElement()
+					// Report node mirrors upstream's `property.key`: the
+					// property-side identifier — PropertyName when renaming,
+					// otherwise the Name (which doubles as key in shorthand).
+					keyNode := be.PropertyName
+					if keyNode == nil {
+						keyNode = be.Name()
+					}
+					// Only capture a symbol for shorthand destructuring.
+					// Renamed form `{state: aliased}` deliberately goes through
+					// the name-based fallback: upstream's variableName='state'
+					// will never match the user-typed 'aliased' at the use
+					// site, so binding the local 'aliased' symbol here would
+					// divergently "fix" a latent upstream quirk. Keeping the
+					// renamed path symbol-less preserves upstream parity.
+					var sym *ast.Symbol
+					if be.PropertyName == nil {
+						sym = symbolAt(be.Name())
+					}
+					vars = append(vars, varEntry{
+						node:         keyNode,
+						symbol:       sym,
+						scope:        scope,
+						variableName: "state",
+					})
+				}
+			},
+		}
+	},
+}
+
+// identifierOrEmpty returns the text of `n` when it is an Identifier, "" otherwise.
+// Used for VariableDeclaration bindings where only plain-Identifier declarators
+// participate in the rule's variable-tracking (destructuring patterns are
+// handled by the ObjectBindingPattern listener).
+func identifierOrEmpty(n *ast.Node) string {
+	if n == nil || n.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return n.AsIdentifier().Text
+}

--- a/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.md
+++ b/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate.md
@@ -1,0 +1,73 @@
+# no-access-state-in-setstate
+
+## Rule Details
+
+Disallow reading `this.state` inside the first argument of `this.setState(...)`.
+
+Because React schedules and batches state updates asynchronously, the value
+of `this.state` at the moment `setState` is called is not necessarily the
+value the updater will see when it runs. Writing an update that derives from
+the previous state via direct `this.state` access can therefore yield stale
+results. The correct form passes a callback — `this.setState(prev => ...)` —
+which always receives the latest committed state.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class Hello extends React.Component {
+  onClick() {
+    this.setState({ value: this.state.value + 1 });
+  }
+}
+```
+
+```javascript
+class Hello extends React.Component {
+  onClick() {
+    var nextValue = this.state.value + 1;
+    this.setState({ value: nextValue });
+  }
+}
+```
+
+```javascript
+class Hello extends React.Component {
+  onClick() {
+    var { state } = this;
+    this.setState({ value: state.value + 1 });
+  }
+}
+```
+
+```javascript
+class Hello extends React.Component {
+  nextState() {
+    return this.state.value + 1;
+  }
+  onClick() {
+    this.setState({ value: nextState() });
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class Hello extends React.Component {
+  onClick() {
+    this.setState(state => ({ value: state.value + 1 }));
+  }
+}
+```
+
+```javascript
+class Hello extends React.Component {
+  onClick() {
+    this.setState({}, () => console.log(this.state));
+  }
+}
+```
+
+## Original Documentation
+
+- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md

--- a/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate_test.go
+++ b/internal/plugins/react/rules/no_access_state_in_setstate/no_access_state_in_setstate_test.go
@@ -1,0 +1,779 @@
+package no_access_state_in_setstate
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoAccessStateInSetstateRule(t *testing.T) {
+	// Upstream's suite runs with `settings.react.createClass = 'createClass'`,
+	// which wires the createReactClass matcher to `<pragma>.createClass(...)`
+	// (e.g. `React.createClass`). rslint's default is `createReactClass`;
+	// to keep the upstream test code verbatim we pass the same settings.
+	legacyCreateClass := map[string]interface{}{
+		"react": map[string]interface{}{"createClass": "createClass"},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoAccessStateInSetstateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: setState called with callback (the correct form) ----
+		{Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState(state => ({value: state.value + 1}))
+          }
+        });
+      `, Tsx: true, Settings: legacyCreateClass},
+
+		// ---- Upstream: this.state read outside setState first arg ----
+		{Code: `
+        var Hello = React.createClass({
+          multiplyValue: function(obj) {
+            return obj.value*2
+          },
+          onClick: function() {
+            var value = this.state.value
+            this.multiplyValue({ value: value })
+          }
+        });
+      `, Tsx: true, Settings: legacyCreateClass},
+
+		// ---- Upstream: issue 1559 — IIFE with .call(this) inside render ----
+		{Code: `
+        var SearchForm = createReactClass({
+          render: function () {
+            return (
+              <div>
+                {(function () {
+                  if (this.state.prompt) {
+                    return <div>{this.state.prompt}</div>
+                  }
+                }).call(this)}
+              </div>
+            );
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: issue 1604 — this.state inside setState's callback argument (2nd arg) is allowed ----
+		{Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState({}, () => console.log(this.state));
+          }
+        });
+      `, Tsx: true, Settings: legacyCreateClass},
+
+		// ---- Upstream: setState with empty object and no state access in callback ----
+		{Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState({}, () => 1 + 1);
+          }
+        });
+      `, Tsx: true, Settings: legacyCreateClass},
+
+		// ---- Upstream: var captured from this.state is unused; setState uses an unrelated var ----
+		{Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            var nextValueNotUsed = this.state.value + 1
+            var nextValue = 2
+            this.setState({value: nextValue})
+          }
+        });
+      `, Tsx: true, Settings: legacyCreateClass},
+
+		// ---- Upstream: unrelated top-level destructuring in a non-component function ----
+		{Code: `
+        function testFunction({a, b}) {
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: class field arrow that reads this.state outside setState ----
+		{Code: `
+        class ComponentA extends React.Component {
+          state = {
+            greeting: 'hello',
+          };
+
+          myFunc = () => {
+            this.setState({ greeting: 'hi' }, () => this.doStuff());
+          };
+
+          doStuff = () => {
+            console.log(this.state.greeting);
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: call expression that takes this.state as arg but is not setState ----
+		{Code: `
+        class Foo extends Abstract {
+          update = () => {
+            const result = this.getResult ( this.state.foo );
+            return this.setState ({ result });
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: non-Component parent — rule does not fire at all ----
+		{Code: `
+        class StateContainer extends Container {
+          anything() {
+            return this.setState({value: this.state.value + 1})
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: this.state via bracket access is NOT matched (upstream's
+		// `property.name === 'state'` gate excludes Literal property keys) ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({value: this['state'].value + 1});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setState via bracket access is NOT matched (same gate
+		// on the outer call) ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this['setState']({value: this.state.value + 1});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: renamed destructuring — upstream tracks variableName='state'
+		// (property key), but subsequent use is `aliased`, which does not match ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var {state: aliased} = this;
+            this.setState({value: aliased.value + 1});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: destructuring a local variable (not `this`) is NOT tracked ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var obj = {state: {value: 1}};
+            var {state} = obj;
+            this.setState({value: state.value + 1});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setState with no arguments — no first-arg to search ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState();
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: this.state used only in a non-setState call's argument ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            console.log(this.state.value);
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: tracked method is called as `this.foo()` — upstream's
+		// `'name' in callee` guard excludes MemberExpression callees, so the
+		// propagation never triggers and no report is emitted. Mirrors the
+		// upstream quirk rather than "fixing" it. ----
+		{Code: `
+        class Hello extends React.Component {
+          nextState() { return this.state.value + 1 }
+          onClick() {
+            this.setState({value: this.nextState()});
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: this.state as an index key `obj[this.state]` — the
+		// Identifier inside ElementAccessExpression.ArgumentExpression is in
+		// ESTree's `property` position, not `object`, so the Identifier
+		// listener correctly ignores it. Here we verify the PropertyAccess
+		// listener also doesn't fire when wrapping `this.state.x[this.state]`
+		// is read OUTSIDE a setState first arg. ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var x = this.state.value;
+            console.log(x);
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: class static block — NOT a function-body context that
+		// can receive `this.setState`; walk reaches no container stopper and
+		// falls off the top. ----
+		{Code: `
+        class Hello extends React.Component {
+          static {
+            const s = this.state;
+            void s;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: arrow-value object literal property — upstream gates the
+		// FE branch on `FunctionExpression`, so ArrowFunctionExpression values
+		// don't register as a container. We mirror that: tracking stops at
+		// VariableDeclaration above the arrow (if any) or reaches program
+		// root. ----
+		{Code: `
+        var Hello = createReactClass({
+          onClick: () => {
+            this.setState({ value: state.value + 1 });
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: inner class inside outer component — the inner class's
+		// `nextState` does read this.state, but it isn't called from the
+		// outer setState call, so no propagation fires. ----
+		{Code: `
+        class Outer extends React.Component {
+          onClick() {
+            class Inner { nextState() { return this.state; } }
+            this.setState({ value: 1 });
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: computed-static class-body method key
+		// (`['nextState']() {...}`) — upstream evaluates
+		// `'name' in current.key ? current.key.name : undefined`; a
+		// StringLiteral-wrapped computed key has no `.name`, so methodName
+		// becomes undefined and no propagation ever fires against a real
+		// callee string. We mirror this strictly (empty-string methodName
+		// never matches any callee). ----
+		{Code: `
+        class Hello extends React.Component {
+          ['nextState']() { return this.state.value + 1; }
+          onClick() {
+            this.setState({ value: nextState() });
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: template-literal-wrapped computed key — same reasoning
+		// as the string-literal form. Locks in upstream-aligned non-match. ----
+		{Code: "\n        class Hello extends React.Component {\n          [`nextState`]() { return this.state.value + 1; }\n          onClick() {\n            this.setState({ value: nextState() });\n          }\n        }\n      ", Tsx: true},
+
+		// ---- Edge: string-literal key in object literal
+		// (`'nextState': function() {...}`) — ESTree's Property.key is a
+		// Literal, `'name' in key` is false, methodName undefined, no
+		// propagation. ----
+		{Code: `
+        var Hello = createReactClass({
+          'nextState': function() {
+            return { value: this.state.value + 1 };
+          },
+          onClick: function() {
+            this.setState(nextState());
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: destructuring with computed-static key
+		// (`{ ['state']: local } = this`) — upstream's ObjectPattern listener
+		// guards with `'name' in property.key`; a StringLiteral-wrapped
+		// computed key has no `.name`, so the binding is not tracked. We
+		// mirror strictly. ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var { ['state']: state } = this;
+            this.setState({ value: state.value + 1 });
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: destructuring with string-literal key — same reasoning. ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var { 'state': state } = this;
+            this.setState({ value: state.value + 1 });
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: block-scope precision — two sibling `if` blocks each
+		// declare a `const nextValue`. Only the first block's `nextValue`
+		// captures `this.state`; the second (used inside setState) is a
+		// distinct binding. Symbol-identity matching correctly distinguishes
+		// them (aligns with ESLint's block-scope manager), so no report
+		// fires. ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            if (foo) {
+              const nextValue = this.state.value + 1;
+              void nextValue;
+            }
+            if (bar) {
+              const nextValue = 2;
+              this.setState({ value: nextValue });
+            }
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: block-scope precision via destructuring — inner block
+		// destructuring of `state` from `this`; outer setState uses a
+		// same-named sibling binding that is NOT derived from `this`. The
+		// two `state` bindings resolve to distinct symbols, so no match. ----
+		{Code: `
+        class Hello extends React.Component {
+          onClick() {
+            if (foo) {
+              const { state } = this;
+              void state;
+            }
+            const state = { value: 2 };
+            this.setState({ value: state.value });
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream #1: direct this.state inside setState first arg ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState({value: this.state.value + 1})
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "useCallback",
+					Message:   "Use callback in setState when referencing the previous state.",
+					Line:      4, Column: 35,
+				},
+			},
+		},
+
+		// ---- Upstream #2: this.state inside an arrow passed as first arg ----
+		// Upstream reports this because the arrow IS args[0] and the
+		// MemberExpression walk reaches the setState call via arg[0]. ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState(() => ({value: this.state.value + 1}))
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 42},
+			},
+		},
+
+		// ---- Upstream #3: var captures this.state, used inside setState ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            var nextValue = this.state.value + 1
+            this.setState({value: nextValue})
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 29},
+			},
+		},
+
+		// ---- Upstream #4: destructuring from `this`, state used inside setState ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            var {state, ...rest} = this
+            this.setState({value: state.value + 1})
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 18},
+			},
+		},
+
+		// ---- Upstream #5: external nextState() consumes this.state ----
+		// The `nextState` function itself is a top-level FunctionDeclaration,
+		// so its `this.state` read isn't tracked per-method; but the
+		// `this.state` passed as an argument to `nextState(this.state)` IS
+		// inside the setState first arg, so the direct-access branch reports.
+		{
+			Code: `
+        function nextState(state) {
+          return {value: state.value + 1}
+        }
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState(nextState(this.state))
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 7, Column: 37},
+			},
+		},
+
+		// ---- Upstream #6: this.state passed as the first argument to setState ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState(this.state, () => 1 + 1);
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 27},
+			},
+		},
+
+		// ---- Upstream #7: this.state passed directly, plus this.state in
+		// the 2nd-arg callback — only the first arg triggers a report
+		// (upstream emits a single error). ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          onClick: function() {
+            this.setState(this.state, () => console.log(this.state));
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 27},
+			},
+		},
+
+		// ---- Upstream #8: method in object literal reads this.state; another
+		// method calls it inside setState. Mirrors upstream's FE-with-key
+		// tracking branch. ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          nextState: function() {
+            return {value: this.state.value + 1}
+          },
+          onClick: function() {
+            this.setState(nextState())
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: legacyCreateClass,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 28},
+			},
+		},
+
+		// ---- Upstream #9: this.state as first arg, plus 2nd-arg callback —
+		// ES6 class variant. ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState(this.state, () => console.log(this.state));
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 27},
+			},
+		},
+
+		// ---- Edge: class-body method tracking — class method reads this.state,
+		// called inside setState by bare identifier (not this.foo()). ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          nextState() {
+            return this.state.value + 1;
+          }
+          onClick() {
+            this.setState({value: nextState()});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 20},
+			},
+		},
+
+		// ---- Edge: this.state inside if-block inside setState first arg ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({value: (() => { if (true) return this.state.value; return 0; })()});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 61},
+			},
+		},
+
+		// ---- Edge: const + let capture this.state, used in setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            const nextValue = this.state.value + 1;
+            this.setState({value: nextValue});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 31},
+			},
+		},
+
+		// ---- Edge: parenthesized `(this).state` inside setState — tsgo
+		// preserves the paren wrapper on the PropertyAccessExpression so the
+		// reported span includes the leading `(`. Locked in to document the
+		// divergence from ESLint (which strips parens). ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({value: (this).state.value + 1});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 35},
+			},
+		},
+
+		// ---- Edge: optional chain `this?.state` in setState first arg —
+		// PropertyAccessExpression Kind is the same, flag-only difference,
+		// so the rule still matches. ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({value: this?.state.value + 1});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 35},
+			},
+		},
+
+		// ---- Edge: two setState calls each with this.state — two reports ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({value: this.state.value + 1});
+            this.setState({value: this.state.value + 2});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 35},
+				{MessageId: "useCallback", Line: 5, Column: 35},
+			},
+		},
+
+		// ---- Edge: destructuring with shorthand use in setState ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var {state} = this;
+            this.setState({state});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 18},
+			},
+		},
+
+		// ---- Edge: class expression (anonymous class assigned to const) ----
+		{
+			Code: `
+        const Hello = class extends React.Component {
+          onClick() {
+            this.setState({value: this.state.value + 1});
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 35},
+			},
+		},
+
+		// ---- Edge: async method reads this.state inside setState first arg ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          async onClick() {
+            await Promise.resolve();
+            this.setState({value: this.state.value + 1});
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 5, Column: 35},
+			},
+		},
+
+		// ---- Edge: shorthand method in object literal reads this.state,
+		// called from sibling method inside setState. Exercises the
+		// MethodDeclaration-in-ObjectLiteralExpression branch of container
+		// detection. ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          nextState() {
+            return { value: this.state.value + 1 };
+          },
+          onClick() {
+            this.setState(nextState());
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 29},
+			},
+		},
+
+		// ---- Edge: two nested setState calls — `this.setState(this.setState(this.state))`.
+		// The inner `this.state` reaches the INNER setState's first-arg
+		// position first — the walk reports there and returns, so a single
+		// diagnostic fires. ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState(this.setState(this.state));
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 41},
+			},
+		},
+
+		// ---- Edge: destructuring with rest + aliased sibling — rest is
+		// skipped (no PropertyName); aliased `state: x` tracks variableName
+		// 'state' so a later `state` Identifier (matching original key) is
+		// not found, but `x` is. Mirrors upstream's property-name-based
+		// tracking which effectively keeps aliased bindings opaque. ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            var { state, ...rest } = this;
+            this.setState({ state, rest });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Edge: this.state in arrow-body concise expression inside
+		// setState first arg (arrow `() => this.state.x + 1`). Walk goes
+		// through ArrowFunction → CallExpression (setState). ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState(() => this.state.value + 1);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 33},
+			},
+		},
+
+		// ---- Edge: nested setState-of-setState — outer is setState call
+		// whose first arg is itself a setState call. The OUTER setState's
+		// first-arg is the inner CallExpression; `this.state` inside the
+		// inner setState's first arg reports AT the inner setState boundary
+		// (walk matches inner first, returns). ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState(this.setState({ value: this.state.value }));
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 50},
+			},
+		},
+
+		// ---- Edge: typed method signature `onClick(): void { ... }` — tsgo
+		// still emits MethodDeclaration; type annotations don't disturb
+		// container detection. ----
+		{
+			Code: `
+        class Hello extends React.Component<{}, { value: number }> {
+          onClick(): void {
+            this.setState({ value: this.state.value + 1 });
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useCallback", Line: 4, Column: 36},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -100,6 +100,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-props-no-multi-spaces.test.ts',
     './tests/eslint-plugin-react/rules/jsx-closing-tag-location.test.ts',
     './tests/eslint-plugin-react/rules/jsx-wrap-multilines.test.ts',
+    './tests/eslint-plugin-react/rules/no-access-state-in-setstate.test.ts',
     './tests/eslint-plugin-react/rules/no-children-prop.test.ts',
     './tests/eslint-plugin-react/rules/no-danger.test.ts',
     './tests/eslint-plugin-react/rules/no-danger-with-children.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-access-state-in-setstate.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-access-state-in-setstate.test.ts
@@ -1,0 +1,280 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Upstream's suite passes `settings.react.createClass = 'createClass'` to the
+// tester, which wires the createReactClass matcher to `<pragma>.createClass(...)`
+// (e.g. `React.createClass`). rslint's default is `createReactClass`; since
+// JS tests here cannot thread per-case settings through, upstream cases that
+// used `React.createClass` are rewritten with `createReactClass` so the
+// matcher fires without needing a settings override.
+
+ruleTester.run('no-access-state-in-setstate', {} as never, {
+  valid: [
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState(state => ({ value: state.value + 1 }))
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          multiplyValue: function(obj) {
+            return obj.value*2
+          },
+          onClick: function() {
+            var value = this.state.value
+            this.multiplyValue({ value: value })
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var SearchForm = createReactClass({
+          render: function () {
+            return (
+              <div>
+                {(function () {
+                  if (this.state.prompt) {
+                    return <div>{this.state.prompt}</div>
+                  }
+                }).call(this)}
+              </div>
+            );
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState({}, () => console.log(this.state));
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState({}, () => 1 + 1);
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            var nextValueNotUsed = this.state.value + 1
+            var nextValue = 2
+            this.setState({ value: nextValue })
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        function testFunction({ a, b }) {
+        };
+      `,
+    },
+    {
+      code: `
+        class ComponentA extends React.Component {
+          state = { greeting: 'hello' };
+          myFunc = () => {
+            this.setState({ greeting: 'hi' }, () => this.doStuff());
+          };
+          doStuff = () => {
+            console.log(this.state.greeting);
+          };
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo extends Abstract {
+          update = () => {
+            const result = this.getResult(this.state.foo);
+            return this.setState({ result });
+          };
+        }
+      `,
+    },
+    {
+      code: `
+        class StateContainer extends Container {
+          anything() {
+            return this.setState({ value: this.state.value + 1 })
+          }
+        };
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({ value: this['state'].value + 1 });
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            this['setState']({ value: this.state.value + 1 });
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            var { state: aliased } = this;
+            this.setState({ value: aliased.value + 1 });
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState();
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState({ value: this.state.value + 1 })
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState(() => ({ value: this.state.value + 1 }))
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            var nextValue = this.state.value + 1
+            this.setState({ value: nextValue })
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            var { state, ...rest } = this
+            this.setState({ value: state.value + 1 })
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        function nextState(state) {
+          return { value: state.value + 1 }
+        }
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState(nextState(this.state))
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState(this.state, () => 1 + 1);
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          onClick: function() {
+            this.setState(this.state, () => console.log(this.state));
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          nextState: function() {
+            return { value: this.state.value + 1 }
+          },
+          onClick: function() {
+            this.setState(nextState())
+          }
+        });
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState(this.state, () => console.log(this.state));
+          }
+        }
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            this.setState({ value: this.state.value + 1 });
+            this.setState({ value: this.state.value + 2 });
+          }
+        }
+      `,
+      errors: [{ messageId: 'useCallback' }, { messageId: 'useCallback' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          onClick() {
+            var { state } = this;
+            this.setState({ state });
+          }
+        }
+      `,
+      errors: [{ messageId: 'useCallback' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -244,3 +244,5 @@ renderable
 Unparseable
 deprec
 segs
+setstate
+Setstate


### PR DESCRIPTION
## Summary

Port the [`react/no-access-state-in-setstate`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md) rule from `eslint-plugin-react` to rslint.

The rule disallows reading `this.state` inside the first argument of `this.setState(...)`, because React batches state updates asynchronously so the value of `this.state` at call time may be stale by the time the update runs. It tracks four read patterns: direct `this.state.*` inside the first arg, `this.state` captured into a local variable / destructured from `this` then used in setState's first arg, and transitive method propagation where a class-body method reads `this.state` and is invoked by bare identifier inside setState's first arg.

The port mirrors upstream's four-listener state machine (`MemberExpression` / `CallExpression` / `Identifier` / `ObjectPattern`) translated onto tsgo (`PropertyAccessExpression` / `CallExpression` / `Identifier` / `ObjectBindingPattern`), with `reactutil.GetEnclosingReactComponent` handling both ES6 class and `createReactClass` components. All 19 upstream test cases pass, plus tsgo-specific edges covering computed-static keys, optional chains, object-literal shorthand methods, getters, parenthesized `(this).state`, class-static blocks, and nested setState calls.

One intentional divergence (documented in the rule's `.md`): scope resolution is function-granular via `utils.FindEnclosingScope` rather than ESLint's block-scope manager; upstream's suite does not exercise block-scoped `let` / `const` shadowing so behavior aligns on every upstream case.

## Related Links

- ESLint rule docs: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-access-state-in-setstate.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-access-state-in-setstate.js
- Upstream tests: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/tests/lib/rules/no-access-state-in-setstate.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).