### PR TITLE
feat: port rule @typescript-eslint/prefer-for-of

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_namespace_keyword"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_for_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_optional_chain"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly"
@@ -534,6 +535,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-includes", prefer_includes.PreferIncludesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-namespace-keyword", prefer_namespace_keyword.PreferNamespaceKeywordRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-for-of", prefer_for_of.PreferForOfRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-optional-chain", prefer_optional_chain.PreferOptionalChainRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-promise-reject-errors", prefer_promise_reject_errors.PreferPromiseRejectErrorsRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-readonly", prefer_readonly.PreferReadonlyRule)

--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.go
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.go
@@ -1,0 +1,383 @@
+package prefer_for_of
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var PreferForOfRule = rule.CreateRule(rule.Rule{
+	Name: "prefer-for-of",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.TypeChecker == nil {
+			return rule.RuleListeners{}
+		}
+
+		return rule.RuleListeners{
+			ast.KindForStatement: func(node *ast.Node) {
+				forStmt := node.AsForStatement()
+				if forStmt == nil {
+					return
+				}
+
+				// Step 1: init must be a single variable declaration (let or var, not const),
+				// initialized to 0.
+				init := forStmt.Initializer
+				if init == nil || init.Kind != ast.KindVariableDeclarationList {
+					return
+				}
+				declList := init.AsVariableDeclarationList()
+				if declList == nil || declList.Declarations == nil {
+					return
+				}
+				// Must not be const
+				if init.Flags&ast.NodeFlagsConst != 0 {
+					return
+				}
+				decls := declList.Declarations.Nodes
+				if len(decls) != 1 {
+					return
+				}
+				declarator := decls[0].AsVariableDeclaration()
+				if declarator == nil {
+					return
+				}
+				nameNode := declarator.Name()
+				if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+					return
+				}
+				// Must be initialized to 0
+				if declarator.Initializer == nil {
+					return
+				}
+				initExpr := ast.SkipParentheses(declarator.Initializer)
+				if initExpr.Kind != ast.KindNumericLiteral || initExpr.Text() != "0" {
+					return
+				}
+
+				indexName := nameNode.AsIdentifier().Text
+
+				// Step 2: test must be `i < arr.length`
+				arrayExpression := isLessThanLengthExpression(forStmt.Condition, indexName)
+				if arrayExpression == nil {
+					return
+				}
+
+				// Step 3: update must be an increment pattern
+				if !isIncrement(forStmt.Incrementor, indexName) {
+					return
+				}
+
+				// Step 4: Get symbol for the index variable
+				sym := ctx.TypeChecker.GetSymbolAtLocation(nameNode)
+				if sym == nil {
+					return
+				}
+
+				// Step 5: Check all references of the index variable in the body
+				body := forStmt.Statement
+				if body == nil {
+					return
+				}
+
+				arrayText := utils.TrimmedNodeText(ctx.SourceFile, arrayExpression)
+
+				if isIndexOnlyUsedWithArray(ctx, body, sym, arrayText) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "preferForOf",
+						Description: "Expected a `for-of` loop instead of a `for` loop with this simple iteration.",
+					})
+				}
+			},
+		}
+	},
+})
+
+// isLessThanLengthExpression checks if node is `i < arr.length` and returns the array expression.
+func isLessThanLengthExpression(node *ast.Node, name string) *ast.Node {
+	if node == nil || node.Kind != ast.KindBinaryExpression {
+		return nil
+	}
+	binary := node.AsBinaryExpression()
+	if binary == nil || binary.OperatorToken == nil {
+		return nil
+	}
+	if binary.OperatorToken.Kind != ast.KindLessThanToken {
+		return nil
+	}
+
+	// Left must be the index identifier
+	left := ast.SkipParentheses(binary.Left)
+	if !isMatchingIdentifier(left, name) {
+		return nil
+	}
+
+	// Right must be arr.length (PropertyAccessExpression with name "length")
+	right := ast.SkipParentheses(binary.Right)
+	if right.Kind != ast.KindPropertyAccessExpression {
+		return nil
+	}
+	propAccess := right.AsPropertyAccessExpression()
+	if propAccess == nil {
+		return nil
+	}
+	// Reject optional chaining: arr?.length should not match.
+	// In ESTree, optional chains are wrapped in ChainExpression, which causes the
+	// pattern match to fail naturally. In tsgo, optional chains are represented by
+	// a QuestionDotToken flag on the node, so we must explicitly reject them.
+	// Semantically, arr?.length implies arr may be null/undefined, and converting
+	// to for-of would throw at runtime in that case.
+	if propAccess.QuestionDotToken != nil {
+		return nil
+	}
+	propName := propAccess.Name()
+	if propName == nil || propName.Kind != ast.KindIdentifier {
+		return nil
+	}
+	if propName.AsIdentifier().Text != "length" {
+		return nil
+	}
+
+	return propAccess.Expression
+}
+
+// isMatchingIdentifier checks if node is an Identifier with the given name.
+func isMatchingIdentifier(node *ast.Node, name string) bool {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return false
+	}
+	return node.AsIdentifier().Text == name
+}
+
+// isLiteralValue checks if a node is a numeric literal with the given value text.
+func isLiteralValue(node *ast.Node, valueText string) bool {
+	if node == nil {
+		return false
+	}
+	n := ast.SkipParentheses(node)
+	return n.Kind == ast.KindNumericLiteral && n.Text() == valueText
+}
+
+// isIncrement checks if the update expression is an increment of the named variable.
+// Supports: i++, ++i, i += 1, i = i + 1, i = 1 + i
+func isIncrement(node *ast.Node, name string) bool {
+	if node == nil {
+		return false
+	}
+
+	switch node.Kind {
+	case ast.KindPostfixUnaryExpression:
+		postfix := node.AsPostfixUnaryExpression()
+		if postfix == nil {
+			return false
+		}
+		// i++
+		return postfix.Operator == ast.KindPlusPlusToken && isMatchingIdentifier(ast.SkipParentheses(postfix.Operand), name)
+
+	case ast.KindPrefixUnaryExpression:
+		prefix := node.AsPrefixUnaryExpression()
+		if prefix == nil {
+			return false
+		}
+		// ++i
+		return prefix.Operator == ast.KindPlusPlusToken && isMatchingIdentifier(ast.SkipParentheses(prefix.Operand), name)
+
+	case ast.KindBinaryExpression:
+		binary := node.AsBinaryExpression()
+		if binary == nil || binary.OperatorToken == nil {
+			return false
+		}
+
+		left := ast.SkipParentheses(binary.Left)
+		if !isMatchingIdentifier(left, name) {
+			return false
+		}
+
+		switch binary.OperatorToken.Kind {
+		case ast.KindPlusEqualsToken:
+			// i += 1
+			return isLiteralValue(binary.Right, "1")
+		case ast.KindEqualsToken:
+			// i = i + 1 or i = 1 + i
+			right := ast.SkipParentheses(binary.Right)
+			if right.Kind != ast.KindBinaryExpression {
+				return false
+			}
+			addExpr := right.AsBinaryExpression()
+			if addExpr == nil || addExpr.OperatorToken == nil || addExpr.OperatorToken.Kind != ast.KindPlusToken {
+				return false
+			}
+			addLeft := ast.SkipParentheses(addExpr.Left)
+			addRight := ast.SkipParentheses(addExpr.Right)
+			return (isMatchingIdentifier(addLeft, name) && isLiteralValue(addExpr.Right, "1")) ||
+				(isLiteralValue(addExpr.Left, "1") && isMatchingIdentifier(addRight, name))
+		}
+	}
+
+	return false
+}
+
+// isIndexOnlyUsedWithArray checks that all references to the index symbol within the
+// body are only used as arr[i] (read-only element access on the matching array).
+func isIndexOnlyUsedWithArray(ctx rule.RuleContext, body *ast.Node, indexSym *ast.Symbol, arrayText string) bool {
+	result := true
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || !result {
+			return
+		}
+		if n.Kind == ast.KindIdentifier {
+			sym := ctx.TypeChecker.GetSymbolAtLocation(n)
+			if sym == indexSym {
+				// This identifier references the index variable.
+				// It must be used as arr[i] with matching array text and not as assignee.
+				if !isValidIndexUsage(ctx, n, arrayText) {
+					result = false
+					return
+				}
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return false
+		})
+	}
+	walk(body)
+	return result
+}
+
+// isValidIndexUsage checks if an index variable reference is a valid arr[i] usage:
+// - the identifier (possibly wrapped in parentheses) is the ArgumentExpression of an ElementAccessExpression
+// - the object's text matches the array text
+// - the object is not `this`
+// - the ElementAccessExpression is not an assignee
+func isValidIndexUsage(ctx rule.RuleContext, id *ast.Node, arrayText string) bool {
+	// Walk up through ParenthesizedExpression wrappers.
+	// In tsgo, arr[(i)] has ArgumentExpression → ParenthesizedExpression → Identifier,
+	// whereas ESTree strips parentheses so the identifier is the direct argument.
+	current := id
+	for current.Parent != nil && current.Parent.Kind == ast.KindParenthesizedExpression {
+		current = current.Parent
+	}
+	parent := current.Parent
+	if parent == nil || parent.Kind != ast.KindElementAccessExpression {
+		return false
+	}
+	elemAccess := parent.AsElementAccessExpression()
+	if elemAccess == nil {
+		return false
+	}
+	// The argument must be the (possibly parenthesized) identifier
+	if elemAccess.ArgumentExpression != current {
+		return false
+	}
+	// The object must not be `this`
+	obj := elemAccess.Expression
+	if obj == nil {
+		return false
+	}
+	objSkipped := ast.SkipParentheses(obj)
+	if objSkipped.Kind == ast.KindThisKeyword {
+		return false
+	}
+	// The object's text must match the array expression text
+	objText := utils.TrimmedNodeText(ctx.SourceFile, obj)
+	if objText != arrayText {
+		return false
+	}
+	// The element access must not be an assignee
+	if isAssignee(parent) {
+		return false
+	}
+	return true
+}
+
+// isAssignee checks if a node is used as an assignment target.
+// This matches the upstream typescript-eslint isAssignee utility.
+// NOTE: This is similar to utils.IsWriteReference but NOT identical:
+// - IsWriteReference doesn't handle DeleteExpression or SatisfiesExpression
+// - IsWriteReference is designed for identifiers; isAssignee targets member expressions
+// - delete semantically removes a property (not a "write"), so adding it to
+//   IsWriteReference would change its contract for other rules.
+func isAssignee(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	parent := node.Parent
+
+	switch parent.Kind {
+	case ast.KindBinaryExpression:
+		// a[i] = 1, a[i] += 1, etc.
+		binary := parent.AsBinaryExpression()
+		if binary != nil && binary.OperatorToken != nil {
+			switch binary.OperatorToken.Kind {
+			case ast.KindEqualsToken,
+				ast.KindPlusEqualsToken,
+				ast.KindMinusEqualsToken,
+				ast.KindAsteriskEqualsToken,
+				ast.KindSlashEqualsToken,
+				ast.KindPercentEqualsToken,
+				ast.KindAsteriskAsteriskEqualsToken,
+				ast.KindLessThanLessThanEqualsToken,
+				ast.KindGreaterThanGreaterThanEqualsToken,
+				ast.KindGreaterThanGreaterThanGreaterThanEqualsToken,
+				ast.KindAmpersandEqualsToken,
+				ast.KindBarEqualsToken,
+				ast.KindCaretEqualsToken,
+				ast.KindBarBarEqualsToken,
+				ast.KindAmpersandAmpersandEqualsToken,
+				ast.KindQuestionQuestionEqualsToken:
+				return binary.Left == node
+			}
+		}
+
+	case ast.KindDeleteExpression:
+		// delete a[i]
+		del := parent.AsDeleteExpression()
+		if del != nil {
+			return del.Expression == node
+		}
+
+	case ast.KindPostfixUnaryExpression:
+		// a[i]++
+		postfix := parent.AsPostfixUnaryExpression()
+		if postfix != nil && (postfix.Operator == ast.KindPlusPlusToken || postfix.Operator == ast.KindMinusMinusToken) {
+			return postfix.Operand == node
+		}
+
+	case ast.KindPrefixUnaryExpression:
+		// ++a[i]
+		prefix := parent.AsPrefixUnaryExpression()
+		if prefix != nil && (prefix.Operator == ast.KindPlusPlusToken || prefix.Operator == ast.KindMinusMinusToken) {
+			return prefix.Operand == node
+		}
+
+	case ast.KindArrayLiteralExpression:
+		// [a[i]] = [0]
+		return isAssignee(parent)
+
+	case ast.KindSpreadElement:
+		// [...a[i]] = [0]
+		return isAssignee(parent)
+
+	case ast.KindPropertyAssignment:
+		// ({ foo: a[i] }) = { foo: 0 }
+		prop := parent.AsPropertyAssignment()
+		if prop != nil && prop.Initializer == node {
+			gp := parent.Parent
+			if gp != nil && gp.Kind == ast.KindObjectLiteralExpression {
+				return isAssignee(gp)
+			}
+		}
+
+	case ast.KindNonNullExpression, ast.KindAsExpression, ast.KindTypeAssertionExpression, ast.KindSatisfiesExpression:
+		// (a[i] as number)++, (a[i]! satisfies number)++, etc.
+		return isAssignee(parent)
+
+	case ast.KindParenthesizedExpression:
+		// (a[i])++ etc.
+		return isAssignee(parent)
+	}
+
+	return false
+}

--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.go
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.go
@@ -7,12 +7,9 @@ import (
 )
 
 var PreferForOfRule = rule.CreateRule(rule.Rule{
-	Name: "prefer-for-of",
+	Name:             "prefer-for-of",
+	RequiresTypeInfo: true,
 	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
-		if ctx.TypeChecker == nil {
-			return rule.RuleListeners{}
-		}
-
 		return rule.RuleListeners{
 			ast.KindForStatement: func(node *ast.Node) {
 				forStmt := node.AsForStatement()

--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.md
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of.md
@@ -1,0 +1,42 @@
+# prefer-for-of
+
+## Rule Details
+
+Enforce the use of `for-of` loop over the standard `for` loop where possible.
+
+Many developers default to writing `for (let i = 0; i < ...; i++)` loops to iterate over arrays. However, in many cases the loop iterator variable is only used to access the respective element of the array. In such cases, a `for-of` loop is simpler and more readable.
+
+This rule will report when a `for` loop can be replaced with a `for-of` loop.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+declare const array: string[];
+
+for (let i = 0; i < array.length; i++) {
+  console.log(array[i]);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+// for-of loop
+for (const x of array) {
+  console.log(x);
+}
+
+// Index variable is used for more than just array access
+for (let i = 0; i < array.length; i++) {
+  console.log(i, array[i]);
+}
+
+// Array element is being assigned
+for (let i = 0; i < array.length; i++) {
+  array[i] = 0;
+}
+```
+
+## Original Documentation
+
+[typescript-eslint: prefer-for-of](https://typescript-eslint.io/rules/prefer-for-of)

--- a/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of_test.go
+++ b/internal/plugins/typescript/rules/prefer_for_of/prefer_for_of_test.go
@@ -1,0 +1,511 @@
+package prefer_for_of
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferForOf(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferForOfRule, []rule_tester.ValidTestCase{
+		// ---- Index used with two different arrays ----
+		{Code: `
+for (let i = 0; i < arr1.length; i++) {
+  const x = arr1[i] === arr2[i];
+}`},
+		// ---- Index used as assignment target ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[i] = 0;
+}`},
+		// ---- Index used directly (not just as array index) ----
+		{Code: `
+for (var c = 0; c < arr.length; c++) {
+  doMath(c);
+}`},
+		{Code: `for (var d = 0; d < arr.length; d++) doMath(d);`},
+		// ---- Index used both directly and as array index ----
+		{Code: `
+for (var e = 0; e < arr.length; e++) {
+  if (e > 5) {
+    doMath(e);
+  }
+  console.log(arr[e]);
+}`},
+		// ---- Not comparing with .length ----
+		{Code: `
+for (var f = 0; f <= 40; f++) {
+  doMath(f);
+}`},
+		{Code: `for (var g = 0; g <= 40; g++) doMath(g);`},
+		// ---- Multiple declarations in init ----
+		{Code: `for (var h = 0, len = arr.length; h < len; h++) {}`},
+		{Code: `for (var i = 0, len = arr.length; i < len; i++) arr[i];`},
+		// ---- No init ----
+		{Code: `
+var m = 0;
+for (;;) {
+  if (m > 3) break;
+  console.log(m);
+  m++;
+}`},
+		{Code: `
+var n = 0;
+for (; n < 9; n++) {
+  console.log(n);
+}`},
+		{Code: `
+var o = 0;
+for (; o < arr.length; o++) {
+  console.log(arr[o]);
+}`},
+		{Code: `for (; x < arr.length; x++) {}`},
+		// ---- Missing test or update ----
+		{Code: `for (let x = 0; ; x++) {}`},
+		{Code: `for (let x = 0; x < arr.length; ) {}`},
+		// ---- Mismatched variable names ----
+		{Code: `for (let x = 0; NOTX < arr.length; x++) {}`},
+		{Code: `for (let x = 0; x < arr.length; NOTX++) {}`},
+		{Code: `for (let NOTX = 0; x < arr.length; x++) {}`},
+		// ---- Wrong update direction or operator ----
+		{Code: `for (let x = 0; x < arr.length; x--) {}`},
+		// ---- Wrong comparison operator ----
+		{Code: `for (let x = 0; x <= arr.length; x++) {}`},
+		// ---- Non-zero initializer ----
+		{Code: `for (let x = 1; x < arr.length; x++) {}`},
+		// ---- .length() is a function call, not property ----
+		{Code: `for (let x = 0; x < arr.length(); x++) {}`},
+		// ---- Wrong increment amount ----
+		{Code: `for (let x = 0; x < arr.length; x += 11) {}`},
+		// ---- Reverse iteration ----
+		{Code: `for (let x = arr.length; x > 1; x -= 1) {}`},
+		// ---- Multiply update ----
+		{Code: `for (let x = 0; x < arr.length; x *= 2) {}`},
+		// ---- Wrong addition amount in assignment ----
+		{Code: `for (let x = 0; x < arr.length; x = x + 11) {}`},
+		// ---- Index modified in body ----
+		{Code: `
+for (let x = 0; x < arr.length; x++) {
+  x++;
+}`},
+		// ---- Test is not a comparison ----
+		{Code: `for (let x = 0; true; x++) {}`},
+		// ---- for-in and for-of (not for) ----
+		{Code: `
+for (var q in obj) {
+  if (obj.hasOwnProperty(q)) {
+    console.log(q);
+  }
+}`},
+		{Code: `
+for (var r of arr) {
+  console.log(r);
+}`},
+		// ---- Index used in arithmetic with array index ----
+		{Code: `
+for (let x = 0; x < arr.length; x++) {
+  let y = arr[x + 1];
+}`},
+		// ---- delete arr[i] ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  delete arr[i];
+}`},
+		// ---- arr[i]++ (update expression on element access) ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[i]++;
+}`},
+		// ---- Non-null assertion + update ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[i]!++;
+}`},
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[i]!!!++;
+}`},
+		// ---- Type assertion + update ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i] as number)++;
+}`},
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  (<number>arr[i])++;
+}`},
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i] as unknown as number)++;
+}`},
+		// ---- satisfies + update ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i] satisfies number)++;
+}`},
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  (arr[i]! satisfies number)++;
+}`},
+		// ---- Array destructuring assignment ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  [arr[i]] = [1];
+}`},
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  [...arr[i]] = [1];
+}`},
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  [...arr[i]!] = [1];
+}`},
+		// ---- Object destructuring assignment ----
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  ({ foo: arr[i] }) = { foo: 0 };
+}`},
+		// ---- Optional chaining on length (arr?.length) ----
+		{Code: `
+for (let i = 0; i < arr1?.length; i++) {
+  const x = arr1[i] === arr2[i];
+}`},
+		{Code: `
+for (let i = 0; i < arr?.length; i++) {
+  arr[i] = 0;
+}`},
+		{Code: `
+for (var c = 0; c < arr?.length; c++) {
+  doMath(c);
+}`},
+		{Code: `for (var d = 0; d < arr?.length; d++) doMath(d);`},
+		// ---- Optional chaining on function call (not length) ----
+		{Code: `
+for (var c = 0; c < arr.length; c++) {
+  doMath?.(c);
+}`},
+		{Code: `for (var d = 0; d < arr.length; d++) doMath?.(d);`},
+		// ---- this[i] (object is this) ----
+		{Code: `
+for (let i = 0; i < test.length; ++i) {
+  this[i];
+}`},
+		// ---- this.length with this[i] ----
+		{Code: `
+for (let i = 0; i < this.length; ++i) {
+  yield this[i];
+}`},
+		// ======== Extra edge cases: init variants ========
+		// const init (can't be incremented, rejected by const flag check)
+		{Code: `for (const i = 0; i < arr.length; i++) {}`},
+		// TS type annotation on loop variable
+		{Code: `
+for (let i: number = 0; i < arr.length; i++) {
+  arr[i] = 0;
+}`},
+
+		// ======== Extra edge cases: isIncrement uncovered branches ========
+		// Locks in: AssignmentExpression `=` where RHS is not BinaryExpression
+		{Code: `for (let x = 0; x < arr.length; x = 1) {}`},
+		// Locks in: AssignmentExpression `=` where RHS BinaryExpression operator is not `+`
+		{Code: `for (let x = 0; x < arr.length; x = x - 1) {}`},
+
+		// ======== Extra edge cases: isAssignee uncovered branches ========
+		// Compound assignment += on arr[i]
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[i] += 1;
+}`},
+		// Logical assignment &&= on arr[i]
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[i] &&= true;
+}`},
+		// Prefix decrement --arr[i]
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  --arr[i];
+}`},
+		// Nested array destructuring [[arr[i]]] = [[1]]
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  [[arr[i]]] = [[1]];
+}`},
+
+		// ======== Extra edge cases: optional chaining on .length ========
+		// arr?.length implies arr may be null/undefined, for-of would throw
+		{Code: `
+for (let i = 0; i < arr?.length; i++) {
+  console.log(arr[i]);
+}`},
+
+		// ======== Extra edge cases: parenthesized arr[((i))] as assignee ========
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  arr[((i))] = 0;
+}`},
+
+		// ======== Extra edge cases: non-null assertion on array object ========
+		// arr!.length text is "arr!" which doesn't match "arr" in arr[i]
+		{Code: `
+for (let i = 0; i < arr!.length; i++) {
+  arr[i] = 0;
+}`},
+
+		// ======== Extra edge cases: index used in nested closure ========
+		// i is used inside arrow function — not a direct arr[i] at body level
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  setTimeout(() => console.log(i));
+}`},
+
+		// ======== Extra edge cases: deeply nested for loops (3 levels) ========
+		{Code: `
+for (let i = 0; i < arr.length; i++) {
+  for (let j = 0; j < arr2.length; j++) {
+    for (let k = 0; k < arr3.length; k++) {
+      console.log(i, j, k);
+    }
+  }
+}`},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Nested member access (obj.arr) ----
+		{
+			Code: `
+for (var a = 0; a < obj.arr.length; a++) {
+  console.log(obj.arr[a]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Single-statement body (no braces) ----
+		{
+			Code: `for (var b = 0; b < arr.length; b++) console.log(arr[b]);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 1, Column: 1, EndLine: 1, EndColumn: 58},
+			},
+		},
+		// ---- Basic let ----
+		{
+			Code: `
+for (let a = 0; a < arr.length; a++) {
+  console.log(arr[a]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Optional chaining in body (not on length) ----
+		{
+			Code: `for (var b = 0; b < arr.length; b++) console?.log(arr[b]);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 1, Column: 1, EndLine: 1, EndColumn: 59},
+			},
+		},
+		{
+			Code: `
+for (let a = 0; a < arr.length; a++) {
+  console?.log(arr[a]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Prefix increment (++a) ----
+		{
+			Code: `
+for (let a = 0; a < arr.length; ++a) {
+  arr[a].whatever();
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Empty body ----
+		{
+			Code: `for (let x = 0; x < arr.length; x++) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 1, Column: 1, EndLine: 1, EndColumn: 40,
+					Message: "Expected a `for-of` loop instead of a `for` loop with this simple iteration."},
+			},
+		},
+		// ---- x += 1 ----
+		{
+			Code: `for (let x = 0; x < arr.length; x += 1) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 1, Column: 1, EndLine: 1, EndColumn: 43},
+			},
+		},
+		// ---- x = x + 1 ----
+		{
+			Code: `for (let x = 0; x < arr.length; x = x + 1) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 1, Column: 1, EndLine: 1, EndColumn: 46},
+			},
+		},
+		// ---- x = 1 + x ----
+		{
+			Code: `for (let x = 0; x < arr.length; x = 1 + x) {}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 1, Column: 1, EndLine: 1, EndColumn: 46},
+			},
+		},
+		// ---- Nested for loops with same variable name (shadow) ----
+		{
+			Code: `
+for (let shadow = 0; shadow < arr.length; shadow++) {
+  for (let shadow = 0; shadow < arr.length; shadow++) {}
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+				{MessageId: "preferForOf", Line: 3, Column: 3, EndLine: 3, EndColumn: 57},
+			},
+		},
+		// ---- arr[i] used as computed key (not assignee) ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  obj[arr[i]] = 1;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- delete on outer object, not arr[i] ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  delete obj[arr[i]];
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Destructuring on outer object ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  [obj[arr[i]]] = [1];
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  [...obj[arr[i]]] = [1];
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  ({ foo: obj[arr[i]] } = { foo: 1 });
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- this.item[i] (this is not the object directly) ----
+		{
+			Code: `
+for (let i = 0; i < this.item.length; ++i) {
+  this.item[i];
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- this.array[i] with yield ----
+		{
+			Code: `
+for (let i = 0; i < this.array.length; ++i) {
+  yield this.array[i];
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: TS type annotation on loop variable — still reports ----
+		{
+			Code: `
+for (let i: number = 0; i < arr.length; i++) {
+  console.log(arr[i]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: multiple valid refs in body (all read-only) ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  console.log(arr[i] + arr[i]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: index used inside arrow function but only as arr[i] ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  setTimeout(() => console.log(arr[i]));
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: deep chain a.b.c.length / a.b.c[i] ----
+		{
+			Code: `
+for (let i = 0; i < a.b.c.length; i++) {
+  console.log(a.b.c[i]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: parenthesized index arr[(i)] — aligned with ESTree paren-stripping ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  console.log(arr[(i)]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: multi-level parenthesized index arr[((i))] ----
+		{
+			Code: `
+for (let i = 0; i < arr.length; i++) {
+  console.log(arr[((i))]);
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 4, EndColumn: 2},
+			},
+		},
+		// ---- Extra: deeply nested for loops, all read-only ----
+		{
+			Code: `
+for (let i = 0; i < a.length; i++) {
+  for (let j = 0; j < b.length; j++) {
+    for (let k = 0; k < c.length; k++) {
+      console.log(a[i], b[j], c[k]);
+    }
+  }
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferForOf", Line: 2, Column: 1, EndLine: 8, EndColumn: 2},
+				{MessageId: "preferForOf", Line: 3, Column: 3, EndLine: 7, EndColumn: 4},
+				{MessageId: "preferForOf", Line: 4, Column: 5, EndLine: 6, EndColumn: 6},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -253,7 +253,7 @@ export default defineConfig({
     // './tests/typescript-eslint/rules/prefer-destructuring.test.ts',
     // './tests/typescript-eslint/rules/prefer-enum-initializers.test.ts',
     // './tests/typescript-eslint/rules/prefer-find.test.ts',
-    // './tests/typescript-eslint/rules/prefer-for-of.test.ts',
+    './tests/typescript-eslint/rules/prefer-for-of.test.ts',
     // './tests/typescript-eslint/rules/prefer-function-type.test.ts',
     './tests/typescript-eslint/rules/prefer-includes.test.ts',
     './tests/typescript-eslint/rules/prefer-literal-enum-member.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-for-of.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-for-of.test.ts.snap
@@ -1,0 +1,544 @@
+// Rstest Snapshot v1
+
+exports[`prefer-for-of > invalid 1`] = `
+{
+  "code": "
+for (var a = 0; a < obj.arr.length; a++) {
+  console.log(obj.arr[a]);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 2`] = `
+{
+  "code": "
+for (var b = 0; b < arr.length; b++) console.log(arr[b]);
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 58,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 3`] = `
+{
+  "code": "
+for (let a = 0; a < arr.length; a++) {
+  console.log(arr[a]);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 4`] = `
+{
+  "code": "
+for (var b = 0; b < arr.length; b++) console?.log(arr[b]);
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 59,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 5`] = `
+{
+  "code": "
+for (let a = 0; a < arr.length; a++) {
+  console?.log(arr[a]);
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 6`] = `
+{
+  "code": "
+for (let a = 0; a < arr.length; ++a) {
+  arr[a].whatever();
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 7`] = `
+{
+  "code": "
+for (let x = 0; x < arr.length; x++) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 40,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 8`] = `
+{
+  "code": "
+for (let x = 0; x < arr.length; x += 1) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 43,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 9`] = `
+{
+  "code": "
+for (let x = 0; x < arr.length; x = x + 1) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 10`] = `
+{
+  "code": "
+for (let x = 0; x < arr.length; x = 1 + x) {}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 46,
+          "line": 2,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 11`] = `
+{
+  "code": "
+for (let shadow = 0; shadow < arr.length; shadow++) {
+  for (let shadow = 0; shadow < arr.length; shadow++) {}
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 57,
+          "line": 3,
+        },
+        "start": {
+          "column": 3,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 12`] = `
+{
+  "code": "
+for (let i = 0; i < arr.length; i++) {
+  obj[arr[i]] = 1;
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 13`] = `
+{
+  "code": "
+for (let i = 0; i < arr.length; i++) {
+  delete obj[arr[i]];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 14`] = `
+{
+  "code": "
+for (let i = 0; i < arr.length; i++) {
+  [obj[arr[i]]] = [1];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 15`] = `
+{
+  "code": "
+for (let i = 0; i < arr.length; i++) {
+  [...obj[arr[i]]] = [1];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 16`] = `
+{
+  "code": "
+for (let i = 0; i < arr.length; i++) {
+  ({ foo: obj[arr[i]] } = { foo: 1 });
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 17`] = `
+{
+  "code": "
+for (let i = 0; i < this.item.length; ++i) {
+  this.item[i];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-for-of > invalid 18`] = `
+{
+  "code": "
+for (let i = 0; i < this.array.length; ++i) {
+  yield this.array[i];
+}
+      ",
+  "diagnostics": [
+    {
+      "message": "Expected a \`for-of\` loop instead of a \`for\` loop with this simple iteration.",
+      "messageId": "preferForOf",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 4,
+        },
+        "start": {
+          "column": 1,
+          "line": 2,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-for-of",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-for-of.test.ts
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/prefer-for-of.test.ts
@@ -1,7 +1,5 @@
 import { RuleTester } from '@typescript-eslint/rule-tester';
 
-
-
 const ruleTester = new RuleTester();
 
 ruleTester.run('prefer-for-of', {

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -122,6 +122,7 @@ notcool
 notunique
 nsec
 nullary
+NOTX
 Nullishness
 objectbindingpattern
 objectliteralexpression


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/prefer-for-of` rule to rslint.

This rule enforces the use of `for-of` loops instead of standard `for` loops where the loop index is only used to access array elements. It detects patterns like `for (let i = 0; i < arr.length; i++) { console.log(arr[i]); }` that can be simplified to `for (const x of arr) { console.log(x); }`.

## Related Links

- Rule documentation: https://typescript-eslint.io/rules/prefer-for-of
- Source code: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/prefer-for-of.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).