### PR TITLE
feat: add promise plugin recommended preset

### DIFF
--- a/packages/rslint/src/configs/index.ts
+++ b/packages/rslint/src/configs/index.ts
@@ -3,6 +3,7 @@ import { recommended as tsRecommended } from './typescript.js';
 import { recommended as jsRecommended } from './javascript.js';
 import { recommended as reactRecommended } from './react.js';
 import { recommended as importRecommended } from './import.js';
+import { recommended as promiseRecommended } from './promise.js';
 
 interface PluginExport {
   configs: { recommended: RslintConfigEntry };
@@ -22,4 +23,8 @@ export const reactPlugin: PluginExport = {
 
 export const importPlugin: PluginExport = {
   configs: { recommended: importRecommended },
+};
+
+export const promisePlugin: PluginExport = {
+  configs: { recommended: promiseRecommended },
 };

--- a/packages/rslint/src/configs/promise.ts
+++ b/packages/rslint/src/configs/promise.ts
@@ -1,0 +1,23 @@
+import type { RslintConfigEntry } from '../define-config.js';
+
+// Aligned with official eslint-plugin-promise@7.x recommended.
+// Rules commented out with "not implemented" are in the official preset but not yet available.
+const recommended: RslintConfigEntry = {
+  plugins: ['promise'],
+  rules: {
+    // 'promise/always-return': 'error', // not implemented
+    // 'promise/no-return-wrap': 'error', // not implemented
+    'promise/param-names': 'error',
+    // 'promise/catch-or-return': 'error', // not implemented
+    // 'promise/no-native': 'off', // not implemented
+    // 'promise/no-nesting': 'warn', // not implemented
+    // 'promise/no-promise-in-callback': 'warn', // not implemented
+    // 'promise/no-callback-in-promise': 'warn', // not implemented
+    // 'promise/avoid-new': 'off', // not implemented
+    // 'promise/no-new-statics': 'error', // not implemented
+    // 'promise/no-return-in-finally': 'warn', // not implemented
+    // 'promise/valid-params': 'warn', // not implemented
+  },
+};
+
+export { recommended };

--- a/packages/rslint/src/index.ts
+++ b/packages/rslint/src/index.ts
@@ -11,7 +11,13 @@ import {
 
 export { defineConfig } from './define-config.js';
 export type { RslintConfigEntry } from './define-config.js';
-export { ts, js, reactPlugin, importPlugin } from './configs/index.js';
+export {
+  ts,
+  js,
+  reactPlugin,
+  importPlugin,
+  promisePlugin,
+} from './configs/index.js';
 
 // Export the main RSLintService class for direct usage
 export { RSLintService } from './service.js';


### PR DESCRIPTION
## Summary

Introduce a new `promisePlugin` export in `@rslint/core` with a `recommended` config aligned to the official `eslint-plugin-promise@7.2.1` `configs.recommended`:

- Verified by runtime-loading upstream (`require('eslint-plugin-promise').configs.recommended.rules`) and diffing against the compiled preset object — no extra rules, no severity mismatches.
- Only `promise/param-names` is currently ported in `internal/plugins/promise/` and is enabled.
- The other 11 rules from upstream recommended are kept as commented placeholders with their upstream severities preserved (`error` / `warn` / `off`), so they can be flipped on as rules are ported.

Upstream reference (eslint-plugin-promise@7.2.1 recommended):

| Rule | Severity |
| --- | --- |
| promise/always-return | error |
| promise/no-return-wrap | error |
| promise/param-names | error (enabled) |
| promise/catch-or-return | error |
| promise/no-native | off |
| promise/no-nesting | warn |
| promise/no-promise-in-callback | warn |
| promise/no-callback-in-promise | warn |
| promise/avoid-new | off |
| promise/no-new-statics | error |
| promise/no-return-in-finally | warn |
| promise/valid-params | warn |

## Related Links

- Upstream recommended source: https://github.com/eslint-community/eslint-plugin-promise/blob/main/index.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).