### PR TITLE
feat: port rule no-irregular-whitespace

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,6 +160,7 @@ import (
 	core_no_implied_eval "github.com/web-infra-dev/rslint/internal/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_import_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
+	"github.com/web-infra-dev/rslint/internal/rules/no_irregular_whitespace"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
 	"github.com/web-infra-dev/rslint/internal/rules/no_label_var"
@@ -613,6 +614,7 @@ func registerAllCoreEslintRules() {
 	GlobalRuleRegistry.Register("no-implied-eval", core_no_implied_eval.NoImpliedEvalRule)
 	GlobalRuleRegistry.Register("no-import-assign", no_import_assign.NoImportAssignRule)
 	GlobalRuleRegistry.Register("no-inner-declarations", no_inner_declarations.NoInnerDeclarationsRule)
+	GlobalRuleRegistry.Register("no-irregular-whitespace", no_irregular_whitespace.NoIrregularWhitespaceRule)
 	GlobalRuleRegistry.Register("no-lone-blocks", no_lone_blocks.NoLoneBlocksRule)
 	GlobalRuleRegistry.Register("no-loop-func", no_loop_func.NoLoopFuncRule)
 	GlobalRuleRegistry.Register("no-loss-of-precision", no_loss_of_precision.NoLossOfPrecisionRule)

--- a/internal/rules/no_irregular_whitespace/no_irregular_whitespace.go
+++ b/internal/rules/no_irregular_whitespace/no_irregular_whitespace.go
@@ -1,0 +1,254 @@
+package no_irregular_whitespace
+
+import (
+	"sort"
+	"unicode/utf8"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// https://eslint.org/docs/latest/rules/no-irregular-whitespace
+var NoIrregularWhitespaceRule = rule.Rule{
+	Name: "no-irregular-whitespace",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		checkNoIrregularWhitespace(ctx, opts)
+		return rule.RuleListeners{}
+	},
+}
+
+type irregularWhitespaceOptions struct {
+	skipStrings   bool
+	skipComments  bool
+	skipRegExps   bool
+	skipTemplates bool
+	skipJSXText   bool
+}
+
+func parseOptions(options any) irregularWhitespaceOptions {
+	opts := irregularWhitespaceOptions{
+		skipStrings:   true,
+		skipComments:  false,
+		skipRegExps:   false,
+		skipTemplates: false,
+		skipJSXText:   false,
+	}
+
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap == nil {
+		return opts
+	}
+
+	if v, ok := optsMap["skipStrings"].(bool); ok {
+		opts.skipStrings = v
+	}
+	if v, ok := optsMap["skipComments"].(bool); ok {
+		opts.skipComments = v
+	}
+	if v, ok := optsMap["skipRegExps"].(bool); ok {
+		opts.skipRegExps = v
+	}
+	if v, ok := optsMap["skipTemplates"].(bool); ok {
+		opts.skipTemplates = v
+	}
+	if v, ok := optsMap["skipJSXText"].(bool); ok {
+		opts.skipJSXText = v
+	}
+
+	return opts
+}
+
+// isIrregularWhitespace returns true if the rune is an irregular whitespace character
+// (not a normal space or tab, but also not a standard line terminator \n, \r).
+func isIrregularWhitespace(ch rune) bool {
+	switch ch {
+	case
+		'\u000B', // verticalTab
+		'\u000C', // formFeed
+		'\u0085', // nextLine
+		'\u00A0', // nonBreakingSpace
+		'\u1680', // ogham
+		'\u180E', // mongolianVowelSeparator
+		'\u2000', // enQuad
+		'\u2001', // emQuad
+		'\u2002', // enSpace
+		'\u2003', // emSpace
+		'\u2004', // threePerEmSpace
+		'\u2005', // fourPerEmSpace
+		'\u2006', // sixPerEmSpace
+		'\u2007', // figureSpace
+		'\u2008', // punctuationSpace
+		'\u2009', // thinSpace
+		'\u200A', // hairSpace
+		'\u200B', // zeroWidthSpace
+		'\u202F', // narrowNoBreakSpace
+		'\u205F', // mediumMathematicalSpace
+		'\u3000', // ideographicSpace
+		'\uFEFF', // byteOrderMark
+		'\u2028', // lineSeparator
+		'\u2029': // paragraphSeparator
+		return true
+	}
+	return false
+}
+
+type errorInfo struct {
+	pos int
+	end int
+}
+
+func checkNoIrregularWhitespace(ctx rule.RuleContext, opts irregularWhitespaceOptions) {
+	text := ctx.SourceFile.Text()
+	if len(text) == 0 {
+		return
+	}
+
+	// Collect all irregular whitespace positions.
+	var errors []errorInfo
+	i := 0
+
+	// Skip BOM at position 0 — matches ESLint behavior where BOM is
+	// stripped from the source before rules see it.
+	if len(text) >= 3 && text[0] == 0xEF && text[1] == 0xBB && text[2] == 0xBF {
+		// UTF-8 BOM for U+FEFF
+		i = 3
+	}
+
+	for i < len(text) {
+		r, size := utf8.DecodeRuneInString(text[i:])
+		if r == utf8.RuneError && size == 1 {
+			i++
+			continue
+		}
+
+		if isIrregularWhitespace(r) {
+			// Group consecutive irregular whitespace (non-line-terminator) into one error,
+			// matching ESLint's IRREGULAR_WHITESPACE regex which matches runs of chars.
+			// But line terminators (\u2028, \u2029) are always reported individually.
+			if r == '\u2028' || r == '\u2029' {
+				errors = append(errors, errorInfo{pos: i, end: i + size})
+			} else {
+				start := i
+				end := i + size
+				for end < len(text) {
+					nextR, nextSize := utf8.DecodeRuneInString(text[end:])
+					if isIrregularWhitespace(nextR) && nextR != '\u2028' && nextR != '\u2029' {
+						end += nextSize
+					} else {
+						break
+					}
+				}
+				errors = append(errors, errorInfo{pos: start, end: end})
+				i = end
+				continue
+			}
+		}
+
+		i += size
+	}
+
+	if len(errors) == 0 {
+		return
+	}
+
+	// Collect exempt ranges based on options.
+	var exemptRanges []errorInfo
+	collectExemptRanges(ctx, opts, &exemptRanges)
+
+	// Sort exempt ranges by position for efficient filtering.
+	sort.Slice(exemptRanges, func(i, j int) bool {
+		return exemptRanges[i].pos < exemptRanges[j].pos
+	})
+
+	// Filter errors: remove those that fall entirely inside an exempt range.
+	msg := rule.RuleMessage{
+		Id:          "noIrregularWhitespace",
+		Description: "Irregular whitespace not allowed.",
+	}
+
+	for _, err := range errors {
+		if isInsideExemptRange(err, exemptRanges) {
+			continue
+		}
+		ctx.ReportRange(core.NewTextRange(err.pos, err.end), msg)
+	}
+}
+
+// isInsideExemptRange checks if the error falls entirely within any exempt range.
+func isInsideExemptRange(err errorInfo, exemptRanges []errorInfo) bool {
+	// Binary search for the first exempt range that could contain this error.
+	idx := sort.Search(len(exemptRanges), func(i int) bool {
+		return exemptRanges[i].end > err.pos
+	})
+	for i := idx; i < len(exemptRanges); i++ {
+		ex := exemptRanges[i]
+		if ex.pos > err.pos {
+			break
+		}
+		if err.pos >= ex.pos && err.end <= ex.end {
+			return true
+		}
+	}
+	return false
+}
+
+func collectExemptRanges(ctx rule.RuleContext, opts irregularWhitespaceOptions, ranges *[]errorInfo) {
+	sf := ctx.SourceFile
+
+	// trimmedPos returns the start of the actual token, skipping leading trivia.
+	// node.Pos() includes leading whitespace/comments; we need the real token start.
+	trimmedPos := func(node *ast.Node) int {
+		r := scanner.GetRangeOfTokenAtPosition(sf, node.Pos())
+		return r.Pos()
+	}
+
+	// Walk the AST to collect exempt node ranges.
+	if opts.skipStrings || opts.skipRegExps || opts.skipTemplates || opts.skipJSXText {
+		var walk func(node *ast.Node) bool
+		walk = func(node *ast.Node) bool {
+			switch node.Kind {
+			case ast.KindStringLiteral:
+				if opts.skipStrings {
+					*ranges = append(*ranges, errorInfo{pos: trimmedPos(node), end: node.End()})
+				}
+			case ast.KindRegularExpressionLiteral:
+				if opts.skipRegExps {
+					*ranges = append(*ranges, errorInfo{pos: trimmedPos(node), end: node.End()})
+				}
+			case ast.KindNoSubstitutionTemplateLiteral:
+				if opts.skipTemplates {
+					*ranges = append(*ranges, errorInfo{pos: trimmedPos(node), end: node.End()})
+				}
+			case ast.KindTemplateHead, ast.KindTemplateMiddle, ast.KindTemplateTail:
+				if opts.skipTemplates {
+					*ranges = append(*ranges, errorInfo{pos: trimmedPos(node), end: node.End()})
+				}
+			case ast.KindJsxText, ast.KindJsxTextAllWhiteSpaces:
+				if opts.skipJSXText {
+					*ranges = append(*ranges, errorInfo{pos: node.Pos(), end: node.End()})
+				}
+			}
+			node.ForEachChild(walk)
+			return false
+		}
+		sf.AsNode().ForEachChild(walk)
+	}
+
+	// Collect comment ranges.
+	if opts.skipComments {
+		nodeFactory := ast.NewNodeFactory(ast.NodeFactoryHooks{})
+		text := sf.Text()
+		// Iterate through all comments in the file using ForEachComment.
+		utils.ForEachComment(sf.AsNode(), func(comment *ast.CommentRange) {
+			*ranges = append(*ranges, errorInfo{pos: comment.Pos(), end: comment.End()})
+		}, sf)
+		// Also check for leading comments at position 0 which ForEachComment may miss.
+		for comment := range scanner.GetLeadingCommentRanges(nodeFactory, text, 0) {
+			*ranges = append(*ranges, errorInfo{pos: comment.Pos(), end: comment.End()})
+		}
+	}
+}

--- a/internal/rules/no_irregular_whitespace/no_irregular_whitespace.md
+++ b/internal/rules/no_irregular_whitespace/no_irregular_whitespace.md
@@ -1,0 +1,78 @@
+# no-irregular-whitespace
+
+## Rule Details
+
+Disallows irregular whitespace characters outside of strings, comments, regular expressions, and template literals. Irregular whitespace characters can cause issues with various parsers and can be difficult to debug.
+
+The following characters are considered irregular whitespace:
+
+- `\u000B` - Line Tabulation
+- `\u000C` - Form Feed
+- `\u0085` - Next Line
+- `\u00A0` - No-Break Space
+- `\u1680` - Ogham Space Mark
+- `\u180E` - Mongolian Vowel Separator
+- `\u2000` - En Quad through `\u200B` - Zero Width Space
+- `\u202F` - Narrow No-Break Space
+- `\u205F` - Medium Mathematical Space
+- `\u3000` - Ideographic Space
+- `\uFEFF` - Zero Width No-Break Space (BOM)
+- `\u2028` - Line Separator
+- `\u2029` - Paragraph Separator
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var any = 'thing';
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var any = 'thing';
+```
+
+Examples of **correct** code for this rule with `{ "skipStrings": true }` (default):
+
+```json
+{ "no-irregular-whitespace": ["error", { "skipStrings": true }] }
+```
+
+```javascript
+var foo = ' ';
+```
+
+Examples of **correct** code for this rule with `{ "skipComments": true }`:
+
+```json
+{ "no-irregular-whitespace": ["error", { "skipComments": true }] }
+```
+
+```javascript
+// Comment with irregular whitespace
+/* Block comment with irregular whitespace */
+```
+
+Examples of **correct** code for this rule with `{ "skipTemplates": true }`:
+
+```json
+{ "no-irregular-whitespace": ["error", { "skipTemplates": true }] }
+```
+
+```javascript
+var foo = ` `;
+```
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `skipStrings` | `boolean` | `true` | Allow irregular whitespace in string literals |
+| `skipComments` | `boolean` | `false` | Allow irregular whitespace in comments |
+| `skipRegExps` | `boolean` | `false` | Allow irregular whitespace in regular expressions |
+| `skipTemplates` | `boolean` | `false` | Allow irregular whitespace in template literals |
+| `skipJSXText` | `boolean` | `false` | Allow irregular whitespace in JSX text |
+
+## Original Documentation
+
+[ESLint - no-irregular-whitespace](https://eslint.org/docs/latest/rules/no-irregular-whitespace)

--- a/internal/rules/no_irregular_whitespace/no_irregular_whitespace.md
+++ b/internal/rules/no_irregular_whitespace/no_irregular_whitespace.md
@@ -23,7 +23,7 @@ The following characters are considered irregular whitespace:
 Examples of **incorrect** code for this rule:
 
 ```javascript
-var any = 'thing';
+var any\u00A0= 'thing';
 ```
 
 Examples of **correct** code for this rule:

--- a/internal/rules/no_irregular_whitespace/no_irregular_whitespace_test.go
+++ b/internal/rules/no_irregular_whitespace/no_irregular_whitespace_test.go
@@ -1,0 +1,698 @@
+package no_irregular_whitespace
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoIrregularWhitespace(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&NoIrregularWhitespaceRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Escaped Unicode in strings (no actual irregular chars) ----
+			{Code: `'\u000B';`},
+			{Code: `'\u000C';`},
+			{Code: `'\u0085';`},
+			{Code: `'\u00A0';`},
+			{Code: `'\u1680';`},
+			{Code: `'\u180E';`},
+			{Code: `'\ufeff';`},
+			{Code: `'\u2000';`},
+			{Code: `'\u2001';`},
+			{Code: `'\u2002';`},
+			{Code: `'\u2003';`},
+			{Code: `'\u2004';`},
+			{Code: `'\u2005';`},
+			{Code: `'\u2006';`},
+			{Code: `'\u2007';`},
+			{Code: `'\u2008';`},
+			{Code: `'\u2009';`},
+			{Code: `'\u200A';`},
+			{Code: `'\u200B';`},
+			{Code: `'\u2028';`},
+			{Code: `'\u2029';`},
+			{Code: `'\u202F';`},
+			{Code: `'\u205f';`},
+			{Code: `'\u3000';`},
+
+			// ---- Actual irregular whitespace inside strings (skipStrings default true) ----
+			{Code: "'\u000B';"},
+			{Code: "'\u000C';"},
+			{Code: "'\u0085';"},
+			{Code: "'\u00A0';"},
+			{Code: "'\u1680';"},
+			{Code: "'\u180E';"},
+			{Code: "'\uFEFF';"},
+			{Code: "'\u2000';"},
+			{Code: "'\u2001';"},
+			{Code: "'\u2002';"},
+			{Code: "'\u2003';"},
+			{Code: "'\u2004';"},
+			{Code: "'\u2005';"},
+			{Code: "'\u2006';"},
+			{Code: "'\u2007';"},
+			{Code: "'\u2008';"},
+			{Code: "'\u2009';"},
+			{Code: "'\u200A';"},
+			{Code: "'\u200B';"},
+			// Multiline strings with escaped backslash + line separator
+			{Code: "'\\\u2028';"},
+			{Code: "'\\\u2029';"},
+			{Code: "'\u202F';"},
+			{Code: "'\u205F';"},
+			{Code: "'\u3000';"},
+
+			// ---- skipComments: true (single-line) ----
+			{Code: "// \u000B", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u000C", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u0085", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u00A0", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u1680", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u180E", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \uFEFF", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2000", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2001", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2002", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2003", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2004", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2005", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2006", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2007", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2008", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u2009", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u200A", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u200B", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u202F", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u205F", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "// \u3000", Options: map[string]interface{}{"skipComments": true}},
+
+			// ---- skipComments: true (block) ----
+			{Code: "/* \u000B */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u000C */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u0085 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u00A0 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u1680 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u180E */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \uFEFF */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2000 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2001 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2002 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2003 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2004 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2005 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2006 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2007 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2008 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2009 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u200A */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u200B */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2028 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u2029 */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u202F */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u205F */", Options: map[string]interface{}{"skipComments": true}},
+			{Code: "/* \u3000 */", Options: map[string]interface{}{"skipComments": true}},
+
+			// ---- skipRegExps: true ----
+			{Code: "/\u000B/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u000C/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u0085/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u00A0/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u1680/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u180E/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\uFEFF/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2000/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2001/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2002/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2003/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2004/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2005/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2006/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2007/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2008/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u2009/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u200A/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u200B/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u202F/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u205F/", Options: map[string]interface{}{"skipRegExps": true}},
+			{Code: "/\u3000/", Options: map[string]interface{}{"skipRegExps": true}},
+
+			// ---- skipTemplates: true ----
+			{Code: "`\u000B`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u000C`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u0085`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u00A0`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u1680`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u180E`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\uFEFF`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2000`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2001`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2002`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2003`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2004`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2005`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2006`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2007`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2008`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u2009`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u200A`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u200B`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u202F`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u205F`", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "`\u3000`", Options: map[string]interface{}{"skipTemplates": true}},
+			// Template with expression
+			{Code: "`\u3000${foo}\u3000`", Options: map[string]interface{}{"skipTemplates": true}},
+			// Template in assignment
+			{Code: "const error = ` \u3000 `;", Options: map[string]interface{}{"skipTemplates": true}},
+			// Template with newlines
+			{Code: "const error = `\n\u3000`;", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "const error = `\u3000\n`;", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "const error = `\n\u3000\n`;", Options: map[string]interface{}{"skipTemplates": true}},
+			{Code: "const error = `foo\u3000bar\nfoo\u3000bar`;", Options: map[string]interface{}{"skipTemplates": true}},
+
+			// ---- skipJSXText: true ----
+			{Code: "<div>\u000B</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u000C</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u0085</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u00A0</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u1680</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u180E</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\uFEFF</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2000</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2001</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2002</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2003</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2004</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2005</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2006</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2007</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2008</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u2009</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u200A</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u200B</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u202F</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u205F</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+			{Code: "<div>\u3000</div>;", Tsx: true, Options: map[string]interface{}{"skipJSXText": true}},
+
+			// ---- Unicode BOM at start of file ----
+			{Code: "\uFEFFconsole.log('hello BOM');"},
+
+			// ---- No irregular whitespace ----
+			{Code: "var a = 1;"},
+			{Code: ""},
+
+			// ---- Options via array format (tests JSON round-trip) ----
+			{Code: "// \u00A0", Options: []interface{}{map[string]interface{}{"skipComments": true}}},
+
+			// ---- Extra: nested template with skipTemplates ----
+			{Code: "`outer ${ `inner\u3000` } outer`", Options: map[string]interface{}{"skipTemplates": true}},
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Irregular whitespace in code (all chars from upstream) ----
+			{
+				Code: "var any \u000B = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Message: "Irregular whitespace not allowed.", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u000C = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u00A0 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			// NOTE: upstream intentionally comments out \u180E (Mongolian Vowel Separator)
+			// because it was removed from General_Category=Zs in Unicode 6.3.0.
+			// We still detect it per the rule's regex, but don't add the upstream's
+			// commented-out var test.
+			{
+				Code: "var any \uFEFF = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2000 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2001 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2002 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2003 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2004 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2005 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2006 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2007 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2008 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2009 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u200A = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u2028 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code: "var any \u2029 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code: "var any \u202F = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u205F = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{
+				Code: "var any \u3000 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+
+			// ---- Multi-line with \u2028 line separators (from upstream) ----
+			{
+				Code: "var a = 'b',\u2028c = 'd',\ne = 'f'\u2028",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 13, EndLine: 2, EndColumn: 1},
+					{MessageId: "noIrregularWhitespace", Line: 3, Column: 8, EndLine: 4, EndColumn: 1},
+				},
+			},
+
+			// ---- Multiple errors on same/multiple lines (from upstream) ----
+			{
+				Code: "var any \u3000 = 'thing', other \u3000 = 'thing';\nvar third \u3000 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 28, EndLine: 1, EndColumn: 29},
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 11, EndLine: 2, EndColumn: 12},
+				},
+			},
+
+			// ---- Single-line comments (all 21 chars from upstream) ----
+			{Code: "// \u000B", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u000C", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u0085", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u00A0", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u180E", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \uFEFF", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2000", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2001", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2002", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2003", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2004", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2005", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2006", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2007", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2008", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u2009", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u200A", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u200B", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u202F", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u205F", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "// \u3000", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+
+			// ---- Block comments (all 23 chars from upstream, including \u2028/\u2029) ----
+			{Code: "/* \u000B */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u000C */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u0085 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u00A0 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u180E */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \uFEFF */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2000 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2001 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2002 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2003 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2004 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2005 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2006 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2007 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2008 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2009 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u200A */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u200B */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u2028 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 2, EndColumn: 1}}},
+			{Code: "/* \u2029 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 2, EndColumn: 1}}},
+			{Code: "/* \u202F */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u205F */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u3000 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+
+			// ---- Regex (from upstream) ----
+			{
+				Code: "var any = /\u3000/, other = /\u000B/;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+				},
+			},
+
+			// ---- skipStrings: false (from upstream) ----
+			{
+				Code:    "var any = '\u3000', other = '\u000B';",
+				Options: map[string]interface{}{"skipStrings": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+				},
+			},
+
+			// ---- Template literals (from upstream) ----
+			{
+				Code: "var any = `\u3000`, other = `\u000B`;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+				},
+			},
+			{
+				Code:    "var any = `\u3000`, other = `\u000B`;",
+				Options: map[string]interface{}{"skipTemplates": false},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 25, EndLine: 1, EndColumn: 26},
+				},
+			},
+
+			// ---- skipTemplates: true but irregular in expression part (from upstream) ----
+			{
+				Code:    "`something ${\u3000 10} another thing`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 14, EndLine: 1, EndColumn: 15},
+				},
+			},
+			{
+				Code:    "`something ${10\u3000} another thing`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 16, EndLine: 1, EndColumn: 17},
+				},
+			},
+
+			// ---- skipTemplates: true but irregular outside template (from upstream) ----
+			{
+				Code:    "\u3000\n`\u3000template`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "\u3000\n`\u3000multiline\ntemplate`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "\u3000`\u3000template`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "\u3000`\u3000multiline\ntemplate`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "`\u3000template`\u3000",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code:    "`\u3000multiline\ntemplate`\u3000",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 10, EndLine: 2, EndColumn: 11},
+				},
+			},
+			{
+				Code:    "`\u3000template`\n\u3000",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code:    "`\u3000multiline\ntemplate`\n\u3000",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 3, Column: 1, EndLine: 3, EndColumn: 2},
+				},
+			},
+
+			// ---- Full location tests (from upstream) ----
+			{
+				Code: "var foo = \u000B bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: "var foo =\u000Bbar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+			{
+				Code: "var foo = \u000B\u000B bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code: "var foo = \u000B\u000C bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 13},
+				},
+			},
+			{
+				Code: "var foo = \u000B \u000B bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 13, EndLine: 1, EndColumn: 14},
+				},
+			},
+			{
+				Code: "var foo = \u000Bbar\u000B;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 15, EndLine: 1, EndColumn: 16},
+				},
+			},
+			{
+				Code: "\u000B",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 1, EndColumn: 2},
+				},
+			},
+			{
+				Code: "\u00A0\u2002\u2003",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 1, EndColumn: 4},
+				},
+			},
+			{
+				Code: "var foo = \u000B\nbar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 12},
+				},
+			},
+			{
+				Code: "var foo =\u000B\n\u000Bbar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+			{
+				Code: "var foo = \u000C\u000B\n\u000C\u000B\u000Cbar\n;\u000B\u000C\n",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 1, EndColumn: 13},
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 1, EndLine: 2, EndColumn: 4},
+					{MessageId: "noIrregularWhitespace", Line: 3, Column: 2, EndLine: 3, EndColumn: 4},
+				},
+			},
+			// Line separator full location
+			{
+				Code: "var foo = \u2028bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 11, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code: "var foo =\u2029 bar;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 10, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code: "var foo = bar;\u2028",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 15, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code: "\u2029",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 1, EndLine: 2, EndColumn: 1},
+				},
+			},
+			{
+				Code: "foo\u2028\u2028",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 2, EndColumn: 1},
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code: "foo\u2029\u2028",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 2, EndColumn: 1},
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 1, EndLine: 3, EndColumn: 1},
+				},
+			},
+			{
+				Code: "foo\u2028\n\u2028",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 2, EndColumn: 1},
+					{MessageId: "noIrregularWhitespace", Line: 3, Column: 1, EndLine: 4, EndColumn: 1},
+				},
+			},
+			{
+				Code: "foo\u000B\u2028\u000B",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5},
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 5, EndLine: 2, EndColumn: 1},
+					{MessageId: "noIrregularWhitespace", Line: 2, Column: 1, EndLine: 2, EndColumn: 2},
+				},
+			},
+
+			// ---- JSX text (all 21 chars from upstream, skipJSXText default false) ----
+			{Code: "<div>\u000B</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u000C</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u0085</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u00A0</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u180E</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\uFEFF</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2000</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2001</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2002</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2003</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2004</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2005</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2006</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2007</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2008</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u2009</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u200A</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u200B</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u202F</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u205F</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+			{Code: "<div>\u3000</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+
+			// ---- Options via array format (tests JSON round-trip) ----
+			{
+				Code:    "var any = '\u3000';",
+				Options: []interface{}{map[string]interface{}{"skipStrings": false}},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 12, EndLine: 1, EndColumn: 13},
+				},
+			},
+
+			// ---- Extra: \u1680 (Ogham Space Mark) — not tested upstream but in the rule's char set ----
+			{
+				Code: "var any \u1680 = 'thing';",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 9, EndLine: 1, EndColumn: 10},
+				},
+			},
+			{Code: "// \u1680", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "/* \u1680 */", Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 4, EndLine: 1, EndColumn: 5}}},
+			{Code: "<div>\u1680</div>;", Tsx: true, Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7}}},
+
+			// ---- Extra: nested template with skipTemplates — irregular in outer expression ----
+			{
+				Code:    "`outer ${\u3000 `inner` } outer`",
+				Options: map[string]interface{}{"skipTemplates": true},
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
+				},
+			},
+		},
+	)
+}

--- a/internal/rules/no_irregular_whitespace/no_irregular_whitespace_test.go
+++ b/internal/rules/no_irregular_whitespace/no_irregular_whitespace_test.go
@@ -693,6 +693,30 @@ func TestNoIrregularWhitespace(t *testing.T) {
 					{MessageId: "noIrregularWhitespace", Line: 1, Column: 10, EndLine: 1, EndColumn: 11},
 				},
 			},
+
+			// ---- Extra: multi-byte chars before irregular WS — UTF-16 column verification ----
+			// CJK char (U+4E2D, 3 bytes UTF-8, 1 UTF-16 code unit)
+			{
+				Code: "var \u4e2d\u00A0= 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// Emoji (U+1F600, 4 bytes UTF-8, 2 UTF-16 code units / surrogate pair)
+			// Use comment context because tsgo doesn't support emoji in identifiers
+			{
+				Code: "// \U0001F600\u00A0",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 6, EndLine: 1, EndColumn: 7},
+				},
+			},
+			// Two CJK chars then irregular WS
+			{
+				Code: "var \u4e2d\u6587\u3000= 1;",
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIrregularWhitespace", Line: 1, Column: 7, EndLine: 1, EndColumn: 8},
+				},
+			},
 		},
 	)
 }

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
     './tests/eslint/rules/no-global-assign.test.ts',
     './tests/eslint/rules/no-import-assign.test.ts',
     './tests/eslint/rules/no-inner-declarations.test.ts',
+    './tests/eslint/rules/no-irregular-whitespace.test.ts',
     './tests/eslint/rules/no-new.test.ts',
     './tests/eslint/rules/no-new-func.test.ts',
     './tests/eslint/rules/no-new-object.test.ts',

--- a/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-irregular-whitespace.test.ts.snap
+++ b/packages/rslint-test-tools/tests/eslint/rules/__snapshots__/no-irregular-whitespace.test.ts.snap
@@ -1,0 +1,494 @@
+// Rstest Snapshot v1
+
+exports[`no-irregular-whitespace > invalid 1`] = `
+{
+  "code": "var any  = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 2`] = `
+{
+  "code": "var any   = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 3`] = `
+{
+  "code": "var any ﻿ = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 4`] = `
+{
+  "code": "var any 　 = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 5`] = `
+{
+  "code": "var any   = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 6`] = `
+{
+  "code": "var any   = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 1,
+          "line": 2,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 7`] = `
+{
+  "code": "var any 　 = 'thing', other 　 = 'thing';
+var third 　 = 'thing';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 10,
+          "line": 1,
+        },
+        "start": {
+          "column": 9,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 28,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 12,
+          "line": 2,
+        },
+        "start": {
+          "column": 11,
+          "line": 2,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 3,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 8`] = `
+{
+  "code": "// ",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 9`] = `
+{
+  "code": "/*   */",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 5,
+          "line": 1,
+        },
+        "start": {
+          "column": 4,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 10`] = `
+{
+  "code": "var any = /　/, other = //;",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 11`] = `
+{
+  "code": "var any = '　', other = '';",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 12`] = `
+{
+  "code": "var any = \`　\`, other = \`\`;",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 12,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 1,
+        },
+        "start": {
+          "column": 25,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 2,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 13`] = `
+{
+  "code": "\`something \${　 10} another thing\`",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 15,
+          "line": 1,
+        },
+        "start": {
+          "column": 14,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 14`] = `
+{
+  "code": "　
+\`　template\`",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 15`] = `
+{
+  "code": "var foo =  bar;",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 13,
+          "line": 1,
+        },
+        "start": {
+          "column": 11,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;
+
+exports[`no-irregular-whitespace > invalid 16`] = `
+{
+  "code": "",
+  "diagnostics": [
+    {
+      "message": "Irregular whitespace not allowed.",
+      "messageId": "noIrregularWhitespace",
+      "range": {
+        "end": {
+          "column": 2,
+          "line": 1,
+        },
+        "start": {
+          "column": 1,
+          "line": 1,
+        },
+      },
+      "ruleName": "no-irregular-whitespace",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "ruleCount": 1,
+}
+`;

--- a/packages/rslint-test-tools/tests/eslint/rules/no-irregular-whitespace.test.ts
+++ b/packages/rslint-test-tools/tests/eslint/rules/no-irregular-whitespace.test.ts
@@ -1,0 +1,155 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-irregular-whitespace', {
+  valid: [
+    // Escaped Unicode in strings (no actual irregular chars)
+    `'\\u000B';`,
+    `'\\u00A0';`,
+    `'\\u3000';`,
+
+    // Actual irregular whitespace inside strings (skipStrings default true)
+    "'\u000B';",
+    "'\u000C';",
+    "'\u0085';",
+    "'\u00A0';",
+    "'\u180E';",
+    "'\uFEFF';",
+    "'\u2000';",
+    "'\u200B';",
+    "'\u202F';",
+    "'\u205F';",
+    "'\u3000';",
+
+    // skipComments: true
+    { code: '// \u000B', options: { skipComments: true } },
+    { code: '// \u00A0', options: { skipComments: true } },
+    { code: '// \u3000', options: { skipComments: true } },
+    { code: '/* \u000B */', options: { skipComments: true } },
+    { code: '/* \u00A0 */', options: { skipComments: true } },
+    { code: '/* \u3000 */', options: { skipComments: true } },
+
+    // skipRegExps: true
+    { code: '/\u000B/', options: { skipRegExps: true } },
+    { code: '/\u00A0/', options: { skipRegExps: true } },
+    { code: '/\u3000/', options: { skipRegExps: true } },
+
+    // skipTemplates: true
+    { code: '`\u000B`', options: { skipTemplates: true } },
+    { code: '`\u00A0`', options: { skipTemplates: true } },
+    { code: '`\u3000`', options: { skipTemplates: true } },
+    { code: '`\u3000${foo}\u3000`', options: { skipTemplates: true } },
+    { code: 'const error = ` \u3000 `;', options: { skipTemplates: true } },
+    { code: 'const error = `\n\u3000`;', options: { skipTemplates: true } },
+
+    // Unicode BOM at start of file
+    '\uFEFFconsole.log("hello BOM");',
+
+    // No irregular whitespace
+    'var a = 1;',
+  ],
+  invalid: [
+    // Irregular whitespace in code
+    {
+      code: "var any \u000B = 'thing';",
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+    {
+      code: "var any \u00A0 = 'thing';",
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+    {
+      code: "var any \uFEFF = 'thing';",
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+    {
+      code: "var any \u3000 = 'thing';",
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+
+    // Line separators
+    {
+      code: "var any \u2028 = 'thing';",
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+    {
+      code: "var any \u2029 = 'thing';",
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+
+    // Multiple errors
+    {
+      code: "var any \u3000 = 'thing', other \u3000 = 'thing';\nvar third \u3000 = 'thing';",
+      errors: [
+        { messageId: 'noIrregularWhitespace' },
+        { messageId: 'noIrregularWhitespace' },
+        { messageId: 'noIrregularWhitespace' },
+      ],
+    },
+
+    // Comments (default skipComments: false)
+    {
+      code: '// \u000B',
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+    {
+      code: '/* \u00A0 */',
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+
+    // Regex (default skipRegExps: false)
+    {
+      code: 'var any = /\u3000/, other = /\u000B/;',
+      errors: [
+        { messageId: 'noIrregularWhitespace' },
+        { messageId: 'noIrregularWhitespace' },
+      ],
+    },
+
+    // skipStrings: false
+    {
+      code: "var any = '\u3000', other = '\u000B';",
+      options: { skipStrings: false },
+      errors: [
+        { messageId: 'noIrregularWhitespace' },
+        { messageId: 'noIrregularWhitespace' },
+      ],
+    },
+
+    // Template literals (default skipTemplates: false)
+    {
+      code: 'var any = `\u3000`, other = `\u000B`;',
+      errors: [
+        { messageId: 'noIrregularWhitespace' },
+        { messageId: 'noIrregularWhitespace' },
+      ],
+    },
+
+    // skipTemplates: true but irregular in expression part
+    {
+      code: '`something ${\u3000 10} another thing`',
+      options: { skipTemplates: true },
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+
+    // skipTemplates: true but irregular outside template
+    {
+      code: '\u3000\n`\u3000template`',
+      options: { skipTemplates: true },
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+
+    // Consecutive irregular chars
+    {
+      code: 'var foo = \u000B\u000B bar;',
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+
+    // Just an irregular char
+    {
+      code: '\u000B',
+      errors: [{ messageId: 'noIrregularWhitespace' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -11,6 +11,7 @@ assertee
 autofixers
 auvred
 bazz
+Bbar
 benchtime
 bigints
 binaryexpression
@@ -19,6 +20,7 @@ bmatcuk
 bodyless
 cachedvfs
 callees
+Cbar
 catchable
 clazz
 clientrc


### PR DESCRIPTION
## Summary

Port the `no-irregular-whitespace` rule from ESLint to rslint.

Disallows irregular whitespace characters outside of strings, comments, regular expressions, template literals, and JSX text. Supports all 5 options: `skipStrings` (default `true`), `skipComments`, `skipRegExps`, `skipTemplates`, `skipJSXText` (all default `false`).

## Related Links

- ESLint rule: https://eslint.org/docs/latest/rules/no-irregular-whitespace
- Source code: https://github.com/eslint/eslint/blob/main/lib/rules/no-irregular-whitespace.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).