### PR TITLE
docs: fix website MDX build errors and refactor plugin registry

### DIFF
--- a/cspell.config.cjs
+++ b/cspell.config.cjs
@@ -19,6 +19,7 @@ module.exports = {
     './agents',
     'internal/linter/*_test.go',
     'internal/rules/valid_typeof/valid_typeof.md',
+    'internal/plugins/react/rules/no_typos/no_typos.md',
     'website/docs/en/rules/*/',
   ],
   dictionaries: ['dictionary'],

--- a/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
+++ b/internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md
@@ -113,5 +113,5 @@ Examples of **correct** code for this rule, when `allowLeadingUnderscore` is
 
 ## Original Documentation
 
-- ESLint-plugin-react rule: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md>
-- Source: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js>
+- ESLint-plugin-react rule: [https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md)
+- Source: [https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-pascal-case.js)

--- a/internal/plugins/react/rules/no_typos/no_typos.md
+++ b/internal/plugins/react/rules/no_typos/no_typos.md
@@ -1,5 +1,3 @@
-<!-- cspell:disable — rule docs deliberately contain casing-typo identifiers (e.g. `componentwillMount`, `isrequired`) that the rule is designed to flag. -->
-
 # react/no-typos
 
 Disallow common typos in React component declarations.

--- a/internal/plugins/typescript/rules/no_redeclare/no_redeclare.md
+++ b/internal/plugins/typescript/rules/no_redeclare/no_redeclare.md
@@ -85,5 +85,5 @@ namespace A {}
 
 ## Original Documentation
 
-- <https://typescript-eslint.io/rules/no-redeclare>
-- <https://eslint.org/docs/latest/rules/no-redeclare>
+- [https://typescript-eslint.io/rules/no-redeclare](https://typescript-eslint.io/rules/no-redeclare)
+- [https://eslint.org/docs/latest/rules/no-redeclare](https://eslint.org/docs/latest/rules/no-redeclare)

--- a/internal/rules/max_lines/max_lines.md
+++ b/internal/rules/max_lines/max_lines.md
@@ -72,4 +72,4 @@ var b = 2;
 
 ## Original Documentation
 
-- <https://eslint.org/docs/latest/rules/max-lines>
+- [https://eslint.org/docs/latest/rules/max-lines](https://eslint.org/docs/latest/rules/max-lines)

--- a/internal/rules/no_misleading_character_class/no_misleading_character_class.md
+++ b/internal/rules/no_misleading_character_class/no_misleading_character_class.md
@@ -72,4 +72,4 @@ new RegExp("[\\uD83D\\uDC4D]");  // surrogate pair in string literal
 
 ## Original Documentation
 
-- <https://eslint.org/docs/latest/rules/no-misleading-character-class>
+- [https://eslint.org/docs/latest/rules/no-misleading-character-class](https://eslint.org/docs/latest/rules/no-misleading-character-class)

--- a/internal/rules/no_regex_spaces/no_regex_spaces.md
+++ b/internal/rules/no_regex_spaces/no_regex_spaces.md
@@ -36,5 +36,5 @@ the parsed pattern would not map cleanly back to source positions.
 
 ## Original Documentation
 
-- ESLint rule: <https://eslint.org/docs/latest/rules/no-regex-spaces>
-- Source code: <https://github.com/eslint/eslint/blob/main/lib/rules/no-regex-spaces.js>
+- ESLint rule: [https://eslint.org/docs/latest/rules/no-regex-spaces](https://eslint.org/docs/latest/rules/no-regex-spaces)
+- Source code: [https://github.com/eslint/eslint/blob/main/lib/rules/no-regex-spaces.js](https://github.com/eslint/eslint/blob/main/lib/rules/no-regex-spaces.js)

--- a/internal/rules/no_shadow/no_shadow.md
+++ b/internal/rules/no_shadow/no_shadow.md
@@ -86,4 +86,4 @@ Ignores shadowing for parameters declared inside a function type. Default:
 
 ## Original Documentation
 
-<https://eslint.org/docs/latest/rules/no-shadow>
+[https://eslint.org/docs/latest/rules/no-shadow](https://eslint.org/docs/latest/rules/no-shadow)

--- a/website/plugin-rule-manifest.ts
+++ b/website/plugin-rule-manifest.ts
@@ -2,8 +2,9 @@ import type { RspressPlugin } from '@rspress/core';
 import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
-import { ts, js, reactPlugin, importPlugin } from '@rslint/core';
+import * as rslintCore from '@rslint/core';
 import type { RslintConfigEntry } from '@rslint/core';
+import { PLUGIN_REGISTRY } from './theme/plugin-registry';
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const MANIFEST_PATH = path.resolve(__dirname, 'generated/rule-manifest.json');
@@ -30,49 +31,30 @@ function groupToRouteSlug(group: string): string {
   return group.replace(/^@/, '');
 }
 
-/**
- * Return the fully-qualified rule name as used in rslint config.
- * Core ESLint rules have no prefix; plugin rules are prefixed with the group.
- * e.g. "no-console" for eslint, "@typescript-eslint/no-explicit-any" for TS plugin.
- */
+const PLUGINS = PLUGIN_REGISTRY.map((p) => {
+  const mod = (rslintCore as Record<string, unknown>)[p.importName] as
+    | { configs?: { recommended?: RslintConfigEntry } }
+    | undefined;
+  const config = mod?.configs?.recommended;
+  return {
+    prefix: p.prefix,
+    group: p.group,
+    presets: p.presetName && config ? [{ config, name: p.presetName }] : [],
+  };
+});
+
 function getFullRuleName(rule: RuleEntry): string {
   if (rule.group === 'eslint') return rule.name;
-  return `${rule.group}/${rule.name}`;
+  const entry = PLUGINS.find((e) => e.group === rule.group);
+  const prefix = entry?.prefix || rule.group;
+  return `${prefix}/${rule.name}`;
 }
 
-/** Each preset config paired with its full reference name (e.g. "ts.configs.recommended"). */
-const PRESETS: { config: RslintConfigEntry; name: string }[] = [
-  { config: ts.configs.recommended, name: 'ts.configs.recommended' },
-  { config: js.configs.recommended, name: 'js.configs.recommended' },
-  {
-    config: reactPlugin.configs.recommended,
-    name: 'reactPlugin.configs.recommended',
-  },
-  {
-    config: importPlugin.configs.recommended,
-    name: 'importPlugin.configs.recommended',
-  },
-];
-
-/**
- * Parse a fully-qualified rule key from a config into the (group, name)
- * pair used by the manifest.
- */
 function parseRuleKey(ruleKey: string): { group: string; name: string } {
-  if (ruleKey.startsWith('@typescript-eslint/')) {
-    return {
-      group: '@typescript-eslint',
-      name: ruleKey.slice('@typescript-eslint/'.length),
-    };
-  }
-  if (ruleKey.startsWith('react/')) {
-    return { group: 'react', name: ruleKey.slice('react/'.length) };
-  }
-  if (ruleKey.startsWith('import/')) {
-    return {
-      group: 'eslint-plugin-import',
-      name: ruleKey.slice('import/'.length),
-    };
+  for (const { prefix, group } of PLUGINS) {
+    if (prefix && ruleKey.startsWith(`${prefix}/`)) {
+      return { group, name: ruleKey.slice(prefix.length + 1) };
+    }
   }
   return { group: 'eslint', name: ruleKey };
 }
@@ -90,16 +72,18 @@ interface PresetInfo {
 function extractPresetRules(): Map<string, PresetInfo[]> {
   const result = new Map<string, PresetInfo[]>();
 
-  for (const { config, name: presetName } of PRESETS) {
-    if (!config.rules) continue;
-    for (const [ruleKey, value] of Object.entries(config.rules)) {
-      const severity = Array.isArray(value) ? value[0] : value;
-      if (severity === 'off') continue;
+  for (const { presets } of PLUGINS) {
+    for (const { config, name: presetName } of presets) {
+      if (!config.rules) continue;
+      for (const [ruleKey, value] of Object.entries(config.rules)) {
+        const severity = Array.isArray(value) ? value[0] : value;
+        if (severity === 'off') continue;
 
-      const { group, name } = parseRuleKey(ruleKey);
-      const manifestKey = `${group}:${name}`;
-      if (!result.has(manifestKey)) result.set(manifestKey, []);
-      result.get(manifestKey)!.push({ name: presetName, value: value! });
+        const { group, name } = parseRuleKey(ruleKey);
+        const manifestKey = `${group}:${name}`;
+        if (!result.has(manifestKey)) result.set(manifestKey, []);
+        result.get(manifestKey)!.push({ name: presetName, value: value! });
+      }
     }
   }
   return result;

--- a/website/theme/components/RuleConfig.tsx
+++ b/website/theme/components/RuleConfig.tsx
@@ -1,22 +1,14 @@
 import React from 'react';
 import { CodeBlockRuntime } from '@rspress/core/theme';
+import { PLUGIN_REGISTRY } from '../plugin-registry';
 
-/**
- * Mapping from plugin group to the import name and preset used in rslint config.
- * Core eslint rules use `js`, everything else maps to its plugin export.
- */
-const GROUP_CONFIG: Record<string, { importName: string; preset: string }> = {
-  eslint: { importName: 'js', preset: 'js.configs.recommended' },
-  '@typescript-eslint': { importName: 'ts', preset: 'ts.configs.recommended' },
-  'eslint-plugin-import': {
-    importName: 'importPlugin',
-    preset: 'importPlugin.configs.recommended',
-  },
-  react: {
-    importName: 'reactPlugin',
-    preset: 'reactPlugin.configs.recommended',
-  },
-};
+const GROUP_CONFIG: Record<string, { importName: string; preset: string }> =
+  Object.fromEntries(
+    PLUGIN_REGISTRY.filter((p) => p.presetName).map((p) => [
+      p.group,
+      { importName: p.importName, preset: p.presetName! },
+    ]),
+  );
 
 /**
  * Displays a complete rslint configuration snippet that users can copy

--- a/website/theme/plugin-registry.ts
+++ b/website/theme/plugin-registry.ts
@@ -1,0 +1,62 @@
+/**
+ * Metadata for a single plugin. All fields are plain strings so this file
+ * can be imported by both Node (build scripts) and the browser (UI components)
+ * without pulling in @rslint/core at runtime.
+ */
+export interface PluginMeta {
+  /** Rule key prefix in rslint config, e.g. "react" → "react/jsx-key".
+   *  Empty string for core ESLint rules (no prefix). */
+  prefix: string;
+  /** Internal group name used in rule-manifest.json, e.g. "eslint-plugin-import". */
+  group: string;
+  /** Named export from @rslint/core used in import statements, e.g. "importPlugin". */
+  importName: string;
+  /** Dot-path to the preset config object, e.g. "reactPlugin.configs.recommended".
+   *  null if the plugin ships no preset. */
+  presetName: string | null;
+}
+
+/**
+ * Single source of truth for every supported plugin.
+ * Both plugin-rule-manifest.ts (build-time) and RuleConfig.tsx (runtime UI)
+ * derive their local mappings from this list — add a plugin here once and
+ * both places pick it up automatically.
+ */
+export const PLUGIN_REGISTRY: PluginMeta[] = [
+  {
+    prefix: '',
+    group: 'eslint',
+    importName: 'js',
+    presetName: 'js.configs.recommended',
+  },
+  {
+    prefix: '@typescript-eslint',
+    group: '@typescript-eslint',
+    importName: 'ts',
+    presetName: 'ts.configs.recommended',
+  },
+  {
+    prefix: 'react',
+    group: 'react',
+    importName: 'reactPlugin',
+    presetName: 'reactPlugin.configs.recommended',
+  },
+  {
+    prefix: 'import',
+    group: 'eslint-plugin-import',
+    importName: 'importPlugin',
+    presetName: 'importPlugin.configs.recommended',
+  },
+  {
+    prefix: 'promise',
+    group: 'eslint-plugin-promise',
+    importName: 'promisePlugin',
+    presetName: 'promisePlugin.configs.recommended',
+  },
+  {
+    prefix: 'jest',
+    group: 'eslint-plugin-jest',
+    importName: 'jestPlugin',
+    presetName: 'jestPlugin.configs.recommended',
+  },
+];


### PR DESCRIPTION
## Summary

### 1. Fix MDX build errors in rule doc source files

The website `pnpm build` was failing with 7 MDX compilation errors because the generated `.mdx` files (derived from source `.md` files) contained syntax valid in standard Markdown but not in MDX.

**`Unexpected character /` (6 files):** MDX parses `<` as JSX tag start, so Markdown autolink syntax `<https://...>` is invalid. Fixed by converting to standard `[url](url)` link syntax in:
- `internal/rules/max_lines/max_lines.md`
- `internal/rules/no_misleading_character_class/no_misleading_character_class.md`
- `internal/rules/no_regex_spaces/no_regex_spaces.md`
- `internal/rules/no_shadow/no_shadow.md`
- `internal/plugins/react/rules/jsx_pascal_case/jsx_pascal_case.md`
- `internal/plugins/typescript/rules/no_redeclare/no_redeclare.md`

**`Unexpected character !` (1 file):** MDX does not support HTML comments (`<- rustup target add wasm32-wasi -->`). Removed the `cspell:disable` HTML comment from `no_typos.md` and added the file to `cspell.config.cjs` `ignorePaths` instead.

### 2. Fix `promise/param-names` rule config name and preset

`promise/param-names` was incorrectly displaying as `eslint-plugin-promise/param-names` in the Configuration section, and `promisePlugin.configs.recommended` was not being matched as a preset. Root causes:
- `parseRuleKey` in `plugin-rule-manifest.ts` was missing handling for the `promise/` prefix, so config rule keys like `promise/param-names` fell through to the `eslint` group
- `RuleConfig.tsx` `GROUP_CONFIG` was missing the `eslint-plugin-promise` entry, so the code snippet fell back to the no-import variant

### 3. Refactor: introduce `plugin-registry.ts` as single source of truth

Plugin metadata (prefix / group / importName / presetName) was previously duplicated across `plugin-rule-manifest.ts` and `RuleConfig.tsx`, which caused the promise bug above (adding a plugin required updating two places independently).

Introduced `website/theme/plugin-registry.ts` — a plain-string registry with no runtime dependencies, importable by both Node (build scripts) and the browser (UI components):

- `plugin-rule-manifest.ts` derives `PLUGINS` from the registry using `import * as rslintCore` and indexes by `importName`, eliminating the separate `PLUGIN_MODULES` mapping
- `RuleConfig.tsx` derives `GROUP_CONFIG` from the same registry

**Adding a new plugin now only requires one entry in `plugin-registry.ts`.**

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).
