### PR TITLE
fix(react): guard nil TypeChecker in no-danger-with-children and style-prop-object

### DIFF
--- a/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.go
+++ b/internal/plugins/react/rules/no_danger_with_children/no_danger_with_children.go
@@ -51,6 +51,13 @@ var NoDangerWithChildrenRule = rule.Rule{
 			if ident == nil || ident.Kind != ast.KindIdentifier {
 				return nil
 			}
+			// TypeChecker is nil for gap files (files in the program but not
+			// in typeInfoFiles). Without it we cannot resolve an identifier to
+			// its declaration — skip spread/identifier lookups and fall back to
+			// structural checks only, rather than panic in GetDeclaration.
+			if ctx.TypeChecker == nil {
+				return nil
+			}
 			decl := utils.GetDeclaration(ctx.TypeChecker, ident)
 			if decl == nil || decl.Kind != ast.KindVariableDeclaration {
 				return nil

--- a/internal/plugins/react/rules/style_prop_object/style_prop_object.go
+++ b/internal/plugins/react/rules/style_prop_object/style_prop_object.go
@@ -39,6 +39,12 @@ var StylePropObjectRule = rule.Rule{
 		// to resolve variable.defs[0].node.init and checks isNonNullaryLiteral.
 		// We use TypeChecker symbol resolution which is more accurate (handles cross-file, type info).
 		checkIdentifier := func(expr *ast.Node, reportNode *ast.Node) {
+			// TypeChecker is nil for gap files (files in the program but not
+			// in typeInfoFiles). Without it we cannot resolve the identifier
+			// to its declaration — skip the check instead of panicking.
+			if ctx.TypeChecker == nil {
+				return
+			}
 			decl := utils.GetDeclaration(ctx.TypeChecker, expr)
 			if decl == nil {
 				return
@@ -167,7 +173,12 @@ var StylePropObjectRule = rule.Rule{
 						if nameNode == nil || nameNode.Kind != ast.KindIdentifier || nameNode.AsIdentifier().Text != "style" {
 							continue
 						}
-						// For shorthand { style }, resolve the value symbol to the variable declaration
+						// For shorthand { style }, resolve the value symbol to the variable declaration.
+						// TypeChecker is nil for gap files — skip the check in that case
+						// rather than panicking.
+						if ctx.TypeChecker == nil {
+							return
+						}
 						valueSymbol := ctx.TypeChecker.GetShorthandAssignmentValueSymbol(prop)
 						if valueSymbol != nil && len(valueSymbol.Declarations) > 0 {
 							decl := valueSymbol.Declarations[0]


### PR DESCRIPTION
## Summary

Fixes a `nil pointer dereference` panic when linting without full type info on every file.

Root cause: `react/no-danger-with-children` (new in v0.5) calls `utils.GetDeclaration(ctx.TypeChecker, ident)` without nil-guarding `ctx.TypeChecker`. The linter deliberately passes `nil` for "gap files" — files in the program but not in `typeInfoFiles` — as defense-in-depth (see `internal/linter/linter.go:179-187`). When such a file is visited, the rule dereferences the nil checker and the goroutine panics.

`react/style-prop-object` has the same latent bug in two places (`checkIdentifier` and the shorthand-property branch), so both are fixed in one commit.

The fix follows the existing convention documented in `no-access-state-in-setstate.go:351-356` ("consistently nil-guards on ctx.TypeChecker"): when `ctx.TypeChecker == nil`, skip the identifier/declaration resolution and fall back to the structural checks.

## Related Links

- Fixes #781

## Checklist

- [x] Tests updated (or not required). — existing tests for both rules still pass; the fix is a defensive guard against a code path exercised only by gap files in real-world projects, which the current test harness does not model.
- [x] Documentation updated (or not required).