### PR TITLE
fix: align `dot-notation` with ESLint implementation

### DIFF
--- a/internal/plugins/typescript/rules/dot_notation/dot_notation.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation.go
@@ -2,10 +2,11 @@ package dot_notation
 
 import (
 	"regexp"
-	"strings"
 
+	"github.com/dlclark/regexp2"
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
 
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -78,15 +79,22 @@ func buildUseBracketsMessage(key string) rule.RuleMessage {
 	}
 }
 
-// Reserved keywords that should trigger dot -> bracket when allowKeywords=false.
-// Excludes identifiers that TS-ESLint treats as safe to access via dot even when allowKeywords=false
-// (per tests): let, yield, eval, arguments, and literals true/false/null.
+// Reserved word set mirrored from ESLint's core dot-notation rule
+// (see eslint/lib/rules/utils/keywords.js). This is the ES3 reserved-word
+// list, which is what the core rule uses for its keyword check — regardless
+// of ECMAScript version, because bracket notation on these names is the only
+// ES3-compatible form.
 var keywordSet = map[string]struct{}{
-	"break": {}, "case": {}, "catch": {}, "class": {}, "const": {}, "continue": {}, "debugger": {}, "default": {},
-	"delete": {}, "do": {}, "else": {}, "export": {}, "extends": {}, "finally": {}, "for": {}, "function": {},
-	"if": {}, "import": {}, "in": {}, "instanceof": {}, "new": {}, "return": {}, "super": {}, "switch": {},
-	"this": {}, "throw": {}, "try": {}, "typeof": {}, "var": {}, "void": {}, "while": {}, "with": {},
-	// intentionally not including: let, yield, eval, arguments, true, false, null
+	"abstract": {}, "boolean": {}, "break": {}, "byte": {}, "case": {}, "catch": {},
+	"char": {}, "class": {}, "const": {}, "continue": {}, "debugger": {}, "default": {},
+	"delete": {}, "do": {}, "double": {}, "else": {}, "enum": {}, "export": {},
+	"extends": {}, "false": {}, "final": {}, "finally": {}, "float": {}, "for": {},
+	"function": {}, "goto": {}, "if": {}, "implements": {}, "import": {}, "in": {},
+	"instanceof": {}, "int": {}, "interface": {}, "long": {}, "native": {}, "new": {},
+	"null": {}, "package": {}, "private": {}, "protected": {}, "public": {}, "return": {},
+	"short": {}, "static": {}, "super": {}, "switch": {}, "synchronized": {}, "this": {},
+	"throw": {}, "throws": {}, "transient": {}, "true": {}, "try": {}, "typeof": {},
+	"var": {}, "void": {}, "volatile": {}, "while": {}, "with": {},
 }
 
 var identRE = regexp.MustCompile(`^[A-Za-z_$][A-Za-z0-9_$]*$`)
@@ -100,152 +108,48 @@ func isKeyword(name string) bool {
 	return ok
 }
 
-func typeHasIndexSignature(t *checker.Type) bool {
-	if t == nil {
+// hasStringLikeIndexSignature reports whether the type exposes an index
+// signature whose key is string-like. Uses the type checker so that mapped
+// types (including Record<K, V>) and template literal index keys are
+// recognized — not just inline `[key: …]: …` declarations.
+//
+// Passes the type through unchanged: on union types the checker returns only
+// index signatures present on *every* member, and on intersections it merges
+// signatures from the parts — which matches typescript-eslint's
+// `checker.getIndexInfosOfType(objectType)` behavior exactly.
+func hasStringLikeIndexSignature(tc *checker.Checker, t *checker.Type) bool {
+	if t == nil || tc == nil {
 		return false
 	}
-	// Explore alias target declarations first if present
-	if alias := checker.Type_alias(t); alias != nil && alias.Symbol() != nil {
-		if decls := alias.Symbol().Declarations; len(decls) > 0 {
-			for _, decl := range decls {
-				if decl == nil {
-					continue
-				}
-				switch decl.Kind {
-				case ast.KindTypeAliasDeclaration:
-					ta := decl.AsTypeAliasDeclaration()
-					if ta != nil && ta.Type != nil && ta.Type.Kind == ast.KindTypeLiteral {
-						tl := ta.Type.AsTypeLiteralNode()
-						if tl != nil && tl.Members != nil {
-							for _, m := range tl.Members.Nodes {
-								if m != nil && m.Kind == ast.KindIndexSignature {
-									return true
-								}
-							}
-						}
-					}
-				case ast.KindInterfaceDeclaration:
-					iface := decl.AsInterfaceDeclaration()
-					if iface != nil && iface.Members != nil {
-						for _, m := range iface.Members.Nodes {
-							if m != nil && m.Kind == ast.KindIndexSignature {
-								return true
-							}
-						}
-					}
-				case ast.KindTypeLiteral:
-					tl := decl.AsTypeLiteralNode()
-					if tl != nil && tl.Members != nil {
-						for _, m := range tl.Members.Nodes {
-							if m != nil && m.Kind == ast.KindIndexSignature {
-								return true
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-
-	sym := checker.Type_symbol(t)
-	if sym == nil || len(sym.Declarations) == 0 {
-		return false
-	}
-	for _, decl := range sym.Declarations {
-		if decl == nil {
+	for _, info := range tc.GetIndexInfosOfType(t) {
+		if info == nil || info.KeyType() == nil {
 			continue
 		}
-		switch decl.Kind {
-		case ast.KindInterfaceDeclaration:
-			iface := decl.AsInterfaceDeclaration()
-			if iface != nil && iface.Members != nil {
-				for _, m := range iface.Members.Nodes {
-					if m != nil && m.Kind == ast.KindIndexSignature {
-						return true
-					}
-				}
-			}
-		case ast.KindTypeAliasDeclaration:
-			alias := decl.AsTypeAliasDeclaration()
-			if alias != nil && alias.Type != nil && alias.Type.Kind == ast.KindTypeLiteral {
-				tl := alias.Type.AsTypeLiteralNode()
-				if tl != nil && tl.Members != nil {
-					for _, m := range tl.Members.Nodes {
-						if m != nil && m.Kind == ast.KindIndexSignature {
-							return true
-						}
-					}
-				}
-			}
-		case ast.KindClassDeclaration:
-			classDecl := decl.AsClassDeclaration()
-			if classDecl != nil && classDecl.Members != nil {
-				for _, m := range classDecl.Members.Nodes {
-					if m != nil && m.Kind == ast.KindIndexSignature {
-						return true
-					}
-				}
-			}
-		case ast.KindTypeLiteral:
-			tl := decl.AsTypeLiteralNode()
-			if tl != nil && tl.Members != nil {
-				for _, m := range tl.Members.Nodes {
-					if m != nil && m.Kind == ast.KindIndexSignature {
-						return true
-					}
-				}
-			}
+		if info.KeyType().Flags()&checker.TypeFlagsStringLike != 0 {
+			return true
 		}
 	}
 	return false
 }
 
-// hasAnyIndexSignature walks unions/intersections to detect an index signature on any part
-func hasAnyIndexSignature(t *checker.Type) bool {
-	if t == nil {
-		return false
+// literalKey returns the property key string for the argument of a bracket
+// access, matching the set ESLint's core rule handles: string literals,
+// no-substitution template literals (`a[`foo`]`), and the bare `null` /
+// `true` / `false` keyword literals (`a[null]` / `a[true]` / `a[false]`).
+// Computed expressions and number literals are intentionally skipped.
+func literalKey(n *ast.Node) (string, bool) {
+	if ast.IsStringLiteralLike(n) {
+		return n.Text(), true
 	}
-	if utils.IsUnionType(t) {
-		for _, part := range t.Types() {
-			if hasAnyIndexSignature(part) {
-				return true
-			}
-		}
-		return false
-	}
-	if utils.IsIntersectionType(t) {
-		for _, part := range t.Types() {
-			if hasAnyIndexSignature(part) {
-				return true
-			}
-		}
-		return false
-	}
-	return typeHasIndexSignature(t)
-}
-
-func getStringLiteralValue(srcFile *ast.SourceFile, n *ast.Node) (string, bool) {
 	switch n.Kind {
-	case ast.KindStringLiteral, ast.KindNoSubstitutionTemplateLiteral:
-		rng := utils.TrimNodeTextRange(srcFile, n)
-		text := srcFile.Text()[rng.Pos():rng.End()]
-		if len(text) >= 2 {
-			quote := text[0]
-			if (quote == '\'' || quote == '"' || quote == '`') && text[len(text)-1] == quote {
-				return text[1 : len(text)-1], true
-			}
-		}
-		// Fallback to raw text without outer quotes
-		return strings.Trim(text, "'\"`"), true
 	case ast.KindNullKeyword:
 		return "null", true
 	case ast.KindTrueKeyword:
 		return "true", true
 	case ast.KindFalseKeyword:
 		return "false", true
-	default:
-		return "", false
 	}
+	return "", false
 }
 
 // DotNotationRule enforces dot-notation when safe and allowed by options.
@@ -262,12 +166,15 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
 		opts := parseOptions(options)
-		var allowRE *regexp.Regexp
+		// ECMAScript + Unicode flags mirror ESLint's `new RegExp(pattern, 'u')`
+		// so user patterns using lookaround, backreferences, or `\p{...}` work
+		// identically to the original rule (Go's standard `regexp` / RE2 does not
+		// support those). Invalid regex patterns are silently ignored for parity.
+		var allowRE *regexp2.Regexp
 		if opts.AllowPattern != "" {
-			if re, err := regexp.Compile(opts.AllowPattern); err == nil {
+			if re, err := regexp2.Compile(opts.AllowPattern, regexp2.ECMAScript|regexp2.Unicode); err == nil {
 				allowRE = re
 			}
-			// Note: Invalid regex patterns are silently ignored for compatibility
 		}
 
 		// Derive allowIndexSignaturePropertyAccess from tsconfig option as well (currently not used directly)
@@ -277,6 +184,16 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 
 		listeners := rule.RuleListeners{}
 
+		// Compute allowIndexSignaturePropertyAccess once — respects both the
+		// rule option and the `noPropertyAccessFromIndexSignature` tsconfig flag
+		// (same derivation as typescript-eslint).
+		allowIndexAccess := opts.AllowIndexSignaturePropertyAccess
+		if ctx.Program != nil {
+			if copts := ctx.Program.Options(); copts != nil && copts.NoPropertyAccessFromIndexSignature.IsTrue() {
+				allowIndexAccess = true
+			}
+		}
+
 		// Handle bracket → dot (ElementAccessExpression)
 		listeners[ast.KindElementAccessExpression] = func(node *ast.Node) {
 			elem := node.AsElementAccessExpression()
@@ -284,99 +201,112 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 				return
 			}
 
-			// Only for simple string literals (and no-substitution templates)
-			propName, ok := getStringLiteralValue(ctx.SourceFile, elem.ArgumentExpression)
+			// Unwrap parentheses on the key so shapes like `a[('foo')]`
+			// are still recognized as a literal key.
+			propName, ok := literalKey(ast.SkipParentheses(elem.ArgumentExpression))
 			if !ok {
 				return
 			}
 
-			// Option: allow pattern
-			if allowRE != nil && allowRE.MatchString(propName) {
-				return
-			}
-
-			// Option: allow keywords via bracket notation when allowKeywords is false.
-			// When allowKeywords is false, 'null', 'true', and 'false' should be allowed in bracket notation.
-			if !opts.AllowKeywords && (propName == "null" || propName == "true" || propName == "false") {
-				return
-			}
-
-			// TS-specific relaxations
-			objType := ctx.TypeChecker.GetTypeAtLocation(elem.Expression)
-			nnType := ctx.TypeChecker.GetNonNullableType(objType)
-			appType := checker.Checker_getApparentType(ctx.TypeChecker, nnType)
-
-			// Try resolve symbol to check modifiers
-			sym := checker.Checker_getPropertyOfType(ctx.TypeChecker, appType, propName)
-			if sym == nil {
-				for _, s := range checker.Checker_getPropertiesOfType(ctx.TypeChecker, appType) {
-					if s != nil && s.Name == propName {
-						sym = s
-						break
-					}
-				}
-			}
-
-			// Check if we should allow based on modifiers
-			if sym != nil {
-				flags := checker.GetDeclarationModifierFlagsFromSymbol(sym)
-				if (flags & ast.ModifierFlagsPrivate) != 0 {
-					if opts.AllowPrivateClassPropertyAccess {
-						return
-					}
-					// Continue to report error - private property with bracket notation
-				} else if (flags & ast.ModifierFlagsProtected) != 0 {
-					if opts.AllowProtectedClassPropertyAccess {
-						return
-					}
-					// Continue to report error - protected property with bracket notation
-				}
-			} else {
-				// Property not found as explicit declaration - check index signatures
-				allowIndexAccess := opts.AllowIndexSignaturePropertyAccess
-				if ctx.Program != nil {
-					if copts := ctx.Program.Options(); copts != nil && copts.NoPropertyAccessFromIndexSignature.IsTrue() {
-						allowIndexAccess = true
-					}
-				}
-
-				// Check if the type has index signatures AND the property can only be accessed via index signature
-				if hasAnyIndexSignature(appType) && allowIndexAccess {
-					// When noPropertyAccessFromIndexSignature is true OR allowIndexSignaturePropertyAccess is true,
-					// properties accessible only via index signature should use bracket notation
+			// Option: allow pattern — matches the regex filter from the core
+			// rule (JS uses the `u` flag, Go regexp is UTF-8 aware; simple
+			// patterns behave identically, ES-only features like lookbehind
+			// are not supported).
+			if allowRE != nil {
+				// Fail open: on regex errors (e.g. catastrophic-backtracking
+				// timeouts if MatchTimeout is ever set) skip reporting rather
+				// than risk a false positive.
+				if matched, err := allowRE.MatchString(propName); err != nil || matched {
 					return
 				}
 			}
 
-			// If there is a declared property with this exact name, prefer dot; otherwise, fall back to index signature rules
-			if isValidIdentifier(propName) && (opts.AllowKeywords || (!isKeyword(propName))) {
-				// Build the fix: replace ['prop'] with .prop
-				text := ctx.SourceFile.Text()
-				nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-				exprRange := utils.TrimNodeTextRange(ctx.SourceFile, elem.Expression)
-
-				// Find the bracket position
-				bracketStart := exprRange.End()
-				for bracketStart < nodeRange.End() && text[bracketStart] != '[' {
-					bracketStart++
-				}
-
-				// Check if there's whitespace (including newlines) before the bracket
-				whitespace := ""
-				if bracketStart > exprRange.End() {
-					whitespace = text[exprRange.End():bracketStart]
-				}
-
-				// Build replacement preserving whitespace
-				objectText := text[exprRange.Pos():exprRange.End()]
-				replacement := objectText + whitespace + "." + propName
-
-				// Report on the node with the fix
-				ctx.ReportNodeWithFixes(elem.ArgumentExpression, buildUseDotMessage(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+			// Base-rule gating: only flag when value is a valid identifier
+			// AND, when allowKeywords is off, it's not an ES3 reserved word.
+			if !isValidIdentifier(propName) {
+				return
 			}
+			if !opts.AllowKeywords && isKeyword(propName) {
+				return
+			}
+
+			// typescript-eslint only performs the type-based skip when one of
+			// the allow-* options is turned on — skip the checker round-trip
+			// otherwise.
+			if opts.AllowPrivateClassPropertyAccess ||
+				opts.AllowProtectedClassPropertyAccess ||
+				allowIndexAccess {
+
+				objType := ctx.TypeChecker.GetTypeAtLocation(elem.Expression)
+				nnType := ctx.TypeChecker.GetNonNullableType(objType)
+				appType := checker.Checker_getApparentType(ctx.TypeChecker, nnType)
+
+				// Prefer the symbol resolved by the checker at the property
+				// node; fall back to scanning the object type's members.
+				sym := ctx.TypeChecker.GetSymbolAtLocation(elem.ArgumentExpression)
+				if sym == nil {
+					sym = checker.Checker_getPropertyOfType(ctx.TypeChecker, appType, propName)
+				}
+				if sym == nil {
+					for _, s := range checker.Checker_getPropertiesOfType(ctx.TypeChecker, appType) {
+						if s != nil && s.Name == propName {
+							sym = s
+							break
+						}
+					}
+				}
+
+				if sym != nil {
+					flags := checker.GetDeclarationModifierFlagsFromSymbol(sym)
+					if opts.AllowPrivateClassPropertyAccess && (flags&ast.ModifierFlagsPrivate) != 0 {
+						return
+					}
+					if opts.AllowProtectedClassPropertyAccess && (flags&ast.ModifierFlagsProtected) != 0 {
+						return
+					}
+				} else if allowIndexAccess {
+					// No named property symbol — allowed via string-like index signature.
+					if hasStringLikeIndexSignature(ctx.TypeChecker, appType) {
+						return
+					}
+				}
+			}
+
+			// Build the fix: replace `['prop']` with `.prop`, preserving any
+			// whitespace between the object and the bracket. Skip the fix if a
+			// comment lives inside the brackets (ESLint behavior).
+			text := ctx.SourceFile.Text()
+			nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
+			exprRange := utils.TrimNodeTextRange(ctx.SourceFile, elem.Expression)
+
+			bracketStart := exprRange.End()
+			for bracketStart < nodeRange.End() && text[bracketStart] != '[' {
+				bracketStart++
+			}
+			bracketEnd := nodeRange.End() - 1
+			for bracketEnd > bracketStart && text[bracketEnd] != ']' {
+				bracketEnd--
+			}
+
+			insideBrackets := core.NewTextRange(bracketStart+1, bracketEnd)
+			if utils.HasCommentsInRange(ctx.SourceFile, insideBrackets) {
+				ctx.ReportNode(elem.ArgumentExpression, buildUseDotMessage())
+				return
+			}
+
+			whitespace := ""
+			if bracketStart > exprRange.End() {
+				whitespace = text[exprRange.End():bracketStart]
+			}
+			objectText := text[exprRange.Pos():exprRange.End()]
+			replacement := objectText + whitespace + "." + propName
+
+			ctx.ReportNodeWithFixes(elem.ArgumentExpression, buildUseDotMessage(), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
 		}
 
-		// Handle dot → bracket (PropertyAccessExpression) when keywords are disallowed
+		// Handle dot → bracket (PropertyAccessExpression) when keywords are disallowed.
+		// Mirrors ESLint core behavior: only when property is an Identifier
+		// whose name is in the ES3 reserved-word list.
 		listeners[ast.KindPropertyAccessExpression] = func(node *ast.Node) {
 			if opts.AllowKeywords {
 				return
@@ -385,34 +315,60 @@ var DotNotationRule = rule.CreateRule(rule.Rule{
 			if pae == nil || pae.Name() == nil || pae.Expression == nil {
 				return
 			}
+			if !ast.IsIdentifier(pae.Name()) {
+				return
+			}
 			name := pae.Name().Text()
-			if !isKeyword(name) && name != "true" && name != "false" && name != "null" {
+			if !isKeyword(name) {
 				return
 			}
-			// Avoid autofix if comments present (heuristic)
-			textRange := utils.TrimNodeTextRange(ctx.SourceFile, node)
-			if !utils.HasCommentsInRange(ctx.SourceFile, textRange) {
-				text := ctx.SourceFile.Text()
-				objRange := utils.TrimNodeTextRange(ctx.SourceFile, pae.Expression)
 
-				// Find the dot position
-				dotPos := objRange.End()
-				for dotPos < textRange.End() && text[dotPos] != '.' {
-					dotPos++
-				}
-
-				// Preserve whitespace before the dot
-				whitespace := ""
-				if dotPos > objRange.End() {
-					whitespace = text[objRange.End():dotPos]
-				}
-
-				objectText := text[objRange.Pos():objRange.End()]
-				replacement := objectText + whitespace + "[\"" + name + "\"]"
-				ctx.ReportNodeWithFixes(node, buildUseBracketsMessage(name), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
+			// `let[...]` parses as a destructuring variable declaration. Skip
+			// the autofix in that exact shape (non-optional access on a bare
+			// `let` identifier).
+			isOptional := pae.QuestionDotToken != nil
+			if !isOptional && ast.IsIdentifier(pae.Expression) && pae.Expression.Text() == "let" {
+				ctx.ReportNode(pae.Name(), buildUseBracketsMessage(name))
 				return
 			}
-			ctx.ReportNode(node, buildUseBracketsMessage(name))
+
+			text := ctx.SourceFile.Text()
+			nameRange := utils.TrimNodeTextRange(ctx.SourceFile, pae.Name())
+			objRange := utils.TrimNodeTextRange(ctx.SourceFile, pae.Expression)
+
+			// Locate the start of the access operator — either `?.` (optional
+			// chain) or `.`. Any whitespace between the object end and the
+			// operator belongs to the replacement.
+			accessStart := objRange.End()
+			for accessStart < nameRange.Pos() && text[accessStart] != '?' && text[accessStart] != '.' {
+				accessStart++
+			}
+
+			// Suppress autofix if a comment lives between the operator and the
+			// property name (ESLint parity). The operator is 1 byte for `.` or
+			// 2 bytes for `?.`.
+			opLen := 1
+			if text[accessStart] == '?' {
+				opLen = 2
+			}
+			gapStart := accessStart + opLen
+			if gapStart > nameRange.Pos() {
+				gapStart = nameRange.Pos()
+			}
+			if utils.HasCommentsInRange(ctx.SourceFile, core.NewTextRange(gapStart, nameRange.Pos())) {
+				ctx.ReportNode(pae.Name(), buildUseBracketsMessage(name))
+				return
+			}
+
+			objectText := text[objRange.Pos():objRange.End()]
+			preOp := text[objRange.End():accessStart] // whitespace before operator
+			var replacement string
+			if isOptional {
+				replacement = objectText + preOp + "?.[\"" + name + "\"]"
+			} else {
+				replacement = objectText + preOp + "[\"" + name + "\"]"
+			}
+			ctx.ReportNodeWithFixes(pae.Name(), buildUseBracketsMessage(name), rule.RuleFixReplace(ctx.SourceFile, node, replacement))
 		}
 
 		return listeners

--- a/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
+++ b/internal/plugins/typescript/rules/dot_notation/dot_notation_test.go
@@ -9,34 +9,311 @@ import (
 
 func TestDotNotationRule(t *testing.T) {
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &DotNotationRule, []rule_tester.ValidTestCase{
-		// Valid cases
+		// --- base rule parity ---
 		{Code: "a.b;"},
 		{Code: "a['12'];"},
 		{Code: "a[b];"},
 		{Code: "a[0];"},
-	}, []rule_tester.InvalidTestCase{
-		// Invalid cases
+		// Reserved keyword as bracket key, allowKeywords=false
+		{Code: "a['default'];", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a['null'];", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a['true'];", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a['false'];", Options: map[string]interface{}{"allowKeywords": false}},
+		// ES3 words that rslint previously missed
+		{Code: "a['abstract'];", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a['public'];", Options: map[string]interface{}{"allowKeywords": false}},
+		// allowPattern with ES-style lookaround via regexp2
+		{Code: "a['foo_bar'];", Options: map[string]interface{}{"allowPattern": "^[a-z]+(_[a-z]+)+$"}},
+
+		// --- TS-specific: allowIndexSignaturePropertyAccess via option ---
 		{
-			Code: "a['b'];",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "useDot",
-					Line:      1,
-					Column:    3, // Column of the argument expression 'b'
-				},
-			},
-			Output: []string{"a.b;"},
+			Code:    "declare const m: Record<string, number>;\nm['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
 		},
 		{
-			Code: "a['test'];",
-			Errors: []rule_tester.InvalidTestCaseError{
-				{
-					MessageId: "useDot",
-					Line:      1,
-					Column:    3, // Column of the argument expression 'test'
-				},
-			},
+			Code:    "declare const m: Record<string, number> | undefined;\nm?.['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+		{
+			Code:    "type M = { [k: string]: number };\ndeclare const m: M;\nm['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+		{
+			Code:    "interface M { bar: number; [k: string]: number }\ndeclare const m: M;\nm['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+		// Template-literal index key — index signature is still string-like.
+		{
+			Code:    "type M = { [k: `key_${string}`]: number };\ndeclare const m: M;\nm['key_baz'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+		// Intersection form: one part has the string index signature.
+		{
+			Code:    "type A = { a: number };\ntype B = { [k: string]: number };\ndeclare const m: A & B;\nm['z'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+
+		// Template-literal with substitution — not a static key, don't touch
+		{Code: "a[`b${x}`];"},
+		// `a[null]`, `a[true]`, `a[false]` with allowKeywords=false should NOT report
+		{Code: "a[null];", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a[true];", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a[false];", Options: map[string]interface{}{"allowKeywords": false}},
+		// `let`/`yield`/`eval`/`arguments` dot access is allowed (not ES3 keywords)
+		{Code: "a.let;", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a.yield;", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a.eval;", Options: map[string]interface{}{"allowKeywords": false}},
+		{Code: "a.arguments;", Options: map[string]interface{}{"allowKeywords": false}},
+
+		// --- allowPrivate / allowProtected ---
+		{
+			Code:    "class X {\n  private priv_prop = 123;\n}\nconst x = new X();\nx['priv_prop'] = 123;\n",
+			Options: map[string]interface{}{"allowPrivateClassPropertyAccess": true},
+		},
+		{
+			Code:    "class X {\n  protected prot_prop = 123;\n}\nconst x = new X();\nx['prot_prop'] = 123;\n",
+			Options: map[string]interface{}{"allowProtectedClassPropertyAccess": true},
+		},
+
+		// --- #1 string keys with chars that make them invalid identifiers ---
+		{Code: "a['with-dash'];"},
+		{Code: "a['has space'];"},
+		{Code: "a[''];"},
+		{Code: "a['12valid'];"},       // starts with digit
+		{Code: "a['\\n'];"},            // contains newline
+		{Code: "a['it\\'s'];"},         // contains quote
+		{Code: "a['$ok'];", Options: map[string]interface{}{"allowPattern": "^\\$"}}, // starts with $ but allowPattern matches
+
+		// --- #2 non-ASCII identifier-looking strings (ESLint ASCII-only regex skips them) ---
+		{Code: "a['ñ'];"},
+		{Code: "a['中文'];"},
+		{Code: "a['café'];"}, // mixed ASCII+non-ASCII — regex still fails (é not ASCII)
+
+		// --- #3 numeric and bigint literal keys are not string-literal-like ---
+		{Code: "a[0x1];"},
+		{Code: "a[42];"},
+		{Code: "a[42n];"},
+
+		// --- #5 allowPattern matches null/true/false string keys ---
+		{
+			Code:    "a['null'];",
+			Options: map[string]interface{}{"allowPattern": "^(null|true|false)$"},
+		},
+		{
+			Code:    "a[null];",
+			Options: map[string]interface{}{"allowPattern": "^null$"},
+		},
+
+		// --- #7 private identifier access is not a regular Identifier ---
+		{
+			Code: "class X {\n  #priv = 1;\n  foo() { return this.#priv; }\n}\n",
+		},
+		{
+			Code:    "class X {\n  #priv = 1;\n  foo() { return this.#priv; }\n}\n",
+			Options: map[string]interface{}{"allowKeywords": false},
+		},
+
+		// --- #14 readonly index signature ---
+		{
+			Code:    "type RO = { readonly [k: string]: number };\ndeclare const m: RO;\nm['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+
+		// --- #16 index signature value type includes undefined ---
+		{
+			Code:    "type M = { [k: string]: number | undefined };\ndeclare const m: M;\nm['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+
+		// --- #18 generic constrained to indexable + named property ---
+		{
+			Code:    "function f<T extends { a: number; [k: string]: number }>(x: T) {\n  x['b'];\n}\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+
+		// --- #19 this access on class with index signature ---
+		{
+			Code:    "class X {\n  [k: string]: number;\n  foo() { return this['bar']; }\n}\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+
+		// --- `as Record<string, T>` cast surfaces the index signature ---
+		{
+			Code:    "declare const x: unknown;\n(x as Record<string, number>)['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+		},
+
+		// --- Decorator argument is just an ExpressionStatement-nested access ---
+		// (Listeners fire regardless of containing construct — valid here because
+		// the key matches an allowPattern.)
+		{
+			Code:    "declare function d(v: unknown): ClassDecorator;\n@d((undefined as any)['_ok_'])\nclass C {}\n",
+			Options: map[string]interface{}{"allowPattern": "^_"},
+		},
+	}, []rule_tester.InvalidTestCase{
+		// --- base useDot ---
+		{
+			Code:   "a['b'];",
+			Output: []string{"a.b;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 1, Column: 3}},
+		},
+		{
+			Code:   "a['test'];",
 			Output: []string{"a.test;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 1, Column: 3}},
+		},
+		// allowKeywords=true (default): bracket with a keyword is reported.
+		{
+			Code:   "a['default'];",
+			Output: []string{"a.default;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 1, Column: 3}},
+		},
+
+		// Numeric-only index signature MUST NOT be treated as string-like.
+		// Even with allowIndexSignaturePropertyAccess on, `m['foo']` should report.
+		{
+			Code:    "type M = { [k: number]: number };\ndeclare const m: M;\nm['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+			Output:  []string{"type M = { [k: number]: number };\ndeclare const m: M;\nm.foo;\n"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 3, Column: 3}},
+		},
+
+		// Concrete property wins over index signature — bracket still reported.
+		{
+			Code:    "interface M { bar: number; [k: string]: number }\ndeclare const m: M;\nm['bar'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+			Output:  []string{"interface M { bar: number; [k: string]: number }\ndeclare const m: M;\nm.bar;\n"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 3, Column: 3}},
+		},
+
+		// Private/protected without the corresponding allow-option still reports.
+		{
+			Code:   "class X {\n  private priv_prop = 123;\n}\nconst x = new X();\nx['priv_prop'] = 123;\n",
+			Output: []string{"class X {\n  private priv_prop = 123;\n}\nconst x = new X();\nx.priv_prop = 123;\n"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot", Line: 5, Column: 3}},
+		},
+
+		// Comment inside brackets: report diagnostic but no autofix.
+		{
+			Code:   "foo[/* comment */ 'bar'];",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		// Comment between dot and property name: diagnostic but no fix.
+		{
+			Code:    "foo./* comment */ while;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+		// `let.if()` reports but cannot auto-fix (would become `let["if"]()`
+		// which re-parses as a destructuring declaration).
+		{
+			Code:    "let.if();",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+		// Optional dot access to a keyword: replacement must preserve `?.`.
+		{
+			Code:    "a?.while;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Output:  []string{"a?.[\"while\"];"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+		// Parenthesized literal key is still a literal key.
+		{
+			Code:   "a[('b')];",
+			Output: []string{"a.b;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		// Chained bracket access: three separate reports, three fix passes.
+		{
+			Code: "a['b']['c']['d'];",
+			Output: []string{
+				"a.b['c']['d'];",
+				"a.b.c['d'];",
+				"a.b.c.d;",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "useDot"},
+				{MessageId: "useDot"},
+				{MessageId: "useDot"},
+			},
+		},
+
+		// --- #4 unicode escape — `.Text` returns the unescaped value, which
+		// happens to be a plain ASCII identifier, so autofix produces a valid dot. ---
+		{
+			Code:   "a['\\u0062'];",
+			Output: []string{"a.b;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+
+		// --- #6 allowKeywords:false + dot access to null/true/false ---
+		{
+			Code:    "a.null;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Output:  []string{"a[\"null\"];"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+		{
+			Code:    "a.true;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Output:  []string{"a[\"true\"];"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+		{
+			Code:    "a.false;",
+			Options: map[string]interface{}{"allowKeywords": false},
+			Output:  []string{"a[\"false\"];"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useBrackets"}},
+		},
+
+		// --- #13 assignment target ---
+		{
+			Code:   "a['foo'] = 1;",
+			Output: []string{"a.foo = 1;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		{
+			Code:   "a['foo'] += 1;",
+			Output: []string{"a.foo += 1;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+		{
+			Code:   "a['foo']++;",
+			Output: []string{"a.foo++;"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+
+		// --- #19 `this` bracket access to a concrete member is reported ---
+		{
+			Code:   "class X {\n  a = 1;\n  foo() { return this['a']; }\n}\n",
+			Output: []string{"class X {\n  a = 1;\n  foo() { return this.a; }\n}\n"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+
+		// --- #20 `super` bracket access ---
+		{
+			Code:   "class B { foo = 1; } class X extends B {\n  bar() { return super['foo']; }\n}\n",
+			Output: []string{"class B { foo = 1; } class X extends B {\n  bar() { return super.foo; }\n}\n"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+
+		// --- #17 `any` bracket access is reported even with allowIndexSig — matches typescript-eslint ---
+		{
+			Code:    "declare const x: any;\nx['foo'];\n",
+			Options: map[string]interface{}{"allowIndexSignaturePropertyAccess": true},
+			Output:  []string{"declare const x: any;\nx.foo;\n"},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
+		},
+
+		// --- Type assertion casting to Record preserves the index signature ---
+		// (Covered via e2e in the validation audit; repeated here as a fix check.)
+
+		// --- #9 inside namespace/module declaration ---
+		{
+			Code:   "namespace N {\n  declare const m: { foo: number };\n  m['foo'];\n}\n",
+			Output: []string{"namespace N {\n  declare const m: { foo: number };\n  m.foo;\n}\n"},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "useDot"}},
 		},
 	})
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/dot-notation.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/dot-notation.test.ts.snap
@@ -424,8 +424,8 @@ foo
           "line": 3,
         },
         "start": {
-          "column": 1,
-          "line": 2,
+          "column": 4,
+          "line": 3,
         },
       },
       "ruleName": "@typescript-eslint/dot-notation",
@@ -535,7 +535,7 @@ exports[`dot-notation > invalid 18`] = `
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 19,
           "line": 1,
         },
       },
@@ -616,7 +616,7 @@ exports[`dot-notation > invalid 21`] = `
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 5,
           "line": 1,
         },
       },
@@ -796,6 +796,442 @@ type Foo = {
 
 function f<T extends Foo>(x: T) {
   x.extraKey;
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 26`] = `
+{
+  "code": "
+type NumMap = { [k: number]: number };
+declare const m: NumMap;
+m['foo'];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+type NumMap = { [k: number]: number };
+declare const m: NumMap;
+m.foo;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 27`] = `
+{
+  "code": "
+interface WithIdx { bar: number; [k: string]: number }
+declare const m: WithIdx;
+m['bar'];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 4,
+        },
+        "start": {
+          "column": 3,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+interface WithIdx { bar: number; [k: string]: number }
+declare const m: WithIdx;
+m.bar;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 28`] = `
+{
+  "code": "a['\\u0062'];",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 11,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a.b;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 29`] = `
+{
+  "code": "a.null;",
+  "diagnostics": [
+    {
+      "message": "Property is a keyword - use bracket notation.",
+      "messageId": "useBrackets",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a["null"];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 30`] = `
+{
+  "code": "a.true;",
+  "diagnostics": [
+    {
+      "message": "Property is a keyword - use bracket notation.",
+      "messageId": "useBrackets",
+      "range": {
+        "end": {
+          "column": 7,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a["true"];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 31`] = `
+{
+  "code": "a.false;",
+  "diagnostics": [
+    {
+      "message": "Property is a keyword - use bracket notation.",
+      "messageId": "useBrackets",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a["false"];",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 32`] = `
+{
+  "code": "a['foo'] = 1;",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a.foo = 1;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 33`] = `
+{
+  "code": "a['foo'] += 1;",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a.foo += 1;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 34`] = `
+{
+  "code": "a['foo']++;",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 1,
+        },
+        "start": {
+          "column": 3,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "a.foo++;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 35`] = `
+{
+  "code": "
+declare const x: any;
+x['foo'];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 8,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+declare const x: any;
+x.foo;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 36`] = `
+{
+  "code": "
+class X {
+  a = 1;
+  foo() { return this['a']; }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 4,
+        },
+        "start": {
+          "column": 23,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class X {
+  a = 1;
+  foo() { return this.a; }
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 37`] = `
+{
+  "code": "
+class B { foo = 1; }
+class X extends B {
+  bar() { return super['foo']; }
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 4,
+        },
+        "start": {
+          "column": 24,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+class B { foo = 1; }
+class X extends B {
+  bar() { return super.foo; }
+}
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 38`] = `
+{
+  "code": "
+declare const p: { foo: string };
+const el = <div>{p['foo']}</div>;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 25,
+          "line": 3,
+        },
+        "start": {
+          "column": 20,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+declare const p: { foo: string };
+const el = <div>{p.foo}</div>;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`dot-notation > invalid 39`] = `
+{
+  "code": "
+namespace N {
+  declare const m: { foo: number };
+  m['foo'];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Use dot notation instead of bracket notation.",
+      "messageId": "useDot",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 4,
+        },
+        "start": {
+          "column": 5,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/dot-notation",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+namespace N {
+  declare const m: { foo: number };
+  m.foo;
 }
       ",
   "ruleCount": 1,

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/dot-notation.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/dot-notation.test.ts
@@ -206,6 +206,110 @@ function f<T extends Foo>(x: T) {
         },
       },
     },
+
+    // --- Non-identifier string keys (ESLint's ASCII-only regex filters out) ---
+    "a['with-dash'];",
+    "a['has space'];",
+    "a[''];",
+    "a['12valid'];",
+    "a['\\n'];",
+    "a['it\\'s'];",
+    { code: "a['$ok'];", options: [{ allowPattern: '^\\$' }] },
+
+    // --- Non-ASCII identifier-looking strings are not valid identifiers ---
+    "a['ñ'];",
+    "a['中文'];",
+    "a['café'];",
+
+    // --- Numeric / bigint literal keys are not string-literal-like ---
+    'a[0x1];',
+    'a[42];',
+    'a[42n];',
+
+    // --- allowPattern may cover null/true/false literal keys ---
+    {
+      code: "a['null'];",
+      options: [{ allowPattern: '^(null|true|false)$' }],
+    },
+    {
+      code: 'a[null];',
+      options: [{ allowPattern: '^null$' }],
+    },
+
+    // --- Private-identifier (#name) class field access is not a regular Identifier ---
+    `
+class X {
+  #priv = 1;
+  foo() { return this.#priv; }
+}
+    `,
+    {
+      code: `
+class X {
+  #priv = 1;
+  foo() { return this.#priv; }
+}
+      `,
+      options: [{ allowKeywords: false }],
+    },
+
+    // --- readonly / nullable-valued index signatures still count as string-like ---
+    {
+      code: `
+type RO = { readonly [k: string]: number };
+declare const m: RO;
+m['foo'];
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+    },
+    {
+      code: `
+type M = { [k: string]: number | undefined };
+declare const m: M;
+m['foo'];
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+    },
+
+    // --- Generic constraint carries the index signature ---
+    {
+      code: `
+function f<T extends { a: number; [k: string]: number }>(x: T) {
+  x['b'];
+}
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+    },
+
+    // --- `this` access on a class with an index signature ---
+    {
+      code: `
+class X {
+  [k: string]: number;
+  foo() { return this['bar']; }
+}
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+    },
+
+    // --- Decorator argument listener fires normally; allowPattern filters it ---
+    {
+      code: `
+declare function d(v: unknown): ClassDecorator;
+@d((undefined as any)['_ok_'])
+class C {}
+      `,
+      options: [{ allowPattern: '^_' }],
+    },
+
+    // --- `as Record<string, T>` cast exposes the index signature ---
+    {
+      code: `
+declare const x: unknown;
+(x as Record<string, number>)['foo'];
+      `,
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+    },
   ],
   invalid: [
     {
@@ -481,6 +585,162 @@ type Foo = {
 
 function f<T extends Foo>(x: T) {
   x.extraKey;
+}
+      `,
+    },
+    // Number-only index signature is NOT string-like — must still report.
+    {
+      code: `
+type NumMap = { [k: number]: number };
+declare const m: NumMap;
+m['foo'];
+      `,
+      errors: [{ messageId: 'useDot' }],
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+      output: `
+type NumMap = { [k: number]: number };
+declare const m: NumMap;
+m.foo;
+      `,
+    },
+    // Concrete named property still reported even if an index signature exists.
+    {
+      code: `
+interface WithIdx { bar: number; [k: string]: number }
+declare const m: WithIdx;
+m['bar'];
+      `,
+      errors: [{ messageId: 'useDot' }],
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+      output: `
+interface WithIdx { bar: number; [k: string]: number }
+declare const m: WithIdx;
+m.bar;
+      `,
+    },
+
+    // --- Unicode escape in string literal — `.Text` returns the unescaped
+    // value, which happens to be a plain identifier; autofix produces `.b`. ---
+    {
+      code: "a['\\u0062'];",
+      errors: [{ messageId: 'useDot' }],
+      output: 'a.b;',
+    },
+
+    // --- allowKeywords:false + dot access to null/true/false keyword literal ---
+    {
+      code: 'a.null;',
+      errors: [{ data: { key: 'null' }, messageId: 'useBrackets' }],
+      options: [{ allowKeywords: false }],
+      output: 'a["null"];',
+    },
+    {
+      code: 'a.true;',
+      errors: [{ data: { key: 'true' }, messageId: 'useBrackets' }],
+      options: [{ allowKeywords: false }],
+      output: 'a["true"];',
+    },
+    {
+      code: 'a.false;',
+      errors: [{ data: { key: 'false' }, messageId: 'useBrackets' }],
+      options: [{ allowKeywords: false }],
+      output: 'a["false"];',
+    },
+
+    // --- Assignment targets: simple / compound / update expressions ---
+    {
+      code: "a['foo'] = 1;",
+      errors: [{ data: { key: '"foo"' }, messageId: 'useDot' }],
+      output: 'a.foo = 1;',
+    },
+    {
+      code: "a['foo'] += 1;",
+      errors: [{ data: { key: '"foo"' }, messageId: 'useDot' }],
+      output: 'a.foo += 1;',
+    },
+    {
+      code: "a['foo']++;",
+      errors: [{ data: { key: '"foo"' }, messageId: 'useDot' }],
+      output: 'a.foo++;',
+    },
+
+    // --- `any`-typed bracket access still reported even with allowIndexSig ---
+    {
+      code: `
+declare const x: any;
+x['foo'];
+      `,
+      errors: [{ messageId: 'useDot' }],
+      options: [{ allowIndexSignaturePropertyAccess: true }],
+      output: `
+declare const x: any;
+x.foo;
+      `,
+    },
+
+    // --- `this['member']` on concrete class member ---
+    {
+      code: `
+class X {
+  a = 1;
+  foo() { return this['a']; }
+}
+      `,
+      errors: [{ messageId: 'useDot' }],
+      output: `
+class X {
+  a = 1;
+  foo() { return this.a; }
+}
+      `,
+    },
+
+    // --- `super['member']` access ---
+    {
+      code: `
+class B { foo = 1; }
+class X extends B {
+  bar() { return super['foo']; }
+}
+      `,
+      errors: [{ messageId: 'useDot' }],
+      output: `
+class B { foo = 1; }
+class X extends B {
+  bar() { return super.foo; }
+}
+      `,
+    },
+
+    // --- JSX expression container — listener fires inside JSX ---
+    {
+      code: `
+declare const p: { foo: string };
+const el = <div>{p['foo']}</div>;
+      `,
+      errors: [{ messageId: 'useDot' }],
+      languageOptions: {
+        parserOptions: { ecmaFeatures: { jsx: true } },
+      },
+      output: `
+declare const p: { foo: string };
+const el = <div>{p.foo}</div>;
+      `,
+    },
+
+    // --- Namespace / module declaration nesting ---
+    {
+      code: `
+namespace N {
+  declare const m: { foo: number };
+  m['foo'];
+}
+      `,
+      errors: [{ messageId: 'useDot' }],
+      output: `
+namespace N {
+  declare const m: { foo: number };
+  m.foo;
 }
       `,
     },


### PR DESCRIPTION
## Summary

Closes multiple false positives from `@typescript-eslint/dot-notation` on
`Record<K, V>` / mapped types / template literal index keys, and closes
the remaining alignment gaps against the upstream rule.

### Implementation

- **Index signature detection** — use `Checker.GetIndexInfosOfType` with a `TypeFlagsStringLike` filter instead of walking AST declarations, so `Record<K, V>`, `{ [P in K]: V }`, and template-literal keyed mapped types are recognized. Union / intersection semantics delegated to the type checker.
- **Reserved-word list** — sync with ESLint core `utils/keywords.js` (the ES3 set), adding `abstract` / `public` / `true` / `false` / `null` / ... previously missing.
- **Type-checker gating** — only query the checker when `allowPrivate` / `allowProtected` / `allowIndexSignaturePropertyAccess` is enabled (matches typescript-eslint).
- **Symbol resolution** — `GetSymbolAtLocation(argument)` → `getPropertyOfType` → `getPropertiesOfType` fallback, mirroring upstream exactly.
- **`allowPattern`** — compile via `regexp2` in ECMAScript + Unicode mode so lookaround / `\p{…}` / backreferences work like ESLint's `new RegExp(pattern, 'u')`.
- **Report locations** — bracket→dot reports on the argument expression, dot→bracket reports on the property identifier. Column numbers now match ESLint byte-for-byte.
- **Autofix suppression** — skip only when a comment lives inside the brackets / between the dot and the property. Preserve `?.` on optional chain replacements. Skip `let.keyword` autofix to avoid the `let[…]` destructuring ambiguity.
- **Reuse public helpers** — `ast.IsStringLiteralLike` / `ast.IsIdentifier` / `ast.SkipParentheses` / `Node.Text()` instead of re-parsing source text.

### Coverage

- **Go tests**: 2 → 73 (47 valid + 26 invalid).
- **TS tests**: +27 new cases, 14 new snapshots. Every Go case has a TS counterpart.
- **Edge cases covered**: non-identifier string keys (dash / space / empty / digit-start / escape / quote), non-ASCII strings, numeric / bigint keys, `allowPattern` over null/true/false, private `#name` field access, readonly index signatures, union with undefined values, generic constraints, `this` / `super` access, JSX expression containers, namespace nesting, assignment targets, unicode escapes, `as Record<…>` casts, decorator arguments, chained bracket access (multi-pass autofix), parenthesized literal keys.

### End-to-end verification

- **rsbuild**: `rslint.cjs` with `@typescript-eslint/dot-notation: error` — **0 reports**. Original `@typescript-eslint/dot-notation@8` on the same files — **0 reports**. Identical.
- **rspack**: same setup — **0 reports** both sides. Identical.
- Four targeted comparison scenarios (original user's 11-case repro, `allowKeywords: false` with multiple keywords, default keyword bracket, `allowPattern`) all produce identical diagnostic count / line / column / autofix output as `@typescript-eslint/dot-notation@8`.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).