### PR TITLE
fix: align format checks with typescript-eslint

### DIFF
--- a/internal/plugins/typescript/rules/naming_convention/naming_convention.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
@@ -293,56 +294,131 @@ type normalizedSelector struct {
 }
 
 // ---- Format checking functions ----
-// These use regex patterns matching the official typescript-eslint implementation,
-// with an additional consecutive-uppercase check for strict variants.
+// These port typescript-eslint's character-based implementation (derived from
+// tslint-consistent-codestyle), NOT a regex. The difference is load-bearing:
+//   - empty strings are considered valid for every format (supports names that
+//     trim down to "" after leadingUnderscore: "allow", e.g. a lone `_`)
+//   - characters that are neither upper nor lowercase letters (e.g. `$`, digits)
+//     are treated neutrally and pass both camelCase and PascalCase first-char
+//     checks, matching JS `c === c.toLowerCase() && c === c.toUpperCase()`.
+// See: https://github.com/typescript-eslint/typescript-eslint/blob/v6.21.0/packages/eslint-plugin/src/rules/naming-convention-utils/format.ts
 
-var (
-	reCamelCase    = regexp.MustCompile(`^[a-z][\da-zA-Z]*$`)
-	rePascalCase   = regexp.MustCompile(`^[A-Z][\da-zA-Z]*$`)
-	reUpperCase    = regexp.MustCompile(`^[A-Z][\dA-Z_]*$`)
-	reSnakeCase  = regexp.MustCompile(`^[a-z][\da-z_]*$`)
-)
-
-func checkCamelCase(name string) bool {
-	return reCamelCase.MatchString(name)
+func firstRune(name string) rune {
+	for _, r := range name {
+		return r
+	}
+	return 0
 }
 
-func checkStrictCamelCase(name string) bool {
-	if !reCamelCase.MatchString(name) {
-		return false
-	}
-	return !hasConsecutiveUppercase(name, 0)
+func isUppercaseRune(r rune) bool {
+	return r == unicode.ToUpper(r) && r != unicode.ToLower(r)
+}
+
+// Matches JS `name[0] === name[0].toUpperCase()`: returns true for uppercase
+// letters AND for characters with no case distinction (e.g. `$`, digits).
+func firstIsUpper(name string) bool {
+	r := firstRune(name)
+	return r == unicode.ToUpper(r)
+}
+
+// Matches JS `name[0] === name[0].toLowerCase()`: symmetric to firstIsUpper.
+func firstIsLower(name string) bool {
+	r := firstRune(name)
+	return r == unicode.ToLower(r)
 }
 
 func checkPascalCase(name string) bool {
-	return rePascalCase.MatchString(name)
+	if len(name) == 0 {
+		return true
+	}
+	return firstIsUpper(name) && !strings.Contains(name, "_")
 }
 
 func checkStrictPascalCase(name string) bool {
-	if !rePascalCase.MatchString(name) {
+	if len(name) == 0 {
+		return true
+	}
+	return firstIsUpper(name) && hasStrictCamelHumps(name, true)
+}
+
+func checkCamelCase(name string) bool {
+	if len(name) == 0 {
+		return true
+	}
+	return firstIsLower(name) && !strings.Contains(name, "_")
+}
+
+func checkStrictCamelCase(name string) bool {
+	if len(name) == 0 {
+		return true
+	}
+	return firstIsLower(name) && hasStrictCamelHumps(name, false)
+}
+
+// hasStrictCamelHumps ports the typescript-eslint algorithm: no leading `_`,
+// no internal `_`, and no two consecutive uppercase letters (case-distinct
+// runs must alternate). `isUpper` tracks whether the *next* run is expected
+// to be uppercase; on a mismatch we flip, on a match of two uppercase runs
+// we reject.
+func hasStrictCamelHumps(name string, isUpper bool) bool {
+	runes := []rune(name)
+	if len(runes) == 0 {
+		return true
+	}
+	if runes[0] == '_' {
 		return false
 	}
-	// Skip the first character for PascalCase consecutive check
-	return !hasConsecutiveUppercase(name, 1)
+	for i := 1; i < len(runes); i++ {
+		if runes[i] == '_' {
+			return false
+		}
+		charIsUpper := isUppercaseRune(runes[i])
+		if isUpper == charIsUpper {
+			if isUpper {
+				return false
+			}
+		} else {
+			isUpper = !isUpper
+		}
+	}
+	return true
 }
 
 func checkSnakeCase(name string) bool {
-	return reSnakeCase.MatchString(name)
+	if len(name) == 0 {
+		return true
+	}
+	return name == strings.ToLower(name) && validateSnakeUnderscores(name)
 }
 
 func checkUpperCase(name string) bool {
-	return reUpperCase.MatchString(name)
+	if len(name) == 0 {
+		return true
+	}
+	return name == strings.ToUpper(name) && validateSnakeUnderscores(name)
 }
 
-// hasConsecutiveUppercase checks if there are two or more consecutive uppercase
-// ASCII letters starting from the given index.
-func hasConsecutiveUppercase(name string, startIdx int) bool {
-	for i := startIdx; i < len(name)-1; i++ {
-		if name[i] >= 'A' && name[i] <= 'Z' && name[i+1] >= 'A' && name[i+1] <= 'Z' {
-			return true
+// validateSnakeUnderscores rejects leading `_`, adjacent `__`, and trailing `_`.
+func validateSnakeUnderscores(name string) bool {
+	runes := []rune(name)
+	if len(runes) == 0 {
+		return true
+	}
+	if runes[0] == '_' {
+		return false
+	}
+	wasUnderscore := false
+	for i := 1; i < len(runes); i++ {
+		if runes[i] == '_' {
+			if wasUnderscore {
+				return false
+			}
+			wasUnderscore = true
+		} else {
+			wasUnderscore = false
 		}
 	}
-	return false
+	return !wasUnderscore
 }
 
 func checkFormat(name string, format predefinedFormat) bool {

--- a/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
+++ b/internal/plugins/typescript/rules/naming_convention/naming_convention_test.go
@@ -429,5 +429,21 @@ func TestNamingConventionRule(t *testing.T) {
 				{MessageId: "doesNotMatchFormat", Line: 2, Column: 10},
 			},
 		},
+
+		// requireDouble on a lone `_`: stripping `__` fails because only one
+		// underscore exists, so missingUnderscore fires.
+		{
+			Code: `const _ = 1;`,
+			Options: []interface{}{
+				map[string]interface{}{
+					"selector":          "variable",
+					"format":            []interface{}{"camelCase"},
+					"leadingUnderscore": "requireDouble",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "missingUnderscore", Line: 1, Column: 7},
+			},
+		},
 	})
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/naming-convention/__snapshots__/naming-convention.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/naming-convention/__snapshots__/naming-convention.test.ts.snap
@@ -2611,3 +2611,211 @@ exports[`naming-convention > invalid 39`] = `
   "ruleCount": 1,
 }
 `;
+
+exports[`naming-convention - rslint edge cases > invalid 1`] = `
+{
+  "code": "const _ = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`_\` must have two leading underscore(s).",
+      "messageId": "missingUnderscore",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 2`] = `
+{
+  "code": "const _x = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`_x\` must not have a leading underscore.",
+      "messageId": "unexpectedUnderscore",
+      "range": {
+        "end": {
+          "column": 9,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 3`] = `
+{
+  "code": "const FOOBar = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`FOOBar\` must match one of the following formats: StrictPascalCase",
+      "messageId": "doesNotMatchFormat",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 4`] = `
+{
+  "code": "const foo__bar = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`foo__bar\` must match one of the following formats: snake_case",
+      "messageId": "doesNotMatchFormat",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 5`] = `
+{
+  "code": "const foo_ = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`foo_\` must match one of the following formats: snake_case",
+      "messageId": "doesNotMatchFormat",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 6`] = `
+{
+  "code": "const FOO__BAR = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`FOO__BAR\` must match one of the following formats: UPPER_CASE",
+      "messageId": "doesNotMatchFormat",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 7`] = `
+{
+  "code": "const foo_bar = 1;",
+  "diagnostics": [
+    {
+      "message": "Variable name \`foo_bar\` must match one of the following formats: camelCase",
+      "messageId": "doesNotMatchFormat",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`naming-convention - rslint edge cases > invalid 8`] = `
+{
+  "code": "class C { foo() {} }",
+  "diagnostics": [
+    {
+      "message": "Class Method name \`foo\` must match one of the following formats: PascalCase",
+      "messageId": "doesNotMatchFormat",
+      "range": {
+        "end": {
+          "column": 14,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/naming-convention",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/naming-convention/naming-convention.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/naming-convention/naming-convention.test.ts
@@ -2293,5 +2293,249 @@ ruleTester.run('naming-convention', {
         },
       ],
     },
+
+    // Regression: names that trim to empty string after stripping the leading
+    // underscore must be treated as valid. typescript-eslint short-circuits
+    // the format check when the processed name is empty
+    // (see naming-convention-utils/format.ts — every check accepts length 0).
+    {
+      code: 'const _ = 1;',
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+          selector: 'variable',
+        },
+      ],
+    },
+    {
+      code: 'const [_, setA] = [1, 2];',
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+          selector: 'variable',
+        },
+      ],
+    },
+    {
+      code: 'function f(_: number) {}',
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+          selector: 'parameter',
+        },
+      ],
+    },
+
+    // Regression: non-letter characters such as `$` (or digits when not in the
+    // leading position) should pass camelCase / PascalCase because JS
+    // `c === c.toLowerCase() && c === c.toUpperCase()` is true for them.
+    {
+      code: 'const $cache = 1; const $svg = 1; const x$y = 1;',
+      options: [
+        { format: ['camelCase'], selector: 'variable' },
+      ],
+    },
+    {
+      code: 'const $Root = 1;',
+      options: [
+        { format: ['PascalCase'], selector: 'variable' },
+      ],
+    },
+    {
+      code: 'class C { private $foo = 1; }',
+      options: [
+        { format: ['camelCase'], selector: 'property' },
+      ],
+    },
+
+    // Regression: strictCamelCase / strictPascalCase must accept `$` runs but
+    // still reject two consecutive uppercase *letters*.
+    {
+      code: 'const fooBar$Baz = 1;',
+      options: [
+        { format: ['strictCamelCase'], selector: 'variable' },
+      ],
+    },
+
+    // Regression: the real-world portal config (filter with match:false over a
+    // snake-camel mix regex) should not fire on `$`-prefixed variables, since
+    // the format check itself now accepts them.
+    {
+      code: 'const $cache = 1;',
+      options: [
+        {
+          format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+          leadingUnderscore: 'allow',
+          filter: {
+            regex:
+              '(^_?[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*_[a-z][a-z0-9]*([A-Z][a-z]?[a-z0-9]*)*$)',
+            match: false,
+          },
+          selector: 'variable',
+        },
+      ],
+    },
   ],
 });
+
+// Additional edge-case suite for empty-name short-circuit and `$`-neutral
+// character handling. Kept in a sibling describe via the `description` option
+// so the rule name passed to the rslint backend stays correct.
+ruleTester.run('naming-convention', {
+  invalid: [
+    // Underscore-only name with leadingUnderscore: 'require' cannot trim to
+    // empty *and* satisfy the underscore requirement at the same time.
+    // The require branch strips one `_`, leaving "", which counts as empty →
+    // format passes. But there is only one `_` to begin with so `require`
+    // sees it, strips it, and passes. That's the symmetric edge case: it's
+    // actually valid. Instead, verify `requireDouble` on a single `_` fails.
+    {
+      code: 'const _ = 1;',
+      errors: [{ messageId: 'missingUnderscore' }],
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'requireDouble',
+          selector: 'variable',
+        },
+      ],
+    },
+    // `_` with leadingUnderscore: 'forbid' must still report the underscore
+    // even though trimming would produce an empty name.
+    {
+      code: 'const _x = 1;',
+      errors: [{ messageId: 'unexpectedUnderscore' }],
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'forbid',
+          selector: 'variable',
+        },
+      ],
+    },
+    // `$` in the middle of a name must still fail strictPascalCase's
+    // consecutive-uppercase rule — only *letter* runs matter.
+    {
+      code: 'const FOOBar = 1;',
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+      options: [
+        { format: ['StrictPascalCase'], selector: 'variable' },
+      ],
+    },
+    // snake_case rejects leading, trailing, and adjacent underscores.
+    {
+      code: 'const foo__bar = 1;',
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+      options: [
+        { format: ['snake_case'], selector: 'variable' },
+      ],
+    },
+    {
+      code: 'const foo_ = 1;',
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+      options: [
+        { format: ['snake_case'], selector: 'variable' },
+      ],
+    },
+    // UPPER_CASE: adjacent underscores rejected, but `$` is accepted.
+    {
+      code: 'const FOO__BAR = 1;',
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+      options: [
+        { format: ['UPPER_CASE'], selector: 'variable' },
+      ],
+    },
+    // camelCase: `_` in the middle is still rejected even though `$` is fine.
+    {
+      code: 'const foo_bar = 1;',
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+      options: [
+        { format: ['camelCase'], selector: 'variable' },
+      ],
+    },
+    // PascalCase: leading-lowercase is still rejected even though `$` leading
+    // would pass. Nested class method inherits the method rule.
+    {
+      code: 'class C { method foo() {} }'.replace('method ', ''),
+      errors: [{ messageId: 'doesNotMatchFormat' }],
+      options: [
+        { format: ['PascalCase'], selector: 'method' },
+      ],
+    },
+  ],
+  valid: [
+    // Empty trimmed name after a leadingUnderscore strip — camelCase.
+    {
+      code: 'const _ = 1;',
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'allow',
+          selector: 'variable',
+        },
+      ],
+    },
+    // Double underscore that trims to empty via allowDouble.
+    {
+      code: 'const __ = 1;',
+      options: [
+        {
+          format: ['camelCase'],
+          leadingUnderscore: 'allowDouble',
+          selector: 'variable',
+        },
+      ],
+    },
+    // Empty trimmed name after prefix strip also passes.
+    {
+      code: 'const IS = 1;',
+      options: [
+        {
+          format: ['camelCase'],
+          prefix: ['IS'],
+          selector: 'variable',
+        },
+      ],
+    },
+    // `$` is accepted as a neutral character at any position for camelCase
+    // and PascalCase.
+    {
+      code: 'const $a = 1; const a$ = 1; const a$b = 1;',
+      options: [{ format: ['camelCase'], selector: 'variable' }],
+    },
+    {
+      code: 'const $A = 1; const A$ = 1; const A$B = 1;',
+      options: [{ format: ['PascalCase'], selector: 'variable' }],
+    },
+    // `$` in UPPER_CASE: uppercased equals itself, no `_` adjacency.
+    {
+      code: 'const FOO$BAR = 1;',
+      options: [{ format: ['UPPER_CASE'], selector: 'variable' }],
+    },
+    // Nested: object method whose filter excludes `$`-prefixed names, and the
+    // variable rule accepts `$`-prefixed.
+    {
+      code: `
+        const obj = { $fn() { return 1; } };
+        const $flag = true;
+      `,
+      options: [
+        { format: ['camelCase'], selector: 'variable' },
+        { format: ['camelCase'], selector: 'objectLiteralMethod' },
+      ],
+    },
+    // strictCamelCase with a `$` run between camel humps.
+    {
+      code: 'const foo$$Bar = 1;',
+      options: [{ format: ['strictCamelCase'], selector: 'variable' }],
+    },
+    // strictPascalCase with `$` after the first uppercase letter.
+    {
+      code: 'const F$ooBar = 1;',
+      options: [{ format: ['StrictPascalCase'], selector: 'variable' }],
+    },
+  ],
+}, { description: 'rslint edge cases' });


### PR DESCRIPTION
## Summary

Port rslint's `@typescript-eslint/naming-convention` format checks to match typescript-eslint's implementation, eliminating two classes of false positives surfaced by a large monorepo's alignment audit.

**Root cause.** rslint used regex-based format checks (e.g. `^[a-z][\da-zA-Z]*$` for camelCase), while typescript-eslint uses a character-based algorithm from `tslint-consistent-codestyle` (`format.ts`). Two load-bearing differences:

1. Empty strings were rejected, so names that trim to `""` after `leadingUnderscore: "allow"` (e.g. a lone `_` in `const [_, setX] = ...`) failed format even though typescript-eslint short-circuits via `name.length === 0`.
2. Non-letter characters like `$` were rejected, so `$cache` / `$svg` failed camelCase/PascalCase even though JS treats them as neutral (`$ === $.toLowerCase() === $.toUpperCase()`).

Verified against real `@typescript-eslint/eslint-plugin` v6.21.0 + the exact portal configs: after the fix, rslint matches upstream output on the reported false-positive cases.

**Fix.** Rewrite the six format checks (`checkCamelCase`, `checkStrictCamelCase`, `checkPascalCase`, `checkStrictPascalCase`, `checkSnakeCase`, `checkUpperCase`) plus helpers (`hasStrictCamelHumps`, `validateSnakeUnderscores`) to mirror `format.ts` one-for-one, using `unicode.ToUpper`/`ToLower` so non-letter runes are treated neutrally.

**Tests.** New rslint-edge-cases suite via `ruleTester.run('naming-convention', ..., { description: 'rslint edge cases' })` covers:
- **Valid**: lone `_` with `allow`, `__` with `allowDouble`, prefix that trims to empty, `$` at leading/middle/trailing positions for camelCase/PascalCase/UPPER_CASE/strictCamelCase/StrictPascalCase, object-literal-method nested with variable selectors, and the exact portal filter on `$cache`.
- **Invalid**: `requireDouble` on a lone `_`, `forbid` on `_x`, `FOOBar` consecutive-uppercase under StrictPascalCase, snake_case with leading/trailing/adjacent `_`, UPPER_CASE with adjacent `_`, camelCase still rejecting `_` mid-name.
- Plus a Go-side invalid test for `requireDouble` on `_`.

## Related Links

N/A (internal alignment audit).

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).