### PR TITLE
feat: port rule react/no-redundant-should-component-update

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -27,6 +27,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
@@ -72,6 +73,7 @@ func GetAllRules() []rule.Rule {
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
+		no_redundant_should_component_update.NoRedundantShouldComponentUpdateRule,
 		no_render_return_value.NoRenderReturnValueRule,
 		no_string_refs.NoStringRefsRule,
 		no_typos.NoTyposRule,

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.go
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.go
@@ -1,0 +1,130 @@
+package no_redundant_should_component_update
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// extendsPureComponent reports whether `classNode`'s extends clause matches
+// upstream's `componentUtil.isPureComponent` regex
+// `/^(<pragma>\.)?PureComponent$/`. Distinct from
+// `reactutil.ExtendsReactComponent` (which also matches plain `Component`).
+//
+// Parens around the extends expression are skipped — matching ESLint's
+// behavior where `getText(node.superClass)` returns the bare member-expression
+// text (range excludes surrounding parens) and the regex still matches.
+func extendsPureComponent(classNode *ast.Node, pragma string) bool {
+	if classNode == nil {
+		return false
+	}
+	heritage := ast.GetClassExtendsHeritageElement(classNode)
+	if heritage == nil {
+		return false
+	}
+	hc := heritage.AsExpressionWithTypeArguments()
+	if hc == nil || hc.Expression == nil {
+		return false
+	}
+	expr := ast.SkipParentheses(hc.Expression)
+	switch expr.Kind {
+	case ast.KindIdentifier:
+		return expr.AsIdentifier().Text == "PureComponent"
+	case ast.KindPropertyAccessExpression:
+		pa := expr.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		return name.AsIdentifier().Text == "PureComponent"
+	}
+	return false
+}
+
+// hasShouldComponentUpdate mirrors upstream's
+// `astUtil.getComponentProperties(node).some(p => getPropertyName(p) === 'shouldComponentUpdate')`.
+//
+// Upstream `getPropertyName` returns `nameNode.name`, which is populated for
+// Identifier and PrivateIdentifier (per spec, PrivateIdentifier exposes its
+// name without the leading `#`) — so `#shouldComponentUpdate` also matches,
+// matching upstream. Other key shapes (StringLiteral / NumericLiteral /
+// ComputedPropertyName) yield undefined `.name` upstream and never match.
+func hasShouldComponentUpdate(members []*ast.Node) bool {
+	for _, m := range members {
+		if m == nil {
+			continue
+		}
+		key := m.Name()
+		if key == nil {
+			continue
+		}
+		var name string
+		switch key.Kind {
+		case ast.KindIdentifier:
+			name = key.AsIdentifier().Text
+		case ast.KindPrivateIdentifier:
+			name = strings.TrimPrefix(key.AsPrivateIdentifier().Text, "#")
+		default:
+			continue
+		}
+		if name == "shouldComponentUpdate" {
+			return true
+		}
+	}
+	return false
+}
+
+// classDisplayName mirrors upstream's `getNodeName`:
+//
+//   - ClassDeclaration / named ClassExpression → its own Identifier name
+//     (e.g. `class Foo …` → "Foo", `class Bar extends …` returned from a
+//     factory → "Bar").
+//   - Anonymous ClassExpression assigned via `var Foo = class …` → "Foo"
+//     (parent VariableDeclaration's binding Identifier).
+//   - Anything else (e.g. `export default class extends …`) → "".
+func classDisplayName(node *ast.Node) string {
+	name := node.Name()
+	if name != nil && name.Kind == ast.KindIdentifier {
+		return name.AsIdentifier().Text
+	}
+	parent := node.Parent
+	if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+		binding := parent.AsVariableDeclaration().Name()
+		if binding != nil && binding.Kind == ast.KindIdentifier {
+			return binding.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+var NoRedundantShouldComponentUpdateRule = rule.Rule{
+	Name: "react/no-redundant-should-component-update",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+
+		check := func(node *ast.Node) {
+			if !extendsPureComponent(node, pragma) {
+				return
+			}
+			if !hasShouldComponentUpdate(node.Members()) {
+				return
+			}
+			name := classDisplayName(node)
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noShouldCompUpdate",
+				Description: name + " does not need shouldComponentUpdate when extending React.PureComponent.",
+			})
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: check,
+			ast.KindClassExpression:  check,
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.md
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.md
@@ -1,0 +1,72 @@
+# react/no-redundant-should-component-update
+
+## Rule Details
+
+Disallow usage of `shouldComponentUpdate` when extending `React.PureComponent`.
+
+`React.PureComponent` already implements `shouldComponentUpdate` with a shallow
+prop and state comparison. Defining your own `shouldComponentUpdate` defeats
+the purpose of extending `PureComponent` — at that point you should extend
+`React.Component` instead.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+class Foo extends React.PureComponent {
+  shouldComponentUpdate() {
+    // do check
+  }
+
+  render() {
+    return <div>Radical!</div>
+  }
+}
+
+function Bar() {
+  return class Baz extends React.PureComponent {
+    shouldComponentUpdate() {
+      // do check
+    }
+
+    render() {
+      return <div>Groovy!</div>
+    }
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+class Foo extends React.Component {
+  shouldComponentUpdate() {
+    // do check
+  }
+
+  render() {
+    return <div>Radical!</div>
+  }
+}
+
+function Bar() {
+  return class Baz extends React.Component {
+    shouldComponentUpdate() {
+      // do check
+    }
+
+    render() {
+      return <div>Groovy!</div>
+    }
+  }
+}
+
+class Qux extends React.PureComponent {
+  render() {
+    return <div>Tubular!</div>
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react: no-redundant-should-component-update](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md)

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update_test.go
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update_test.go
@@ -1,0 +1,580 @@
+package no_redundant_should_component_update
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoRedundantShouldComponentUpdateRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoRedundantShouldComponentUpdateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid: shouldComponentUpdate on plain React.Component ----
+		{Code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: class field arrow shouldComponentUpdate on Component ----
+		{Code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: nested class expression on plain Component ----
+		{Code: `
+        function Foo() {
+          return class Bar extends React.Component {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Edge: PureComponent without shouldComponentUpdate — clean ----
+		{Code: `
+        class Foo extends React.PureComponent {
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bare PureComponent without shouldComponentUpdate ----
+		{Code: `
+        class Foo extends PureComponent {
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: extends some other namespace's PureComponent — strict regex ----
+		{Code: `
+        class Foo extends Other.PureComponent {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: extends PureComponent.Inner — full-text regex requires terminal `PureComponent` ----
+		{Code: `
+        class Foo extends PureComponent.Inner {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: extends a CallExpression returning PureComponent — only Identifier / qualified `<pragma>.PureComponent` matches ----
+		{Code: `
+        class Foo extends getBase() {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: shouldComponentUpdate as STRING-LITERAL key — upstream getPropertyName returns undefined for non-Identifier keys, so no match ----
+		{Code: `
+        class Foo extends React.PureComponent {
+          "shouldComponentUpdate"() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: shouldComponentUpdate as COMPUTED key — non-Identifier key never matches ----
+		{Code: "\n        class Foo extends React.PureComponent {\n          [`shouldComponentUpdate`]() { return true; }\n        }\n      ", Tsx: true},
+
+		// ---- Edge: settings.react.pragma="Preact" — `React.PureComponent` no longer matches ----
+		{Code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- Edge: empty class body extending PureComponent — clean (no scu) ----
+		{Code: `
+        class Foo extends React.PureComponent {}
+      `, Tsx: true},
+
+		// ---- Edge: extends without superClass — graceful ----
+		{Code: `
+        class Foo {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: a sibling NON-Pure class is fine even when same file has a Pure one ----
+		{Code: `
+        class A extends React.Component {
+          shouldComponentUpdate() { return true; }
+        }
+        class B extends React.PureComponent {
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge (TS): TypeAssertion `as` wrapper on extends — ESLint's text-regex
+		// won't match either, so we mirror that miss. ----
+		{Code: `
+        class Foo extends (React.PureComponent as any) {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge (TS): ElementAccess form `React['PureComponent']` — neither side matches ----
+		{Code: `
+        class Foo extends React['PureComponent'] {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: SubClass off PureComponent — strict regex requires terminal `PureComponent` ----
+		{Code: `
+        class Foo extends React.PureComponent.SubClass {
+          shouldComponentUpdate() { return true; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: doubly-nested classes where ONLY outer extends PureComponent
+		// and inner non-Pure class hosts shouldComponentUpdate — outer must NOT
+		// report (inner's scu doesn't pollute outer's Members) ----
+		{Code: `
+        class Outer extends React.PureComponent {
+          render() {
+            return class Inner extends React.Component {
+              shouldComponentUpdate() { return true; }
+            };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: shouldComponentUpdate on a UNRELATED inner class extending Component
+		// nested inside an outer PureComponent class with NO scu ----
+		{Code: `
+        class Outer extends React.PureComponent {
+          method() {
+            class Local {
+              shouldComponentUpdate() { return true; }
+            }
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid: ClassDeclaration extends React.PureComponent ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Upstream invalid: bare PureComponent ----
+		{
+			Code: `
+        class Foo extends PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Upstream invalid: class field arrow shouldComponentUpdate ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Upstream invalid: nested ClassExpression with own name (Bar) ----
+		{
+			Code: `
+        function Foo() {
+          return class Bar extends React.PureComponent {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Bar does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      3,
+					Column:    18,
+				},
+			},
+		},
+
+		// ---- Upstream invalid: nested ClassExpression bare PureComponent ----
+		{
+			Code: `
+        function Foo() {
+          return class Bar extends PureComponent {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Bar does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      3,
+					Column:    18,
+				},
+			},
+		},
+
+		// ---- Upstream invalid: anonymous ClassExpression assigned to var (name from binding) ----
+		{
+			Code: `
+        var Foo = class extends PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    19,
+				},
+			},
+		},
+
+		// ---- Edge: ClassExpression IIFE with no enclosing binding — name is empty ----
+		{
+			Code: `
+        (class extends React.PureComponent {
+          shouldComponentUpdate() { return true; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					// Empty class name — upstream's `{{component}}` placeholder
+					// substitutes to "" producing a leading-space message.
+					Message: " does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:    2,
+					Column:  10,
+				},
+			},
+		},
+
+		// ---- Edge: parens around extends expression — paren-transparent on our side, matching ESTree ----
+		{
+			Code: `
+        class Foo extends (React.PureComponent) {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: settings.react.pragma="Preact" + extends Preact.PureComponent ----
+		{
+			Code: `
+        class Foo extends Preact.PureComponent {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: outer Component class encloses inner PureComponent — only inner reports (listener fires per node) ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          render() {
+            class Inner extends React.PureComponent {
+              shouldComponentUpdate() { return true; }
+            }
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Inner does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      4,
+					Column:    13,
+				},
+			},
+		},
+
+		// ---- Edge (TS): generic class with type params on extends ----
+		{
+			Code: `
+        class Foo extends React.PureComponent<Props, State> {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge (TS): bare PureComponent with type args ----
+		{
+			Code: `
+        class Foo extends PureComponent<Props> {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier `#shouldComponentUpdate` — upstream's
+		// `getPropertyName` strips the leading `#` and matches; we mirror that. ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          #shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: static shouldComponentUpdate — upstream doesn't filter by
+		// `static`, so we report (mirroring upstream's behavior even though
+		// runtime React doesn't actually use a static lifecycle hook). ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          static shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: getter `get shouldComponentUpdate()` — same upstream behavior ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          get shouldComponentUpdate() { return () => true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge (TS): abstract class — same shape, must still report ----
+		{
+			Code: `
+        abstract class Foo extends React.PureComponent {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge (TS): decorated class — decorators are siblings of the
+		// class node, must not affect detection ----
+		{
+			Code: `
+        @decorator
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge (TS): overload signatures + implementation — Members()
+		// includes both the bodyless signature and the implementation; we
+		// only need ONE Identifier-keyed match so we still report. ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate(): boolean;
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: multi-level parens around extends — SkipParentheses must
+		// peel every level, matching ESLint's identifier-text-only regex match. ----
+		{
+			Code: `
+        class Foo extends ((React.PureComponent)) {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Foo does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Edge: deeply nested ClassDeclaration inside object method body —
+		// listener must still fire on the inner class. ----
+		{
+			Code: `
+        const utils = {
+          make() {
+            class Inner extends React.PureComponent {
+              shouldComponentUpdate() { return true; }
+            }
+            return Inner;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   "Inner does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      4,
+					Column:    13,
+				},
+			},
+		},
+
+		// ---- Edge: anonymous class inside `module.exports = class extends PureComponent {...}`
+		// — parent is BinaryExpression, not VariableDeclaration → empty name. ----
+		{
+			Code: `
+        module.exports = class extends React.PureComponent {
+          shouldComponentUpdate() { return true; }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "noShouldCompUpdate",
+					Message:   " does not need shouldComponentUpdate when extending React.PureComponent.",
+					Line:      2,
+					Column:    26,
+				},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -109,6 +109,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-direct-mutation-state.test.ts',
     './tests/eslint-plugin-react/rules/no-find-dom-node.test.ts',
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
+    './tests/eslint-plugin-react/rules/no-redundant-should-component-update.test.ts',
     './tests/eslint-plugin-react/rules/no-render-return-value.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-redundant-should-component-update.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-redundant-should-component-update.test.ts
@@ -1,0 +1,149 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-redundant-should-component-update', {} as never, {
+  valid: [
+    // ---- Upstream valid: shouldComponentUpdate on plain React.Component ----
+    {
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+    },
+    // ---- Upstream valid: class field arrow shouldComponentUpdate on Component ----
+    {
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+        }
+      `,
+    },
+    // ---- Upstream valid: nested class expression on plain Component ----
+    {
+      code: `
+        function Foo() {
+          return class Bar extends React.Component {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
+    },
+    // ---- Edge: PureComponent without shouldComponentUpdate — clean ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          render() { return null; }
+        }
+      `,
+    },
+    // ---- Edge: shouldComponentUpdate as STRING-LITERAL key — non-Identifier never matches ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          "shouldComponentUpdate"() { return true; }
+        }
+      `,
+    },
+    // ---- Edge: shouldComponentUpdate as COMPUTED key — non-Identifier never matches ----
+    {
+      code: '\n        class Foo extends React.PureComponent {\n          [`shouldComponentUpdate`]() { return true; }\n        }\n      ',
+    },
+    // ---- Edge: extends some other namespace's PureComponent — strict regex ----
+    {
+      code: `
+        class Foo extends Other.PureComponent {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Upstream invalid: ClassDeclaration extends React.PureComponent ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+    // ---- Upstream invalid: bare PureComponent ----
+    {
+      code: `
+        class Foo extends PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+    // ---- Upstream invalid: class field arrow shouldComponentUpdate ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+    // ---- Upstream invalid: nested ClassExpression with own name (Bar) ----
+    {
+      code: `
+        function Foo() {
+          return class Bar extends React.PureComponent {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+    // ---- Upstream invalid: nested ClassExpression bare PureComponent ----
+    {
+      code: `
+        function Foo() {
+          return class Bar extends PureComponent {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+    // ---- Upstream invalid: anonymous ClassExpression assigned to var (name from binding) ----
+    {
+      code: `
+        var Foo = class extends PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+    // ---- Edge: parens around extends expression — paren-transparent matching ESTree ----
+    {
+      code: `
+        class Foo extends (React.PureComponent) {
+          shouldComponentUpdate() { return true; }
+        }
+      `,
+      errors: [{ messageId: 'noShouldCompUpdate' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-redundant-should-component-update` rule from `eslint-plugin-react` to rslint.

The rule flags classes that define their own `shouldComponentUpdate` while extending `React.PureComponent` (or a bare `PureComponent`). `PureComponent` already ships a shallow-comparison `shouldComponentUpdate`; overriding it defeats the purpose of extending `PureComponent` and the author should extend `React.Component` instead.

Semantic parity with upstream is maintained:

- Pragma scoping via `settings.react.pragma` (both `<pragma>.PureComponent` and bare `PureComponent` match).
- Class name reporting mirrors upstream `getNodeName`: own class Identifier, else the `var/let/const` binding when the anonymous `ClassExpression` is assigned, else empty (matching the upstream `{{component}}` template producing a leading-space message).
- Member-key matching aligns with upstream `getPropertyName`: `Identifier` / `PrivateIdentifier` (with the `#` stripped) match; `StringLiteral` / `ComputedPropertyName` / literal keys do not.
- `extends` expression is paren-transparent (matching ESTree's flattened range) but rejects `as` casts, `ElementAccess`, and qualifier chains like `PureComponent.Sub` — identical to upstream's regex behavior on the source text.

Go tests cover every upstream `valid` / `invalid` case plus TS-specific forms (generic type params on extends, `abstract class`, decorators, overload signatures, private method, static method, getter, multi-level parens, `module.exports = class …`), nesting boundaries (outer `Component` ∋ inner `PureComponent`, outer `PureComponent` ∋ unrelated inner class), and container-form equivalence classes (ClassDeclaration / named ClassExpression / `var`-bound anonymous ClassExpression / IIFE class / `module.exports` assignment).

## Related Links

- eslint-plugin-react rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-redundant-should-component-update.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-redundant-should-component-update.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).