### PR TITLE
feat: port rule react/prefer-es6-class

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -31,6 +31,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_will_update_set_state"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_es6_class"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
@@ -73,6 +74,7 @@ func GetAllRules() []rule.Rule {
 		no_typos.NoTyposRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		no_will_update_set_state.NoWillUpdateSetStateRule,
+		prefer_es6_class.PreferEs6ClassRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		require_render_return.RequireRenderReturnRule,
 		self_closing_comp.SelfClosingCompRule,

--- a/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class.go
+++ b/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class.go
@@ -1,0 +1,192 @@
+package prefer_es6_class
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// parseMode reads the first option, accepting "always" (default) or "never".
+// Any other shape falls back to "always" — matches eslint-plugin-react's
+// `context.options[0] || 'always'`.
+func parseMode(options any) string {
+	mode := "always"
+	switch opts := options.(type) {
+	case []interface{}:
+		if len(opts) > 0 {
+			if s, ok := opts[0].(string); ok && s != "" {
+				mode = s
+			}
+		}
+	case string:
+		if opts != "" {
+			mode = opts
+		}
+	}
+	if mode != "always" && mode != "never" {
+		mode = "always"
+	}
+	return mode
+}
+
+// skipParenParent walks up ParenthesizedExpression wrappers and returns the
+// first non-paren ancestor of `node`, or nil. ESTree flattens parentheses so
+// ESLint's `node.parent` is always the first non-paren ancestor; tsgo
+// preserves them.
+func skipParenParent(node *ast.Node) *ast.Node {
+	p := node.Parent
+	for p != nil && p.Kind == ast.KindParenthesizedExpression {
+		p = p.Parent
+	}
+	return p
+}
+
+// isCreateClassCallee reports whether `callee` names `<createClass>` or
+// `<pragma>.<createClass>`. Parentheses are skipped on both the callee
+// itself and the pragma identifier.
+func isCreateClassCallee(callee *ast.Node, pragma, createClass string) bool {
+	if callee == nil {
+		return false
+	}
+	callee = ast.SkipParentheses(callee)
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text == createClass
+	case ast.KindPropertyAccessExpression:
+		pa := callee.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		return name.AsIdentifier().Text == createClass
+	}
+	return false
+}
+
+// classKeywordStart returns the start position of the ESLint-equivalent
+// ClassDeclaration range.
+//
+// In ESTree the ClassDeclaration itself does NOT include `export` /
+// `export default` — those live on an outer `ExportNamedDeclaration` /
+// `ExportDefaultDeclaration` wrapper. TS-specific modifiers that stay on the
+// ClassDeclaration in TSESTree (`abstract`, `declare`) and decorators are
+// part of the node's range. tsgo inlines everything into the
+// ClassDeclaration's modifier list, so we selectively skip only
+// `export` / `default` keyword modifiers to recover the ESLint position.
+func classKeywordStart(text string, node *ast.Node) int {
+	mods := node.Modifiers()
+	pos := node.Pos()
+	if mods != nil {
+		for _, mod := range mods.Nodes {
+			switch mod.Kind {
+			case ast.KindExportKeyword, ast.KindDefaultKeyword:
+				pos = mod.End()
+			default:
+				// First non-export/default modifier (decorator, abstract,
+				// declare, …) is where the ESLint range begins.
+				return scanner.SkipTrivia(text, mod.Pos())
+			}
+		}
+	}
+	return scanner.SkipTrivia(text, pos)
+}
+
+func containsArg(args *ast.NodeList, target *ast.Node) bool {
+	if args == nil {
+		return false
+	}
+	for _, a := range args.Nodes {
+		// The argument may be wrapped in one or more
+		// ParenthesizedExpressions before reaching the object literal
+		// (ESTree flattens these; tsgo preserves them).
+		current := a
+		for current != nil && current.Kind == ast.KindParenthesizedExpression {
+			current = current.AsParenthesizedExpression().Expression
+		}
+		if current == target {
+			return true
+		}
+	}
+	return false
+}
+
+var PreferEs6ClassRule = rule.Rule{
+	Name: "react/prefer-es6-class",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		mode := parseMode(options)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		listeners := rule.RuleListeners{}
+
+		if mode == "always" {
+			listeners[ast.KindObjectLiteralExpression] = func(node *ast.Node) {
+				parent := skipParenParent(node)
+				if parent == nil {
+					return
+				}
+				// ESLint's `isES5Component` gate is `node.parent.callee` —
+				// any parent node kind that exposes a `.callee` property.
+				// In ESTree that is both CallExpression AND NewExpression,
+				// so `new createReactClass({...})` also reports.
+				var callee *ast.Node
+				var arguments *ast.NodeList
+				switch parent.Kind {
+				case ast.KindCallExpression:
+					call := parent.AsCallExpression()
+					callee = call.Expression
+					arguments = call.Arguments
+				case ast.KindNewExpression:
+					newExpr := parent.AsNewExpression()
+					callee = newExpr.Expression
+					arguments = newExpr.Arguments
+				default:
+					return
+				}
+				if !isCreateClassCallee(callee, pragma, createClass) {
+					return
+				}
+				// Belt-and-suspenders: make sure the object is an argument
+				// (i.e. not somehow the callee itself); in practice the
+				// callee check above already rejects object callees.
+				if !containsArg(arguments, node) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "shouldUseES6Class",
+					Description: "Component should use es6 class instead of createClass",
+				})
+			}
+		}
+
+		if mode == "never" {
+			// Upstream only subscribes to ClassDeclaration; ClassExpression is
+			// not reported even when it extends React.Component. Matching that
+			// behavior — lock-in test in the Go test file.
+			listeners[ast.KindClassDeclaration] = func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				// Report from the `class` keyword (not from any preceding
+				// modifiers like `export` / `export default`). In ESTree the
+				// ClassDeclaration node starts at `class` and modifiers live on
+				// the outer Export* wrapper; tsgo inlines modifiers into the
+				// ClassDeclaration, so we skip past them to match ESLint's
+				// report position.
+				classStart := classKeywordStart(ctx.SourceFile.Text(), node)
+				ctx.ReportRange(core.NewTextRange(classStart, node.End()), rule.RuleMessage{
+					Id:          "shouldUseCreateClass",
+					Description: "Component should use createClass instead of es6 class",
+				})
+			}
+		}
+
+		return listeners
+	},
+}

--- a/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class.md
+++ b/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class.md
@@ -1,0 +1,83 @@
+# prefer-es6-class
+
+## Rule Details
+
+Enforce consistency between the two React component declaration styles: ES6
+classes extending `React.Component` / `React.PureComponent` and the legacy
+`createReactClass({...})` factory. The rule reports whichever style does not
+match the configured option.
+
+- `"always"` (default) — flag `createReactClass({...})` calls; prefer ES6
+  classes.
+- `"never"` — flag ES6 class declarations extending `Component` /
+  `PureComponent` (bare or pragma-qualified); prefer `createReactClass`.
+
+## Options
+
+```json
+{ "react/prefer-es6-class": ["error", "always"] }
+```
+
+Accepted values: `"always"` (default), `"never"`.
+
+Examples of **incorrect** code for this rule (default `"always"`):
+
+```javascript
+var Hello = createReactClass({
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+```
+
+Examples of **correct** code for this rule (default `"always"`):
+
+```javascript
+class Hello extends React.Component {
+  render() {
+    return <div>Hello {this.props.name}</div>;
+  }
+}
+```
+
+Examples of **incorrect** code for this rule with `"never"`:
+
+```json
+{ "react/prefer-es6-class": ["error", "never"] }
+```
+
+```javascript
+class Hello extends React.Component {
+  render() {
+    return <div>Hello {this.props.name}</div>;
+  }
+}
+```
+
+Examples of **correct** code for this rule with `"never"`:
+
+```json
+{ "react/prefer-es6-class": ["error", "never"] }
+```
+
+```javascript
+var Hello = createReactClass({
+  render: function () {
+    return <div>Hello {this.props.name}</div>;
+  },
+});
+```
+
+## Settings
+
+The rule honors the shared React settings:
+
+- `settings.react.pragma` — controls the namespace used for qualified
+  references (default `"React"`, so `React.Component` and `React.createClass`
+  are recognized).
+- `settings.react.createClass` — controls the factory name (default
+  `"createReactClass"`).
+
+## Original Documentation
+
+- [eslint-plugin-react `prefer-es6-class`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md)

--- a/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class_test.go
+++ b/internal/plugins/react/rules/prefer_es6_class/prefer_es6_class_test.go
@@ -1,0 +1,782 @@
+package prefer_es6_class
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferEs6ClassRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferEs6ClassRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: default (always) — ES6 class is fine ----
+		{Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        Hello.displayName = 'Hello'
+      `, Tsx: true},
+
+		// ---- Upstream: default (always) — export default ES6 class is fine ----
+		{Code: `
+        export default class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        Hello.displayName = 'Hello'
+      `, Tsx: true},
+
+		// ---- Upstream: no component at all ----
+		{Code: `
+        var Hello = "foo";
+        module.exports = {};
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass is fine when mode is "never" ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Upstream: ES6 class is fine when mode is "always" (explicit) ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"always"},
+		},
+
+		// ---- Edge: mode "never" + non-component class (no extends) — not reported ----
+		{
+			Code: `
+        class Hello {
+          render() {
+            return <div>Hello</div>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: mode "never" + class extending something other than
+		// React.Component / React.PureComponent — not reported ----
+		{
+			Code: `
+        class Hello extends SomethingElse {
+          render() {
+            return <div>Hello</div>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: mode "never" + ClassExpression extending React.Component —
+		// upstream only subscribes to ClassDeclaration, so ClassExpressions must
+		// NOT be reported. Locks the upstream behavior. ----
+		{
+			Code: `
+        const Hello = class extends React.Component {
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+		{
+			Code: `
+        const Hello = class extends React.PureComponent {
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: mode "always" + ObjectExpression passed to a non-createReactClass
+		// callee — not reported. ----
+		{Code: `
+        var x = something({ foo: 1 });
+      `, Tsx: true},
+
+		// ---- Edge: mode "always" + pragma-mismatched member-expression callee
+		// `Other.createClass({...})` — not reported when pragma is default
+		// ("React"). ----
+		{Code: `
+        var Hello = Other.createClass({
+          render: function() {
+            return <div/>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: mode "always" + pragma-mismatched member-expression method
+		// `React.somethingElse({...})` — not reported (property name mismatch). ----
+		{Code: `
+        var x = React.somethingElse({ foo: 1 });
+      `, Tsx: true},
+
+		// ---- Edge: mode "always" + object literal that is NOT a direct argument
+		// of a CallExpression (nested inside another object) — not reported. ----
+		{Code: `
+        var x = {
+          inner: { foo: 1 }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: mode "always" + object literal as value of a PropertyAssignment
+		// inside createReactClass — only the OUTER object (the createReactClass
+		// arg) should report, not the INNER one. Here we lock the inner-object
+		// non-report by putting it on the valid side with mode "never". ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          defaultProps: { foo: 1 },
+          render: function() {
+            return <div/>;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: mode "always" + IIFE `({foo:1})()` — callee is the object
+		// itself, not a createClass identifier. Not reported. ----
+		{Code: `
+        var x = ({ foo: 1 })();
+      `, Tsx: true},
+
+		// ---- Edge: custom `settings.react.createClass` — createFoo({...})
+		// NOT reported with default pragma settings. ----
+		{Code: `
+        var Hello = createFoo({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: custom `settings.react.createClass` — createReactClass
+		// is NOT a matching callee when settings points elsewhere. ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"createClass": "createFoo",
+				},
+			},
+		},
+
+		// ---- Edge: custom `settings.react.pragma` — `React.createClass`
+		// NOT matching once pragma is overridden. ----
+		{
+			Code: `
+        var Hello = React.createClass({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma": "Foo",
+				},
+			},
+		},
+
+		// ---- Edge: mode "always" + default settings + `React.createClass({...})`
+		// — the default `createClass` name is `createReactClass`, NOT
+		// `createClass`, so this is NOT flagged. Locks the upstream default. ----
+		{Code: `
+        var Hello = React.createClass({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: computed-property access `React['createReactClass']({...})`
+		// — upstream reads `callee.property.name` which is undefined for a
+		// computed/string-literal property. Not reported. ----
+		{Code: `
+        var Hello = React['createReactClass']({
+          render: function() { return <div/>; }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: mode "always" + tagged template ``createReactClass` ``` —
+		// TaggedTemplateExpression has no `.callee` in ESTree; upstream skips.
+		// No object literal here so the listener is irrelevant, but lock that
+		// no false positive fires from the surrounding ObjectLiteral either. ----
+		{Code: `
+        var Hello = createReactClass` + "`ignored`" + `;
+        var Other = foo({ nested: { inner: 1 } });
+      `, Tsx: true},
+
+		// ---- Edge: `class X extends A.B.C {}` (C happens to be "Component")
+		// — upstream's superClass check only matches a 2-segment
+		// `<pragma>.Component` member access. Deeper chains don't match. ----
+		{
+			Code: `
+        class Hello extends A.B.Component {
+          render() { return <div/>; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: `class X extends (React.Component as any) {}` —
+		// TS type-assertion wraps the superClass as `TSAsExpression` in ESTree
+		// (AsExpression in tsgo); upstream's superClass type check matches
+		// neither Identifier nor MemberExpression. Not reported. ----
+		{
+			Code: `
+        class Hello extends (React.Component as any) {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: `class X extends React.Component.foo {}` — rightmost
+		// property name is not `Component` / `PureComponent`; upstream's
+		// `/^(Pure)?Component$/.test(property.name)` fails. Not reported. ----
+		{
+			Code: `
+        class Hello extends React.Component.foo {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: `class X extends Other.Component {}` — object name does
+		// NOT match the default pragma ("React"); not reported. ----
+		{
+			Code: `
+        class Hello extends Other.Component {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: `class X extends fn() {}` — superClass is a
+		// CallExpression; matches neither Identifier nor MemberExpression.
+		// Not reported. ----
+		{
+			Code: `
+        class Hello extends getBase() {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+		},
+
+		// ---- Edge: `class X extends React.Component<P, {}> {}` under mode
+		// "always" — the ClassDeclaration listener never fires in "always"
+		// mode. Not reported. ----
+		{Code: `
+        class Hello<P> extends React.Component<P, {}> {
+          render() { return null; }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: default (always) — createReactClass should be flagged ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Message: "Component should use es6 class instead of createClass", Line: 2, Column: 38},
+			},
+		},
+
+		// ---- Upstream: explicit mode "always" — createReactClass should be flagged ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+			Tsx:     true,
+			Options: []any{"always"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 38},
+			},
+		},
+
+		// ---- Upstream: mode "never" — ES6 class extending React.Component flagged ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Message: "Component should use createClass instead of es6 class", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "always" + pragma-qualified
+		// `React.createReactClass({...})`. Default pragma is "React" and
+		// default createClass name is "createReactClass", so this is the
+		// literal member-expression form the rule recognizes out of the box. ----
+		{
+			Code: `
+        var Hello = React.createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 44},
+			},
+		},
+
+		// ---- Edge: mode "always" + paren-wrapped object `createReactClass(({...}))`
+		// — tsgo preserves parens; ESTree flattens them. Must still report. ----
+		{
+			Code: `
+        var Hello = createReactClass(({
+          render: function() { return <div/>; }
+        }));
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 39},
+			},
+		},
+
+		// ---- Edge: mode "always" + paren-wrapped callee `(createReactClass)({...})` ----
+		{
+			Code: `
+        var Hello = (createReactClass)({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 40},
+			},
+		},
+
+		// ---- Edge: mode "never" + bare `Component` (no pragma) ----
+		{
+			Code: `
+        class Hello extends Component {
+          render() {
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + bare `PureComponent` (no pragma) ----
+		{
+			Code: `
+        class Hello extends PureComponent {
+          render() {
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + pragma-qualified `React.PureComponent` ----
+		{
+			Code: `
+        class Hello extends React.PureComponent {
+          render() {
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + `export class X ...` — report starts at
+		// the `class` keyword, past the `export` modifier. ----
+		{
+			Code: `
+        export class Hello extends React.Component {
+          render() {
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 16},
+			},
+		},
+
+		// ---- Edge: mode "never" + `export default class ...` — still a
+		// ClassDeclaration, so it fires. The report starts at the `class`
+		// keyword, mirroring ESLint (whose ESTree ClassDeclaration begins at
+		// `class`; tsgo inlines the `export default` modifiers into the
+		// ClassDeclaration, so we skip past them before reporting). ----
+		{
+			Code: `
+        export default class Hello extends React.Component {
+          render() {
+            return <div/>;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 24, EndLine: 6, EndColumn: 10},
+			},
+		},
+
+		// ---- Edge: custom `settings.react.pragma` — pragma-qualified
+		// `Foo.createReactClass({...})` reports when pragma is set to "Foo". ----
+		{
+			Code: `
+        var Hello = Foo.createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma": "Foo",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 42},
+			},
+		},
+
+		// ---- Edge: custom `settings.react.createClass` — bare `createFoo({...})`
+		// reports when createClass is set to "createFoo". ----
+		{
+			Code: `
+        var Hello = createFoo({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"createClass": "createFoo",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 31},
+			},
+		},
+
+		// ---- Edge: custom pragma + custom createClass — `Foo.createFoo({...})`
+		// reports when both settings are overridden. ----
+		{
+			Code: `
+        var Hello = Foo.createFoo({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma":      "Foo",
+					"createClass": "createFoo",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 35},
+			},
+		},
+
+		// ---- Edge: `new createReactClass({...})` — NewExpression also has
+		// `.callee` in ESTree so upstream reports. Locks the alignment. ----
+		{
+			Code: `
+        var Hello = new createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 42},
+			},
+		},
+
+		// ---- Edge: `new React.createReactClass({...})` — pragma-qualified
+		// NewExpression. Upstream reports. ----
+		{
+			Code: `
+        var Hello = new React.createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 48},
+			},
+		},
+
+		// ---- Edge: mode "always" + second-argument object literal —
+		// upstream's `node.parent.callee` check fires regardless of argument
+		// position, so a createReactClass call with multiple object-literal
+		// arguments reports on each. Also locks in that a non-object first
+		// argument doesn't gate later object-literal arguments. ----
+		{
+			Code: `
+        var Hello = createReactClass(mixin, {
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 45},
+			},
+		},
+
+		// ---- Edge: mode "always" + nested object-literal as property value —
+		// upstream reports ONLY on the outer (direct-argument) object, not
+		// on the inner property-value object. Lock with errors length = 1. ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          defaultProps: { foo: 1 },
+          render: function() { return <div/>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 38},
+			},
+		},
+
+		// ---- Edge: mode "never" + custom pragma on ES6 class — pragma-qualified
+		// `Foo.Component` fires when `settings.react.pragma: "Foo"`. ----
+		{
+			Code: `
+        class Hello extends Foo.Component {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma": "Foo",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + custom pragma + PureComponent ----
+		{
+			Code: `
+        class Hello extends Foo.PureComponent {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Settings: map[string]interface{}{
+				"react": map[string]interface{}{
+					"pragma": "Foo",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + class with type parameters on heritage —
+		// `class X<P> extends React.Component<P, S>` still fires; type-args
+		// wrap via ExpressionWithTypeArguments and ExtendsReactComponent
+		// unwraps to the underlying PropertyAccessExpression. ----
+		{
+			Code: `
+        class Hello<P> extends React.Component<P, {}> {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + two nested ClassDeclarations both
+		// extending React.Component — each ClassDeclaration is visited
+		// independently, so both fire. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          render() {
+            class Inner extends React.Component {
+              render() { return null; }
+            }
+            return null;
+          }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+				{MessageId: "shouldUseCreateClass", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Edge: mode "never" + `abstract class X extends React.Component`
+		// — `abstract` is a TS modifier kept on the TSESTree ClassDeclaration
+		// (unlike `export`, which lives on an outer wrapper), so ESLint
+		// reports starting at `abstract`, not at `class`. Lock alignment. ----
+		{
+			Code: `
+        abstract class Hello extends React.Component {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + `declare class X extends React.Component`
+		// — `declare` also stays on the ClassDeclaration in TSESTree. Report
+		// starts at `declare`. ----
+		{
+			Code: `
+        declare class Hello extends React.Component {
+          render(): any;
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: mode "never" + decorator (`@foo class X ...`) — decorators
+		// are part of the ClassDeclaration range in TSESTree. Report starts
+		// at the `@`. ----
+		{
+			Code: `
+@foo
+class Hello extends React.Component {
+  render() { return null; }
+}
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 1},
+			},
+		},
+
+		// ---- Edge: mode "never" + `export default abstract class X ...` —
+		// `export default` are stripped; `abstract` is kept. Report starts
+		// at `abstract`. ----
+		{
+			Code: `
+        export default abstract class Hello extends React.Component {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Edge: mode "never" + `export default class` with NO name — the
+		// anonymous form is a valid ClassDeclaration in tsgo (the rspack/rsbuild
+		// patterns also look like this in practice). Report still at `class`. ----
+		{
+			Code: `
+        export default class extends React.Component {
+          render() { return null; }
+        }
+      `,
+			Tsx:     true,
+			Options: []any{"never"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseCreateClass", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Edge: mode "always" + paren-wrapped object inside `new` —
+		// `new createReactClass(({...}))` combines NewExpression parent
+		// detection with paren unwrapping. ----
+		{
+			Code: `
+        var Hello = new createReactClass(({
+          render: function() { return <div/>; }
+        }));
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "shouldUseES6Class", Line: 2, Column: 43},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -113,6 +113,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
     './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',
+    './tests/eslint-plugin-react/rules/prefer-es6-class.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/prefer-es6-class.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/prefer-es6-class.test.ts
@@ -1,0 +1,151 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-es6-class', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        Hello.displayName = 'Hello'
+      `,
+    },
+    {
+      code: `
+        export default class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+        Hello.displayName = 'Hello'
+      `,
+    },
+    {
+      code: `
+        var Hello = "foo";
+        module.exports = {};
+      `,
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      options: ['never'],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+      options: ['always'],
+    },
+
+    // ---- Edge: class expression extending React.Component not reported ----
+    {
+      code: `
+        const Hello = class extends React.Component {
+          render() {
+            return <div>Hello</div>;
+          }
+        };
+      `,
+      options: ['never'],
+    },
+
+    // ---- Edge: non-matching callee not reported ----
+    {
+      code: `
+        var x = something({ foo: 1 });
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `
+        var Hello = createReactClass({
+          displayName: 'Hello',
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'shouldUseES6Class' }],
+    },
+    {
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      `,
+      options: ['always'],
+      errors: [{ messageId: 'shouldUseES6Class' }],
+    },
+    {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      `,
+      options: ['never'],
+      errors: [{ messageId: 'shouldUseCreateClass' }],
+    },
+
+    // ---- Edge: pragma-qualified React.createReactClass ----
+    {
+      code: `
+        var Hello = React.createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+      errors: [{ messageId: 'shouldUseES6Class' }],
+    },
+
+    // ---- Edge: PureComponent variant reported in mode "never" ----
+    {
+      code: `
+        class Hello extends React.PureComponent {
+          render() { return <div/>; }
+        }
+      `,
+      options: ['never'],
+      errors: [{ messageId: 'shouldUseCreateClass' }],
+    },
+    {
+      code: `
+        class Hello extends PureComponent {
+          render() { return <div/>; }
+        }
+      `,
+      options: ['never'],
+      errors: [{ messageId: 'shouldUseCreateClass' }],
+    },
+
+    // ---- Edge: `new createReactClass({...})` — NewExpression also has
+    // `.callee` in ESTree, upstream fires. ----
+    {
+      code: `
+        var Hello = new createReactClass({
+          render: function() { return <div/>; }
+        });
+      `,
+      errors: [{ messageId: 'shouldUseES6Class' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -75,6 +75,7 @@ hotpink
 hujson
 iface
 imul
+inlines
 instane
 IPC
 isnan


### PR DESCRIPTION
## Summary

Port the `react/prefer-es6-class` rule from `eslint-plugin-react` to rslint.

Enforces consistency between the two React component declaration styles: ES6 classes extending `React.Component` / `React.PureComponent` and the legacy `createReactClass({...})` factory. Reports whichever style does not match the configured option (`"always"` — the default — flags `createReactClass`; `"never"` flags ES6 class declarations).

Honors `settings.react.pragma` and `settings.react.createClass`. Matches upstream's listener surface (only `ClassDeclaration`, never `ClassExpression`) and also fires on `new createReactClass({...})` (NewExpression parent has `.callee` in ESTree).

Report position aligned with ESLint / TSESTree: `export` / `export default` are stripped (they live on outer wrappers in ESTree), while `abstract` / `declare` / decorators stay on the ClassDeclaration range. Cross-checked against real ESLint + eslint-plugin-react on `rspack/tests/e2e/cases/react/class-component/src/App.jsx` — report column matches.

## Related Links

- ESLint rule docs: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-es6-class.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/prefer-es6-class.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).