### PR TITLE
feat: port rule react/no-this-in-sfc

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -29,6 +29,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_this_in_sfc"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_typos"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unescaped_entities"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unknown_property"
@@ -74,6 +75,7 @@ func GetAllRules() []rule.Rule {
 		no_is_mounted.NoIsMountedRule,
 		no_render_return_value.NoRenderReturnValueRule,
 		no_string_refs.NoStringRefsRule,
+		no_this_in_sfc.NoThisInSfcRule,
 		no_typos.NoTyposRule,
 		no_unescaped_entities.NoUnescapedEntitiesRule,
 		no_unknown_property.NoUnknownPropertyRule,

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
@@ -1,0 +1,96 @@
+package no_this_in_sfc
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// getParentStatelessComponent mirrors eslint-plugin-react's
+// `Components.detect`-paired helper of the same name: walk up enclosing
+// FunctionLike scopes from `node` and return the first one classified as a
+// stateless functional component. A non-component function does NOT stop the
+// walk — the next outer FunctionLike still gets a chance, matching upstream's
+// `scope.upper` traversal.
+//
+// ES6 class scopes / class field initializers / module scope are non-FunctionLike
+// nodes that are simply skipped during the walk; `this` inside a class field
+// thus resolves to the nearest enclosing function-like (matching upstream's
+// `getScope` + `scope.upper` chain, which also walks past class scope without
+// classifying it as a component).
+func getParentStatelessComponent(node *ast.Node, pragma string) *ast.Node {
+	for p := node.Parent; p != nil; p = p.Parent {
+		if !ast.IsFunctionLike(p) {
+			continue
+		}
+		if reactutil.IsStatelessReactComponent(p, pragma) {
+			return p
+		}
+	}
+	return nil
+}
+
+// isPropertyOwnedSFC mirrors upstream's
+// `component.node.parent.type === 'Property'` filter. ESTree wraps every
+// object-literal entry in a `Property` node, so any FunctionExpression /
+// ArrowFunction / method serving as a property value has parent `Property`.
+//
+// In tsgo there is no `Property` wrapper:
+//   - `{ Foo() {} }`         → MethodDeclaration directly inside ObjectLiteralExpression
+//   - `{ Foo: function() }`  → FunctionExpression as the initializer of a PropertyAssignment
+//   - `{ Foo: () => {} }`    → ArrowFunction as the initializer of a PropertyAssignment
+//
+// All three correspond to upstream's "Property" filter and must skip reporting.
+func isPropertyOwnedSFC(component *ast.Node) bool {
+	parent := component.Parent
+	if parent == nil {
+		return false
+	}
+	switch component.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return parent.Kind == ast.KindObjectLiteralExpression
+	}
+	return parent.Kind == ast.KindPropertyAssignment
+}
+
+var NoThisInSfcRule = rule.Rule{
+	Name: "react/no-this-in-sfc",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+
+		report := func(node *ast.Node) {
+			ctx.ReportNode(node, rule.RuleMessage{
+				Id:          "noThisInSFC",
+				Description: "Stateless functional components should not use `this`",
+			})
+		}
+
+		// check fires on a member-access node whose object position must be
+		// inspected for `this`. Both PropertyAccessExpression (`this.x`) and
+		// ElementAccessExpression (`this['x']`) reach here, matching ESTree's
+		// unified `MemberExpression` listener. ParenthesizedExpression wrappers
+		// around the object are transparent (tsgo preserves; ESTree flattens).
+		check := func(node, expr *ast.Node) {
+			if ast.SkipParentheses(expr).Kind != ast.KindThisKeyword {
+				return
+			}
+			component := getParentStatelessComponent(node, pragma)
+			if component == nil {
+				return
+			}
+			if isPropertyOwnedSFC(component) {
+				return
+			}
+			report(node)
+		}
+
+		return rule.RuleListeners{
+			ast.KindPropertyAccessExpression: func(node *ast.Node) {
+				check(node, node.AsPropertyAccessExpression().Expression)
+			},
+			ast.KindElementAccessExpression: func(node *ast.Node) {
+				check(node, node.AsElementAccessExpression().Expression)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.go
@@ -41,8 +41,17 @@ func getParentStatelessComponent(node *ast.Node, pragma string) *ast.Node {
 //   - `{ Foo: () => {} }`    → ArrowFunction as the initializer of a PropertyAssignment
 //
 // All three correspond to upstream's "Property" filter and must skip reporting.
+//
+// ParenthesizedExpression wrappers between a FunctionExpression / ArrowFunction
+// and its PropertyAssignment owner are transparent — tsgo preserves them while
+// ESTree flattens them — so `{ Foo: (function() {...}) }` still hits the
+// carve-out. MethodDeclaration cannot be paren-wrapped (illegal syntax), so
+// the walk only matters for the FE/Arrow path.
 func isPropertyOwnedSFC(component *ast.Node) bool {
 	parent := component.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		parent = parent.Parent
+	}
 	if parent == nil {
 		return false
 	}

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.md
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc.md
@@ -1,0 +1,94 @@
+# no-this-in-sfc
+
+## Rule Details
+
+Disallow `this` from being used inside stateless functional components (SFCs).
+React supports two component styles: class components access instance state and
+props through `this` (e.g. `this.props.foo`), and functional components receive
+their props as the first argument. Reaching for `this.props` / `this.state`
+inside a functional component is almost always a mistake — typically an
+unfinished migration from a class component — because `this` is not bound to
+the component instance.
+
+The rule covers `this.x` and `this['x']` access (PropertyAccess and
+ElementAccess forms), bracket access included, parens transparent. It targets
+the same set of stateless components as eslint-plugin-react: capitalized
+function declarations / expressions / arrows that return JSX or `null`,
+`React.memo` / `React.forwardRef` (and their bare aliases) wrapped components,
+and anonymous `export default function() { ... }` components.
+
+A `this` access inside a class component (an ES6 class extending
+`Component` / `PureComponent`) or inside a `createReactClass` ES5 component
+is never reported — those bind `this` to the component instance.
+
+A `this` access inside a function that happens to be a property value of an
+object literal (e.g. `{ Foo() { return <div>{this.x}</div> } }`) is also not
+reported, mirroring upstream's "Property" carve-out.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function Foo(props) {
+  const { foo } = this.props;
+  return <div>{foo}</div>;
+}
+```
+
+```javascript
+function Foo(props) {
+  return <div>{this.state.foo}</div>;
+}
+```
+
+```javascript
+const Foo = (props) => <span>{this.props.foo}</span>;
+```
+
+```javascript
+const Foo = React.memo(() => <div>{this.props.foo}</div>);
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function Foo(props) {
+  const { foo } = props;
+  return <div bar={foo} />;
+}
+```
+
+```javascript
+function Foo({ foo }) {
+  return <div bar={foo} />;
+}
+```
+
+```javascript
+class Foo extends React.Component {
+  render() {
+    const { foo } = this.props;
+    return <div bar={foo} />;
+  }
+}
+```
+
+```javascript
+const Foo = createReactClass({
+  render: function () {
+    return <div>{this.props.foo}</div>;
+  },
+});
+```
+
+## Differences from ESLint
+
+- A function wrapped in a custom higher-order component (configured via
+  `settings.componentWrapperFunctions` in ESLint) is not treated as a
+  stateless component. For example, given `wrap(() => <div>{this.props.x}</div>)`,
+  ESLint reports the `this` access while rslint does not. Only `memo` and
+  `forwardRef` wrappers (bare, or qualified by the configured React pragma)
+  are recognized.
+
+## Original Documentation
+
+- [eslint-plugin-react `no-this-in-sfc`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md)

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc_test.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc_test.go
@@ -1,0 +1,612 @@
+package no_this_in_sfc
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoThisInSfcRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoThisInSfcRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: function component without `this` ----
+		{Code: `
+        function Foo(props) {
+          const { foo } = props;
+          return <div bar={foo} />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: destructured-parameter function component ----
+		{Code: `
+        function Foo({ foo }) {
+          return <div bar={foo} />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ES6 class component using `this.props` legitimately ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.props;
+            return <div bar={foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass (default ES5 factory) ----
+		{Code: `
+        const Foo = createReactClass({
+          render: function() {
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: pragma-qualified createClass via settings ----
+		{
+			Code: `
+        const Foo = React.createClass({
+          render: function() {
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "createClass"}},
+		},
+
+		// ---- Upstream: regular non-component function may use `this` freely ----
+		{Code: `
+        function foo(bar) {
+          this.bar = bar;
+          this.props = 'baz';
+          this.getFoo = function() {
+            return this.bar + this.props;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ConditionalExpression returning JSX-or-null is OK without this ----
+		{Code: `
+        function Foo(props) {
+          return props.foo ? <span>{props.bar}</span> : null;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: if/return JSX, no this ----
+		{Code: `
+        function Foo(props) {
+          if (props.foo) {
+            return <div>{props.bar}</div>;
+          }
+          return null;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: if branches with side effects, no this ----
+		{Code: `
+        function Foo(props) {
+          if (props.foo) {
+            something();
+          }
+          return null;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow expression body — no this ----
+		{Code: `const Foo = (props) => <span>{props.foo}</span>`, Tsx: true},
+		{Code: `const Foo = ({ foo }) => <span>{foo}</span>`, Tsx: true},
+		{Code: `const Foo = (props) => props.foo ? <span>{props.bar}</span> : null;`, Tsx: true},
+		{Code: `const Foo = ({ foo, bar }) => foo ? <span>{bar}</span> : null;`, Tsx: true},
+
+		// ---- Upstream: arrow inside non-React class method — `this` allowed ----
+		{Code: `
+        class Foo {
+          bar() {
+            () => {
+              this.something();
+              return null;
+            };
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class-field arrow (TS class fields) ----
+		{Code: `
+        class Foo {
+          bar = () => {
+            this.something();
+            return null;
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow returns object whose method uses `this` —
+		// the inner method has lowercase key (`renderNode`) so it isn't an SFC,
+		// and the outer arrow returns an object (not JSX/null) so it isn't an
+		// SFC either. ----
+		{Code: `
+        export const Example = ({ prop }) => {
+          return {
+            handleClick: () => {},
+            renderNode() {
+              return <div onClick={this.handleClick} />;
+            },
+          };
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: Meteor ValidatedMethod-style — `run()` is a property method
+		// of a non-component CallExpression argument; outer call isn't a wrapper. ----
+		{Code: `
+        export const prepareLogin = new ValidatedMethod({
+          name: "user.prepare",
+          validate: new SimpleSchema({
+          }).validator(),
+          run({ remember }) {
+              if (Meteor.isServer) {
+                  const connectionId = this.connection.id;
+                  return Methods.prepareLogin(connectionId, remember);
+              }
+              return null;
+          },
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: assignment of FE returning `this.a || null` to obj.notAComponent —
+		// rightmost MemberExpression name is lowercase → not a component. ----
+		{Code: `
+        obj.notAComponent = function () {
+          return this.a || null;
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: jQuery plugin idiom with TS return type — `$.fn.x = function...` ----
+		{Code: `
+        $.fn.getValueAsStringWeak = function (): string | null {
+          const val = this.length === 1 ? this.val() : null;
+
+          return typeof val === 'string' ? val : null;
+        };
+      `, Tsx: true},
+
+		// ---- Edge (universal): lowercase function declaration cannot be SFC ----
+		{Code: `
+        function foo(props) {
+          return <div>{this.props.foo}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Edge (universal): capitalized function returning a string is not SFC ----
+		{Code: `
+        function Foo(props) {
+          return this.props.foo;
+        }
+      `, Tsx: true},
+
+		// ---- Edge (tsgo Dimension 4): `(this).foo` — paren-wrapped receiver still skipped via SkipParentheses
+		// in non-component context, no report ----
+		{Code: `
+        function regular() {
+          return (this).foo;
+        }
+      `, Tsx: true},
+
+		// ---- Edge (universal): `this` in inner FunctionDeclaration of non-component outer
+		// — no enclosing SFC up the chain ----
+		{Code: `
+        function regular() {
+          function inner() {
+            return this.foo;
+          }
+          return inner();
+        }
+      `, Tsx: true},
+
+		// ---- Edge: PropertyAssignment with capitalized key holding a function returning JSX
+		// makes the function-value an SFC, but its parent is PropertyAssignment, so the
+		// "Property" carve-out skips reporting (mirrors upstream test #16). ----
+		{Code: `
+        export const obj = {
+          Renderer: function() {
+            return <div>{this.x}</div>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Edge: capitalized MethodDeclaration on object literal — also under the
+		// "Property" carve-out (MethodDeclaration parent is ObjectLiteralExpression). ----
+		{Code: `
+        export const obj = {
+          Renderer() {
+            return <div>{this.x}</div>;
+          },
+        };
+      `, Tsx: true},
+
+		// ---- Boundary (TS-only): `(this as any).x` — receiver is TS as-expression.
+		// tsgo wraps in KindAsExpression; ESTree wraps in TSAsExpression; neither
+		// is a ThisKeyword/ThisExpression, so neither tool reports. Locked in. ----
+		{Code: `
+        function Foo(props) {
+          return <div>{(this as any).x}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Boundary (TS-only): `this!.x` — non-null assertion wraps the receiver.
+		// tsgo: KindNonNullExpression; ESTree: TSNonNullExpression. Neither is
+		// ThisExpression/ThisKeyword → no report. ----
+		{Code: `
+        function Foo(props) {
+          return <div>{this!.x}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Boundary: SFC returning a non-JSX value (string) is not an SFC,
+		// so `this.x` inside is not flagged. ----
+		{Code: `
+        function Foo() {
+          this.x;
+          return "hi";
+        }
+      `, Tsx: true},
+
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: `const { foo } = this.props` in SFC ----
+		{
+			Code: `
+        function Foo(props) {
+          const { foo } = this.props;
+          return <div>{foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC", Message: "Stateless functional components should not use `this`", Line: 3, Column: 27, EndLine: 3, EndColumn: 37},
+			},
+		},
+
+		// ---- Upstream: `this.props.foo` in JSX expression ----
+		{
+			Code: `
+        function Foo(props) {
+          return <div>{this.props.foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC", Line: 3, Column: 24, EndLine: 3, EndColumn: 34},
+			},
+		},
+
+		// ---- Upstream: `this.state.foo` in JSX ----
+		{
+			Code: `
+        function Foo(props) {
+          return <div>{this.state.foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC", Line: 3, Column: 24, EndLine: 3, EndColumn: 34},
+			},
+		},
+
+		// ---- Upstream: destructure from this.state ----
+		{
+			Code: `
+        function Foo(props) {
+          const { foo } = this.state;
+          return <div>{foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Upstream: ConditionalExpression with `this.props` in WhenTrue ----
+		{
+			Code: `
+        function Foo(props) {
+          return props.foo ? <div>{this.props.bar}</div> : null;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Upstream: if branch with this.props ----
+		{
+			Code: `
+        function Foo(props) {
+          if (props.foo) {
+            return <div>{this.props.bar}</div>;
+          }
+          return null;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Upstream: this.props inside if test ----
+		{
+			Code: `
+        function Foo(props) {
+          if (this.props.foo) {
+            something();
+          }
+          return null;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Upstream: arrow returning JSX with this.props in JSX ----
+		{
+			Code: `const Foo = (props) => <span>{this.props.foo}</span>`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC", Line: 1, Column: 31, EndLine: 1, EndColumn: 41},
+			},
+		},
+
+		// ---- Upstream: arrow returning ConditionalExpression with this.props in test ----
+		{
+			Code: `const Foo = (props) => this.props.foo ? <span>{props.bar}</span> : null;`,
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC", Line: 1, Column: 24, EndLine: 1, EndColumn: 34},
+			},
+		},
+
+		// ---- Upstream: nested non-SFC function inside SFC — both `this.props` accesses
+		// resolve to the outer SFC. Two reports (one inside `onClick`, one in JSX). ----
+		{
+			Code: `
+        function Foo(props) {
+          function onClick(bar) {
+            this.props.onClick();
+          }
+          return <div onClick={onClick}>{this.props.foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Lock-in: bracket access `this['props']` is also flagged (ESTree
+		// MemberExpression covers both forms; tsgo splits into PropertyAccessExpression
+		// and ElementAccessExpression — listener on both keeps parity). ----
+		{
+			Code: `
+        function Foo(props) {
+          return <div>{this['props'].foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Lock-in: paren-wrapped receiver `(this).x` — tsgo preserves parens,
+		// SkipParentheses unwraps, so this matches just like ESTree's flattened form. ----
+		{
+			Code: `
+        function Foo(props) {
+          return <div>{((this)).props.foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Lock-in: optional chain `this?.foo` — tsgo flags the access via flag, no
+		// ChainExpression wrapper; receiver is still ThisKeyword. ----
+		{
+			Code: `
+        function Foo(props) {
+          return <div>{this?.props}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Lock-in: anonymous `export default function() { ... }` is an SFC
+		// (matches upstream's `!node.id || capitalized(node.id.name)` branch). ----
+		{
+			Code: `
+        export default function() {
+          return <div>{this.props.foo}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Lock-in: pragma wrapper `React.memo(() => <div>{this.x}</div>)`
+		// — wrapped functions are SFCs regardless of position. ----
+		{
+			Code: `
+        const Foo = React.memo(() => <div>{this.props.foo}</div>);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Lock-in: bare `forwardRef(...)` wrapper. ----
+		{
+			Code: `
+        const Foo = forwardRef((props, ref) => <div ref={ref}>{this.props.foo}</div>);
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: forwardRef wrapping a NAMED FunctionExpression.
+		// Wrapper-call branch in IsStatelessReactComponent classifies regardless
+		// of name. ----
+		{
+			Code: `
+        const Foo = forwardRef(function Inner(props, ref) {
+          return <div ref={ref}>{this.props.foo}</div>;
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: SFC returning a JSX Fragment (not just an Element).
+		// `<>` is KindJsxFragment in tsgo and JSXFragment in ESTree — both
+		// classify as JSX. ----
+		{
+			Code: `
+        function Foo() {
+          return <>{this.props.foo}</>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: nested SFCs — inner `Inner` is itself an SFC, so
+		// `this.x` inside Inner resolves to Inner (not Outer). ----
+		{
+			Code: `
+        function Outer() {
+          function Inner() {
+            return <span>{this.x}</span>;
+          }
+          return <Inner />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: deep member chain `this.foo.bar.baz` — only the
+		// innermost `this.foo` MemberExpression has ThisKeyword as receiver,
+		// so exactly one report fires. ----
+		{
+			Code: `
+        function Foo() {
+          return <div>{this.foo.bar.baz}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: ElementAccess via computed key — `this[Symbol.iterator]`
+		// — the bracket form is also a MemberExpression in ESTree and an
+		// ElementAccessExpression in tsgo; both flag it. ----
+		{
+			Code: `
+        function Foo() {
+          return <div>{this[Symbol.iterator]}</div>;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: `obj.Foo = function () { return <div>{this.x}</div> }`
+		// — MemberExpression LHS with capitalized rightmost name; isMEAssign
+		// path classifies as SFC and parent is BinaryExpression (not Property),
+		// so it is reported. ----
+		{
+			Code: `
+        obj.Foo = function () {
+          return <div>{this.x}</div>;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: anonymous arrow exported as default — arrow has
+		// ExportAssignment parent; Branch 1 classifies on strict isReturningJSX. ----
+		{
+			Code: `
+        export default () => <div>{this.props.foo}</div>;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: SFC inside an Outer non-component arrow that returns
+		// the SFC — the inner arrow is in a `ReturnStatement` allowed position,
+		// strictly returns JSX, and Outer wrapping it is non-component (returns
+		// the inner arrow, not JSX). Inner classified as SFC; report fires. ----
+		{
+			Code: `
+        const make = () => {
+          const Foo = () => <div>{this.props.x}</div>;
+          return Foo;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+
+		// ---- Boundary: capitalized FunctionDeclaration returning ONLY `null`
+		// with a `this` access. Upstream auto-registers the SFC via the
+		// FunctionDeclaration detection instruction (no JSX is required for
+		// registration), so `components.get(sfc)` is truthy and the rule
+		// reports. rslint reaches the same conclusion through
+		// IsStatelessReactComponent (capitalized + isReturningJSXOrNull). ----
+		{
+			Code: `
+        function Foo() {
+          if (this.x) return null;
+          return null;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noThisInSFC"},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc_test.go
+++ b/internal/plugins/react/rules/no_this_in_sfc/no_this_in_sfc_test.go
@@ -225,6 +225,28 @@ func TestNoThisInSfcRule(t *testing.T) {
         };
       `, Tsx: true},
 
+		// ---- Edge: PropertyAssignment value wrapped in parens — tsgo preserves
+		// ParenthesizedExpression so the FE's direct parent is the paren wrapper,
+		// not the PropertyAssignment. The "Property" carve-out must walk through
+		// paren wrappers, otherwise this case would falsely report. Locks in the
+		// paren-transparent owner detection in `isPropertyOwnedSFC`. ----
+		{Code: `
+        export const obj = {
+          Renderer: (function () {
+            return <div>{this.x}</div>;
+          }),
+        };
+      `, Tsx: true},
+
+		// ---- Edge: same as above but multi-level parens. ----
+		{Code: `
+        export const obj = {
+          Renderer: (((function () {
+            return <div>{this.x}</div>;
+          }))),
+        };
+      `, Tsx: true},
+
 		// ---- Boundary (TS-only): `(this as any).x` — receiver is TS as-expression.
 		// tsgo wraps in KindAsExpression; ESTree wraps in TSAsExpression; neither
 		// is a ThisKeyword/ThisExpression, so neither tool reports. Locked in. ----

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -111,6 +111,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-is-mounted.test.ts',
     './tests/eslint-plugin-react/rules/no-render-return-value.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
+    './tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
     './tests/eslint-plugin-react/rules/no-unknown-property.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts
@@ -79,7 +79,9 @@ ruleTester.run('no-this-in-sfc', {} as never, {
     },
     { code: `const Foo = (props) => <span>{props.foo}</span>` },
     { code: `const Foo = ({ foo }) => <span>{foo}</span>` },
-    { code: `const Foo = (props) => props.foo ? <span>{props.bar}</span> : null;` },
+    {
+      code: `const Foo = (props) => props.foo ? <span>{props.bar}</span> : null;`,
+    },
     { code: `const Foo = ({ foo, bar }) => foo ? <span>{bar}</span> : null;` },
     {
       code: `

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts
@@ -1,0 +1,236 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-this-in-sfc', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    {
+      code: `
+        function Foo(props) {
+          const { foo } = props;
+          return <div bar={foo} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function Foo({ foo }) {
+          return <div bar={foo} />;
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.props;
+            return <div bar={foo} />;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        const Foo = createReactClass({
+          render: function() {
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
+    },
+    {
+      code: `
+        function foo(bar) {
+          this.bar = bar;
+          this.props = 'baz';
+          this.getFoo = function() {
+            return this.bar + this.props;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        function Foo(props) {
+          return props.foo ? <span>{props.bar}</span> : null;
+        }
+      `,
+    },
+    {
+      code: `
+        function Foo(props) {
+          if (props.foo) {
+            return <div>{props.bar}</div>;
+          }
+          return null;
+        }
+      `,
+    },
+    {
+      code: `
+        function Foo(props) {
+          if (props.foo) {
+            something();
+          }
+          return null;
+        }
+      `,
+    },
+    { code: `const Foo = (props) => <span>{props.foo}</span>` },
+    { code: `const Foo = ({ foo }) => <span>{foo}</span>` },
+    { code: `const Foo = (props) => props.foo ? <span>{props.bar}</span> : null;` },
+    { code: `const Foo = ({ foo, bar }) => foo ? <span>{bar}</span> : null;` },
+    {
+      code: `
+        class Foo {
+          bar() {
+            () => {
+              this.something();
+              return null;
+            };
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo {
+          bar = () => {
+            this.something();
+            return null;
+          };
+        }
+      `,
+    },
+    {
+      code: `
+        export const Example = ({ prop }) => {
+          return {
+            handleClick: () => {},
+            renderNode() {
+              return <div onClick={this.handleClick} />;
+            },
+          };
+        };
+      `,
+    },
+    {
+      code: `
+        export const prepareLogin = new ValidatedMethod({
+          name: "user.prepare",
+          validate: new SimpleSchema({
+          }).validator(),
+          run({ remember }) {
+              if (Meteor.isServer) {
+                  const connectionId = this.connection.id;
+                  return Methods.prepareLogin(connectionId, remember);
+              }
+              return null;
+          },
+        });
+      `,
+    },
+    {
+      code: `
+        obj.notAComponent = function () {
+          return this.a || null;
+        };
+      `,
+    },
+    {
+      code: `
+        $.fn.getValueAsStringWeak = function (): string | null {
+          const val = this.length === 1 ? this.val() : null;
+
+          return typeof val === 'string' ? val : null;
+        };
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Foo(props) {
+          const { foo } = this.props;
+          return <div>{foo}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          return <div>{this.props.foo}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          return <div>{this.state.foo}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          const { foo } = this.state;
+          return <div>{foo}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          return props.foo ? <div>{this.props.bar}</div> : null;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          if (props.foo) {
+            return <div>{this.props.bar}</div>;
+          }
+          return null;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          if (this.props.foo) {
+            something();
+          }
+          return null;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `const Foo = (props) => <span>{this.props.foo}</span>`,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `const Foo = (props) => this.props.foo ? <span>{props.bar}</span> : null;`,
+      errors: [{ messageId: 'noThisInSFC' }],
+    },
+    {
+      code: `
+        function Foo(props) {
+          function onClick(bar) {
+            this.props.onClick();
+          }
+          return <div onClick={onClick}>{this.props.foo}</div>;
+        }
+      `,
+      errors: [{ messageId: 'noThisInSFC' }, { messageId: 'noThisInSFC' }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/no-this-in-sfc` rule from `eslint-plugin-react` to rslint.

The rule disallows `this` access (both `this.x` and `this['x']`) inside stateless functional components — a common mistake when migrating from class components, since `this` is not bound to the component instance in SFCs. Class components, `createReactClass` ES5 components, regular non-component functions, and methods/values living on object-literal properties are all left untouched.

## Related Links

- ESLint rule: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-this-in-sfc.md>
- Source code: <https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-this-in-sfc.js>

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).