### PR TITLE
fix: align no-use-before-define with typescript-eslint for heritage clauses

### DIFF
--- a/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/edge_cases_test.go
@@ -82,8 +82,39 @@ func TestEdgeCases(t *testing.T) {
 				Options: map[string]interface{}{"typedefs": false, "ignoreTypeReferences": false},
 			},
 			{
+				Code:    `var x: Foo = {} as any; interface Foo {}`,
+				Options: map[string]interface{}{"typedefs": false},
+			},
+			{
 				Code:    `let myVar: MyString; type MyString = string;`,
 				Options: map[string]interface{}{"typedefs": false, "ignoreTypeReferences": false},
+			},
+
+			// ----- ignoreTypeReferences covers heritage in type-only positions -----
+			// Interface `extends` is a pure type position.
+			{Code: `interface A extends B {} interface B {}`},
+			{Code: `interface A extends B<C> {} interface B<T> { x: T; } interface C {}`},
+			{Code: `interface A extends ns.B {} namespace ns { export interface B {} }`},
+			{Code: `interface A extends ns.sub.B {} namespace ns { export namespace sub { export interface B {} } }`},
+			{Code: `interface A extends B, C {} interface B {} interface C {}`},
+			// Class `implements` is a pure type position (single and multiple, generic, qualified).
+			{Code: `class A implements B { x: number = 1; } interface B { x: number; }`},
+			{Code: `class A implements ns.B { x = 1; } namespace ns { export interface B { x: number; } }`},
+			{Code: `class A implements B, C { x = 1; y = 2; } interface B { x: number; } interface C { y: number; }`},
+			{Code: `class A implements B<number> { x!: number; } interface B<T> { x: T; }`},
+			// Class expression + implements.
+			{Code: `const Cls = class implements B { x = 1; }; interface B { x: number; }`},
+			// Class extends + implements in same declaration (class extends is NOT ignored,
+			// so put declaration first).
+			{Code: `class Base {} interface I {} class D extends Base implements I {}`},
+			// Heritage with type argument that itself references later type.
+			{Code: `interface A extends B<C> {} interface B<T> {} type C = number;`},
+			// Class implements where the implemented interface extends a later one.
+			{Code: `class A implements B { x = 1 } interface B extends C { x: number } interface C {}`},
+			// Explicit ignoreTypeReferences:false but still valid because B is defined before.
+			{
+				Code:    `interface B {} interface A extends B {}`,
+				Options: map[string]interface{}{"ignoreTypeReferences": false},
 			},
 
 			// ----- Optional chaining with declared variables -----
@@ -136,6 +167,23 @@ class A {
 			// ----- Type predicate (value is Type) -----
 			{Code: `type T = (value: unknown) => value is string;`},
 
+			// ----- JSX: implicit React reference should not trigger -----
+			{Code: `import * as React from 'react'; <div />;`, Tsx: true},
+			{Code: `import React from 'react'; <div />;`, Tsx: true},
+			{Code: `const React = require('react'); <div />;`, Tsx: true},
+			{Code: `import { h } from 'preact'; <div />;`, Tsx: true},
+
+			// ----- JSX: component defined before use -----
+			{Code: `const App = () => <div/>; <App />;`, Tsx: true},
+			{Code: `let Foo: any, Bar: any; <Foo><Bar /></Foo>;`, Tsx: true},
+			{Code: `function App() { return <div/> } <App />;`, Tsx: true},
+			// Function component used before define — valid with functions:false
+			{
+				Code:    `<App />; function App() { return <div/> }`,
+				Tsx:     true,
+				Options: map[string]interface{}{"functions": false},
+			},
+
 			// ----- Global augmentation -----
 			{Code: `
 (globalThis as any).foo = true;
@@ -159,6 +207,40 @@ declare global {
 				Code: `class C extends D {} class D {}`,
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "noUseBeforeDefine", Line: 1, Column: 17},
+				},
+			},
+
+			// ----- Class extends is a VALUE reference — ignoreTypeReferences must not suppress it -----
+			{
+				Code:    `class C extends D {} class D {}`,
+				Options: map[string]interface{}{"ignoreTypeReferences": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 17},
+				},
+			},
+
+			// ----- Heritage in type-only position with ignoreTypeReferences:false must report -----
+			{
+				Code:    `interface A extends B {} interface B {}`,
+				Options: map[string]interface{}{"ignoreTypeReferences": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 21},
+				},
+			},
+			{
+				Code:    `class A implements B { x: number = 1 } interface B { x: number }`,
+				Options: map[string]interface{}{"ignoreTypeReferences": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 20},
+				},
+			},
+			// Qualified-name heritage: both `ns` and `B` resolve to later declarations.
+			{
+				Code:    `interface A extends ns.B {} namespace ns { export interface B {} }`,
+				Options: map[string]interface{}{"ignoreTypeReferences": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 21},
+					{MessageId: "noUseBeforeDefine", Line: 1, Column: 24},
 				},
 			},
 
@@ -226,7 +308,48 @@ declare global {
 				},
 			},
 
-			// ----- export const / export function still reports with allowNamedExports -----
+			// ----- JSX: component used before define -----
+			{
+				Code: `<App />; const App = () => <div />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `function render() { return <Widget /> } const Widget = () => <span />;`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code: `<Foo.Bar />; const Foo = { Bar: () => <div/> };`,
+				Tsx:  true,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- export default still reports with allowNamedExports -----
+			{
+				Code:    `export default a; const a = 1;`,
+				Options: map[string]interface{}{"allowNamedExports": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- same-scope TDZ: classes:false + functions:false still catches class declaration -----
+			{
+				Code:    `new A(); class A {}`,
+				Options: map[string]interface{}{"functions": false, "classes": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+
+			// ----- export const / export function / export class body still reports with allowNamedExports -----
 			{
 				Code:    `export const foo = a; const a = 1;`,
 				Options: map[string]interface{}{"allowNamedExports": true},
@@ -236,6 +359,13 @@ declare global {
 			},
 			{
 				Code:    `export function foo() { return a; } const a = 1;`,
+				Options: map[string]interface{}{"allowNamedExports": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noUseBeforeDefine"},
+				},
+			},
+			{
+				Code:    `export class C { foo() { return a; } } const a = 1;`,
 				Options: map[string]interface{}{"allowNamedExports": true},
 				Errors: []rule_tester.InvalidTestCaseError{
 					{MessageId: "noUseBeforeDefine"},

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define.go
@@ -147,16 +147,34 @@ func isExportedAliasName(node *ast.Node) bool {
 	return spec.PropertyName != nil && spec.Name() == node
 }
 
-// isTypeReference checks if the identifier is in a type-only context:
-// inside a TypeReference (e.g. `x: Foo`) or a typeof type query (e.g. `typeof Foo`).
+// isTypeReference reports whether the identifier sits in a type-only context.
+//
+// Composes tsgo helpers that mirror the TypeScript compiler:
+//   - IsPartOfTypeNode: covers TypeReference, QualifiedName chains in type
+//     nodes, and ExpressionWithTypeArguments in every heritage clause except
+//     a class's own `extends` (evaluated as a value at runtime).
+//   - IsPartOfTypeQuery: covers identifiers inside `typeof T`.
+//
+// IsPartOfTypeNode only walks up through the RIGHT side of property access
+// chains, so the leftmost identifier of a qualified heritage target (e.g. the
+// `ns` in `extends ns.B`) is not caught. The final block handles that by
+// walking up through PropertyAccessExpression to its enclosing
+// ExpressionWithTypeArguments and reusing
+// IsExpressionWithTypeArgumentsInClassExtendsClause to exclude class extends.
 func isTypeReference(node *ast.Node) bool {
 	if node == nil || node.Parent == nil {
 		return false
 	}
-	if node.Parent.Kind == ast.KindTypeReference {
+	if ast.IsPartOfTypeNode(node) || ast.IsPartOfTypeQuery(node) {
 		return true
 	}
-	return ast.IsPartOfTypeQuery(node)
+	current := node.Parent
+	for current != nil && current.Kind == ast.KindPropertyAccessExpression {
+		current = current.Parent
+	}
+	return current != nil &&
+		ast.IsExpressionWithTypeArguments(current) &&
+		!ast.IsExpressionWithTypeArgumentsInClassExtendsClause(current)
 }
 
 // isInFunctionTypeScope checks if the identifier is inside a function type

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_test.go
@@ -258,7 +258,7 @@ const Foo = {
 `,
 			Options: map[string]interface{}{"ignoreTypeReferences": true},
 		},
-		// Interface with same name as later variable (issue #435)
+		// Interface with same name as later variable
 		{
 			Code: `
 interface Foo {
@@ -267,7 +267,7 @@ interface Foo {
 const bar = 'blah';
 `,
 		},
-		// Interface members do not conflict with later let/export/namespace (issue #141)
+		// Interface members do not conflict with later let/export/namespace
 		{
 			Code: `
 interface ITest {
@@ -282,7 +282,7 @@ export namespace Third {
 }
 `,
 		},
-		// typeof on parameter member (issue #550)
+		// typeof on parameter member
 		{
 			Code: `
 function test(file: Blob) {

--- a/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_test.go
+++ b/internal/plugins/typescript/rules/no_use_before_define/no_use_before_define_test.go
@@ -28,6 +28,16 @@ interface Foo {}
 const x: Foo = {};
 `,
 		},
+		// Global object method call — no local variable involved
+		{Code: `Object.hasOwnProperty.call(a);`},
+		// Function using arguments keyword — no forward reference
+		{
+			Code: `
+function a() {
+  alert(arguments);
+}
+`,
+		},
 		// Variable declared before use
 		{
 			Code: `
@@ -98,7 +108,9 @@ new A();
 var a = 0, b = a;
 `,
 		},
-		// var _a = { a: 0, b: _a } = {} as any; — skipped, complex destructuring assignment target
+		// Destructuring with sequential defaults (b uses a, which is already bound)
+		{Code: `var { a = 0, b = a } = {} as any;`},
+		{Code: `var [a = 0, b = a] = {} as any;`},
 		// Self-referencing function
 		{
 			Code: `
@@ -134,6 +146,15 @@ for (a of a) {}
 a();
 {
   function a() {}
+}
+`,
+		},
+		// a() is in outer scope; block-scoped let function expression doesn't conflict
+		{
+			Code: `
+a();
+{
+  let a = function () {};
 }
 `,
 		},
@@ -237,13 +258,38 @@ const Foo = {
 `,
 			Options: map[string]interface{}{"ignoreTypeReferences": true},
 		},
-		// Interface with same name as later variable
+		// Interface with same name as later variable (issue #435)
 		{
 			Code: `
 interface Foo {
   bar: string;
 }
 const bar = 'blah';
+`,
+		},
+		// Interface members do not conflict with later let/export/namespace (issue #141)
+		{
+			Code: `
+interface ITest {
+  first: boolean;
+  second: string;
+  third: boolean;
+}
+let first = () => console.log('first');
+export let second = () => console.log('second');
+export namespace Third {
+  export let third = () => console.log('third');
+}
+`,
+		},
+		// typeof on parameter member (issue #550)
+		{
+			Code: `
+function test(file: Blob) {
+  const slice: typeof file.slice =
+    file.slice || (file as any).webkitSlice || (file as any).mozSlice;
+  return slice;
+}
 `,
 		},
 		// Enums with enums: false
@@ -296,6 +342,43 @@ enum Foo { BAR }
 `,
 			Options: map[string]interface{}{"allowNamedExports": true},
 		},
+		{
+			Code: `
+export { a, b };
+let a: any, b: any;
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		{
+			Code: `
+export { a };
+var a: any;
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		{
+			Code: `
+export { f };
+function f() {}
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		{
+			Code: `
+export { C };
+class C {}
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
+		{
+			Code: `
+export { Foo };
+namespace Foo {
+  export let bar = () => console.log('bar');
+}
+`,
+			Options: map[string]interface{}{"allowNamedExports": true},
+		},
 		// Decorators
 		{
 			Code: `
@@ -335,10 +418,37 @@ const obj = {
 `,
 			Options: map[string]interface{}{"ignoreTypeReferences": false},
 		},
+		// Nested object with as — ignoreTypeReferences: false (no forward ref, still valid)
+		{
+			Code: `
+const obj = {
+  foo: {
+    foo: 'foo',
+  } as {
+    [key in 'foo' | 'bar']: key;
+  },
+};
+`,
+			Options: map[string]interface{}{"ignoreTypeReferences": false},
+		},
 		// Namespace alias
 		{
 			Code: `
 namespace A.X.Y {}
+import Z = A.X.Y;
+const X = 23;
+`,
+		},
+		// Extended namespace alias (non-dotted form)
+		{
+			Code: `
+namespace A {
+  export namespace X {
+    export namespace Y {
+      export const foo = 40;
+    }
+  }
+}
 import Z = A.X.Y;
 const X = 23;
 `,
@@ -756,6 +866,38 @@ enum Foo { FOO }
 			Code: `
 export { a };
 const a = 1;
+`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		// Empty object options — same as default
+		{
+			Code: `
+export { a };
+const a = 1;
+`,
+			Options: map[string]interface{}{},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		// "nofunc" string option — allowNamedExports still defaults to false
+		{
+			Code: `
+export { a };
+const a = 1;
+`,
+			Options: "nofunc",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},
+			},
+		},
+		// export var before define
+		{
+			Code: `
+export { a };
+var a: any;
 `,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "noUseBeforeDefine", Line: 2, Column: 10},


### PR DESCRIPTION
## Summary

- Use tsgo's `IsPartOfTypeNode`/`IsPartOfTypeQuery` in `isTypeReference()` to correctly classify `interface extends` and `class implements` as type-only positions (covered by `ignoreTypeReferences: true`), while keeping `class extends` as a value reference.
- Add walk-up through `PropertyAccessExpression` for qualified heritage names (e.g. `ns.B` in `interface A extends ns.B {}`).
- Expand test suite to fully cover every case from the original typescript-eslint and ESLint base rule test files, plus additional edge cases for heritage clauses, JSX, allowNamedExports variants, destructuring defaults, and namespace aliases.

## Related Links

- https://typescript-eslint.io/rules/no-use-before-define

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).