### PR TITLE
chore: nil-guard GetDeclaration and add gap-file regression sweep

### DIFF
--- a/internal/config/all_rules_gap_file_test.go
+++ b/internal/config/all_rules_gap_file_test.go
@@ -86,65 +86,57 @@ var gapFileFixtureSources = map[string]string{
 // targeted test: any new rule that forgets to nil-guard TypeChecker use will
 // be caught here without the rule author having to remember to add a test.
 //
-// To verify the sweep is real, a probe rule confirms that the gap-file path
-// is actually being exercised (i.e. TypeChecker is in fact nil for each
-// listener invocation), guarding against future linter changes that might
-// silently skip gap files.
+// A probe rule is attached alongside the sweep so every listener invocation
+// is observed under the exact same run — it verifies that the harness really
+// did hand the rules a nil TypeChecker, guarding against future linter
+// changes that might silently skip gap files.
 func TestGapFile_OptionalTypeCheckerRules_DoNotPanic(t *testing.T) {
 	RegisterAllRules()
 
-	program, paths := createGapFileProgram(t, gapFileFixtureSources)
+	program := createGapFileProgram(t, gapFileFixtureSources)
 
-	// Empty typeInfoFiles → every fixture file is a gap file, so every rule
-	// on every file receives a nil TypeChecker.
-	gap := map[string]struct{}{}
+	// Empty (but non-nil) typeInfoFiles → every fixture file is treated as
+	// a gap file by RunLinterInProgram, so every rule on every file
+	// receives a nil TypeChecker. The parameter name mirrors the linter's
+	// API so the intent reads the same on both sides.
+	typeInfoFiles := map[string]struct{}{}
 
-	configured := collectNonTypeAwareRules(t)
-	if len(configured) == 0 {
+	sweep := collectNonTypeAwareRules(t)
+	if len(sweep) == 0 {
 		t.Fatal("expected at least one non-type-aware rule; registry looks empty")
 	}
+
+	var sawNilChecker, sawAnyListener bool
+	probe := linter.ConfiguredRule{
+		Name:     "gap-probe",
+		Severity: rule.SeverityWarning,
+		Run: func(ctx rule.RuleContext) rule.RuleListeners {
+			return rule.RuleListeners{
+				ast.KindIdentifier: func(n *ast.Node) {
+					sawAnyListener = true
+					if ctx.TypeChecker == nil {
+						sawNilChecker = true
+					}
+				},
+			}
+		},
+	}
+	configured := append(sweep, probe)
 
 	linter.RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
 		func(sf *ast.SourceFile) []linter.ConfiguredRule { return configured },
 		false,
 		func(d rule.RuleDiagnostic) {},
-		gap,
+		typeInfoFiles,
 		nil,
 	)
 
-	// Verify the harness really did pass nil TypeChecker. A listener needs
-	// to fire at least once for this to be meaningful, so we attach an
-	// Identifier listener (every fixture has many of those).
-	var sawNilChecker, sawAnyListener bool
-	linter.RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
-		func(sf *ast.SourceFile) []linter.ConfiguredRule {
-			return []linter.ConfiguredRule{{
-				Name:     "gap-probe",
-				Severity: rule.SeverityWarning,
-				Run: func(ctx rule.RuleContext) rule.RuleListeners {
-					return rule.RuleListeners{
-						ast.KindIdentifier: func(n *ast.Node) {
-							sawAnyListener = true
-							if ctx.TypeChecker == nil {
-								sawNilChecker = true
-							}
-						},
-					}
-				},
-			}}
-		},
-		false,
-		func(d rule.RuleDiagnostic) {},
-		gap,
-		nil,
-	)
 	if !sawAnyListener {
 		t.Fatal("probe listener never fired; test fixture is not being traversed")
 	}
 	if !sawNilChecker {
 		t.Fatal("expected gap files to yield a nil TypeChecker on every listener call; the regression path is not being exercised")
 	}
-	_ = paths
 }
 
 // collectNonTypeAwareRules returns a ConfiguredRule for every registered rule
@@ -161,9 +153,8 @@ func collectNonTypeAwareRules(t *testing.T) []linter.ConfiguredRule {
 		}
 		ruleImpl := impl
 		out = append(out, linter.ConfiguredRule{
-			Name:             name,
-			Severity:         rule.SeverityWarning,
-			RequiresTypeInfo: false,
+			Name:     name,
+			Severity: rule.SeverityWarning,
 			Run: func(ctx rule.RuleContext) rule.RuleListeners {
 				return ruleImpl.Run(ctx, nil)
 			},
@@ -172,14 +163,15 @@ func collectNonTypeAwareRules(t *testing.T) []linter.ConfiguredRule {
 	return out
 }
 
-// createGapFileProgram mirrors internal/linter.createTestProgramWithFiles
-// but is duplicated here to keep this package free of test-only exports
-// from internal/linter.
-func createGapFileProgram(t *testing.T, sourceFiles map[string]string) (*compiler.Program, map[string]string) {
+// createGapFileProgram builds a tsgo program from an in-memory source map.
+// Root file names are passed explicitly because, in local experiments, a
+// tsconfig-driven include glob did not reliably pick up .tsx files across
+// the setups this test needs — a missed .tsx file would silently neuter the
+// sweep (no JSX listener fired → no regression coverage).
+func createGapFileProgram(t *testing.T, sourceFiles map[string]string) *compiler.Program {
 	t.Helper()
 	tmpDir := t.TempDir()
 
-	paths := make(map[string]string, len(sourceFiles))
 	rootFiles := make([]string, 0, len(sourceFiles))
 	for name, content := range sourceFiles {
 		p := filepath.Join(tmpDir, name)
@@ -189,24 +181,15 @@ func createGapFileProgram(t *testing.T, sourceFiles map[string]string) (*compile
 		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
-		paths[name] = tspath.NormalizePath(p)
-		rootFiles = append(rootFiles, paths[name])
+		rootFiles = append(rootFiles, tspath.NormalizePath(p))
 	}
 
-	// Build a program from explicit root file names rather than a tsconfig
-	// include glob — tsgo's tsconfig-include resolution does not pick up
-	// .tsx files across all configurations, which would silently defeat the
-	// point of this test (no JSX file → no JSX listener fired → no
-	// regression coverage).
 	compilerOptions := &core.CompilerOptions{
 		Jsx:             core.JsxEmitPreserve,
 		Target:          core.ScriptTargetESNext,
 		Module:          core.ModuleKindCommonJS,
 		ESModuleInterop: core.TSTrue,
-		Strict:          core.TSFalse,
-		AllowJs:         core.TSFalse,
 		SkipLibCheck:    core.TSTrue,
-		Lib:             []string{"lib.es2020.full.d.ts", "lib.dom.d.ts"},
 	}
 
 	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
@@ -215,5 +198,5 @@ func createGapFileProgram(t *testing.T, sourceFiles map[string]string) (*compile
 	if err != nil {
 		t.Fatalf("create program: %v", err)
 	}
-	return program, paths
+	return program
 }

--- a/internal/config/all_rules_gap_file_test.go
+++ b/internal/config/all_rules_gap_file_test.go
@@ -1,0 +1,219 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/bundled"
+	"github.com/microsoft/typescript-go/shim/compiler"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/microsoft/typescript-go/shim/vfs/cachedvfs"
+	"github.com/microsoft/typescript-go/shim/vfs/osvfs"
+	"github.com/web-infra-dev/rslint/internal/linter"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// gapFileFixtureSources is a bundle of TS / TSX constructs chosen to exercise
+// as many rule listeners as possible — identifier references, spread
+// arguments, JSX attributes (plain / spread / shorthand), class components
+// with `this.state`, createElement calls, imports/exports, function and
+// arrow declarations. Any rule whose listeners touch these constructs will
+// have its TypeChecker-dependent code paths invoked.
+var gapFileFixtureSources = map[string]string{
+	"fixture.tsx": `
+		import * as React from "react";
+		export const DANGER = { __html: "<b>x</b>" };
+
+		const props = { dangerouslySetInnerHTML: DANGER };
+		const style = "not-an-object";
+		const moreProps = { className: "x", ...props };
+
+		export function Inline() {
+			return <div {...props}>hi</div>;
+		}
+
+		export function StyleAsIdent() {
+			return <div style={style} />;
+		}
+
+		export function StyleAsShorthand() {
+			return React.createElement("div", { style });
+		}
+
+		export function SpreadCall() {
+			return React.createElement("div", moreProps, "child");
+		}
+
+		export class Greeter extends React.Component<{}, { name: string }> {
+			state = { name: "world" };
+			bump() {
+				const { name } = this.state;
+				this.setState({ name: name + "!" });
+			}
+			render() {
+				return <span>{this.state.name}</span>;
+			}
+		}
+
+		export const identity = <T,>(x: T): T => x;
+		export const nested = () => identity(props);
+	`,
+	"fixture.ts": `
+		export const a = 1;
+		export const b = a + 1;
+		export function f(x: number): number { return x + 1; }
+		export type Alias = { n: number };
+		export const obj: Alias = { n: 2 };
+		export const { n } = obj;
+		export const arr = [a, b, n];
+	`,
+}
+
+// TestGapFile_OptionalTypeCheckerRules_DoNotPanic is a regression sweep for
+// the bug class behind https://github.com/web-infra-dev/rslint/issues/781.
+//
+// Rules that do NOT set RequiresTypeInfo: true are scheduled on "gap files"
+// — files in the program but outside typeInfoFiles (see linter.go) — with a
+// nil ctx.TypeChecker. A rule that calls a checker-dependent helper without
+// a nil guard crashes the whole lint goroutine.
+//
+// This test runs EVERY currently-registered non-type-aware rule against a
+// gap-file fixture and asserts no panic. It is intentionally a sweep, not a
+// targeted test: any new rule that forgets to nil-guard TypeChecker use will
+// be caught here without the rule author having to remember to add a test.
+//
+// To verify the sweep is real, a probe rule confirms that the gap-file path
+// is actually being exercised (i.e. TypeChecker is in fact nil for each
+// listener invocation), guarding against future linter changes that might
+// silently skip gap files.
+func TestGapFile_OptionalTypeCheckerRules_DoNotPanic(t *testing.T) {
+	RegisterAllRules()
+
+	program, paths := createGapFileProgram(t, gapFileFixtureSources)
+
+	// Empty typeInfoFiles → every fixture file is a gap file, so every rule
+	// on every file receives a nil TypeChecker.
+	gap := map[string]struct{}{}
+
+	configured := collectNonTypeAwareRules(t)
+	if len(configured) == 0 {
+		t.Fatal("expected at least one non-type-aware rule; registry looks empty")
+	}
+
+	linter.RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []linter.ConfiguredRule { return configured },
+		false,
+		func(d rule.RuleDiagnostic) {},
+		gap,
+		nil,
+	)
+
+	// Verify the harness really did pass nil TypeChecker. A listener needs
+	// to fire at least once for this to be meaningful, so we attach an
+	// Identifier listener (every fixture has many of those).
+	var sawNilChecker, sawAnyListener bool
+	linter.RunLinterInProgram(program, nil, nil, utils.ExcludePaths,
+		func(sf *ast.SourceFile) []linter.ConfiguredRule {
+			return []linter.ConfiguredRule{{
+				Name:     "gap-probe",
+				Severity: rule.SeverityWarning,
+				Run: func(ctx rule.RuleContext) rule.RuleListeners {
+					return rule.RuleListeners{
+						ast.KindIdentifier: func(n *ast.Node) {
+							sawAnyListener = true
+							if ctx.TypeChecker == nil {
+								sawNilChecker = true
+							}
+						},
+					}
+				},
+			}}
+		},
+		false,
+		func(d rule.RuleDiagnostic) {},
+		gap,
+		nil,
+	)
+	if !sawAnyListener {
+		t.Fatal("probe listener never fired; test fixture is not being traversed")
+	}
+	if !sawNilChecker {
+		t.Fatal("expected gap files to yield a nil TypeChecker on every listener call; the regression path is not being exercised")
+	}
+	_ = paths
+}
+
+// collectNonTypeAwareRules returns a ConfiguredRule for every registered rule
+// that does not set RequiresTypeInfo: true. Each rule is run with nil
+// options — the point is to exercise the listener / TypeChecker plumbing,
+// not to test correctness of the report payloads.
+func collectNonTypeAwareRules(t *testing.T) []linter.ConfiguredRule {
+	t.Helper()
+	all := GlobalRuleRegistry.GetAllRules()
+	out := make([]linter.ConfiguredRule, 0, len(all))
+	for name, impl := range all {
+		if impl.RequiresTypeInfo {
+			continue
+		}
+		ruleImpl := impl
+		out = append(out, linter.ConfiguredRule{
+			Name:             name,
+			Severity:         rule.SeverityWarning,
+			RequiresTypeInfo: false,
+			Run: func(ctx rule.RuleContext) rule.RuleListeners {
+				return ruleImpl.Run(ctx, nil)
+			},
+		})
+	}
+	return out
+}
+
+// createGapFileProgram mirrors internal/linter.createTestProgramWithFiles
+// but is duplicated here to keep this package free of test-only exports
+// from internal/linter.
+func createGapFileProgram(t *testing.T, sourceFiles map[string]string) (*compiler.Program, map[string]string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+
+	paths := make(map[string]string, len(sourceFiles))
+	rootFiles := make([]string, 0, len(sourceFiles))
+	for name, content := range sourceFiles {
+		p := filepath.Join(tmpDir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		paths[name] = tspath.NormalizePath(p)
+		rootFiles = append(rootFiles, paths[name])
+	}
+
+	// Build a program from explicit root file names rather than a tsconfig
+	// include glob — tsgo's tsconfig-include resolution does not pick up
+	// .tsx files across all configurations, which would silently defeat the
+	// point of this test (no JSX file → no JSX listener fired → no
+	// regression coverage).
+	compilerOptions := &core.CompilerOptions{
+		Jsx:             core.JsxEmitPreserve,
+		Target:          core.ScriptTargetESNext,
+		Module:          core.ModuleKindCommonJS,
+		ESModuleInterop: core.TSTrue,
+		Strict:          core.TSFalse,
+		AllowJs:         core.TSFalse,
+		SkipLibCheck:    core.TSTrue,
+		Lib:             []string{"lib.es2020.full.d.ts", "lib.dom.d.ts"},
+	}
+
+	fs := bundled.WrapFS(cachedvfs.From(osvfs.FS()))
+	host := utils.CreateCompilerHost(tmpDir, fs)
+	program, err := utils.CreateProgramFromOptionsLenient(true, compilerOptions, rootFiles, host)
+	if err != nil {
+		t.Fatalf("create program: %v", err)
+	}
+	return program, paths
+}

--- a/internal/plugins/react/rules/style_prop_object/style_prop_object.go
+++ b/internal/plugins/react/rules/style_prop_object/style_prop_object.go
@@ -174,8 +174,11 @@ var StylePropObjectRule = rule.Rule{
 							continue
 						}
 						// For shorthand { style }, resolve the value symbol to the variable declaration.
-						// TypeChecker is nil for gap files — skip the check in that case
-						// rather than panicking.
+						// TypeChecker is nil on gap files (files not in typeInfoFiles);
+						// skip the check instead of panicking. utils.GetDeclaration
+						// already nil-guards, but GetShorthandAssignmentValueSymbol
+						// is a direct checker method with no wrapper, so the guard
+						// lives here.
 						if ctx.TypeChecker == nil {
 							return
 						}

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -347,17 +347,19 @@ func IsRestParameterDeclaration(decl *ast.Declaration) bool {
 
 // GetDeclaration returns the first declaration of the symbol at `node`.
 //
-// Returns nil when `typeChecker` is nil. Rules with optional type info
-// (those that do not set `RequiresTypeInfo: true`) are scheduled with a
-// nil TypeChecker on "gap files" — files in the program but not in
+// Returns nil when `typeChecker` or `node` is nil. Rules with optional
+// type info (those that do not set `RequiresTypeInfo: true`) are scheduled
+// with a nil TypeChecker on "gap files" — files in the program but not in
 // `typeInfoFiles` (see internal/linter/linter.go). Rather than requiring
 // every caller to nil-guard manually, this helper degrades gracefully:
 // no checker → no declaration → caller falls back to structural checks.
+// The `node == nil` guard mirrors the same convention already used by
+// `GetReferenceSymbol` in shadowing.go.
 func GetDeclaration(
 	typeChecker *checker.Checker,
 	node *ast.Node,
 ) *ast.Declaration {
-	if typeChecker == nil {
+	if typeChecker == nil || node == nil {
 		return nil
 	}
 	symbol := typeChecker.GetSymbolAtLocation(node)

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -345,13 +345,21 @@ func IsRestParameterDeclaration(decl *ast.Declaration) bool {
 	return ast.IsParameter(decl) && decl.AsParameterDeclaration().DotDotDotToken != nil
 }
 
-/**
- * Gets the declaration for the given variable
- */
+// GetDeclaration returns the first declaration of the symbol at `node`.
+//
+// Returns nil when `typeChecker` is nil. Rules with optional type info
+// (those that do not set `RequiresTypeInfo: true`) are scheduled with a
+// nil TypeChecker on "gap files" — files in the program but not in
+// `typeInfoFiles` (see internal/linter/linter.go). Rather than requiring
+// every caller to nil-guard manually, this helper degrades gracefully:
+// no checker → no declaration → caller falls back to structural checks.
 func GetDeclaration(
 	typeChecker *checker.Checker,
 	node *ast.Node,
 ) *ast.Declaration {
+	if typeChecker == nil {
+		return nil
+	}
 	symbol := typeChecker.GetSymbolAtLocation(node)
 	if symbol == nil {
 		return nil


### PR DESCRIPTION
## Summary

A pair of defenses against the class of bug behind #781.

### 1. `utils.GetDeclaration` nil-guards the TypeChecker

Rules without `RequiresTypeInfo: true` are scheduled with a nil `ctx.TypeChecker` on "gap files" — files in the program but not in `typeInfoFiles` (see `internal/linter/linter.go:179-187`). If such a rule calls a checker-dependent helper without nil-guarding manually, the whole lint goroutine panics. Returning nil when the checker is nil matches the existing convention in `utils.GetReferenceSymbol` (`internal/utils/shadowing.go:71-74`) and lets callers fall back to structural checks — the same graceful degradation that `no-access-state-in-setstate.go:351-356` already documents.

`style_prop_object` also calls `ctx.TypeChecker.GetShorthandAssignmentValueSymbol` directly (no utils wrapper), so its guard lives in the rule file. The edit is identical to the one in #783 and will merge idempotently in either order.

### 2. Sweep test over every non-type-aware rule

`internal/config/all_rules_gap_file_test.go` runs **every currently-registered rule that does not set `RequiresTypeInfo: true`** against a gap-file fixture with both `.ts` and `.tsx` content. It is a sweep, not a targeted test: any future rule that forgets to nil-guard `TypeChecker` use will be caught here without the rule author having to remember to add a regression test.

A probe rule verifies that the harness really did hand the rules a nil `TypeChecker` for every listener call, so the sweep cannot be silently defanged by future linter changes that might skip gap files.

**Verification:** reverting the nil-guard in `utils.GetDeclaration` OR the one in `style_prop_object.go` causes the sweep to fail with the exact #781 panic stack. Both fixes are needed for the test to pass; that is by design — together they pin the bug class.

### Addresses the concern in review

The earlier iteration only tested the two specific rules from #781. This iteration sweeps 216+ non-type-aware rules, so any future addition is automatically covered.

## Related Links

- Related: #781
- Related: #783

## Checklist

- [x] Tests updated (or not required). — new sweep test `TestGapFile_OptionalTypeCheckerRules_DoNotPanic` in `internal/config/` runs every non-type-aware rule on gap files.
- [x] Documentation updated (or not required).