### PR TITLE
fix: recognize destructuring defaults and JSX expressions as parameters

### DIFF
--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions.go
@@ -152,6 +152,18 @@ func run(ctx rule.RuleContext, options any) rule.RuleListeners {
 			return true
 		case ast.KindParameter:
 			return true
+		case ast.KindBindingElement:
+			// Default value in a destructuring pattern, e.g. `function f({ x = {} as Foo }) {}`.
+			// The equivalent of ESTree AssignmentPattern.
+			return true
+		case ast.KindJsxExpression:
+			// JSX attribute value, e.g. `<Foo style={{} as Bar} />`.
+			return true
+		case ast.KindParenthesizedExpression:
+			// ESTree has no explicit parenthesis node, so upstream treats
+			// `foo(({} as Foo))` as having CallExpression as the parent.
+			// TypeScript's AST preserves the parens, so recurse through them.
+			return isAsParameter(parent)
 		case ast.KindPropertyAssignment:
 			// Check if it's a default value in a parameter
 			propAssignment := parent.AsPropertyAssignment()

--- a/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
+++ b/internal/plugins/typescript/rules/consistent_type_assertions/consistent_type_assertions_test.go
@@ -61,6 +61,16 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 		{Code: `const x = { bar: 5 } as const;`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
 		{Code: `function foo() { throw { bar: 5 } as Foo; }`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
 		{Code: `const foo = (x = { bar: 5 } as Foo) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const foo = ({ x = { bar: 5 } as Foo } = {}) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const foo = ({ x = {} as Record<string, string[]> }) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const foo = ([x = {} as Foo]) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `function b({ x = {} as Foo.Bar }) {}`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const foo = ({ a: { b = {} as Foo } = {} }) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `print?.({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `print?.call({ bar: 5 } as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: "print`${{ bar: 5 } as Foo}`;", Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const bar = <Foo style={{ bar: 5 } as Bar} />;`, Tsx: true, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `foo(({ bar: 5 } as Foo));`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}}},
 
 		// arrayLiteralTypeAssertions: 'never'
 		{Code: `const x: string[] = [];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "never"}}},
@@ -71,6 +81,14 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 
 		// arrayLiteralTypeAssertions: 'allow-as-parameter'
 		{Code: `const x: string[] = [];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const foo = ({ x = [] as string[] }) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const foo = ([x = [] as string[]]) => {};`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `function b(x = [5] as Foo.Bar) {}`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `print?.([5] as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `print?.call([5] as Foo);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: "print`${[5] as Foo}`;", Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `const bar = <Foo style={[5] as Bar} />;`, Tsx: true, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
+		{Code: `foo(([5] as Foo));`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
 		{Code: `foo([] as string[]);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
 		{Code: `new Foo([] as string[]);`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
 		{Code: `throw [] as string[];`, Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "arrayLiteralTypeAssertions": "allow-as-parameter"}}},
@@ -241,6 +259,27 @@ func TestConsistentTypeAssertionsRule(t *testing.T) {
 			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "object-literal-with-type-annotation"},
+			},
+		},
+		{
+			Code:    `class C { x = {} as Foo; }`,
+			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "object-literal-with-type-annotation"},
+			},
+		},
+		{
+			Code:    `const foo = () => ({ bar: 5 } as Foo);`,
+			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "never-object-literal"},
+			},
+		},
+		{
+			Code:    `const x = [{ a: {} as Foo }];`,
+			Options: []interface{}{map[string]interface{}{"assertionStyle": "as", "objectLiteralTypeAssertions": "allow-as-parameter"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "never-object-literal"},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

The `isAsParameter` helper in `@typescript-eslint/consistent-type-assertions` only handled `Parameter` and `PropertyAssignment` parents, missing:

- `BindingElement` — destructuring default values, e.g. `({ x = {} as Foo })` / `([x = [] as Foo])`
- `JsxExpression` — JSX attribute values, e.g. `<Foo style={{} as Bar} />`

Upstream typescript-eslint covers both cases via `AssignmentPattern` / `JSXExpressionContainer`. Missing them in rslint caused false positives under `objectLiteralTypeAssertions: 'allow-as-parameter'` / `arrayLiteralTypeAssertions: 'allow-as-parameter'` for literal assertions used as destructuring defaults or JSX attribute values.

This PR:

- Adds `KindBindingElement` and `KindJsxExpression` branches to `isAsParameter`.
- Extends the Go rule tests with destructuring (object/array, with outer default, nested), optional call (`?.()` / `?.call()`), tagged template, JSX attribute, class property (`PropertyDeclaration`), and non-annotatable positions (`() => ({} as Foo)`).

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

<!--- Check and mark with an "x" -->

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).