### PR TITLE
docs: document plugins field and core rules usage in config reference

### DIFF
--- a/website/docs/en/config/index.md
+++ b/website/docs/en/config/index.md
@@ -121,6 +121,28 @@ For file exclusion patterns, negation, and `.gitignore` integration, see [Ignori
 
 For rule severity levels, option format, and plugin configuration, see [Rules & Presets](/config/rules-and-presets).
 
+### plugins
+
+- **Type:** `string[]`
+
+Plugin names that this entry activates. A plugin name declares a rule namespace; its rules become available under the `<plugin>/<rule>` prefix inside `rules`.
+
+Built-in plugin names: `@typescript-eslint`, `import`, `jest`, `promise`, `react`.
+
+ESLint core rules (unprefixed names like `no-unused-vars` or `prefer-const`) are not part of any plugin and can be enabled directly in `rules` without listing anything here.
+
+```ts
+{
+  files: ['**/*.ts'],
+  plugins: ['@typescript-eslint'],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'error',
+  },
+}
+```
+
+Presets like `ts.configs.recommended` already include their own `plugins` entry, so you only need this field when configuring plugin rules outside a preset.
+
 ### languageOptions
 
 - **Type:** `object`

--- a/website/docs/en/config/rules-and-presets.md
+++ b/website/docs/en/config/rules-and-presets.md
@@ -56,11 +56,15 @@ rules: {
 
 Plugin names to enable. Available plugins:
 
-| Plugin                 | Rules Prefix           |
-| ---------------------- | ---------------------- |
-| `@typescript-eslint`   | `@typescript-eslint/*` |
-| `eslint-plugin-import` | `import/*`             |
-| `react`                | `react/*`              |
+| Plugin               | Rules Prefix           |
+| -------------------- | ---------------------- |
+| `@typescript-eslint` | `@typescript-eslint/*` |
+| `import`             | `import/*`             |
+| `jest`               | `jest/*`               |
+| `promise`            | `promise/*`            |
+| `react`              | `react/*`              |
+
+ESLint core rules (e.g. `no-unused-vars`, `prefer-const`, `no-var`) have no prefix and do not belong to any plugin — they can be enabled directly in `rules` without listing anything in `plugins`.
 
 :::tip
 When using JS/TS config with presets (e.g., `ts.configs.recommended`), plugins are declared within the preset — you don't need to specify them separately.


### PR DESCRIPTION
## Summary

- Add a dedicated `plugins` section to `website/docs/en/config/index.md` covering the field type, built-in plugin names (`@typescript-eslint`, `import`, `jest`, `promise`, `react`), and a usage example, filling the gap where the previous page described every other config field except `plugins`.
- Expand the plugins table in `website/docs/en/config/rules-and-presets.md` to include `jest` and `promise`, aligning the docs with the current `KnownPlugins` list on the Go side.
- Clarify in both pages that ESLint core rules (e.g. `no-unused-vars`, `prefer-const`) carry no prefix and can be enabled directly in `rules` without declaring anything under `plugins`.

## Related Links

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).