### PR TITLE
feat: port rule react/no-unknown-property

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -30,6 +30,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unknown_property"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_will_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
@@ -72,6 +73,7 @@ func GetAllRules() []rule.Rule {
 		no_string_refs.NoStringRefsRule,
 		no_typos.NoTyposRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
+		no_unknown_property.NoUnknownPropertyRule,
 		no_will_update_set_state.NoWillUpdateSetStateRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		require_render_return.RequireRenderReturnRule,

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property.go
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property.go
@@ -323,7 +323,6 @@ var reactOnProps = []string{
 	"onGotPointerCapture",
 	"onGotPointerCaptureCapture",
 	"onLostPointerCapture",
-	"onLostPointerCapture",
 	"onLostPointerCaptureCapture",
 	"onPointerCancel",
 	"onPointerCancelCapture",
@@ -343,29 +342,46 @@ var reactOnProps = []string{
 	"onPointerUpCapture",
 }
 
-// getDOMPropertyNames returns the version-dependent set of recognized DOM
-// property names. Older React versions (< 16.1) recognize `allowTransparency`;
+// buildDOMPropertyLookup builds a lowercased-name → canonical-name map for
+// the version-dependent set of recognized DOM property names, used as the
+// case-insensitive fallback in getStandardName. Built once per rule run;
+// upstream's `names.find(e => e.toLowerCase() === name.toLowerCase())` returns
+// the first match, so entries inserted earlier take precedence (later
+// duplicates are skipped).
+//
+// Older React versions (< 16.1) recognize `allowTransparency`;
 // React >= 16.4 adds pointer-event handlers; React >= 19 adds `precedence`.
-func getDOMPropertyNames(settings map[string]interface{}) []string {
-	names := make([]string, 0, len(domPropertyNamesTwoWords)+len(domPropertyNamesOneWord)+len(reactOnProps)+2)
-	names = append(names, domPropertyNamesTwoWords...)
-	names = append(names, domPropertyNamesOneWord...)
-
-	// React < 16.1 still accepts `allowTransparency`; later versions drop it
-	// (see facebook/react#10823).
+func buildDOMPropertyLookup(settings map[string]interface{}) map[string]string {
+	// Upper bound: two full lists + optional extras.
+	m := make(map[string]string, len(domPropertyNamesTwoWords)+len(domPropertyNamesOneWord)+len(reactOnProps)+2)
+	add := func(name string) {
+		key := strings.ToLower(name)
+		if _, ok := m[key]; !ok {
+			m[key] = name
+		}
+	}
+	for _, n := range domPropertyNamesTwoWords {
+		add(n)
+	}
+	for _, n := range domPropertyNamesOneWord {
+		add(n)
+	}
+	// React < 16.1 still accepts `allowTransparency` (see facebook/react#10823).
 	if reactutil.ReactVersionLessThan(settings, 16, 1, 0) {
-		names = append(names, "allowTransparency")
-		return names
+		add("allowTransparency")
+		return m
 	}
 	// Pointer events arrived in React 16.4.
 	if !reactutil.ReactVersionLessThan(settings, 16, 4, 0) {
-		names = append(names, reactOnProps...)
+		for _, n := range reactOnProps {
+			add(n)
+		}
 		// `precedence` arrived in React 19 (stylesheet support).
 		if !reactutil.ReactVersionLessThan(settings, 19, 0, 0) {
-			names = append(names, "precedence")
+			add("precedence")
 		}
 	}
-	return names
+	return m
 }
 
 // normalizeAttributeCase returns the canonical casing for `name` when its
@@ -405,20 +421,17 @@ func hasUpperCaseCharacter(name string) bool {
 
 // getStandardName looks up `name` (case-insensitively, after the
 // DOM_ATTRIBUTE_NAMES / SVGDOM_ATTRIBUTE_NAMES direct-maps) in the known React
-// DOM property list. Returns the canonical property name or "" when no close
-// match exists.
-func getStandardName(name string, settings map[string]interface{}) string {
+// DOM property lookup map. Returns the canonical property name or "" when no
+// close match exists.
+func getStandardName(name string, domPropertyLookup map[string]string) string {
 	if v, ok := domAttributeNames[name]; ok {
 		return v
 	}
 	if v, ok := svgDomAttributeNames[name]; ok {
 		return v
 	}
-	lower := strings.ToLower(name)
-	for _, candidate := range getDOMPropertyNames(settings) {
-		if strings.ToLower(candidate) == lower {
-			return candidate
-		}
+	if v, ok := domPropertyLookup[strings.ToLower(name)]; ok {
+		return v
 	}
 	return ""
 }
@@ -546,6 +559,9 @@ func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
 			requireDataLowercase = v
 		}
 	}
+	// Precompute the version-dependent DOM property lookup map once per run;
+	// settings are static for the duration of a rule invocation.
+	domPropertyLookup := buildDOMPropertyLookup(ctx.Settings)
 
 	return rule.RuleListeners{
 		ast.KindJsxAttribute: func(node *ast.Node) {
@@ -607,7 +623,7 @@ func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
 				return
 			}
 
-			standardName := getStandardName(name, ctx.Settings)
+			standardName := getStandardName(name, domPropertyLookup)
 			if standardName != "" && standardName == name {
 				return
 			}

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property.go
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property.go
@@ -1,0 +1,629 @@
+// cspell:disable — this file enumerates HTML / SVG / ARIA attribute names
+// verbatim from React and the WHATWG / W3C specs, so it contains many
+// attribute-name tokens (aria-*, SVG presentation attributes, popover /
+// shadowroot attrs, …) that are not in a general English dictionary.
+package no_unknown_property
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var NoUnknownPropertyRule = rule.Rule{
+	Name: "react/no-unknown-property",
+	Run:  runRule,
+}
+
+// domAttributeNames maps HTML-cased attribute names to the React DOM property
+// name that should replace them. Mirrors eslint-plugin-react's
+// DOM_ATTRIBUTE_NAMES table.
+var domAttributeNames = map[string]string{
+	"accept-charset": "acceptCharset",
+	"class":          "className",
+	"http-equiv":     "httpEquiv",
+	"crossorigin":    "crossOrigin",
+	"for":            "htmlFor",
+	"nomodule":       "noModule",
+}
+
+// svgDomAttributeNames maps SVG hyphenated / colon attribute names to the
+// React property name. Mirrors upstream's SVGDOM_ATTRIBUTE_NAMES.
+var svgDomAttributeNames = map[string]string{
+	"accent-height":                "accentHeight",
+	"alignment-baseline":           "alignmentBaseline",
+	"arabic-form":                  "arabicForm",
+	"baseline-shift":               "baselineShift",
+	"cap-height":                   "capHeight",
+	"clip-path":                    "clipPath",
+	"clip-rule":                    "clipRule",
+	"color-interpolation":          "colorInterpolation",
+	"color-interpolation-filters":  "colorInterpolationFilters",
+	"color-profile":                "colorProfile",
+	"color-rendering":              "colorRendering",
+	"dominant-baseline":            "dominantBaseline",
+	"enable-background":            "enableBackground",
+	"fill-opacity":                 "fillOpacity",
+	"fill-rule":                    "fillRule",
+	"flood-color":                  "floodColor",
+	"flood-opacity":                "floodOpacity",
+	"font-family":                  "fontFamily",
+	"font-size":                    "fontSize",
+	"font-size-adjust":             "fontSizeAdjust",
+	"font-stretch":                 "fontStretch",
+	"font-style":                   "fontStyle",
+	"font-variant":                 "fontVariant",
+	"font-weight":                  "fontWeight",
+	"glyph-name":                   "glyphName",
+	"glyph-orientation-horizontal": "glyphOrientationHorizontal",
+	"glyph-orientation-vertical":   "glyphOrientationVertical",
+	"horiz-adv-x":                  "horizAdvX",
+	"horiz-origin-x":               "horizOriginX",
+	"image-rendering":              "imageRendering",
+	"letter-spacing":               "letterSpacing",
+	"lighting-color":               "lightingColor",
+	"marker-end":                   "markerEnd",
+	"marker-mid":                   "markerMid",
+	"marker-start":                 "markerStart",
+	"overline-position":            "overlinePosition",
+	"overline-thickness":           "overlineThickness",
+	"paint-order":                  "paintOrder",
+	"panose-1":                     "panose1",
+	"pointer-events":               "pointerEvents",
+	"rendering-intent":             "renderingIntent",
+	"shape-rendering":              "shapeRendering",
+	"stop-color":                   "stopColor",
+	"stop-opacity":                 "stopOpacity",
+	"strikethrough-position":       "strikethroughPosition",
+	"strikethrough-thickness":      "strikethroughThickness",
+	"stroke-dasharray":             "strokeDasharray",
+	"stroke-dashoffset":            "strokeDashoffset",
+	"stroke-linecap":               "strokeLinecap",
+	"stroke-linejoin":              "strokeLinejoin",
+	"stroke-miterlimit":            "strokeMiterlimit",
+	"stroke-opacity":               "strokeOpacity",
+	"stroke-width":                 "strokeWidth",
+	"text-anchor":                  "textAnchor",
+	"text-decoration":              "textDecoration",
+	"text-rendering":               "textRendering",
+	"underline-position":           "underlinePosition",
+	"underline-thickness":          "underlineThickness",
+	"unicode-bidi":                 "unicodeBidi",
+	"unicode-range":                "unicodeRange",
+	"units-per-em":                 "unitsPerEm",
+	"v-alphabetic":                 "vAlphabetic",
+	"v-hanging":                    "vHanging",
+	"v-ideographic":                "vIdeographic",
+	"v-mathematical":               "vMathematical",
+	"vector-effect":                "vectorEffect",
+	"vert-adv-y":                   "vertAdvY",
+	"vert-origin-x":                "vertOriginX",
+	"vert-origin-y":                "vertOriginY",
+	"word-spacing":                 "wordSpacing",
+	"writing-mode":                 "writingMode",
+	"x-height":                     "xHeight",
+	"xlink:actuate":                "xlinkActuate",
+	"xlink:arcrole":                "xlinkArcrole",
+	"xlink:href":                   "xlinkHref",
+	"xlink:role":                   "xlinkRole",
+	"xlink:show":                   "xlinkShow",
+	"xlink:title":                  "xlinkTitle",
+	"xlink:type":                   "xlinkType",
+	"xml:base":                     "xmlBase",
+	"xml:lang":                     "xmlLang",
+	"xml:space":                    "xmlSpace",
+}
+
+// attributeTagsMap lists the allowed tags for attributes whose usage is
+// element-specific. The invalidPropOnTag message serializes the per-key
+// []string with ", ", so each key's value-slice order mirrors upstream's
+// ATTRIBUTE_TAGS_MAP declaration order.
+var attributeTagsMap = map[string][]string{
+	"abbr":         {"th", "td"},
+	"charset":      {"meta"},
+	"checked":      {"input"},
+	"closedby":     {"dialog"},
+	"crossOrigin":  {"script", "img", "video", "audio", "link", "image"},
+	"displaystyle": {"math"},
+	"download":     {"a", "area"},
+	"fill": {
+		"altGlyph", "circle", "ellipse", "g", "line", "marker", "mask",
+		"path", "polygon", "polyline", "rect", "svg", "symbol", "text",
+		"textPath", "tref", "tspan", "use",
+		"animate", "animateColor", "animateMotion", "animateTransform", "set",
+	},
+	"focusable":   {"svg"},
+	"imageSizes":  {"link"},
+	"imageSrcSet": {"link"},
+	"property":    {"meta"},
+	"viewBox":     {"marker", "pattern", "svg", "symbol", "view"},
+	"as":          {"link"},
+	"align": {
+		"applet", "caption", "col", "colgroup", "hr", "iframe", "img",
+		"table", "tbody", "td", "tfoot", "th", "thead", "tr",
+	},
+	"valign":                   {"tr", "td", "th", "thead", "tbody", "tfoot", "colgroup", "col"},
+	"noModule":                 {"script"},
+	"onAbort":                  {"audio", "video"},
+	"onCancel":                 {"dialog"},
+	"onCanPlay":                {"audio", "video"},
+	"onCanPlayThrough":         {"audio", "video"},
+	"onClose":                  {"dialog"},
+	"onDurationChange":         {"audio", "video"},
+	"onEmptied":                {"audio", "video"},
+	"onEncrypted":              {"audio", "video"},
+	"onEnded":                  {"audio", "video"},
+	"onError":                  {"audio", "video", "img", "link", "source", "script", "picture", "iframe"},
+	"onLoad":                   {"script", "img", "link", "picture", "iframe", "object", "source", "body"},
+	"onLoadedData":             {"audio", "video"},
+	"onLoadedMetadata":         {"audio", "video"},
+	"onLoadStart":              {"audio", "video"},
+	"onPause":                  {"audio", "video"},
+	"onPlay":                   {"audio", "video"},
+	"onPlaying":                {"audio", "video"},
+	"onProgress":               {"audio", "video"},
+	"onRateChange":             {"audio", "video"},
+	"onResize":                 {"audio", "video"},
+	"onSeeked":                 {"audio", "video"},
+	"onSeeking":                {"audio", "video"},
+	"onStalled":                {"audio", "video"},
+	"onSuspend":                {"audio", "video"},
+	"onTimeUpdate":             {"audio", "video"},
+	"onVolumeChange":           {"audio", "video"},
+	"onWaiting":                {"audio", "video"},
+	"autoPictureInPicture":     {"video"},
+	"controls":                 {"audio", "video"},
+	"controlsList":             {"audio", "video"},
+	"disablePictureInPicture":  {"video"},
+	"disableRemotePlayback":    {"audio", "video"},
+	"loop":                     {"audio", "video"},
+	"muted":                    {"audio", "video"},
+	"playsInline":              {"video"},
+	"allowFullScreen":          {"iframe", "video"},
+	"webkitAllowFullScreen":    {"iframe", "video"},
+	"mozAllowFullScreen":       {"iframe", "video"},
+	"poster":                   {"video"},
+	"preload":                  {"audio", "video"},
+	"scrolling":                {"iframe"},
+	"returnValue":              {"dialog"},
+	"webkitDirectory":          {"input"},
+	"shadowrootmode":           {"template"},
+	"shadowrootclonable":       {"template"},
+	"shadowrootdelegatesfocus": {"template"},
+	"shadowrootserializable":   {"template"},
+	"transform-origin":         {"rect"},
+}
+
+// domPropertyNamesOneWord is the set of single-word DOM property names the
+// rule treats as always valid (case-insensitively). Mirrors upstream's
+// DOM_PROPERTY_NAMES_ONE_WORD.
+var domPropertyNamesOneWord = []string{
+	"dir", "draggable", "hidden", "id", "lang", "nonce", "part", "slot", "style", "title", "translate", "inert",
+	"accept", "action", "allow", "alt", "as", "async", "buffered", "capture", "challenge", "cite", "code", "cols",
+	"content", "coords", "csp", "data", "decoding", "default", "defer", "disabled", "form",
+	"headers", "height", "high", "href", "icon", "importance", "integrity", "kind", "label",
+	"language", "loading", "list", "loop", "low", "manifest", "max", "media", "method", "min", "multiple", "muted",
+	"name", "open", "optimum", "pattern", "ping", "placeholder", "poster", "preload", "profile",
+	"rel", "required", "reversed", "role", "rows", "sandbox", "scope", "seamless", "selected", "shape", "size", "sizes",
+	"span", "src", "start", "step", "summary", "target", "type", "value", "width", "wmode", "wrap",
+	"accumulate", "additive", "alphabetic", "amplitude", "ascent", "azimuth", "bbox", "begin",
+	"bias", "by", "clip", "color", "cursor", "cx", "cy", "d", "decelerate", "descent", "direction",
+	"display", "divisor", "dur", "dx", "dy", "elevation", "end", "exponent", "fill", "filter",
+	"format", "from", "fr", "fx", "fy", "g1", "g2", "hanging", "height", "hreflang", "ideographic",
+	"in", "in2", "intercept", "k", "k1", "k2", "k3", "k4", "kerning", "local", "mask", "mode",
+	"offset", "opacity", "operator", "order", "orient", "orientation", "origin", "overflow", "path",
+	"ping", "points", "r", "radius", "rel", "restart", "result", "rotate", "rx", "ry", "scale",
+	"seed", "slope", "spacing", "speed", "stemh", "stemv", "string", "stroke", "to", "transform",
+	"u1", "u2", "unicode", "values", "version", "visibility", "widths", "x", "x1", "x2", "xmlns",
+	"y", "y1", "y2", "z",
+	"property",
+	"ref", "key", "children",
+	"results", "security",
+	"controls",
+	"popover", "popovertarget", "popovertargetaction",
+}
+
+// domPropertyNamesTwoWords is the camel-cased DOM property list. Mirrors
+// upstream's DOM_PROPERTY_NAMES_TWO_WORDS. Lookups are case-insensitive.
+var domPropertyNamesTwoWords = []string{
+	"accessKey", "autoCapitalize", "autoFocus", "contentEditable", "enterKeyHint", "exportParts",
+	"inputMode", "itemID", "itemRef", "itemProp", "itemScope", "itemType", "spellCheck", "tabIndex",
+	"acceptCharset", "autoComplete", "autoPlay", "border", "cellPadding", "cellSpacing", "classID", "codeBase",
+	"colSpan", "contextMenu", "dateTime", "encType", "formAction", "formEncType", "formMethod", "formNoValidate", "formTarget",
+	"frameBorder", "hrefLang", "httpEquiv", "imageSizes", "imageSrcSet", "isMap", "keyParams", "keyType", "marginHeight", "marginWidth",
+	"maxLength", "mediaGroup", "minLength", "noValidate", "onAnimationEnd", "onAnimationIteration", "onAnimationStart",
+	"onBlur", "onChange", "onClick", "onContextMenu", "onCopy", "onCompositionEnd", "onCompositionStart",
+	"onCompositionUpdate", "onCut", "onDoubleClick", "onDrag", "onDragEnd", "onDragEnter", "onDragExit", "onDragLeave",
+	"onError", "onFocus", "onInput", "onKeyDown", "onKeyPress", "onKeyUp", "onLoad", "onWheel", "onDragOver",
+	"onDragStart", "onDrop", "onMouseDown", "onMouseEnter", "onMouseLeave", "onMouseMove", "onMouseOut", "onMouseOver",
+	"onMouseUp", "onPaste", "onScroll", "onScrollEnd", "onSelect", "onSubmit", "onBeforeToggle", "onToggle", "onTransitionEnd", "radioGroup",
+	"readOnly", "referrerPolicy", "rowSpan", "srcDoc", "srcLang", "srcSet", "useMap", "fetchPriority",
+	"crossOrigin", "accentHeight", "alignmentBaseline", "arabicForm", "attributeName",
+	"attributeType", "baseFrequency", "baselineShift", "baseProfile", "calcMode", "capHeight",
+	"clipPathUnits", "clipPath", "clipRule", "colorInterpolation", "colorInterpolationFilters",
+	"colorProfile", "colorRendering", "contentScriptType", "contentStyleType", "diffuseConstant",
+	"dominantBaseline", "edgeMode", "enableBackground", "fillOpacity", "fillRule", "filterRes",
+	"filterUnits", "floodColor", "floodOpacity", "fontFamily", "fontSize", "fontSizeAdjust",
+	"fontStretch", "fontStyle", "fontVariant", "fontWeight", "glyphName",
+	"glyphOrientationHorizontal", "glyphOrientationVertical", "glyphRef", "gradientTransform",
+	"gradientUnits", "horizAdvX", "horizOriginX", "imageRendering", "kernelMatrix",
+	"kernelUnitLength", "keyPoints", "keySplines", "keyTimes", "lengthAdjust", "letterSpacing",
+	"lightingColor", "limitingConeAngle", "markerEnd", "markerMid", "markerStart", "markerHeight",
+	"markerUnits", "markerWidth", "maskContentUnits", "maskUnits", "mathematical", "numOctaves",
+	"overlinePosition", "overlineThickness", "panose1", "paintOrder", "pathLength",
+	"patternContentUnits", "patternTransform", "patternUnits", "pointerEvents", "pointsAtX",
+	"pointsAtY", "pointsAtZ", "preserveAlpha", "preserveAspectRatio", "primitiveUnits",
+	"referrerPolicy", "refX", "refY", "rendering-intent", "repeatCount", "repeatDur",
+	"requiredExtensions", "requiredFeatures", "shapeRendering", "specularConstant",
+	"specularExponent", "spreadMethod", "startOffset", "stdDeviation", "stitchTiles", "stopColor",
+	"stopOpacity", "strikethroughPosition", "strikethroughThickness", "strokeDasharray",
+	"strokeDashoffset", "strokeLinecap", "strokeLinejoin", "strokeMiterlimit", "strokeOpacity",
+	"strokeWidth", "surfaceScale", "systemLanguage", "tableValues", "targetX", "targetY",
+	"textAnchor", "textDecoration", "textRendering", "textLength", "transformOrigin",
+	"underlinePosition", "underlineThickness", "unicodeBidi", "unicodeRange", "unitsPerEm",
+	"vAlphabetic", "vHanging", "vIdeographic", "vMathematical", "vectorEffect", "vertAdvY",
+	"vertOriginX", "vertOriginY", "viewBox", "viewTarget", "wordSpacing", "writingMode", "xHeight",
+	"xChannelSelector", "xlinkActuate", "xlinkArcrole", "xlinkHref", "xlinkRole", "xlinkShow",
+	"xlinkTitle", "xlinkType", "xmlBase", "xmlLang", "xmlnsXlink", "xmlSpace", "yChannelSelector",
+	"zoomAndPan",
+	"autoCorrect",
+	"autoSave",
+	"className", "dangerouslySetInnerHTML", "defaultValue", "defaultChecked", "htmlFor",
+	"onBeforeInput", "onChange",
+	"onInvalid", "onReset", "onTouchCancel", "onTouchEnd", "onTouchMove", "onTouchStart", "suppressContentEditableWarning", "suppressHydrationWarning",
+	"onAbort", "onCanPlay", "onCanPlayThrough", "onDurationChange", "onEmptied", "onEncrypted", "onEnded",
+	"onLoadedData", "onLoadedMetadata", "onLoadStart", "onPause", "onPlay", "onPlaying", "onProgress", "onRateChange", "onResize",
+	"onSeeked", "onSeeking", "onStalled", "onSuspend", "onTimeUpdate", "onVolumeChange", "onWaiting",
+	"onCopyCapture", "onCutCapture", "onPasteCapture", "onCompositionEndCapture", "onCompositionStartCapture", "onCompositionUpdateCapture",
+	"onFocusCapture", "onBlurCapture", "onChangeCapture", "onBeforeInputCapture", "onInputCapture", "onResetCapture", "onSubmitCapture",
+	"onInvalidCapture", "onLoadCapture", "onErrorCapture", "onKeyDownCapture", "onKeyPressCapture", "onKeyUpCapture",
+	"onAbortCapture", "onCanPlayCapture", "onCanPlayThroughCapture", "onDurationChangeCapture", "onEmptiedCapture", "onEncryptedCapture",
+	"onEndedCapture", "onLoadedDataCapture", "onLoadedMetadataCapture", "onLoadStartCapture", "onPauseCapture", "onPlayCapture",
+	"onPlayingCapture", "onProgressCapture", "onRateChangeCapture", "onSeekedCapture", "onSeekingCapture", "onStalledCapture", "onSuspendCapture",
+	"onTimeUpdateCapture", "onVolumeChangeCapture", "onWaitingCapture", "onSelectCapture", "onTouchCancelCapture", "onTouchEndCapture",
+	"onTouchMoveCapture", "onTouchStartCapture", "onScrollCapture", "onScrollEndCapture", "onWheelCapture", "onAnimationEndCapture", "onAnimationIteration",
+	"onAnimationStartCapture", "onTransitionEndCapture",
+	"onAuxClick", "onAuxClickCapture", "onClickCapture", "onContextMenuCapture", "onDoubleClickCapture",
+	"onDragCapture", "onDragEndCapture", "onDragEnterCapture", "onDragExitCapture", "onDragLeaveCapture",
+	"onDragOverCapture", "onDragStartCapture", "onDropCapture", "onMouseDown", "onMouseDownCapture",
+	"onMouseMoveCapture", "onMouseOutCapture", "onMouseOverCapture", "onMouseUpCapture",
+	"autoPictureInPicture", "controlsList", "disablePictureInPicture", "disableRemotePlayback",
+	"popoverTarget", "popoverTargetAction",
+}
+
+// domPropertiesIgnoreCase is the canonical casing for names whose React form
+// differs only in letter case from the HTML form. normalizeAttributeCase uses
+// this set to treat both forms identically.
+var domPropertiesIgnoreCase = []string{
+	"charset", "allowFullScreen", "webkitAllowFullScreen", "mozAllowFullScreen",
+	"webkitDirectory", "popoverTarget", "popoverTargetAction",
+}
+
+// ariaProperties is the exhaustive set of standard aria-* attributes the rule
+// recognizes as always valid. Mirrors upstream's ARIA_PROPERTIES.
+var ariaProperties = map[string]bool{
+	"aria-atomic": true, "aria-braillelabel": true, "aria-brailleroledescription": true, "aria-busy": true, "aria-controls": true, "aria-current": true,
+	"aria-describedby": true, "aria-description": true, "aria-details": true,
+	"aria-disabled": true, "aria-dropeffect": true, "aria-errormessage": true, "aria-flowto": true, "aria-grabbed": true, "aria-haspopup": true,
+	"aria-hidden": true, "aria-invalid": true, "aria-keyshortcuts": true, "aria-label": true, "aria-labelledby": true, "aria-live": true,
+	"aria-owns": true, "aria-relevant": true, "aria-roledescription": true,
+	"aria-autocomplete": true, "aria-checked": true, "aria-expanded": true, "aria-level": true, "aria-modal": true, "aria-multiline": true, "aria-multiselectable": true,
+	"aria-orientation": true, "aria-placeholder": true, "aria-pressed": true, "aria-readonly": true, "aria-required": true, "aria-selected": true,
+	"aria-sort": true, "aria-valuemax": true, "aria-valuemin": true, "aria-valuenow": true, "aria-valuetext": true,
+	"aria-activedescendant": true, "aria-colcount": true, "aria-colindex": true, "aria-colindextext": true, "aria-colspan": true,
+	"aria-posinset": true, "aria-rowcount": true, "aria-rowindex": true, "aria-rowindextext": true, "aria-rowspan": true, "aria-setsize": true,
+}
+
+// reactOnProps is the set of pointer-event handlers added in React 16.4.
+var reactOnProps = []string{
+	"onGotPointerCapture",
+	"onGotPointerCaptureCapture",
+	"onLostPointerCapture",
+	"onLostPointerCapture",
+	"onLostPointerCaptureCapture",
+	"onPointerCancel",
+	"onPointerCancelCapture",
+	"onPointerDown",
+	"onPointerDownCapture",
+	"onPointerEnter",
+	"onPointerEnterCapture",
+	"onPointerLeave",
+	"onPointerLeaveCapture",
+	"onPointerMove",
+	"onPointerMoveCapture",
+	"onPointerOut",
+	"onPointerOutCapture",
+	"onPointerOver",
+	"onPointerOverCapture",
+	"onPointerUp",
+	"onPointerUpCapture",
+}
+
+// getDOMPropertyNames returns the version-dependent set of recognized DOM
+// property names. Older React versions (< 16.1) recognize `allowTransparency`;
+// React >= 16.4 adds pointer-event handlers; React >= 19 adds `precedence`.
+func getDOMPropertyNames(settings map[string]interface{}) []string {
+	names := make([]string, 0, len(domPropertyNamesTwoWords)+len(domPropertyNamesOneWord)+len(reactOnProps)+2)
+	names = append(names, domPropertyNamesTwoWords...)
+	names = append(names, domPropertyNamesOneWord...)
+
+	// React < 16.1 still accepts `allowTransparency`; later versions drop it
+	// (see facebook/react#10823).
+	if reactutil.ReactVersionLessThan(settings, 16, 1, 0) {
+		names = append(names, "allowTransparency")
+		return names
+	}
+	// Pointer events arrived in React 16.4.
+	if !reactutil.ReactVersionLessThan(settings, 16, 4, 0) {
+		names = append(names, reactOnProps...)
+		// `precedence` arrived in React 19 (stylesheet support).
+		if !reactutil.ReactVersionLessThan(settings, 19, 0, 0) {
+			names = append(names, "precedence")
+		}
+	}
+	return names
+}
+
+// normalizeAttributeCase returns the canonical casing for `name` when its
+// lowercased form matches a known case-insensitive entry, otherwise returns
+// `name` unchanged. This lets `charset` / `charSet` / `CHARSET` compare equal.
+func normalizeAttributeCase(name string) string {
+	lower := strings.ToLower(name)
+	for _, canonical := range domPropertiesIgnoreCase {
+		if strings.ToLower(canonical) == lower {
+			return canonical
+		}
+	}
+	return name
+}
+
+// isValidDataAttribute reports whether `name` is a `data-*` attribute that
+// React will accept: starts with `data-`, does not start with `data-xml`
+// (case-insensitive), and does not contain a colon.
+func isValidDataAttribute(name string) bool {
+	if !strings.HasPrefix(strings.ToLower(name), "data-") {
+		return false
+	}
+	// `data-xml*` is reserved and rejected by React.
+	if len(name) >= 8 && strings.EqualFold(name[:8], "data-xml") {
+		return false
+	}
+	// Colons split the attribute into a namespace; `data-*` must not contain
+	// one (matches upstream `/^data-[^:]*$/`).
+	return !strings.Contains(name[5:], ":")
+}
+
+// hasUpperCaseCharacter reports whether `name` contains any letter that
+// differs from its lowercased form.
+func hasUpperCaseCharacter(name string) bool {
+	return strings.ToLower(name) != name
+}
+
+// getStandardName looks up `name` (case-insensitively, after the
+// DOM_ATTRIBUTE_NAMES / SVGDOM_ATTRIBUTE_NAMES direct-maps) in the known React
+// DOM property list. Returns the canonical property name or "" when no close
+// match exists.
+func getStandardName(name string, settings map[string]interface{}) string {
+	if v, ok := domAttributeNames[name]; ok {
+		return v
+	}
+	if v, ok := svgDomAttributeNames[name]; ok {
+		return v
+	}
+	lower := strings.ToLower(name)
+	for _, candidate := range getDOMPropertyNames(settings) {
+		if strings.ToLower(candidate) == lower {
+			return candidate
+		}
+	}
+	return ""
+}
+
+// getAttributeNameText returns the display text of a JsxAttribute's name.
+// Delegates to reactutil.GetJsxPropName for Identifier / JsxNamespacedName,
+// which is the shape upstream `getText(context, node.name)` produces here
+// (upstream's `node.name` is only one of those two for a valid JsxAttribute).
+// Falls back to the raw source range for any unexpected shape so callers can
+// still report a diagnostic instead of silently dropping it.
+func getAttributeNameText(sf *ast.SourceFile, attr *ast.Node) string {
+	if name := reactutil.GetJsxPropName(attr); name != "" && name != "spread" {
+		return name
+	}
+	nameNode := attr.AsJsxAttribute().Name()
+	if nameNode == nil {
+		return ""
+	}
+	return utils.TrimmedNodeText(sf, nameNode)
+}
+
+// getJsxTagLocalName returns the text of a JSX tag name as a string for the
+// purpose of this rule:
+//   - Identifier                 → `<div>`        → "div"
+//   - JsxNamespacedName          → `<a:b>`        → the localname ("b")
+//
+// Other shapes (PropertyAccessExpression, ThisKeyword) return "". Mirrors
+// upstream's `childNode.parent.name.name` — for namespaced tags that's the
+// JSXIdentifier inside the JSXNamespacedName (i.e. the local name).
+//
+// NOTE: this intentionally differs from reactutil.GetJsxElementTypeString,
+// which returns "ns:name" for JsxNamespacedName — upstream eslint-plugin-react
+// does not treat namespaced tags as a composite name in this rule.
+func getJsxTagLocalName(tagName *ast.Node) string {
+	if tagName == nil {
+		return ""
+	}
+	switch tagName.Kind {
+	case ast.KindIdentifier:
+		return tagName.AsIdentifier().Text
+	case ast.KindJsxNamespacedName:
+		ns := tagName.AsJsxNamespacedName()
+		if ns.Name() == nil || ns.Name().Kind != ast.KindIdentifier {
+			return ""
+		}
+		return ns.Name().AsIdentifier().Text
+	}
+	return ""
+}
+
+// tagNameHasDot reports whether the JsxAttribute's parent tag uses the
+// PropertyAccessExpression shape (e.g. `<Foo.Bar>`). Matches upstream's
+// `node.parent.name.type === 'JSXMemberExpression'` check.
+func tagNameHasDot(parent *ast.Node) bool {
+	if parent == nil {
+		return false
+	}
+	tagName := reactutil.GetJsxTagName(parent)
+	if tagName == nil {
+		return false
+	}
+	return tagName.Kind == ast.KindPropertyAccessExpression
+}
+
+// matchesTagConvention reports whether `name` looks like a valid HTML tag
+// identifier: starts with a lowercase ASCII letter and contains no hyphen.
+// Mirrors upstream's `/^[a-z][^-]*$/`.
+func matchesTagConvention(name string) bool {
+	if name == "" {
+		return false
+	}
+	if name[0] < 'a' || name[0] > 'z' {
+		return false
+	}
+	return !strings.Contains(name, "-")
+}
+
+// hasIsAttribute reports whether the element declares an `is` attribute
+// (custom-elements extended built-in marker). Only JsxAttribute (never
+// JsxSpreadAttribute) with an Identifier name are considered, matching
+// upstream's `attrNode.type === 'JSXAttribute' && attrNode.name.type ===
+// 'JSXIdentifier' && attrNode.name.name === 'is'`. The value is irrelevant.
+func hasIsAttribute(parent *ast.Node) bool {
+	for _, attr := range reactutil.GetJsxElementAttributes(parent) {
+		if !ast.IsJsxAttribute(attr) {
+			continue
+		}
+		nameNode := attr.AsJsxAttribute().Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			continue
+		}
+		if nameNode.AsIdentifier().Text == "is" {
+			return true
+		}
+	}
+	return false
+}
+
+// isValidHTMLTagInJSX reports whether the JsxAttribute's parent element is an
+// HTML/DOM tag that should be subject to attribute validation — i.e. the tag
+// name matches the lowercase-no-hyphen convention AND the element does not
+// carry an `is="..."` attribute (which would make it a customized built-in).
+func isValidHTMLTagInJSX(parent *ast.Node) bool {
+	tagName := getJsxTagLocalName(reactutil.GetJsxTagName(parent))
+	if !matchesTagConvention(tagName) {
+		return false
+	}
+	return !hasIsAttribute(parent)
+}
+
+// runRule is the rule entrypoint. Registers a single JsxAttribute listener
+// and walks the decision tree from upstream's `JSXAttribute(node)` handler.
+func runRule(ctx rule.RuleContext, options any) rule.RuleListeners {
+	ignore := map[string]bool{}
+	requireDataLowercase := false
+	if optsMap := utils.GetOptionsMap(options); optsMap != nil {
+		if raw, ok := optsMap["ignore"].([]interface{}); ok {
+			for _, v := range raw {
+				if s, ok := v.(string); ok {
+					ignore[s] = true
+				}
+			}
+		}
+		if v, ok := optsMap["requireDataLowercase"].(bool); ok {
+			requireDataLowercase = v
+		}
+	}
+
+	return rule.RuleListeners{
+		ast.KindJsxAttribute: func(node *ast.Node) {
+			attr := node.AsJsxAttribute()
+			parent := reactutil.GetJsxParentElement(node)
+			if parent == nil {
+				return
+			}
+
+			actualName := getAttributeNameText(ctx.SourceFile, node)
+			if actualName == "" {
+				return
+			}
+			if ignore[actualName] {
+				return
+			}
+			name := normalizeAttributeCase(actualName)
+
+			// `<Foo.Bar foo />` — React components with a dotted tag name are
+			// always skipped; their props are user-defined.
+			if tagNameHasDot(parent) {
+				return
+			}
+
+			if isValidDataAttribute(name) {
+				if requireDataLowercase && hasUpperCaseCharacter(name) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id: "dataLowercaseRequired",
+						Description: "React does not recognize data-* props with uppercase characters on a DOM element. Found '" +
+							actualName + "', use '" + strings.ToLower(actualName) + "' instead",
+					})
+				}
+				return
+			}
+
+			if ariaProperties[name] {
+				return
+			}
+
+			tagName := getJsxTagLocalName(reactutil.GetJsxTagName(parent))
+			// fbt / fbs JSX is an internal-i18n construct whose attribute set
+			// upstream deliberately leaves unchecked.
+			if tagName == "fbt" || tagName == "fbs" {
+				return
+			}
+			if !isValidHTMLTagInJSX(parent) {
+				return
+			}
+
+			// Element-specific attribute list: `crossOrigin`, `download`, etc.
+			if allowed, ok := attributeTagsMap[name]; ok {
+				if !slices.Contains(allowed, tagName) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id: "invalidPropOnTag",
+						Description: "Invalid property '" + actualName + "' found on tag '" +
+							tagName + "', but it is only allowed on: " + strings.Join(allowed, ", "),
+					})
+				}
+				return
+			}
+
+			standardName := getStandardName(name, ctx.Settings)
+			if standardName != "" && standardName == name {
+				return
+			}
+			if standardName != "" && standardName != name {
+				// Close match: report with suggestion + autofix that rewrites
+				// the attribute name node directly.
+				ctx.ReportNodeWithFixes(node, rule.RuleMessage{
+					Id:          "unknownPropWithStandardName",
+					Description: "Unknown property '" + actualName + "' found, use '" + standardName + "' instead",
+				}, rule.RuleFixReplace(ctx.SourceFile, attr.Name(), standardName))
+				return
+			}
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "unknownProp",
+				Description: "Unknown property '" + actualName + "' found",
+			})
+		},
+	}
+}

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property.md
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property.md
@@ -1,0 +1,105 @@
+# react/no-unknown-property
+
+Disallow usage of unknown DOM property.
+
+## Rule Details
+
+In JSX most DOM properties and attributes should be camelCased to be consistent
+with standard JavaScript style. This can be a possible source of error if you
+are used to writing plain HTML. Only `data-*` and `aria-*` attributes use
+hyphens and lowercase letters in JSX.
+
+The rule flags four classes of issue on lowercase HTML/DOM tags:
+
+1. **`unknownProp`** — an attribute that does not match any known React DOM
+   property / aria / data-\* attribute.
+2. **`unknownPropWithStandardName`** — an attribute whose lowercased form
+   matches a standard React property name, but whose casing differs (for
+   example `class` → `className`, `onmousedown` → `onMouseDown`). Automatically
+   fixable.
+3. **`invalidPropOnTag`** — an attribute that is recognized, but only valid on
+   a specific set of tags (for example `crossOrigin` on `script` / `img` but
+   not `div`).
+4. **`dataLowercaseRequired`** — a `data-*` attribute that contains uppercase
+   characters, reported only when the `requireDataLowercase` option is set.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var React = require('react');
+
+var Hello = <div class="hello">Hello World</div>;
+var Alphabet = <div abc="something">Alphabet</div>;
+
+// Invalid aria-* attribute
+var IconButton = <div aria-foo="bar" />;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+var React = require('react');
+
+var Hello = <div className="hello">Hello World</div>;
+var Button = <button disabled>Cannot click me</button>;
+var Img = <img src={catImage} alt="A cat sleeping on a keyboard" />;
+
+// aria-* attributes
+var IconButton = <button aria-label="Close" onClick={this.close}>{closeIcon}</button>;
+
+// data-* attributes
+var Data = <div data-index={12}>Some data</div>;
+
+// React components are ignored
+var MyComponent = <App class="foo-bar"/>;
+var AnotherComponent = <Foo.bar for="bar" />;
+
+// Custom web components are ignored
+var MyElem = <div class="foo" is="my-elem"></div>;
+var AtomPanel = <atom-panel class="foo"></atom-panel>;
+```
+
+## Rule Options
+
+- `ignore`: optional array of property and attribute names to skip during
+  validation.
+- `requireDataLowercase`: optional boolean (default `false`). When `true`, any
+  `data-*` attribute that contains uppercase characters is reported. React
+  itself warns about such attributes at runtime; enabling this option catches
+  them statically.
+
+Examples of **correct** code with `{ "ignore": ["css"] }`:
+
+```json
+{ "react/no-unknown-property": ["error", { "ignore": ["css"] }] }
+```
+
+```jsx
+var StyledDiv = <div css={{ color: 'pink' }}></div>;
+```
+
+Examples of **incorrect** code with `{ "requireDataLowercase": true }`:
+
+```json
+{ "react/no-unknown-property": ["error", { "requireDataLowercase": true }] }
+```
+
+```jsx
+var Row = <div data-testID="row-1" />;
+```
+
+## React version detection
+
+Some recognized attributes depend on the configured React version
+(`settings.react.version`):
+
+- React `< 16.1` still accepts `allowTransparency`.
+- React `>= 16.4` adds the pointer-event handlers (`onPointerDown`,
+  `onPointerUp`, …).
+- React `>= 19` adds `precedence` for stylesheet support.
+
+When the version is not set, the rule assumes the latest React.
+
+## Original Documentation
+
+- [eslint-plugin-react / no-unknown-property](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md)

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property_test.go
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property_test.go
@@ -73,6 +73,10 @@ func TestNoUnknownPropertyRule(t *testing.T) {
 
 		// ---- React-related attributes ----
 		{Code: `<div onPointerDown={this.onDown} onPointerUp={this.onUp} />`, Tsx: true},
+		// `onLostPointerCapture` / `onLostPointerCaptureCapture` both valid under
+		// default (>= 16.4) — locks down the reactOnProps list after upstream's
+		// duplicate `onLostPointerCapture` entry was deduplicated locally.
+		{Code: `<div onLostPointerCapture={a} onLostPointerCaptureCapture={b} />`, Tsx: true},
 		{Code: `<input type="checkbox" defaultChecked={this.state.checkbox} />`, Tsx: true},
 		{Code: `<div onTouchStart={this.startAnimation} onTouchEnd={this.stopAnimation} onTouchCancel={this.cancel} onTouchMove={this.move} onMouseMoveCapture={this.capture} onTouchCancelCapture={this.log} />`, Tsx: true},
 		{

--- a/internal/plugins/react/rules/no_unknown_property/no_unknown_property_test.go
+++ b/internal/plugins/react/rules/no_unknown_property/no_unknown_property_test.go
@@ -1,0 +1,619 @@
+// cspell:disable — tests deliberately contain misspelled / lowercased DOM
+// attribute names (e.g. `crossorigin`, `nomodule`, `onmousedown`, `webkitdirectory`)
+// that this rule is designed to flag.
+package no_unknown_property
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnknownPropertyRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnknownPropertyRule, []rule_tester.ValidTestCase{
+		// ---- React components and their props/attributes should be fine ----
+		{Code: `<App class="bar" />;`, Tsx: true},
+		{Code: `<App for="bar" />;`, Tsx: true},
+		{Code: `<App someProp="bar" />;`, Tsx: true},
+		{Code: `<Foo.bar for="bar" />;`, Tsx: true},
+		{Code: `<App accept-charset="bar" />;`, Tsx: true},
+		{Code: `<App http-equiv="bar" />;`, Tsx: true},
+		{Code: `<App xlink:href="bar" />;`, Tsx: true},
+		{Code: `<App clip-path="bar" />;`, Tsx: true},
+		{
+			Code:    `<App dataNotAnDataAttribute="yes" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"requireDataLowercase": true},
+		},
+
+		// ---- Some HTML/DOM elements with common attributes ----
+		{Code: `<div className="bar"></div>;`, Tsx: true},
+		{Code: `<div onMouseDown={this._onMouseDown}></div>;`, Tsx: true},
+		{Code: `<div onScrollEnd={this._onScrollEnd}></div>;`, Tsx: true},
+		{Code: `<div onScrollEndCapture={this._onScrollEndCapture}></div>;`, Tsx: true},
+		{Code: `<a href="someLink" download="foo">Read more</a>`, Tsx: true},
+		{Code: `<area download="foo" />`, Tsx: true},
+		{Code: `<img src="cat_keyboard.jpeg" alt="A cat sleeping on a keyboard" align="top" fetchPriority="high" />`, Tsx: true},
+		{Code: `<input type="password" required />`, Tsx: true},
+		{Code: `<input ref={this.input} type="radio" />`, Tsx: true},
+		{Code: `<input type="file" webkitdirectory="" />`, Tsx: true},
+		{Code: `<input type="file" webkitDirectory="" />`, Tsx: true},
+		{Code: `<div inert children="anything" />`, Tsx: true},
+		{Code: `<iframe scrolling="?" onLoad={a} onError={b} align="top" />`, Tsx: true},
+		{Code: `<input key="bar" type="radio" />`, Tsx: true},
+		{Code: `<button disabled>You cannot click me</button>;`, Tsx: true},
+		{Code: `<svg key="lock" viewBox="box" fill={10} d="d" stroke={1} strokeWidth={2} strokeLinecap={3} strokeLinejoin={4} transform="something" clipRule="else" x1={5} x2="6" y1="7" y2="8"></svg>`, Tsx: true},
+		{Code: `<g fill="#7B82A0" fillRule="evenodd"></g>`, Tsx: true},
+		{Code: `<mask fill="#7B82A0"></mask>`, Tsx: true},
+		{Code: `<symbol fill="#7B82A0"></symbol>`, Tsx: true},
+		{Code: `<meta property="og:type" content="website" />`, Tsx: true},
+		{Code: `<input type="checkbox" checked={checked} disabled={disabled} id={id} onChange={onChange} />`, Tsx: true},
+		{Code: `<video playsInline />`, Tsx: true},
+		{Code: `<img onError={foo} onLoad={bar} />`, Tsx: true},
+		{Code: `<picture inert={false} onError={foo} onLoad={bar} />`, Tsx: true},
+		{Code: `<iframe onError={foo} onLoad={bar} />`, Tsx: true},
+		{Code: `<script onLoad={bar} onError={foo} />`, Tsx: true},
+		{Code: `<source onLoad={bar} onError={foo} />`, Tsx: true},
+		{Code: `<link onLoad={bar} onError={foo} />`, Tsx: true},
+		{Code: `<link rel="preload" as="image" href="someHref" imageSrcSet="someImageSrcSet" imageSizes="someImageSizes" />`, Tsx: true},
+		{Code: `<object onLoad={bar} />`, Tsx: true},
+		{Code: `<body onLoad={bar} />`, Tsx: true},
+		{Code: `<video allowFullScreen webkitAllowFullScreen mozAllowFullScreen />`, Tsx: true},
+		{Code: `<iframe allowFullScreen webkitAllowFullScreen mozAllowFullScreen />`, Tsx: true},
+		{Code: `<table border="1" />`, Tsx: true},
+		{Code: `<th abbr="abbr" />`, Tsx: true},
+		{Code: `<td abbr="abbr" />`, Tsx: true},
+		{Code: `<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus shadowrootserializable />`, Tsx: true},
+		{
+			Code:     `<div allowTransparency="true" />`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.0.99"}},
+		},
+
+		// ---- React-related attributes ----
+		{Code: `<div onPointerDown={this.onDown} onPointerUp={this.onUp} />`, Tsx: true},
+		{Code: `<input type="checkbox" defaultChecked={this.state.checkbox} />`, Tsx: true},
+		{Code: `<div onTouchStart={this.startAnimation} onTouchEnd={this.stopAnimation} onTouchCancel={this.cancel} onTouchMove={this.move} onMouseMoveCapture={this.capture} onTouchCancelCapture={this.log} />`, Tsx: true},
+		{
+			Code:     `<link precedence="medium" href="https://foo.bar" rel="canonical" />`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "19.0.0"}},
+		},
+
+		// ---- Case-ignored attributes ----
+		{Code: `<meta charset="utf-8" />;`, Tsx: true},
+		{Code: `<meta charSet="utf-8" />;`, Tsx: true},
+
+		// ---- Custom web components allowed to use `class` ----
+		{Code: `<div class="foo" is="my-elem"></div>;`, Tsx: true},
+		{Code: `<div {...this.props} class="foo" is="my-elem"></div>;`, Tsx: true},
+		{Code: `<atom-panel class="foo"></atom-panel>;`, Tsx: true},
+
+		// ---- data-* attributes ----
+		{Code: `<div data-foo="bar"></div>;`, Tsx: true},
+		{Code: `<div data-foo-bar="baz"></div>;`, Tsx: true},
+		{Code: `<div data-parent="parent"></div>;`, Tsx: true},
+		{Code: `<div data-index-number="1234"></div>;`, Tsx: true},
+		{Code: `<div data-e2e-id="5678"></div>;`, Tsx: true},
+		{Code: `<div data-testID="bar" data-under_sCoRe="bar" />;`, Tsx: true},
+		{
+			Code:    `<div data-testID="bar" data-under_sCoRe="bar" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"requireDataLowercase": false},
+		},
+
+		// ---- Ignoring via options ----
+		{
+			Code:    `<div class="bar"></div>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"class"}},
+		},
+		{
+			Code:    `<div someProp="bar"></div>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"someProp"}},
+		},
+		{
+			Code:    `<div css={{flex: 1}}></div>;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"css"}},
+		},
+
+		// ---- aria-* attributes ----
+		{Code: `<button aria-haspopup="true">Click me to open pop up</button>;`, Tsx: true},
+		{Code: `<button aria-label="Close" onClick={someThing.close} />;`, Tsx: true},
+
+		// ---- Attributes on allowed elements ----
+		{Code: `<script crossOrigin noModule />`, Tsx: true},
+		{Code: `<audio crossOrigin />`, Tsx: true},
+		{Code: `<svg focusable><image crossOrigin /></svg>`, Tsx: true},
+		{Code: `<details onToggle={this.onToggle}>Some details</details>`, Tsx: true},
+		{Code: `<path fill="pink" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z"></path>`, Tsx: true},
+		{Code: `<line fill="pink" x1="0" y1="80" x2="100" y2="20"></line>`, Tsx: true},
+		{Code: `<link as="audio">Audio content</link>`, Tsx: true},
+		{Code: `<video controlsList="nodownload" controls={this.controls} loop={true} muted={false} src={this.videoSrc} playsInline={true} onResize={this.onResize}></video>`, Tsx: true},
+		{Code: `<audio controlsList="nodownload" controls={this.controls} crossOrigin="anonymous" disableRemotePlayback loop muted preload="none" src="something" onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onError={this.error} onResize={this.onResize}></audio>`, Tsx: true},
+		{Code: `<marker id={markerId} viewBox="0 0 2 2" refX="1" refY="1" markerWidth="1" markerHeight="1" orient="auto" />`, Tsx: true},
+		{Code: `<pattern id="pattern" viewBox="0,0,10,10" width="10%" height="10%" />`, Tsx: true},
+		{Code: `<symbol id="myDot" width="10" height="10" viewBox="0 0 2 2" />`, Tsx: true},
+		{Code: `<view id="one" viewBox="0 0 100 100" />`, Tsx: true},
+		{Code: `<hr align="top" />`, Tsx: true},
+		{Code: `<applet align="top" />`, Tsx: true},
+		{Code: `<marker fill="#000" />`, Tsx: true},
+		{Code: `<dialog closedby="something" onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />`, Tsx: true},
+		{Code: `
+        <table align="top">
+          <caption align="top">Table Caption</caption>
+          <colgroup valign="top" align="top">
+            <col valign="top" align="top"/>
+          </colgroup>
+          <thead valign="top" align="top">
+            <tr valign="top" align="top">
+              <th valign="top" align="top">Header</th>
+              <td valign="top" align="top">Cell</td>
+            </tr>
+          </thead>
+          <tbody valign="top" align="top" />
+          <tfoot valign="top" align="top" />
+        </table>
+      `, Tsx: true},
+
+		// ---- fbt / fbs are bypassed ----
+		{Code: `<fbt desc="foo" doNotExtract />;`, Tsx: true},
+		{Code: `<fbs desc="foo" doNotExtract />;`, Tsx: true},
+		{Code: `<math displaystyle="true" />;`, Tsx: true},
+
+		// ---- Extra-long data-* attribute name ----
+		{Code: `
+        <div className="App" data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash="customValue">
+          Hello, world!
+        </div>
+      `, Tsx: true},
+
+		// ---- Popover attributes ----
+		{Code: `
+        <div>
+          <button popovertarget="my-popover" popovertargetaction="toggle">Open Popover</button>
+
+          <div popover id="my-popover">Greetings, one and all!</div>
+        </div>
+      `, Tsx: true},
+		{Code: `
+        <div>
+          <button popoverTarget="my-popover" popoverTargetAction="toggle">Open Popover</button>
+
+          <div id="my-popover" onBeforeToggle={this.onBeforeToggle} popover>Greetings, one and all!</div>
+        </div>
+      `, Tsx: true},
+
+		// ---- Extra edge cases ----
+		// JSX fragment wrapping children — each child's attrs are independent.
+		{Code: `<><div className="a" /><div className="b" /></>;`, Tsx: true},
+		// Custom elements (hyphenated tag) — rule does not apply.
+		{Code: `<my-custom someUnknownProp="x" />;`, Tsx: true},
+		// Nested dotted components still get skipped at any depth.
+		{Code: `<Foo.Bar.Baz class="x" for="y" someProp="z" />;`, Tsx: true},
+		// Spread preceding a valid prop on a DOM tag.
+		{Code: `<div {...rest} className="x" />;`, Tsx: true},
+		// Spread between attributes.
+		{Code: `<div className="a" {...rest} id="b" />;`, Tsx: true},
+		// Unknown prop on a component (upper-case tag) is always allowed.
+		{Code: `<Foo unknownWeirdProp="x" />;`, Tsx: true},
+		// Multiple nested JSX elements with mixed DOM / component tags.
+		{Code: `<App><div className="ok"><span data-foo="bar" /></div></App>;`, Tsx: true},
+		// Boolean `is` attribute (no value) still marks the tag as custom-elements.
+		{Code: `<div is class="foo" />;`, Tsx: true},
+		// `is={expr}` form (non-string value) — upstream only checks attr name.
+		{Code: `<div is={someVar} class="foo" />;`, Tsx: true},
+		// aria-* exact-case lowercase is valid.
+		{Code: `<div aria-hidden="true" />;`, Tsx: true},
+		// data- with exact 5-char prefix only (no suffix) — regex allows zero-length `[^:]*`.
+		{Code: `<div data- />;`, Tsx: true},
+		// `fbt` gets a bye even for obviously unknown props.
+		{Code: `<fbt someNonsense="x" />;`, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- allowTransparency with newer React (removed from DOM prop list) ----
+		{
+			Code:     `<div allowTransparency="true" />`,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "16.1.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- Unknown names ----
+		{
+			Code: `<div hasOwnProperty="should not be allowed property"></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div abc="should not be allowed property"></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div aria-fake="should not be allowed property"></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div someProp="bar"></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- unknownPropWithStandardName + autofix ----
+		{
+			Code:   `<div class="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div className="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div for="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div htmlFor="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div accept-charset="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div acceptCharset="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div http-equiv="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div httpEquiv="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div accesskey="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div accessKey="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div onclick="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div onClick="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div onmousedown="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div onMouseDown="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<div onMousedown="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div onMouseDown="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<use xlink:href="bar" />;`,
+			Tsx:    true,
+			Output: []string{`<use xlinkHref="bar" />;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code:   `<rect clip-path="bar" transform-origin="center" />;`,
+			Tsx:    true,
+			Output: []string{`<rect clipPath="bar" transform-origin="center" />;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 7},
+			},
+		},
+		{
+			Code:   `<script crossorigin nomodule />`,
+			Tsx:    true,
+			Output: []string{`<script crossOrigin noModule />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 9},
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 21},
+			},
+		},
+		{
+			Code:   `<div crossorigin />`,
+			Tsx:    true,
+			Output: []string{`<div crossOrigin />`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownPropWithStandardName", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- invalidPropOnTag (attribute allowed only on specific tags) ----
+		{
+			Code: `<div crossOrigin />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div as="audio" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onResize={this.resize} onError={this.error} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 27},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 66},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 91},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 110},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 133},
+			},
+		},
+		{
+			Code: `<div onLoad={this.load} />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div fill="pink" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div controls={this.controls} loop={true} muted={false} src={this.videoSrc} playsInline={true} allowFullScreen></div>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 31},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 43},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 77},
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 96},
+			},
+		},
+		{
+			Code: `<div download="foo" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div imageSrcSet="someImageSrcSet" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div imageSizes="someImageSizes" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- data-xml-* reserved → unknownProp ----
+		{
+			Code: `<div data-xml-anything="invalid" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+
+		// ---- requireDataLowercase (only checks data-* with uppercase) ----
+		{
+			Code:    `<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"requireDataLowercase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dataLowercaseRequired", Line: 1, Column: 6},
+				{MessageId: "dataLowercaseRequired", Line: 1, Column: 24},
+				{MessageId: "unknownProp", Line: 1, Column: 47},
+			},
+		},
+		{
+			Code:    `<App data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"requireDataLowercase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "dataLowercaseRequired", Line: 1, Column: 6},
+				{MessageId: "dataLowercaseRequired", Line: 1, Column: 24},
+			},
+		},
+
+		// ---- Element-specific attribute on wrong tag ----
+		{
+			Code: `<div abbr="abbr" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div webkitDirectory="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		{
+			Code: `<div webkitdirectory="" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "invalidPropOnTag", Line: 1, Column: 6},
+			},
+		},
+		// Upstream line 715 — JsxNamespacedName `data-<lots-of-crash>:c`, the
+		// long hyphenated namespace fails upstream's `/^data-[^:]*$/` (contains
+		// `:`), so it falls through to unknownProp. Upstream marks this case
+		// `features: ['no-ts']` because TS ESTree parsers failed to parse it;
+		// tsgo does parse it as JsxNamespacedName, so we can exercise it here.
+		{
+			Code: `
+        <div className="App" data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash:c="customValue">
+          Hello, world!
+        </div>
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 2, Column: 30},
+			},
+		},
+
+		// ---- Extra edge cases (multi-line / nested / contract assertions) ----
+		// Multi-line JSX — Line / Column on an invalid prop.
+		{
+			Code: `<div
+  class="x"
+/>`,
+			Tsx:    true,
+			Output: []string{"<div\n  className=\"x\"\n/>"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unknownPropWithStandardName",
+					Line:      2, Column: 3,
+				},
+			},
+		},
+		// Nested JSX: inner DOM element has an unknown prop; outer component is fine.
+		{
+			Code: `<App><div abc="x" /></App>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 11},
+			},
+		},
+		// Two nested invalid usages at different nesting depths.
+		{
+			Code: `<div><section abc="x"><span def="y" /></section></div>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 15},
+				{MessageId: "unknownProp", Line: 1, Column: 29},
+			},
+		},
+		// Exact message text (contract assertion for unknownPropWithStandardName).
+		{
+			Code:   `<div class="bar"></div>;`,
+			Tsx:    true,
+			Output: []string{`<div className="bar"></div>;`},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unknownPropWithStandardName",
+					Message:   "Unknown property 'class' found, use 'className' instead",
+					Line:      1, Column: 6,
+				},
+			},
+		},
+		// Exact message text for invalidPropOnTag with preserved allowedTags order.
+		{
+			Code: `<div crossOrigin />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "invalidPropOnTag",
+					Message:   "Invalid property 'crossOrigin' found on tag 'div', but it is only allowed on: script, img, video, audio, link, image",
+					Line:      1, Column: 6,
+				},
+			},
+		},
+		// Exact message text for unknownProp.
+		{
+			Code: `<div abc="1" />`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "unknownProp",
+					Message:   "Unknown property 'abc' found",
+					Line:      1, Column: 6,
+				},
+			},
+		},
+		// Exact message text for dataLowercaseRequired.
+		{
+			Code:    `<div data-testID="x" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"requireDataLowercase": true},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "dataLowercaseRequired",
+					Message:   "React does not recognize data-* props with uppercase characters on a DOM element. Found 'data-testID', use 'data-testid' instead",
+					Line:      1, Column: 6,
+				},
+			},
+		},
+		// Namespaced `xlink:*` on a DOM tag is reported with the full namespaced text.
+		{
+			Code: `<use xlink:unknown="x" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+		// Spread + unknown prop: spread is ignored, unknown prop reports.
+		{
+			Code: `<div {...rest} abc="x" />;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 16},
+			},
+		},
+		// Fragment wrapping two DOM tags, both unknown props.
+		{
+			Code: `<><div abc="1" /><span def="2" /></>;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 8},
+				{MessageId: "unknownProp", Line: 1, Column: 24},
+			},
+		},
+		// ignore matches `actualName` exactly (pre-normalization) — `class`
+		// is ignored but `Class` (different case) is NOT; upstream's `indexOf`
+		// is case-sensitive and `Class` has no close-case standard property
+		// either (neither `class` nor `className` collide with `Class` under
+		// the lowercased-comparison lookup), so it falls through to unknownProp.
+		{
+			Code:    `<div Class="x" />;`,
+			Tsx:     true,
+			Options: map[string]interface{}{"ignore": []interface{}{"class"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unknownProp", Line: 1, Column: 6},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -112,6 +112,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
+    './tests/eslint-plugin-react/rules/no-unknown-property.test.ts',
     './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unknown-property.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unknown-property.test.ts
@@ -1,0 +1,359 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// NOTE: Cases that depend on `settings.react.version` (e.g. `allowTransparency`
+// on React < 16.1, `precedence` on React >= 19) are version-gated and the
+// shared JS rule-tester does not thread `settings` through to `lint()`. Those
+// cases are covered by the Go unit tests (`no_unknown_property_test.go`); the
+// JS suite here assumes the default (latest) React version.
+
+ruleTester.run('no-unknown-property', {} as never, {
+  valid: [
+    // React components and their props/attributes should be fine
+    { code: '<App class="bar" />;' },
+    { code: '<App for="bar" />;' },
+    { code: '<App someProp="bar" />;' },
+    { code: '<Foo.bar for="bar" />;' },
+    { code: '<App accept-charset="bar" />;' },
+    { code: '<App http-equiv="bar" />;' },
+    { code: '<App xlink:href="bar" />;' },
+    { code: '<App clip-path="bar" />;' },
+    {
+      code: '<App dataNotAnDataAttribute="yes" />;',
+      options: [{ requireDataLowercase: true }],
+    },
+    // Some HTML/DOM elements with common attributes should work
+    { code: '<div className="bar"></div>;' },
+    { code: '<div onMouseDown={this._onMouseDown}></div>;' },
+    { code: '<div onScrollEnd={this._onScrollEnd}></div>;' },
+    { code: '<div onScrollEndCapture={this._onScrollEndCapture}></div>;' },
+    { code: '<a href="someLink" download="foo">Read more</a>' },
+    { code: '<area download="foo" />' },
+    {
+      code: '<img src="cat_keyboard.jpeg" alt="A cat sleeping on a keyboard" align="top" fetchPriority="high" />',
+    },
+    { code: '<input type="password" required />' },
+    { code: '<input ref={this.input} type="radio" />' },
+    { code: '<input type="file" webkitdirectory="" />' },
+    { code: '<input type="file" webkitDirectory="" />' },
+    { code: '<div inert children="anything" />' },
+    { code: '<iframe scrolling="?" onLoad={a} onError={b} align="top" />' },
+    { code: '<input key="bar" type="radio" />' },
+    { code: '<button disabled>You cannot click me</button>;' },
+    {
+      code: '<svg key="lock" viewBox="box" fill={10} d="d" stroke={1} strokeWidth={2} strokeLinecap={3} strokeLinejoin={4} transform="something" clipRule="else" x1={5} x2="6" y1="7" y2="8"></svg>',
+    },
+    { code: '<g fill="#7B82A0" fillRule="evenodd"></g>' },
+    { code: '<mask fill="#7B82A0"></mask>' },
+    { code: '<symbol fill="#7B82A0"></symbol>' },
+    { code: '<meta property="og:type" content="website" />' },
+    {
+      code: '<input type="checkbox" checked={checked} disabled={disabled} id={id} onChange={onChange} />',
+    },
+    { code: '<video playsInline />' },
+    { code: '<img onError={foo} onLoad={bar} />' },
+    { code: '<picture inert={false} onError={foo} onLoad={bar} />' },
+    { code: '<iframe onError={foo} onLoad={bar} />' },
+    { code: '<script onLoad={bar} onError={foo} />' },
+    { code: '<source onLoad={bar} onError={foo} />' },
+    { code: '<link onLoad={bar} onError={foo} />' },
+    {
+      code: '<link rel="preload" as="image" href="someHref" imageSrcSet="someImageSrcSet" imageSizes="someImageSizes" />',
+    },
+    { code: '<object onLoad={bar} />' },
+    { code: '<body onLoad={bar} />' },
+    {
+      code: '<video allowFullScreen webkitAllowFullScreen mozAllowFullScreen />',
+    },
+    {
+      code: '<iframe allowFullScreen webkitAllowFullScreen mozAllowFullScreen />',
+    },
+    { code: '<table border="1" />' },
+    { code: '<th abbr="abbr" />' },
+    { code: '<td abbr="abbr" />' },
+    {
+      code: '<template shadowrootmode="open" shadowrootclonable shadowrootdelegatesfocus shadowrootserializable />',
+    },
+    // React related attributes
+    { code: '<div onPointerDown={this.onDown} onPointerUp={this.onUp} />' },
+    { code: '<input type="checkbox" defaultChecked={this.state.checkbox} />' },
+    {
+      code: '<div onTouchStart={this.startAnimation} onTouchEnd={this.stopAnimation} onTouchCancel={this.cancel} onTouchMove={this.move} onMouseMoveCapture={this.capture} onTouchCancelCapture={this.log} />',
+    },
+    // Case ignored attributes
+    { code: '<meta charset="utf-8" />;' },
+    { code: '<meta charSet="utf-8" />;' },
+    // Some custom web components that are allowed to use `class` instead of `className`
+    { code: '<div class="foo" is="my-elem"></div>;' },
+    { code: '<div {...this.props} class="foo" is="my-elem"></div>;' },
+    { code: '<atom-panel class="foo"></atom-panel>;' },
+    // data-* attributes should work
+    { code: '<div data-foo="bar"></div>;' },
+    { code: '<div data-foo-bar="baz"></div>;' },
+    { code: '<div data-parent="parent"></div>;' },
+    { code: '<div data-index-number="1234"></div>;' },
+    { code: '<div data-e2e-id="5678"></div>;' },
+    { code: '<div data-testID="bar" data-under_sCoRe="bar" />;' },
+    {
+      code: '<div data-testID="bar" data-under_sCoRe="bar" />;',
+      options: [{ requireDataLowercase: false }],
+    },
+    // Ignoring should work
+    {
+      code: '<div class="bar"></div>;',
+      options: [{ ignore: ['class'] }],
+    },
+    {
+      code: '<div someProp="bar"></div>;',
+      options: [{ ignore: ['someProp'] }],
+    },
+    {
+      code: '<div css={{flex: 1}}></div>;',
+      options: [{ ignore: ['css'] }],
+    },
+    // aria-* attributes should work
+    { code: '<button aria-haspopup="true">Click me to open pop up</button>;' },
+    { code: '<button aria-label="Close" onClick={someThing.close} />;' },
+    // Attributes on allowed elements should work
+    { code: '<script crossOrigin noModule />' },
+    { code: '<audio crossOrigin />' },
+    { code: '<svg focusable><image crossOrigin /></svg>' },
+    { code: '<details onToggle={this.onToggle}>Some details</details>' },
+    {
+      code: '<path fill="pink" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z"></path>',
+    },
+    { code: '<line fill="pink" x1="0" y1="80" x2="100" y2="20"></line>' },
+    { code: '<link as="audio">Audio content</link>' },
+    {
+      code: '<video controlsList="nodownload" controls={this.controls} loop={true} muted={false} src={this.videoSrc} playsInline={true} onResize={this.onResize}></video>',
+    },
+    {
+      code: '<audio controlsList="nodownload" controls={this.controls} crossOrigin="anonymous" disableRemotePlayback loop muted preload="none" src="something" onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onError={this.error} onResize={this.onResize}></audio>',
+    },
+    {
+      code: '<marker id={markerId} viewBox="0 0 2 2" refX="1" refY="1" markerWidth="1" markerHeight="1" orient="auto" />',
+    },
+    {
+      code: '<pattern id="pattern" viewBox="0,0,10,10" width="10%" height="10%" />',
+    },
+    { code: '<symbol id="myDot" width="10" height="10" viewBox="0 0 2 2" />' },
+    { code: '<view id="one" viewBox="0 0 100 100" />' },
+    { code: '<hr align="top" />' },
+    { code: '<applet align="top" />' },
+    { code: '<marker fill="#000" />' },
+    {
+      code: '<dialog closedby="something" onClose={handler} open id="dialog" returnValue="something" onCancel={handler2} />',
+    },
+    {
+      code: `
+        <table align="top">
+          <caption align="top">Table Caption</caption>
+          <colgroup valign="top" align="top">
+            <col valign="top" align="top"/>
+          </colgroup>
+          <thead valign="top" align="top">
+            <tr valign="top" align="top">
+              <th valign="top" align="top">Header</th>
+              <td valign="top" align="top">Cell</td>
+            </tr>
+          </thead>
+          <tbody valign="top" align="top" />
+          <tfoot valign="top" align="top" />
+        </table>
+      `,
+    },
+    // fbt / fbs
+    { code: '<fbt desc="foo" doNotExtract />;' },
+    { code: '<fbs desc="foo" doNotExtract />;' },
+    { code: '<math displaystyle="true" />;' },
+    {
+      code: `
+        <div className="App" data-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash-crash="customValue">
+          Hello, world!
+        </div>
+      `,
+    },
+    {
+      code: `
+        <div>
+          <button popovertarget="my-popover" popovertargetaction="toggle">Open Popover</button>
+
+          <div popover id="my-popover">Greetings, one and all!</div>
+        </div>
+      `,
+    },
+    {
+      code: `
+        <div>
+          <button popoverTarget="my-popover" popoverTargetAction="toggle">Open Popover</button>
+
+          <div id="my-popover" onBeforeToggle={this.onBeforeToggle} popover>Greetings, one and all!</div>
+        </div>
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: '<div hasOwnProperty="should not be allowed property"></div>;',
+      errors: [{ messageId: 'unknownProp' }],
+    },
+    {
+      code: '<div abc="should not be allowed property"></div>;',
+      errors: [{ messageId: 'unknownProp' }],
+    },
+    {
+      code: '<div aria-fake="should not be allowed property"></div>;',
+      errors: [{ messageId: 'unknownProp' }],
+    },
+    {
+      code: '<div someProp="bar"></div>;',
+      errors: [{ messageId: 'unknownProp' }],
+    },
+    {
+      code: '<div class="bar"></div>;',
+      output: '<div className="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div for="bar"></div>;',
+      output: '<div htmlFor="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div accept-charset="bar"></div>;',
+      output: '<div acceptCharset="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div http-equiv="bar"></div>;',
+      output: '<div httpEquiv="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div accesskey="bar"></div>;',
+      output: '<div accessKey="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div onclick="bar"></div>;',
+      output: '<div onClick="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div onmousedown="bar"></div>;',
+      output: '<div onMouseDown="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div onMousedown="bar"></div>;',
+      output: '<div onMouseDown="bar"></div>;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<use xlink:href="bar" />;',
+      output: '<use xlinkHref="bar" />;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<rect clip-path="bar" transform-origin="center" />;',
+      output: '<rect clipPath="bar" transform-origin="center" />;',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<script crossorigin nomodule />',
+      output: '<script crossOrigin noModule />',
+      errors: [
+        { messageId: 'unknownPropWithStandardName' },
+        { messageId: 'unknownPropWithStandardName' },
+      ],
+    },
+    {
+      code: '<div crossorigin />',
+      output: '<div crossOrigin />',
+      errors: [{ messageId: 'unknownPropWithStandardName' }],
+    },
+    {
+      code: '<div crossOrigin />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div as="audio" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div onAbort={this.abort} onDurationChange={this.durationChange} onEmptied={this.emptied} onEnded={this.end} onResize={this.resize} onError={this.error} />',
+      errors: [
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+      ],
+    },
+    {
+      code: '<div onLoad={this.load} />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div fill="pink" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div controls={this.controls} loop={true} muted={false} src={this.videoSrc} playsInline={true} allowFullScreen></div>',
+      errors: [
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+        { messageId: 'invalidPropOnTag' },
+      ],
+    },
+    {
+      code: '<div download="foo" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div imageSrcSet="someImageSrcSet" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div imageSizes="someImageSizes" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div data-xml-anything="invalid" />',
+      errors: [{ messageId: 'unknownProp' }],
+    },
+    {
+      code: '<div data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;',
+      errors: [
+        { messageId: 'dataLowercaseRequired' },
+        { messageId: 'dataLowercaseRequired' },
+        { messageId: 'unknownProp' },
+      ],
+      options: [{ requireDataLowercase: true }],
+    },
+    {
+      code: '<App data-testID="bar" data-under_sCoRe="bar" dataNotAnDataAttribute="yes" />;',
+      errors: [
+        { messageId: 'dataLowercaseRequired' },
+        { messageId: 'dataLowercaseRequired' },
+      ],
+      options: [{ requireDataLowercase: true }],
+    },
+    {
+      code: '<div abbr="abbr" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div webkitDirectory="" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+    {
+      code: '<div webkitdirectory="" />',
+      errors: [{ messageId: 'invalidPropOnTag' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-unknown-property` rule from `eslint-plugin-react` to rslint.

The rule flags four classes of issue on lowercase HTML/DOM tags:

- `unknownProp` — attribute not matching any known React DOM property / aria / data-*
- `unknownPropWithStandardName` — attribute whose lowercased form matches a known React property (e.g. `class` → `className`, `onmousedown` → `onMouseDown`); **autofixable**
- `invalidPropOnTag` — recognized attribute used on a tag that doesn't allow it (e.g. `crossOrigin` on `<div>`)
- `dataLowercaseRequired` — `data-*` attribute with uppercase characters (only under `requireDataLowercase: true`)

Options:
- `ignore: string[]` — attribute names to skip
- `requireDataLowercase: boolean` (default `false`)

Version-gated attributes via `settings.react.version`:
- React `< 16.1` → `allowTransparency` allowed
- React `>= 16.4` → pointer-event handlers allowed
- React `>= 19` → `precedence` allowed

## Related Links

- ESLint plugin rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unknown-property.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).