### PR TITLE
fix: align `prefer-optional-chain` with ESLint implementation

### DIFF
--- a/internal/plugins/typescript/rules/prefer_optional_chain/analyze_chain.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/analyze_chain.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
 	"github.com/microsoft/typescript-go/shim/scanner"
 	"github.com/web-infra-dev/rslint/internal/rule"
 	"github.com/web-infra-dev/rslint/internal/utils"
@@ -19,6 +20,19 @@ func NewChainAnalyzer(ctx rule.RuleContext, opts PreferOptionalChainOptions) *Ch
 	return &ChainAnalyzer{
 		ctx:  ctx,
 		opts: opts,
+	}
+}
+
+// reportRangeWithFixesOrSuggestions reports a diagnostic at the given range,
+// using either fixes (auto-fix) or suggestions based on the useFix flag.
+func reportRangeWithFixesOrSuggestions(ctx rule.RuleContext, textRange core.TextRange, fix bool, msg rule.RuleMessage, suggestionMsg rule.RuleMessage, fixes ...rule.RuleFix) {
+	if fix {
+		ctx.ReportRangeWithFixes(textRange, msg, fixes...)
+	} else {
+		ctx.ReportRangeWithSuggestions(textRange, msg, rule.RuleSuggestion{
+			Message:  suggestionMsg,
+			FixesArr: fixes,
+		})
 	}
 }
 
@@ -197,12 +211,49 @@ func (ca *ChainAnalyzer) AnalyzeChain(
 		// truthiness when the optional chain returns undefined.
 		// e.g., `data && data.value !== null` → `data?.value !== null` changes
 		// from falsy to true when data is null/undefined.
+		complementaryMerged := false
 		if wouldChangeTruthiness(operands[chainStart:chainEnd], operator) {
-			i = originalChainEnd
-			continue
+			// Recovery: if the trimmed operand (just past chainEnd) forms a
+			// complementary pair with the last chain operand, merge them into
+			// loose equality (!= null / == null). Together they cover both null
+			// and undefined, making the transformation safe.
+			// E.g., `existing && existing.id !== null && existing.id !== undefined`
+			// → trim to [existing, existing.id !== null] (rejected)
+			// → merge to [existing, existing.id != null] (safe)
+			if chainEnd < len(operands) && chainEnd-chainStart >= 2 {
+				last := &operands[chainEnd-1]
+				next := operands[chainEnd]
+				if last.ComparedNode != nil && next.ComparedNode != nil &&
+					compareNodesUncached(last.ComparedNode, next.ComparedNode) == NodeComparisonEqual &&
+					isComplementaryGuard(*last, next) {
+					if operator == ast.KindAmpersandAmpersandToken {
+						last.ComparisonType = ComparisonNotEqualNullOrUndefined
+					} else {
+						last.ComparisonType = ComparisonEqualNullOrUndefined
+					}
+					last.UsesNull = true
+					last.IsYoda = false
+					last.IsTypeof = false
+					if !wouldChangeTruthiness(operands[chainStart:chainEnd], operator) {
+						complementaryMerged = true
+					}
+				}
+			}
+			if !complementaryMerged {
+				i = originalChainEnd
+				continue
+			}
 		}
 
-		if chainEnd < originalChainEnd {
+		// When a complementary pair was merged, the operand at chainEnd was
+		// consumed into the chain's last operand. Advance past it so it
+		// doesn't appear in the tail or output.
+		if complementaryMerged {
+			// The merged operand's range should be covered by the fix.
+			// Include it in the chain's report range by treating it as part
+			// of the chain for range calculation only.
+			ca.reportChainCoveringMerged(operands[chainStart:chainEnd], operands[chainEnd], operator, parentNode)
+		} else if chainEnd < originalChainEnd {
 			ca.reportChainWithTail(operands[chainStart:chainEnd], operands[chainEnd:originalChainEnd], operator, parentNode)
 		} else {
 			ca.reportChain(operands[chainStart:chainEnd], operator, parentNode)
@@ -276,7 +327,62 @@ func (ca *ChainAnalyzer) reportChain(
 		rule.RuleFixReplaceRange(reportRange, fixCode),
 	}
 
-	rule.ReportNodeWithFixesOrSuggestions(ca.ctx, reportNode, useFix, msg, sugMsg, fixes...)
+	reportRangeWithFixesOrSuggestions(ca.ctx, reportRange, useFix, msg, sugMsg, fixes...)
+}
+
+// reportChainCoveringMerged reports a chain where the last operand was merged
+// with a complementary strict-equality partner (mergedOp). The fix text covers
+// the chain operands, and the fix range extends to include the merged operand
+// so it is replaced along with the rest of the chain.
+func (ca *ChainAnalyzer) reportChainCoveringMerged(
+	operands []Operand,
+	mergedOp Operand,
+	operator ast.Kind,
+	parentNode *ast.Node,
+) {
+	if len(operands) < 2 {
+		return
+	}
+
+	if ca.shouldSkipForRequireNullish(operands) {
+		return
+	}
+	if ca.hasOnlyVacuousStrictGuards(operands[:len(operands)-1]) {
+		return
+	}
+
+	fixCode := ca.buildOptionalChainCode(operands, operator)
+	if fixCode == "" {
+		return
+	}
+	lastOperand := operands[len(operands)-1]
+	fixCode = wrapChainCode(fixCode, lastOperand)
+
+	firstNode := operands[0].Node
+	// The report/fix range must cover up to the merged operand's end.
+	reportNode := findBinaryExpressionCovering(parentNode, firstNode, mergedOp.Node)
+	if reportNode == nil {
+		reportNode = parentNode
+	}
+
+	startNode := firstNode
+	n := firstNode.Parent
+	for n != nil && n != reportNode.Parent {
+		if ast.IsParenthesizedExpression(n) {
+			startNode = n
+		}
+		n = n.Parent
+	}
+	reportRange := utils.TrimNodeTextRange(ca.ctx.SourceFile, startNode).WithEnd(reportNode.End())
+
+	// Complementary-pair merges always produce a suggestion, not an auto-fix,
+	// because the output changes the comparison operator (!== to !=).
+	msg := buildPreferOptionalChainMessage()
+	sugMsg := buildOptionalChainSuggestMessage()
+	fixes := []rule.RuleFix{
+		rule.RuleFixReplaceRange(reportRange, fixCode),
+	}
+	reportRangeWithFixesOrSuggestions(ca.ctx, reportRange, false, msg, sugMsg, fixes...)
 }
 
 // reportChainWithTail reports a chain where the fix only covers the truncated
@@ -332,6 +438,8 @@ func (ca *ChainAnalyzer) reportChainWithTail(
 	}
 	// Fix range: from start to the last chain operand's end (tail preserved as-is).
 	fixRange := utils.TrimNodeTextRange(ca.ctx.SourceFile, startNode).WithEnd(lastChainNode.End())
+	// Report range: from start to the end of the full expression (chain + tail).
+	reportRange := utils.TrimNodeTextRange(ca.ctx.SourceFile, startNode).WithEnd(reportNode.End())
 
 	// For truncated chains, force suggestion for && chains (matches TS-ESLint).
 	useFix := ca.shouldUseFix(chainOps)
@@ -346,7 +454,7 @@ func (ca *ChainAnalyzer) reportChainWithTail(
 		rule.RuleFixReplaceRange(fixRange, fixCode),
 	}
 
-	rule.ReportNodeWithFixesOrSuggestions(ca.ctx, reportNode, useFix, msg, sugMsg, fixes...)
+	reportRangeWithFixesOrSuggestions(ca.ctx, reportRange, useFix, msg, sugMsg, fixes...)
 }
 
 func (ca *ChainAnalyzer) shouldUseFix(operands []Operand) bool {

--- a/internal/plugins/typescript/rules/prefer_optional_chain/compare_nodes.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/compare_nodes.go
@@ -66,7 +66,13 @@ func compareNodesUncached(nodeA *ast.Node, nodeB *ast.Node) NodeComparisonResult
 
 		exprResult := compareNodesUncached(propA.Expression, propB.Expression)
 		if exprResult != NodeComparisonEqual {
-			return exprResult
+			// Names match but expressions differ (e.g., foo.x vs foo.y.x).
+			// Don't propagate Subset — matching terminal names doesn't mean
+			// one is a prefix of the other. Use isChainPrefix for a proper check.
+			if isChainPrefix(a, b) {
+				return NodeComparisonSubset
+			}
+			return NodeComparisonInvalid
 		}
 		return NodeComparisonEqual
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/gather_logical_operands.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/gather_logical_operands.go
@@ -56,6 +56,36 @@ func (a *OperandAnalyzer) GatherLogicalOperands(node *ast.Node) ([]Operand, ast.
 
 	operands := make([]Operand, 0, 4)
 	a.flattenLogicalOperands(node, operator, &operands)
+
+	// The last operand in the chain is not used as a guard — it's the
+	// chain target. Re-classify it without the falsy-literal restriction
+	// so that types like `boolean` (which contain `false`) can still
+	// appear as the final expression. Matches upstream's `areMoreOperands`
+	// guard that skips the falsy-literal check for the last operand.
+	if len(operands) >= 2 {
+		last := &operands[len(operands)-1]
+		if last.Validity == OperandInvalid {
+			raw := ast.SkipParentheses(last.Node)
+			if operator == ast.KindBarBarToken && ast.IsPrefixUnaryExpression(raw) {
+				prefix := raw.AsPrefixUnaryExpression()
+				if prefix.Operator == ast.KindExclamationToken {
+					inner := ast.SkipParentheses(prefix.Operand)
+					if isValidChainTarget(inner, true) && a.isValidBooleanCheckTypeNoFalsy(inner) {
+						last.ComparedNode = inner
+						last.ComparisonType = ComparisonNotBoolean
+						last.Validity = OperandValid
+					}
+				}
+			} else if operator == ast.KindAmpersandAmpersandToken && isValidChainTarget(raw, true) {
+				if a.isValidBooleanCheckTypeNoFalsy(raw) {
+					last.ComparedNode = raw
+					last.ComparisonType = ComparisonBoolean
+					last.Validity = OperandValid
+				}
+			}
+		}
+	}
+
 	return operands, operator
 }
 
@@ -278,7 +308,20 @@ func invertComparisonType(ct NullishComparisonType) NullishComparisonType {
 	return ct
 }
 
+// isValidBooleanCheckType checks if a node's type is valid for boolean
+// truthiness in optional chain detection. disallowFalsyLiteral controls
+// whether falsy literal types (false, 0, '', 0n) cause rejection — set to
+// true for guard operands, false for the last operand in a chain.
+// Matches upstream's `isValidFalseBooleanCheckType(node, disallowFalsyLiteral, ...)`.
 func (a *OperandAnalyzer) isValidBooleanCheckType(node *ast.Node) bool {
+	return a.isValidBooleanCheckTypeImpl(node, true)
+}
+
+func (a *OperandAnalyzer) isValidBooleanCheckTypeNoFalsy(node *ast.Node) bool {
+	return a.isValidBooleanCheckTypeImpl(node, false)
+}
+
+func (a *OperandAnalyzer) isValidBooleanCheckTypeImpl(node *ast.Node, disallowFalsyLiteral bool) bool {
 	if a.ctx.TypeChecker == nil {
 		return true
 	}
@@ -288,32 +331,18 @@ func (a *OperandAnalyzer) isValidBooleanCheckType(node *ast.Node) bool {
 		return true
 	}
 
-	// Check for falsy literal unions: if the type is a union containing a falsy
-	// literal (false, 0, '', 0n) alongside an object type, but NO null/undefined/void,
-	// then the truthiness check is being used as a type discriminator
-	// (e.g., `false | { a: string }`), not as a null guard.
-	// Don't suggest optional chaining in this case.
-	// Note: we require an object type in the union to distinguish discriminated unions
-	// (like `false | { a: string }`) from plain primitive types (like `boolean` = `true | false`).
 	parts := utils.UnionTypeParts(t)
-	if len(parts) > 1 {
-		hasFalsyLiteral := false
-		hasNullUndefined := false
-		hasObjectType := false
+
+	// When disallowFalsyLiteral is true, reject if any union constituent is
+	// a falsy literal (false, 0, '', 0n). The truthiness check is narrowing
+	// out a non-nullish falsy value, not guarding against null/undefined.
+	// E.g., `boolean` = `true | false` → has `false` literal → skip.
+	// Skipped for the last operand (chain target, not a guard).
+	if disallowFalsyLiteral {
 		for _, part := range parts {
-			pFlags := checker.Type_flags(part)
-			if pFlags&(checker.TypeFlagsNull|checker.TypeFlagsUndefined|checker.TypeFlagsVoid) != 0 {
-				hasNullUndefined = true
-			}
-			if pFlags&checker.TypeFlagsObject != 0 {
-				hasObjectType = true
-			}
 			if isFalsyLiteralType(part) {
-				hasFalsyLiteral = true
+				return false
 			}
-		}
-		if hasFalsyLiteral && !hasNullUndefined && hasObjectType {
-			return false
 		}
 	}
 
@@ -348,7 +377,6 @@ func (a *OperandAnalyzer) isValidBooleanCheckType(node *ast.Node) bool {
 			if constraint == nil {
 				continue
 			}
-			// Recurse into constraint
 			constraintValid := true
 			for _, cPart := range utils.UnionTypeParts(constraint) {
 				cFlags := checker.Type_flags(cPart)
@@ -366,8 +394,6 @@ func (a *OperandAnalyzer) isValidBooleanCheckType(node *ast.Node) bool {
 		}
 
 		if flags&checker.TypeFlagsObject != 0 {
-			// object types are always truthy (when not null/undefined),
-			// so boolean coercion is safe for null/undefined guards
 			continue
 		}
 

--- a/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
+++ b/internal/plugins/typescript/rules/prefer_optional_chain/prefer_optional_chain_test.go
@@ -458,6 +458,14 @@ func TestPreferOptionalChainRule(t *testing.T) {
 			Code:    "declare const foo: string | null;\n(foo || 'a' || {}).toString();",
 			Options: PreferOptionalChainOptions{RequireNullish: utils.Ref(true)},
 		},
+
+		// --- Diverging property access paths (same terminal name, different chains) ---
+		// foo.x and foo.y.x share the terminal name "x" but are different access paths
+		{Code: `foo.x && foo.y.x;`},
+		{Code: `!foo.x || !foo.y.x;`},
+		{Code: "declare const entry: {success: boolean; result?: {success: boolean}};\nentry.success && entry.result?.success;"},
+		// a.bar and a.baz.bar share terminal name "bar"
+		{Code: `a.bar && a.baz.bar;`},
 	}
 
 	// =====================================================================
@@ -1003,18 +1011,62 @@ func TestPreferOptionalChainRule(t *testing.T) {
 		},
 
 		// =================================================================
-		// Category 29: Unrelated prefix with chain
+		// Category 29: Unrelated prefix with chain (with Column assertions)
 		// =================================================================
 		{
 			Code:   "unrelated != null && foo != null && foo.bar != null;",
 			Output: []string{"unrelated != null && foo?.bar != null;"},
 			Errors: []rule_tester.InvalidTestCaseError{
-				{MessageId: "preferOptionalChain"},
+				{MessageId: "preferOptionalChain", Column: 22},
 			},
 		},
 		{
 			Code:   "unrelated1 != null && unrelated2 != null && foo != null && foo.bar != null;",
 			Output: []string{"unrelated1 != null && unrelated2 != null && foo?.bar != null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferOptionalChain", Column: 45},
+			},
+		},
+
+		// =================================================================
+		// Category 31: Complementary strict-equality pair recovery
+		// =================================================================
+		// Truthy guard + complementary pair on deeper property → merge to != null
+		{
+			Code: "declare const existing: {id: number | null | undefined} | null | undefined;\nexisting && existing.id !== null && existing.id !== undefined;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "optionalChainSuggest",
+							Output:    "declare const existing: {id: number | null | undefined} | null | undefined;\nexisting?.id != null;",
+						},
+					},
+				},
+			},
+		},
+		// Same pattern with || chain (DeMorgan)
+		{
+			Code: "declare const existing: {id: number | null | undefined} | null | undefined;\n!existing || existing.id === null || existing.id === undefined;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "preferOptionalChain",
+					Suggestions: []rule_tester.InvalidTestCaseSuggestion{
+						{
+							MessageId: "optionalChainSuggest",
+							Output:    "declare const existing: {id: number | null | undefined} | null | undefined;\nexisting?.id == null;",
+						},
+					},
+				},
+			},
+		},
+		// Reversed order: !== undefined first, then !== null.
+		// !== undefined doesn't trigger wouldChangeTruthiness, so the chain
+		// proceeds as a normal chain-with-tail (no complementary merge needed).
+		{
+			Code:   "declare const data: {value: string | null | undefined} | null | undefined;\ndata && data.value !== undefined && data.value !== null;",
+			Output: []string{"declare const data: {value: string | null | undefined} | null | undefined;\ndata?.value !== undefined && data.value !== null;"},
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "preferOptionalChain"},
 			},

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-optional-chain/__snapshots__/prefer-optional-chain.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-optional-chain/__snapshots__/prefer-optional-chain.test.ts.snap
@@ -13747,7 +13747,7 @@ exports[`hand-crafted cases > prefer-optional-chain > invalid 44`] = `
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 22,
           "line": 1,
         },
       },
@@ -13774,7 +13774,7 @@ exports[`hand-crafted cases > prefer-optional-chain > invalid 45`] = `
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 45,
           "line": 1,
         },
       },
@@ -13816,7 +13816,7 @@ exports[`hand-crafted cases > prefer-optional-chain > invalid 46`] = `
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 37,
           "line": 1,
         },
       },
@@ -13858,7 +13858,7 @@ exports[`hand-crafted cases > prefer-optional-chain > invalid 47`] = `
           "line": 1,
         },
         "start": {
-          "column": 1,
+          "column": 17,
           "line": 1,
         },
       },
@@ -15017,7 +15017,7 @@ exports[`hand-crafted cases > prefer-optional-chain > invalid 83`] = `
           "line": 2,
         },
         "start": {
-          "column": 11,
+          "column": 48,
           "line": 2,
         },
       },


### PR DESCRIPTION
## Summary

Fix four alignment issues in `@typescript-eslint/prefer-optional-chain` found by comparing rslint output against `@typescript-eslint/prefer-optional-chain@8.59.0` on 30+ test patterns and real projects (rsbuild, rspack).

**Bug 1 — Report position offset** (`analyze_chain.go`): When a chain starts after unrelated operands (e.g., `unrelated && foo && foo.bar`), the diagnostic position incorrectly included the unrelated prefix. Fixed by reporting at the chain's `startNode` range instead of the covering binary expression.

**Bug 2 — False Subset for diverging property accesses** (`compare_nodes.go`): `foo.x` and `foo.y.x` were incorrectly treated as a chain because they share the terminal name `x`. Fixed by using `isChainPrefix` instead of propagating the recursive Subset result.

**Bug 3 — Complementary pair dropped by trim** (`analyze_chain.go`): `existing && existing.id !== null && existing.id !== undefined` was silently skipped because the trim logic removed the `!== undefined` operand, then `wouldChangeTruthiness` rejected the remaining chain. Fixed by recovering: when truthiness check fails, try merging the trimmed operand as a complementary pair (`!= null`).

**Bug 4 — Falsy literal over-rejection** (`gather_logical_operands.go`): `boolean` types (expanded to `true | false`) caused the falsy-literal check to reject ALL operands, including the last one. But the upstream only applies this check to guard operands (`areMoreOperands`). Fixed by splitting `isValidBooleanCheckType` into a shared impl with a `disallowFalsyLiteral` parameter.

**Verification**: E2E comparison on 30 patterns (17 categories) and real projects (rsbuild 138 files, rspack 258 files) shows 0 diff against ESLint 8.59.0.

## Related Links

- Original gap report: `_typescript-eslint_prefer-optional-chain.md`

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).