### PR TITLE
fix: skip no-import-assign member-write when wrapped in type assertion

### DIFF
--- a/internal/rules/no_import_assign/no_import_assign.go
+++ b/internal/rules/no_import_assign/no_import_assign.go
@@ -119,10 +119,33 @@ func isArgumentOfWellKnownMutationFunction(node *ast.Node, ctx *rule.RuleContext
 	return true
 }
 
+// isWrappedInTypeAssertion checks whether a node is wrapped in a type assertion
+// (e.g. `as any`, `<any>`, or `!`) before reaching the actual write position.
+// When a developer writes `(ns.prop as any) = value`, the `as any` is an intentional
+// type-level escape hatch; ESLint does not flag such cases, so we skip them too.
+func isWrappedInTypeAssertion(node *ast.Node) bool {
+	current := node.Parent
+	for current != nil {
+		switch current.Kind {
+		case ast.KindParenthesizedExpression:
+			current = current.Parent
+		case ast.KindAsExpression, ast.KindTypeAssertionExpression, ast.KindNonNullExpression:
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
 // isMemberExpressionWrite checks if a member expression (PropertyAccess or ElementAccess)
 // is a write target: assignment left side, update expression operand, delete operand,
 // or for-in/of initializer.
 func isMemberExpressionWrite(memberExpr *ast.Node) bool {
+	// Type assertion wrappers (as any, <any>, !) indicate intentional bypass — skip.
+	if isWrappedInTypeAssertion(memberExpr) {
+		return false
+	}
 	if utils.IsWriteReference(memberExpr) {
 		return true
 	}

--- a/internal/rules/no_import_assign/no_import_assign_test.go
+++ b/internal/rules/no_import_assign/no_import_assign_test.go
@@ -68,6 +68,30 @@ func TestNoImportAssignRule(t *testing.T) {
 			{Code: `import * as mod from 'mod'; { let mod = 0; mod = 1 }`},
 			{Code: `import * as mod from 'mod'; { let mod = 0; mod.named = 1 }`},
 
+			// Type assertion wrappers — intentional bypass, not flagged (aligns with ESLint)
+			// PropertyAccess with various assertion styles
+			{Code: `import * as mod from 'mod'; (mod.named as any) = 0`},
+			{Code: `import * as mod from 'mod'; (mod.named as any) += 0`},
+			{Code: `import * as mod from 'mod'; (mod.named as any)++`},
+			{Code: `import * as mod from 'mod'; (<any>mod.named) = 0`},
+			{Code: `import * as mod from 'mod'; (mod.named!) = 0`},
+			// ElementAccess with type assertion
+			{Code: `import * as mod from 'mod'; (mod["named"] as any) = 0`},
+			// Nested parentheses around type assertion
+			{Code: `import * as mod from 'mod'; ((mod.named as any)) = 0`},
+			// Chained type assertions
+			{Code: `import * as mod from 'mod'; (mod.named as any as unknown) = 0`},
+			// delete with type assertion
+			{Code: `import * as mod from 'mod'; delete (mod.named as any)`},
+			// for-in/of with type assertion
+			{Code: `import * as mod from 'mod'; for ((mod.named as any) in foo);`},
+			{Code: `import * as mod from 'mod'; for ((mod.named as any) of foo);`},
+			// Destructuring with type assertion
+			{Code: `import * as mod from 'mod'; [(mod.named as any)] = foo`},
+			{Code: `import * as mod from 'mod'; ({ bar: (mod.named as any) } = foo)`},
+			// Mutation function with type assertion on the namespace
+			{Code: `import * as mod from 'mod'; Object.assign(mod as any, obj)`},
+
 			// Object/Reflect locally shadowed — mutation calls are safe
 			{Code: `import * as mod from 'mod'; { var Object; Object.assign(mod, obj); }`},
 			{Code: `import * as mod from 'mod'; var Object; Object.assign(mod, obj);`},


### PR DESCRIPTION
## Summary

- `no-import-assign` now skips namespace member-write detection when the member expression is wrapped in a type assertion (`as any`, `<any>`, `!`), aligning with ESLint behavior.
- ESLint's `isAssignmentLeft` does not traverse through `TSAsExpression` nodes, so patterns like `(ns.prop as any) = val` are not flagged. Our `IsWriteReference` utility does traverse type assertions, which caused false positives. This fix adds an `isWrappedInTypeAssertion` check in `isMemberExpressionWrite` to skip these cases.
- Added comprehensive test coverage for type assertion bypass scenarios: `as`, angle-bracket, non-null, element access, delete, for-in/of, destructuring, chained assertions, and mutation functions.

## Related Links

- ESLint rule: [`no-import-assign`](https://eslint.org/docs/latest/rules/no-import-assign)

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).