### PR TITLE
feat: port rule react/jsx-no-script-url

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -44,6 +44,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_comment_textnodes"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_script_url"
 )
 
 func GetAllRules() []rule.Rule {
@@ -89,5 +90,6 @@ func GetAllRules() []rule.Rule {
 		style_prop_object.StylePropObjectRule,
 		void_dom_elements_no_children.VoidDomElementsNoChildrenRule,
 		jsx_no_comment_textnodes.JsxNoCommentTextnodesRule,
+		jsx_no_script_url.JsxNoScriptUrlRule,
 	}
 }

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -2,6 +2,7 @@ package reactutil
 
 import (
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -1196,4 +1197,97 @@ func IsDOMComponent(element *ast.Node) bool {
 	}
 	first := text[0]
 	return first >= 'a' && first <= 'z'
+}
+
+// ComponentMap maps a component tag name (e.g. "a", "Link") to the set of
+// attribute names that identify its link target (e.g. ["href"] or ["to"]).
+type ComponentMap map[string][]string
+
+// DefaultLinkComponents returns the default link-component map: {"a": ["href"]}.
+func DefaultLinkComponents() ComponentMap {
+	return ComponentMap{"a": {"href"}}
+}
+
+// DefaultFormComponents returns the default form-component map: {"form": ["action"]}.
+func DefaultFormComponents() ComponentMap {
+	return ComponentMap{"form": {"action"}}
+}
+
+// ReadComponentsFromSettings extracts a component-name→attribute-list map
+// from `settings.<key>`, matching upstream `util/linkComponents`.
+//
+// Upstream builds the map via `new Map(DEFAULT.concat(settings[key]).map(…))`,
+// where same-key entries use last-wins (replace) semantics. This function
+// mirrors that: a settings entry for an already-present component replaces
+// the base entry entirely.
+//
+// Shapes accepted (each entry may appear standalone or as an element of an
+// outer array, mirroring upstream's `DEFAULT.concat(settings[key] || [])`):
+//
+//   - string: "Link"                                    → {Link: [defaultAttr]}
+//   - {name, <attrField>}: <attrField> string or []str  → {name: [attr…]}
+//
+// `attrField` is "linkAttribute" for linkComponents and "formAttribute" for
+// formComponents — upstream uses distinct field names for each category
+// (`value.linkAttribute` vs `value.formAttribute`), so getting this wrong
+// would silently fall back to the default attribute for every custom form
+// component the user configures.
+func ReadComponentsFromSettings(settings map[string]interface{}, key, attrField, defaultAttr string, base ComponentMap) ComponentMap {
+	out := ComponentMap{}
+	for k, v := range base {
+		out[k] = slices.Clone(v)
+	}
+	if settings == nil {
+		return out
+	}
+	raw, ok := settings[key]
+	if !ok {
+		return out
+	}
+	// addOne mirrors upstream's per-entry mapper inside the Map constructor.
+	// Each entry REPLACES any previous entry with the same name (last-wins),
+	// matching `new Map([...pairs])` semantics.
+	addOne := func(entry interface{}) {
+		switch e := entry.(type) {
+		case string:
+			out[e] = []string{defaultAttr}
+		case map[string]interface{}:
+			name, _ := e["name"].(string)
+			if name == "" {
+				return
+			}
+			var attrs []string
+			// Mirrors upstream's `[].concat(value[attrField])` coercion:
+			// string → single-element list, array → as-is, missing → empty
+			// (which we backfill with the default attribute).
+			switch la := e[attrField].(type) {
+			case string:
+				attrs = []string{la}
+			case []interface{}:
+				for _, v := range la {
+					if s, ok := v.(string); ok {
+						attrs = append(attrs, s)
+					}
+				}
+			}
+			if len(attrs) == 0 {
+				attrs = []string{defaultAttr}
+			}
+			out[name] = attrs
+		}
+	}
+	// Upstream accepts either a single entry (string/object) or an array of
+	// them at `settings[key]`. JS's `[].concat(x)` flattens both into the
+	// final list; we mirror that by accepting either shape here.
+	switch r := raw.(type) {
+	case string:
+		addOne(r)
+	case map[string]interface{}:
+		addOne(r)
+	case []interface{}:
+		for _, entry := range r {
+			addOne(entry)
+		}
+	}
+	return out
 }

--- a/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.go
+++ b/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.go
@@ -1,0 +1,178 @@
+package jsx_no_script_url
+
+import (
+	"regexp"
+	"slices"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+// isJavaScriptProtocol matches the `javascript:` scheme with optional control
+// characters (\u0000-\u001F) and spaces before the scheme, and optional \r \n
+// \t characters between the letters. Case-insensitive. Mirrors React's
+// sanitizeURL check:
+// https://github.com/facebook/react/blob/d0ebde77f6d1232cefc0da184d731943d78e86f2/packages/react-dom/src/shared/sanitizeURL.js#L30
+var isJavaScriptProtocol = regexp.MustCompile(
+	`(?i)^[\x00-\x1f ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:`)
+
+const noScriptURLMessage = "A future version of React will block javascript: URLs as a security precaution. " +
+	"Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead."
+
+var JsxNoScriptUrlRule = rule.Rule{
+	Name: "react/jsx-no-script-url",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		config := parseConfig(options, ctx.Settings)
+
+		return rule.RuleListeners{
+			ast.KindJsxAttribute: func(node *ast.Node) {
+				if !shouldVerifyProp(node, config) {
+					return
+				}
+				if !hasJavaScriptProtocol(node) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{
+					Id:          "noScriptURL",
+					Description: noScriptURLMessage,
+				})
+			},
+		}
+	},
+}
+
+// hasJavaScriptProtocol reports whether the attribute value is a string literal
+// that starts with the `javascript:` protocol. Only direct string literals are
+// checked — expression containers like `href={"javascript:"}` are not flagged,
+// matching upstream behavior.
+func hasJavaScriptProtocol(attr *ast.Node) bool {
+	init := attr.AsJsxAttribute().Initializer
+	if init == nil {
+		return false
+	}
+	if init.Kind != ast.KindStringLiteral {
+		return false
+	}
+	return isJavaScriptProtocol.MatchString(init.AsStringLiteral().Text)
+}
+
+// shouldVerifyProp reports whether a JsxAttribute should be checked for
+// javascript: URLs based on the component/prop configuration. Upstream uses
+// `node.parent.name.name` which resolves to:
+//   - Identifier tag: the element name (e.g. "a", "Link")
+//   - JsxNamespacedName tag: the local part (e.g. "a" in "ns:a")
+//   - MemberExpression tag: undefined (not matched)
+func shouldVerifyProp(node *ast.Node, config reactutil.ComponentMap) bool {
+	attrName := reactutil.GetJsxPropName(node)
+	if attrName == "" {
+		return false
+	}
+	parent := reactutil.GetJsxParentElement(node)
+	if parent == nil {
+		return false
+	}
+	tagName := reactutil.GetJsxTagName(parent)
+	if tagName == nil {
+		return false
+	}
+	var parentName string
+	switch tagName.Kind {
+	case ast.KindIdentifier:
+		parentName = tagName.AsIdentifier().Text
+	case ast.KindJsxNamespacedName:
+		// Upstream: node.parent.name.name on a JSXNamespacedName returns
+		// the local part (e.g., "a" for <ns:a>).
+		ns := tagName.AsJsxNamespacedName()
+		nameNode := ns.Name()
+		if nameNode != nil && nameNode.Kind == ast.KindIdentifier {
+			parentName = nameNode.AsIdentifier().Text
+		}
+	default:
+		return false
+	}
+	if parentName == "" {
+		return false
+	}
+	props, ok := config[parentName]
+	if !ok {
+		return false
+	}
+	return slices.Contains(props, attrName)
+}
+
+// parseConfig builds the component→props map from rule options and settings.
+//
+// Options format (after config.go unwrapping):
+//   - nil → default {"a": ["href"]}
+//   - map{"includeFromSettings": true} → merge settings
+//   - [{name, props}, ...] → legacy custom components
+//   - [[{name, props}, ...], {includeFromSettings: true}] → both
+func parseConfig(options any, settings map[string]interface{}) reactutil.ComponentMap {
+	var legacyOptions []interface{}
+	includeFromSettings := false
+
+	switch opts := options.(type) {
+	case nil:
+		// no options
+	case map[string]interface{}:
+		// Object option only: {includeFromSettings: true}
+		if v, ok := opts["includeFromSettings"].(bool); ok {
+			includeFromSettings = v
+		}
+	case []interface{}:
+		if len(opts) > 0 {
+			if inner, ok := opts[0].([]interface{}); ok {
+				// Shape: [[{name, props}, ...], {includeFromSettings}]
+				legacyOptions = inner
+				if len(opts) > 1 {
+					if objOpt, ok := opts[1].(map[string]interface{}); ok {
+						if v, ok := objOpt["includeFromSettings"].(bool); ok {
+							includeFromSettings = v
+						}
+					}
+				}
+			} else {
+				// Shape: [{name, props}, ...] — config.go unwrapped single-element
+				legacyOptions = opts
+			}
+		}
+	}
+
+	// Start with defaults, optionally merging settings.
+	var config reactutil.ComponentMap
+	if includeFromSettings {
+		config = reactutil.ReadComponentsFromSettings(
+			settings, "linkComponents", "linkAttribute", "href",
+			reactutil.DefaultLinkComponents())
+	} else {
+		config = reactutil.DefaultLinkComponents()
+	}
+
+	// Merge legacy option components. Upstream uses config.set(name, props)
+	// which REPLACES the entry — if a legacy option redefines "a", the
+	// default ["href"] is dropped entirely.
+	for _, opt := range legacyOptions {
+		item, ok := opt.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		name, _ := item["name"].(string)
+		if name == "" {
+			continue
+		}
+		propsRaw, ok := item["props"].([]interface{})
+		if !ok {
+			continue
+		}
+		var props []string
+		for _, p := range propsRaw {
+			if s, ok := p.(string); ok {
+				props = append(props, s)
+			}
+		}
+		config[name] = props
+	}
+
+	return config
+}

--- a/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.md
+++ b/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url.md
@@ -1,0 +1,67 @@
+# react/jsx-no-script-url
+
+## Rule Details
+
+Disallow usage of `javascript:` URLs in JSX attributes. In React 16.9, any URLs starting with `javascript:` log a warning. In a future major release, React will throw an error if it encounters a `javascript:` URL.
+
+By default, this rule checks the `href` attribute of the `<a>` element. Additional components and attributes can be configured via options.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<a href="javascript:"></a>
+<a href="javascript:void(0)"></a>
+<a href="j
+a
+v	ascript:"></a>
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+<a href="https://reactjs.org"></a>
+<a href="mailto:foo@bar.com"></a>
+<a href="#"></a>
+<a href={"javascript:"}></a>
+<Foo href="javascript:"></Foo>
+```
+
+## Options
+
+This rule accepts an optional array of custom component configurations and an optional object option.
+
+### Array option (default `[]`)
+
+```json
+{ "react/jsx-no-script-url": ["error", [{ "name": "Link", "props": ["to"] }, { "name": "Foo", "props": ["href", "to"] }]] }
+```
+
+Allows you to indicate a specific list of properties used by a custom component to be checked.
+
+Examples of **incorrect** code with the above options:
+
+```jsx
+<Link to="javascript:void(0)"></Link>
+<Foo href="javascript:void(0)"></Foo>
+<Foo to="javascript:void(0)"></Foo>
+```
+
+### Object option
+
+#### `includeFromSettings` (default `false`)
+
+Indicates if the `linkComponents` config in shared settings should also be taken into account. If enabled, components and properties defined in settings will be added to the list provided in the first option (if provided).
+
+```json
+{ "react/jsx-no-script-url": ["error", [{ "name": "Link", "props": ["to"] }], { "includeFromSettings": true }] }
+```
+
+If only settings should be used, the array option can be omitted:
+
+```json
+{ "react/jsx-no-script-url": ["error", { "includeFromSettings": true }] }
+```
+
+## Original Documentation
+
+- [eslint-plugin-react/jsx-no-script-url](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-script-url.md)

--- a/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url_test.go
+++ b/internal/plugins/react/rules/jsx_no_script_url/jsx_no_script_url_test.go
@@ -1,0 +1,422 @@
+package jsx_no_script_url
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoScriptUrl(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoScriptUrlRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases ----
+		{Code: `<a href="https://reactjs.org"></a>`, Tsx: true},
+		{Code: `<a href="mailto:foo@bar.com"></a>`, Tsx: true},
+		{Code: `<a href="#"></a>`, Tsx: true},
+		{Code: `<a href=""></a>`, Tsx: true},
+		{Code: `<a name="foo"></a>`, Tsx: true},
+		// Expression container — upstream only checks Literal, not JSXExpressionContainer
+		{Code: `<a href={"javascript:"}></a>`, Tsx: true},
+		// User component without config — not matched
+		{Code: `<Foo href="javascript:"></Foo>`, Tsx: true},
+		// Boolean shorthand — no value
+		{Code: `<a href />`, Tsx: true},
+		// Custom component with non-matching attribute name
+		{
+			Code:    `<Foo other="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo", "props": []interface{}{"to", "href"}}},
+			Tsx:     true,
+		},
+		// Settings cases — includeFromSettings defaults to false
+		{
+			Code: `<Foo href="javascript:"></Foo>`,
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Tsx: true,
+		},
+		// includeFromSettings explicitly false — settings not read
+		{
+			Code:    `<Foo href="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": false},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Tsx: true,
+		},
+		// includeFromSettings true, but attribute doesn't match
+		{
+			Code:    `<Foo other="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Tsx: true,
+		},
+
+		// Empty legacy array + includeFromSettings false — settings not used
+		{
+			Code: `<Foo href="javascript:"></Foo>`,
+			Options: []interface{}{
+				[]interface{}{},
+				map[string]interface{}{"includeFromSettings": false},
+			},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Tsx: true,
+		},
+		// Empty legacy array + includeFromSettings true, non-matching attribute
+		{
+			Code: `<Foo other="javascript:"></Foo>`,
+			Options: []interface{}{
+				[]interface{}{},
+				map[string]interface{}{"includeFromSettings": true},
+			},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Tsx: true,
+		},
+		// Legacy option redefines "a" with only "to" — "href" is replaced, not appended
+		{
+			Code:    `<a href="javascript:"></a>`,
+			Options: []interface{}{map[string]interface{}{"name": "a", "props": []interface{}{"to"}}},
+			Tsx:     true,
+		},
+
+		// ---- Additional edge cases ----
+		// Template literal — not a Literal node, not flagged
+		{Code: "<a href={`javascript:`}></a>", Tsx: true},
+		// Number value — not a string literal
+		{Code: `<a href={0}></a>`, Tsx: true},
+		// Null/undefined — no value
+		{Code: `<a href={null}></a>`, Tsx: true},
+		// Member expression tag — upstream doesn't match these
+		{Code: `<Foo.Bar href="javascript:"></Foo.Bar>`, Tsx: true},
+		// Spread attribute — not a JsxAttribute
+		{Code: `const x: any = {href: "javascript:"}; <a {...x}></a>;`, Tsx: true},
+		// Non-javascript protocol that starts with "j"
+		{Code: `<a href="jot:something"></a>`, Tsx: true},
+		// Close but not javascript: protocol
+		{Code: `<a href="javas:void(0)"></a>`, Tsx: true},
+		// Uppercase element name — config is case-sensitive, "A" ≠ "a"
+		{Code: `<A href="javascript:"></A>`, Tsx: true},
+		// Paren-wrapped expression container — NOT a direct StringLiteral
+		{Code: `<a href={("javascript:")}></a>`, Tsx: true},
+		// Settings override "a" with only "to" — "href" is replaced
+		{
+			Code:    `<a href="javascript:"></a>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "a", "linkAttribute": "to"},
+				},
+			},
+			Tsx: true,
+		},
+		// Settings as single object (not array)
+		{
+			Code:    `<Foo other="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "Foo", "linkAttribute": "to"},
+			},
+			Tsx: true,
+		},
+		// Settings as single string (not array)
+		{
+			Code:    `<Link other="javascript:"></Link>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": "Link",
+			},
+			Tsx: true,
+		},
+		// Malformed legacy option: missing props
+		{
+			Code:    `<Foo href="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo"}},
+			Tsx:     true,
+		},
+		// Malformed legacy option: missing name
+		{
+			Code:    `<Foo href="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"props": []interface{}{"href"}}},
+			Tsx:     true,
+		},
+		// Malformed legacy option: props is string instead of array
+		{
+			Code:    `<Foo href="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo", "props": "href"}},
+			Tsx:     true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid cases ----
+		// Defaults — with full position assertion (EndLine/EndColumn)
+		{
+			Code:   `<a href="javascript:"></a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4, EndLine: 1, EndColumn: 22}},
+			Tsx:    true,
+		},
+		{
+			Code:   `<a href="javascript:void(0)"></a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		{
+			Code:   "<a href=\"j\n\n\na\rv\tascript:\"></a>",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		// With component passed by options
+		{
+			Code:    `<Foo to="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo", "props": []interface{}{"to", "href"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:     true,
+		},
+		{
+			Code:    `<Foo href="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo", "props": []interface{}{"to", "href"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:     true,
+		},
+		// Default "a" is still checked even when custom components are specified
+		{
+			Code:    `<a href="javascript:void(0)"></a>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo", "props": []interface{}{"to", "href"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:     true,
+		},
+		// With components passed by settings (includeFromSettings: true)
+		{
+			Code:    `<Foo to="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": "to"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:    true,
+		},
+		{
+			Code:    `<Foo href="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:    true,
+		},
+		// Settings + legacy options combined
+		{
+			Code: `
+			<div>
+				<Foo href="javascript:"></Foo>
+				<Bar link="javascript:"></Bar>
+			</div>
+			`,
+			Options: []interface{}{
+				[]interface{}{map[string]interface{}{"name": "Bar", "props": []interface{}{"link"}}},
+				map[string]interface{}{"includeFromSettings": true},
+			},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noScriptURL"},
+				{MessageId: "noScriptURL"},
+			},
+			Tsx: true,
+		},
+		// Settings without includeFromSettings — only legacy options apply
+		{
+			Code: `
+			<div>
+				<Foo href="javascript:"></Foo>
+				<Bar link="javascript:"></Bar>
+			</div>
+			`,
+			Options: []interface{}{
+				[]interface{}{map[string]interface{}{"name": "Bar", "props": []interface{}{"link"}}},
+			},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": []interface{}{"to", "href"}},
+				},
+			},
+			// Only Bar fires — Foo is in settings but includeFromSettings is false
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noScriptURL"},
+			},
+			Tsx: true,
+		},
+
+		// ---- Additional edge cases ----
+		// Case insensitive
+		{
+			Code:   `<a href="JAVASCRIPT:void(0)"></a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		{
+			Code:   `<a href="JavaScript:void(0)"></a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		// Control chars before javascript:
+		{
+			Code:   "<a href=\"\x01javascript:\"></a>",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		// Spaces before javascript:
+		{
+			Code:   `<a href="  javascript:"></a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		// Tab and newline between javascript: letters
+		{
+			Code:   "<a href=\"j\ta\nv\ra\tscript:\"></a>",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		// Message text assertion
+		{
+			Code: `<a href="javascript:"></a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{
+				MessageId: "noScriptURL",
+				Message:   noScriptURLMessage,
+				Line:      1,
+				Column:    4,
+			}},
+			Tsx: true,
+		},
+		// Namespaced tag — upstream resolves local part "a", matches default config
+		{
+			Code:   `<ns:a href="javascript:"></ns:a>`,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 7}},
+			Tsx:    true,
+		},
+		// Multiple custom components
+		{
+			Code: `<Link to="javascript:"></Link>`,
+			Options: []interface{}{
+				map[string]interface{}{"name": "Link", "props": []interface{}{"to"}},
+				map[string]interface{}{"name": "Button", "props": []interface{}{"href"}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 7}},
+			Tsx:    true,
+		},
+		// Options via JSON path (map format — matches config.go single-option unwrap)
+		{
+			Code:    `<Foo to="javascript:"></Foo>`,
+			Options: []interface{}{map[string]interface{}{"name": "Foo", "props": []interface{}{"to"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:     true,
+		},
+		// Multiline — full position assertion including EndLine/EndColumn
+		{
+			Code:   "<a\n\thref=\"javascript:void(0)\">\n</a>",
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 2, Column: 2, EndLine: 2, EndColumn: 27}},
+			Tsx:    true,
+		},
+		// Nested JSX — both fire independently
+		{
+			Code: `<div><a href="javascript:"><a href="javascript:void(0)"></a></a></div>`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noScriptURL"},
+				{MessageId: "noScriptURL"},
+			},
+			Tsx: true,
+		},
+		// Settings with string-only component entry
+		{
+			Code:    `<Link href="javascript:"></Link>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{"Link"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 7}},
+			Tsx:    true,
+		},
+		// Legacy option redefines "a" with ["href", "to"] — "to" now fires too
+		{
+			Code:    `<a to="javascript:"></a>`,
+			Options: []interface{}{map[string]interface{}{"name": "a", "props": []interface{}{"href", "to"}}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:     true,
+		},
+		// Settings with linkAttribute as string (not array)
+		{
+			Code:    `<Foo to="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "Foo", "linkAttribute": "to"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:    true,
+		},
+		// Settings as single object (not array) — triggers addOne directly
+		{
+			Code:    `<Foo to="javascript:"></Foo>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": map[string]interface{}{"name": "Foo", "linkAttribute": "to"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:    true,
+		},
+		// Settings as single string — component gets default attr "href"
+		{
+			Code:    `<Link href="javascript:"></Link>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": "Link",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 7}},
+			Tsx:    true,
+		},
+		// Settings override "a" to only check "to" — "href" no longer flagged, "to" is
+		{
+			Code:    `<a to="javascript:"></a>`,
+			Options: map[string]interface{}{"includeFromSettings": true},
+			Settings: map[string]interface{}{
+				"linkComponents": []interface{}{
+					map[string]interface{}{"name": "a", "linkAttribute": "to"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 4}},
+			Tsx:    true,
+		},
+		// Multiple legacy options for same name — last wins (set semantics)
+		{
+			Code: `<Foo to="javascript:"></Foo>`,
+			Options: []interface{}{
+				map[string]interface{}{"name": "Foo", "props": []interface{}{"href"}},
+				map[string]interface{}{"name": "Foo", "props": []interface{}{"to"}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noScriptURL", Line: 1, Column: 6}},
+			Tsx:    true,
+		},
+	})
+}

--- a/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.go
+++ b/internal/plugins/react/rules/jsx_no_target_blank/jsx_no_target_blank.go
@@ -58,97 +58,6 @@ func parseOptions(raw any) options {
 	return opts
 }
 
-// componentMap maps a component tag name (e.g. "a", "Link") to the set of
-// attribute names that identify its link target (e.g. ["href"] or ["to"]).
-type componentMap map[string][]string
-
-func newDefaultLinkComponents() componentMap {
-	return componentMap{"a": {"href"}}
-}
-
-func newDefaultFormComponents() componentMap {
-	return componentMap{"form": {"action"}}
-}
-
-// readComponentsFromSettings extracts a component-name→attribute-list map
-// from `settings.<key>`, matching upstream `util/linkComponents`.
-//
-// Shapes accepted (each entry may appear standalone or as an element of an
-// outer array, mirroring upstream's `DEFAULT.concat(settings[key] || [])`):
-//
-//   - string: "Link"                                    → {Link: [defaultAttr]}
-//   - {name, <attrField>}: <attrField> string or []str  → {name: [attr…]}
-//
-// `attrField` is "linkAttribute" for linkComponents and "formAttribute" for
-// formComponents — upstream uses distinct field names for each category
-// (`value.linkAttribute` vs `value.formAttribute`), so getting this wrong
-// would silently fall back to the default attribute for every custom form
-// component the user configures.
-func readComponentsFromSettings(settings map[string]interface{}, key, attrField, defaultAttr string, base componentMap) componentMap {
-	out := componentMap{}
-	for k, v := range base {
-		out[k] = slices.Clone(v)
-	}
-	if settings == nil {
-		return out
-	}
-	raw, ok := settings[key]
-	if !ok {
-		return out
-	}
-	addOne := func(entry interface{}) {
-		switch e := entry.(type) {
-		case string:
-			out[e] = appendUnique(out[e], defaultAttr)
-		case map[string]interface{}:
-			name, _ := e["name"].(string)
-			if name == "" {
-				return
-			}
-			var attrs []string
-			// Mirrors upstream's `[].concat(value[attrField])` coercion:
-			// string → single-element list, array → as-is, missing → empty
-			// (which we backfill with the default attribute).
-			switch la := e[attrField].(type) {
-			case string:
-				attrs = []string{la}
-			case []interface{}:
-				for _, v := range la {
-					if s, ok := v.(string); ok {
-						attrs = append(attrs, s)
-					}
-				}
-			}
-			if len(attrs) == 0 {
-				attrs = []string{defaultAttr}
-			}
-			for _, a := range attrs {
-				out[name] = appendUnique(out[name], a)
-			}
-		}
-	}
-	// Upstream accepts either a single entry (string/object) or an array of
-	// them at `settings[key]`. JS's `[].concat(x)` flattens both into the
-	// final list; we mirror that by accepting either shape here.
-	switch r := raw.(type) {
-	case string:
-		addOne(r)
-	case map[string]interface{}:
-		addOne(r)
-	case []interface{}:
-		for _, entry := range r {
-			addOne(entry)
-		}
-	}
-	return out
-}
-
-func appendUnique(list []string, s string) []string {
-	if slices.Contains(list, s) {
-		return list
-	}
-	return append(list, s)
-}
 
 // jsxExpressionInner unwraps a JsxExpression container and transparently
 // skips ParenthesizedExpression wrappers on its payload. tsgo preserves
@@ -508,8 +417,8 @@ var JsxNoTargetBlankRule = rule.Rule{
 	Name: "react/jsx-no-target-blank",
 	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
 		opts := parseOptions(rawOptions)
-		linkComponents := readComponentsFromSettings(ctx.Settings, "linkComponents", "linkAttribute", "href", newDefaultLinkComponents())
-		formComponents := readComponentsFromSettings(ctx.Settings, "formComponents", "formAttribute", "action", newDefaultFormComponents())
+		linkComponents := reactutil.ReadComponentsFromSettings(ctx.Settings, "linkComponents", "linkAttribute", "href", reactutil.DefaultLinkComponents())
+		formComponents := reactutil.ReadComponentsFromSettings(ctx.Settings, "formComponents", "formAttribute", "action", reactutil.DefaultFormComponents())
 
 		messageId := "noTargetBlankWithoutNoreferrer"
 		description := msgNoreferrer

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -95,6 +95,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-script-url.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',
     './tests/eslint-plugin-react/rules/jsx-pascal-case.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-script-url.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-script-url.test.ts
@@ -1,0 +1,99 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-script-url', {} as never, {
+  valid: [
+    // ---- Upstream valid cases ----
+    { code: `<a href="https://reactjs.org"></a>` },
+    { code: `<a href="mailto:foo@bar.com"></a>` },
+    { code: `<a href="#"></a>` },
+    { code: `<a href=""></a>` },
+    { code: `<a name="foo"></a>` },
+    { code: `<a href={"javascript:"}></a>` },
+    { code: `<Foo href="javascript:"></Foo>` },
+    { code: `<a href />` },
+    {
+      code: `<Foo other="javascript:"></Foo>`,
+      options: [[{ name: 'Foo', props: ['to', 'href'] }]],
+    },
+
+    // ---- Additional edge cases ----
+    // Template literal — not flagged
+    { code: '<a href={`javascript:`}></a>' },
+    // Member expression tag — not matched
+    { code: `<Foo.Bar href="javascript:"></Foo.Bar>` },
+    // Spread — not a JsxAttribute
+    { code: `const x: any = {href: "javascript:"}; <a {...x}></a>;` },
+    // Non-javascript protocol
+    { code: `<a href="jot:something"></a>` },
+  ],
+  invalid: [
+    // ---- Upstream invalid cases ----
+    {
+      code: `<a href="javascript:"></a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    {
+      code: `<a href="javascript:void(0)"></a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    {
+      code: '<a href="j\n\n\na\rv\tascript:"></a>',
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    // With component passed by options
+    {
+      code: `<Foo to="javascript:"></Foo>`,
+      errors: [{ message: /javascript: URLs/ }],
+      options: [[{ name: 'Foo', props: ['to', 'href'] }]],
+    },
+    {
+      code: `<Foo href="javascript:"></Foo>`,
+      errors: [{ message: /javascript: URLs/ }],
+      options: [[{ name: 'Foo', props: ['to', 'href'] }]],
+    },
+    {
+      code: `<a href="javascript:void(0)"></a>`,
+      errors: [{ message: /javascript: URLs/ }],
+      options: [[{ name: 'Foo', props: ['to', 'href'] }]],
+    },
+
+    // ---- Additional edge cases ----
+    // Case insensitive
+    {
+      code: `<a href="JAVASCRIPT:void(0)"></a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    {
+      code: `<a href="JavaScript:void(0)"></a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    // Spaces before javascript:
+    {
+      code: `<a href="  javascript:"></a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    // Namespaced tag — local part "a" matches default config
+    {
+      code: `<ns:a href="javascript:"></ns:a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    // Multiple custom components
+    {
+      code: `<Link to="javascript:"></Link>`,
+      options: [
+        [
+          { name: 'Link', props: ['to'] },
+          { name: 'Button', props: ['href'] },
+        ],
+      ],
+      errors: [{ message: /javascript: URLs/ }],
+    },
+    // Multiline
+    {
+      code: `<a\n\thref="javascript:void(0)">\n</a>`,
+      errors: [{ message: /javascript: URLs/ }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -7,6 +7,7 @@ anee
 arraybindingpattern
 arrayish
 arrayliteralexpression
+ascript
 assertee
 autofixers
 auvred
@@ -183,6 +184,7 @@ stype
 subclassing
 symb
 symbolname
+tascript
 testdata
 testrule
 textnodes


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-script-url` rule from eslint-plugin-react to rslint.

Disallows usage of `javascript:` URLs in JSX attributes. By default checks `<a href="...">`, with support for custom components via options and `linkComponents` settings.

Also extracts shared link-component helpers (`ComponentMap`, `ReadComponentsFromSettings`, `DefaultLinkComponents`, `DefaultFormComponents`) from `jsx_no_target_blank` to `reactutil` to avoid duplication.

## Related Links

- eslint-plugin-react rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-script-url.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-script-url.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).