### PR TITLE
fix: detect unused TypeScript type parameters in no-unused-vars

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1629,6 +1629,7 @@ func processVariable(ctx rule.RuleContext, nameNode *ast.Node, name string, defi
 	isTypeOrImportDeclaration := definition != nil && (definition.Kind == ast.KindInterfaceDeclaration ||
 		definition.Kind == ast.KindTypeAliasDeclaration ||
 		definition.Kind == ast.KindEnumDeclaration ||
+		definition.Kind == ast.KindTypeParameter ||
 		definition.Kind == ast.KindImportSpecifier ||
 		definition.Kind == ast.KindImportClause ||
 		definition.Kind == ast.KindNamespaceImport ||
@@ -2054,6 +2055,36 @@ var NoUnusedVarsRule = rule.CreateRule(rule.Rule{
 					return
 				}
 				nameNode := importEquals.Name()
+				if nameNode == nil || !ast.IsIdentifier(nameNode) {
+					return
+				}
+				identifier := nameNode.AsIdentifier()
+				if identifier == nil {
+					return
+				}
+				ensureCollected(node)
+				processVariable(ctx, nameNode, identifier.Text, node, opts, ac)
+			},
+
+			ast.KindTypeParameter: func(node *ast.Node) {
+				// Generic type parameter declarations: `<T>`, `<T = unknown>`, `<T extends U>`.
+				// Skip nodes that syntactically share KindTypeParameter in tsgo but aren't
+				// parameter declarations: `infer T`, mapped-type `[P in K]`, JSDoc @template.
+				parent := node.Parent
+				if parent != nil {
+					switch parent.Kind {
+					case ast.KindInferType, ast.KindMappedType, ast.KindJSDocTemplateTag:
+						return
+					}
+				}
+				if isInsideAmbientModuleBlock(node) || isInDtsWithoutExplicitExports(node) {
+					return
+				}
+				typeParam := node.AsTypeParameter()
+				if typeParam == nil {
+					return
+				}
+				nameNode := typeParam.Name()
 				if nameNode == nil || !ast.IsIdentifier(nameNode) {
 					return
 				}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_typescript_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_typescript_test.go
@@ -330,3 +330,166 @@ export type X = (typeof fooObj2)['x'];
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)
 }
+
+func TestNoUnusedVarsTypeParameters(t *testing.T) {
+	validTestCases := []rule_tester.ValidTestCase{
+		// --- Type parameter USED in function return type ---
+		{Code: `export function fn<T>(x: T): T { return x; }`},
+		// --- Type parameter USED in parameter type ---
+		{Code: `export function fn<T>(x: T): void { console.log(x); }`},
+		// --- Type parameter USED in interface body ---
+		{Code: `export interface I<T> { value: T; }`},
+		// --- Type parameter USED in type alias body ---
+		{Code: `export type A<T> = T[];`},
+		// --- Type parameter USED in class member ---
+		{Code: `export class C<T> { x!: T; }`},
+		// --- Type parameter USED by another TP's constraint ---
+		{Code: `export function fn<T, U extends T>(x: T, y: U): void { console.log(x, y); }`},
+		// --- Type parameter USED by another TP's default ---
+		{Code: `export interface I<T, U = T> { x?: U; }`},
+		// --- Type parameter USED in conditional type ---
+		{Code: `export type IsString<T> = T extends string ? true : false;`},
+		// --- Type parameter USED in template literal type ---
+		{Code: `export type Greeting<T extends string> = ` + "`Hello ${T}`" + `;`},
+		// --- Type parameter USED in mapped type ---
+		{Code: `export type MyRecord<K extends string> = { [P in K]: number };`},
+		// --- infer type is not a declaration — P in mapped type not reported ---
+		{Code: `export type ElementOf<T> = T extends (infer U)[] ? U : never;`},
+		// --- arrow function type parameter ---
+		{Code: `export const fn = <T,>(x: T): T => x;`},
+		// --- method type parameter ---
+		{Code: `
+export class C {
+  fn<T>(x: T): T { return x; }
+}
+`},
+		// --- varsIgnorePattern applies to type parameters ---
+		{
+			Code:    `export interface I<_T> {}`,
+			Options: map[string]interface{}{"varsIgnorePattern": "^_"},
+		},
+		// --- call signature type parameter used ---
+		{Code: `
+export interface Factory {
+  <T>(x: T): T;
+}
+`},
+		// --- construct signature type parameter used ---
+		{Code: `
+export interface Constructable {
+  new <T>(x: T): T;
+}
+`},
+		// --- overloaded function with type parameter ---
+		{Code: `
+export function foo<T>(a: number): T;
+export function foo<T>(a: string): T;
+export function foo<T>(a: number | string): T { return a as unknown as T; }
+`},
+		// --- declare function type parameter (ambient) ---
+		{Code: `declare function fn<T>(x: T): T; export { fn };`},
+		// --- declare module type parameter skipped ---
+		{Code: `
+declare module 'foo' {
+  function bar<T>(x: T): T;
+}
+`},
+		// --- Type parameter used in typeof ---
+		{Code: `
+export function foo<T>(value: T): T { return value; }
+export type Foo<T> = typeof foo<T>;
+`},
+		// --- Type parameter used in spread parameter ---
+		{Code: `export type Fn<A extends unknown[]> = (...a: A) => unknown;`},
+		// --- Type parameter used in nested generic ---
+		{Code: `export type Wrapper<T> = Promise<Array<T>>;`},
+	}
+
+	invalidTestCases := []rule_tester.InvalidTestCase{
+		// --- Unused type parameter on interface ---
+		{
+			Code:   `export interface I<T> { x?: number; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 20}},
+		},
+		// --- Unused type parameter with default ---
+		{
+			Code:   `export interface I<T = unknown> { x?: number; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 20}},
+		},
+		// --- Unused type parameter with constraint ---
+		{
+			Code:   `export interface I<T extends string> { x?: number; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 20}},
+		},
+		// --- Unused type parameter on type alias ---
+		{
+			Code:   `export type A<T> = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 15}},
+		},
+		// --- Unused type parameter on type alias with default ---
+		{
+			Code:   `export type A<T = unknown> = string;`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 15}},
+		},
+		// --- Unused type parameter on function ---
+		{
+			Code:   `export function fn<T>(): void {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 20}},
+		},
+		// --- Unused type parameter on class ---
+		{
+			Code:   `export class C<T> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 16}},
+		},
+		// --- Unused type parameter on class with default ---
+		{
+			Code:   `export class C<T = unknown> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 16}},
+		},
+		// --- Multiple type params: only unused one reported ---
+		{
+			Code:   `export interface I<T, U> { x: T; }`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 23}},
+		},
+		// --- CrossRef: T used by U's constraint, but U itself unused ---
+		{
+			Code:   `export interface I<T, U extends T> {}`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 23}},
+		},
+		// --- Arrow function unused type parameter ---
+		{
+			Code:   `export const fn = <T,>(): void => {};`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 20}},
+		},
+		// --- Method unused type parameter ---
+		{
+			Code: `
+export class C {
+  fn<T>(): void {}
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 3, Column: 6}},
+		},
+		// --- Call signature unused type parameter ---
+		{
+			Code: `
+export interface Factory {
+  <T>(): void;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 3, Column: 4}},
+		},
+		// --- Construct signature unused type parameter ---
+		{
+			Code: `
+export interface Constructable {
+  new <T>(): void;
+}
+`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 3, Column: 8}},
+		},
+	}
+
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)
+}
+

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -1150,6 +1150,8 @@ func IsDeclarationIdentifier(node *ast.Node) bool {
 		return parent.AsImportEqualsDeclaration().Name() == node
 	case ast.KindEnumMember:
 		return parent.AsEnumMember().Name() == node
+	case ast.KindTypeParameter:
+		return parent.AsTypeParameter().Name() == node
 	}
 	return false
 }
@@ -1188,6 +1190,8 @@ func GetDeclarationIdentifier(decl *ast.Node) *ast.Node {
 		return decl.AsParameterDeclaration().Name()
 	case ast.KindBindingElement:
 		return decl.AsBindingElement().Name()
+	case ast.KindTypeParameter:
+		return decl.AsTypeParameter().Name()
 	}
 	return nil
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/__snapshots__/no-unused-vars.test.ts.snap
@@ -2506,3 +2506,145 @@ export {};
   "ruleCount": 1,
 }
 `;
+
+exports[`no-unused-vars > invalid 77`] = `
+{
+  "code": "
+export interface RpcResponse<T = unknown> {
+  code?: number;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "'T' is defined but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-vars > invalid 78`] = `
+{
+  "code": "
+export type Alias<T = unknown> = string;
+      ",
+  "diagnostics": [
+    {
+      "message": "'T' is defined but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 2,
+        },
+        "start": {
+          "column": 19,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-vars > invalid 79`] = `
+{
+  "code": "
+export function fn<T>(): void {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'T' is defined but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 2,
+        },
+        "start": {
+          "column": 20,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-vars > invalid 80`] = `
+{
+  "code": "
+export class Cls<T = unknown> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'T' is defined but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 19,
+          "line": 2,
+        },
+        "start": {
+          "column": 18,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-unused-vars > invalid 81`] = `
+{
+  "code": "
+export interface CrossRef<T, U extends T> {}
+      ",
+  "diagnostics": [
+    {
+      "message": "'U' is defined but never used.",
+      "messageId": "unusedVar",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 2,
+        },
+        "start": {
+          "column": 30,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/no-unused-vars",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/no-unused-vars/no-unused-vars.test.ts
@@ -1138,6 +1138,38 @@ export {};
       ],
       filename: 'foo.d.ts',
     },
+    {
+      code: `
+export interface RpcResponse<T = unknown> {
+  code?: number;
+}
+      `,
+      errors: [{ messageId: 'unusedVar' }],
+    },
+    {
+      code: `
+export type Alias<T = unknown> = string;
+      `,
+      errors: [{ messageId: 'unusedVar' }],
+    },
+    {
+      code: `
+export function fn<T>(): void {}
+      `,
+      errors: [{ messageId: 'unusedVar' }],
+    },
+    {
+      code: `
+export class Cls<T = unknown> {}
+      `,
+      errors: [{ messageId: 'unusedVar' }],
+    },
+    {
+      code: `
+export interface CrossRef<T, U extends T> {}
+      `,
+      errors: [{ messageId: 'unusedVar' }],
+    },
   ],
 
   valid: [
@@ -2488,6 +2520,43 @@ class Foo {}
 declare class Bar {}
       `,
       filename: 'foo.d.ts',
+    },
+    // Type parameters: used in the body counts as used
+    `
+export function used<T>(x: T): T {
+  return x;
+}
+    `,
+    `
+export interface UsedIface<T> {
+  value: T;
+}
+    `,
+    `
+export class UsedCls<T> {
+  x!: T;
+}
+    `,
+    // `infer T` is not a declaration — never reported
+    `
+export type ElementOf<T> = T extends (infer U)[] ? U : never;
+    `,
+    // Mapped type `[P in K]` is not a declaration — never reported
+    `
+export type MyRecord<K extends string> = { [P in K]: number };
+    `,
+    // Type parameter used only by another type parameter's default/constraint counts as used
+    `
+export interface DefaultUses<T, U = T> {
+  x?: U;
+}
+    `,
+    // varsIgnorePattern applies to type parameters
+    {
+      code: `
+export interface IgnoredByPattern<_T> {}
+      `,
+      options: [{ varsIgnorePattern: '^_' }],
     },
   ],
 });


### PR DESCRIPTION
## Summary

The `@typescript-eslint/no-unused-vars` rule was not detecting unused generic type parameters (`<T>`) on interfaces, type aliases, classes, functions, arrow functions, call/construct signatures. This caused false negatives compared to typescript-eslint v8.

**Root cause**: The rule's `RuleListeners` did not include `ast.KindTypeParameter`. Type parameters were only referenced in `isInTypeContext` for context detection, never as declaration entry points.

**Changes**:
- Add `KindTypeParameter` listener in `no_unused_vars.go` (skips `infer`/mapped type/JSDoc contexts and ambient declarations)
- Add `KindTypeParameter` to `isTypeOrImportDeclaration` check so type-only references count as "used"
- Update `IsDeclarationIdentifier` and `GetDeclarationIdentifier` in `internal/utils/ts_eslint.go` to handle `KindTypeParameter`

**Verified against typescript-eslint v8** — identical output on all edge cases.

## Related Links

Discovered via lint-migration gap analysis on `@typescript-eslint/no-unused-vars`.

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).