### PR TITLE
feat(rslint): align typescript recommended preset with upstream

### DIFF
--- a/packages/rslint/src/configs/typescript.ts
+++ b/packages/rslint/src/configs/typescript.ts
@@ -21,26 +21,26 @@ const recommended: RslintConfigEntry = {
     'no-class-assign': 'off',
     'no-const-assign': 'off',
     'no-dupe-args': 'off',
-    // 'no-dupe-class-members': 'off', // not implemented
+    'no-dupe-class-members': 'off',
     'no-dupe-keys': 'off',
     'no-func-assign': 'off',
     'no-import-assign': 'off',
-    // 'no-new-native-nonconstructor': 'off', // not implemented
-    // 'no-new-symbol': 'off', // not implemented (deprecated, use no-new-native-nonconstructor)
+    'no-new-native-nonconstructor': 'off',
+    'no-new-symbol': 'off',
     'no-obj-calls': 'off',
-    // 'no-redeclare': 'off', // not implemented
+    'no-redeclare': 'off',
     'no-setter-return': 'off',
     'no-this-before-super': 'off',
     'no-undef': 'off',
-    // 'no-unreachable': 'off', // not implemented
+    'no-unreachable': 'off',
     'no-unsafe-negation': 'off',
-    // 'no-with': 'off', // not implemented
+    'no-with': 'off',
 
     // TS-beneficial rules enabled by eslint-recommended override
     'no-var': 'error',
     'prefer-const': 'error',
     'prefer-rest-params': 'error',
-    // 'prefer-spread': 'error', // not implemented
+    'prefer-spread': 'error',
 
     // Remaining eslint:recommended rules (not turned off by TS)
     // 'no-control-regex': 'error', // not implemented
@@ -102,11 +102,11 @@ const recommended: RslintConfigEntry = {
     '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
     '@typescript-eslint/no-require-imports': 'error',
     '@typescript-eslint/no-this-alias': 'error',
-    // '@typescript-eslint/no-unnecessary-type-constraint': 'error', // not implemented
+    '@typescript-eslint/no-unnecessary-type-constraint': 'error',
     // '@typescript-eslint/no-unsafe-declaration-merging': 'error', // not implemented
     // '@typescript-eslint/no-unsafe-function-type': 'error', // not implemented
-    // 'no-unused-expressions': 'off', // not implemented
-    // '@typescript-eslint/no-unused-expressions': 'error', // not implemented
+    'no-unused-expressions': 'off',
+    '@typescript-eslint/no-unused-expressions': 'error',
     'no-unused-vars': 'off',
     // Differs from typescript-eslint recommended (which uses bare 'error').
     // Ignoring _-prefixed vars/args is a widely adopted community convention,


### PR DESCRIPTION
## Summary

Align `packages/rslint/src/configs/typescript.ts` (the `recommended` preset exposed as `ts.configs.recommended`) with the upstream `@typescript-eslint/recommended` three-layer config (`base` + `eslint-recommended` + `typescript-eslint/recommended`).

- Enable rules already ported/registered in rslint that the official preset specifies:
  - `prefer-spread: 'error'`
  - `@typescript-eslint/no-unnecessary-type-constraint: 'error'`
  - `@typescript-eslint/no-unused-expressions: 'error'` (with `no-unused-expressions: 'off'`)
- Fill in the `off` entries from the `eslint-recommended` override layer that were previously left as `// not implemented`:
  - `no-dupe-class-members`, `no-new-native-nonconstructor`, `no-new-symbol`, `no-redeclare`, `no-unreachable`, `no-with`
  - `GetEnabledRules` is safe for unregistered rule names set to `off` (it simply skips), so this is a no-op for the unregistered ones while keeping the preset byte-aligned with upstream.
- The only intentional deviation from upstream remains `@typescript-eslint/no-unused-vars` carrying `{ varsIgnorePattern: '^_', argsIgnorePattern: '^_' }` (already documented inline).
- Still commented out pending port: `@typescript-eslint/no-empty-object-type`, `no-unsafe-declaration-merging`, `no-unsafe-function-type`, `no-wrapper-object-types`.

## Related Links

- Upstream source: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/flat/recommended.ts
- Upstream eslint-recommended override: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/configs/eslint-recommended-raw.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).