### PR TITLE
feat: port rule @typescript-eslint/prefer-destructuring

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,10 +87,11 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/only_throw_error"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/parameter_properties"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_as_const"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_destructuring"
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_for_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_includes"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_literal_enum_member"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_namespace_keyword"
-	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_for_of"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_optional_chain"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_promise_reject_errors"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/prefer_readonly"
@@ -162,8 +163,8 @@ import (
 	core_no_implied_eval "github.com/web-infra-dev/rslint/internal/rules/no_implied_eval"
 	"github.com/web-infra-dev/rslint/internal/rules/no_import_assign"
 	"github.com/web-infra-dev/rslint/internal/rules/no_inner_declarations"
-	"github.com/web-infra-dev/rslint/internal/rules/no_irregular_whitespace"
 	"github.com/web-infra-dev/rslint/internal/rules/no_invalid_regexp"
+	"github.com/web-infra-dev/rslint/internal/rules/no_irregular_whitespace"
 	"github.com/web-infra-dev/rslint/internal/rules/no_iterator"
 	"github.com/web-infra-dev/rslint/internal/rules/no_label_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_labels"
@@ -197,6 +198,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_sparse_arrays"
 	"github.com/web-infra-dev/rslint/internal/rules/no_template_curly_in_string"
 	"github.com/web-infra-dev/rslint/internal/rules/no_this_before_super"
+	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef"
 	"github.com/web-infra-dev/rslint/internal/rules/no_undef_init"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unmodified_loop_condition"
@@ -204,13 +206,12 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rules/no_unreachable"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_finally"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_negation"
-	"github.com/web-infra-dev/rslint/internal/rules/no_throw_literal"
 	"github.com/web-infra-dev/rslint/internal/rules/no_unsafe_optional_chaining"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_call"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_catch"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_computed_key"
-	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_concat"
+	"github.com/web-infra-dev/rslint/internal/rules/no_useless_constructor"
 	"github.com/web-infra-dev/rslint/internal/rules/no_useless_rename"
 	"github.com/web-infra-dev/rslint/internal/rules/no_var"
 	"github.com/web-infra-dev/rslint/internal/rules/no_with"
@@ -535,6 +536,7 @@ func registerAllTypeScriptEslintPluginRules() {
 	GlobalRuleRegistry.Register("@typescript-eslint/only-throw-error", only_throw_error.OnlyThrowErrorRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/parameter-properties", parameter_properties.ParameterPropertiesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-as-const", prefer_as_const.PreferAsConstRule)
+	GlobalRuleRegistry.Register("@typescript-eslint/prefer-destructuring", prefer_destructuring.PreferDestructuringRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-includes", prefer_includes.PreferIncludesRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-literal-enum-member", prefer_literal_enum_member.PreferLiteralEnumMemberRule)
 	GlobalRuleRegistry.Register("@typescript-eslint/prefer-namespace-keyword", prefer_namespace_keyword.PreferNamespaceKeywordRule)

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.go
@@ -1,0 +1,438 @@
+package prefer_destructuring
+
+import (
+	"math"
+	"strconv"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// destructuringConfig holds the array/object enforcement flags for a given context.
+type destructuringConfig struct {
+	Array  bool
+	Object bool
+}
+
+// Options for the prefer-destructuring rule.
+// First element: enforcement types (flat or per-node-type).
+// Second element: additional enforcement flags.
+type options struct {
+	VariableDeclarator   destructuringConfig
+	AssignmentExpression destructuringConfig
+
+	EnforceForRenamedProperties             bool
+	EnforceForDeclarationWithTypeAnnotation bool
+}
+
+func parseOptions(raw any) options {
+	opts := options{
+		VariableDeclarator:   destructuringConfig{Array: true, Object: true},
+		AssignmentExpression: destructuringConfig{Array: true, Object: true},
+	}
+
+	if raw == nil {
+		return opts
+	}
+
+	// Options come as an array [enabledTypes, enforcementOptions]
+	optArray, isArray := raw.([]interface{})
+	if !isArray || len(optArray) == 0 {
+		// Try bare object format (from CLI single-option unwrap)
+		if m, ok := raw.(map[string]interface{}); ok {
+			parseFirstOption(m, &opts)
+		}
+		return opts
+	}
+
+	// Parse first element: enabled types
+	if first, ok := optArray[0].(map[string]interface{}); ok {
+		parseFirstOption(first, &opts)
+	}
+
+	// Parse second element: enforcement options
+	if len(optArray) > 1 {
+		if second, ok := optArray[1].(map[string]interface{}); ok {
+			if v, ok := second["enforceForRenamedProperties"].(bool); ok {
+				opts.EnforceForRenamedProperties = v
+			}
+			if v, ok := second["enforceForDeclarationWithTypeAnnotation"].(bool); ok {
+				opts.EnforceForDeclarationWithTypeAnnotation = v
+			}
+		}
+	}
+
+	return opts
+}
+
+// parseFirstOption handles the first option element which can be either:
+// - flat: { array: bool, object: bool }
+// - per-context: { VariableDeclarator: { array, object }, AssignmentExpression: { array, object } }
+func parseFirstOption(m map[string]interface{}, opts *options) {
+	// Check if flat format (has "array" or "object" key)
+	_, hasArray := m["array"]
+	_, hasObject := m["object"]
+	if hasArray || hasObject {
+		// Flat format: only explicitly set keys are enabled, rest defaults to false.
+		// This matches ESLint where `{ array: true }` means object is undefined (falsy).
+		cfg := destructuringConfig{}
+		if v, ok := m["array"].(bool); ok {
+			cfg.Array = v
+		}
+		if v, ok := m["object"].(bool); ok {
+			cfg.Object = v
+		}
+		opts.VariableDeclarator = cfg
+		opts.AssignmentExpression = cfg
+		return
+	}
+
+	// Per-context format
+	if vd, ok := m["VariableDeclarator"].(map[string]interface{}); ok {
+		cfg := destructuringConfig{} // defaults to false
+		if v, ok := vd["array"].(bool); ok {
+			cfg.Array = v
+		}
+		if v, ok := vd["object"].(bool); ok {
+			cfg.Object = v
+		}
+		opts.VariableDeclarator = cfg
+	}
+	if ae, ok := m["AssignmentExpression"].(map[string]interface{}); ok {
+		cfg := destructuringConfig{} // defaults to false
+		if v, ok := ae["array"].(bool); ok {
+			cfg.Array = v
+		}
+		if v, ok := ae["object"].(bool); ok {
+			cfg.Object = v
+		}
+		opts.AssignmentExpression = cfg
+	}
+}
+
+func buildPreferDestructuringMessage(typ string) rule.RuleMessage {
+	return rule.RuleMessage{
+		Id:          "preferDestructuring",
+		Description: "Use " + typ + " destructuring.",
+	}
+}
+
+const precedenceOfAssignmentExpr = 1
+
+// PreferDestructuringRule implements @typescript-eslint/prefer-destructuring.
+var PreferDestructuringRule = rule.CreateRule(rule.Rule{
+	Name:             "prefer-destructuring",
+	RequiresTypeInfo: true,
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+
+		return rule.RuleListeners{
+			// VariableDeclarator (ESTree) → VariableDeclaration (tsgo)
+			ast.KindVariableDeclaration: func(node *ast.Node) {
+				varDecl := node.AsVariableDeclaration()
+				if varDecl == nil {
+					return
+				}
+				init := varDecl.Initializer
+				if init == nil {
+					return
+				}
+
+				// Skip using/await using declarations
+				parent := node.Parent
+				if parent != nil && parent.Kind == ast.KindVariableDeclarationList {
+					if ast.IsVarUsing(parent) || ast.IsVarAwaitUsing(parent) {
+						return
+					}
+				}
+
+				performCheck(ctx, opts, varDecl.Name(), init, node, true)
+			},
+
+			// AssignmentExpression (ESTree) → BinaryExpression with = operator (tsgo)
+			ast.KindBinaryExpression: func(node *ast.Node) {
+				bin := node.AsBinaryExpression()
+				if bin == nil || bin.OperatorToken == nil {
+					return
+				}
+				if bin.OperatorToken.Kind != ast.KindEqualsToken {
+					return
+				}
+				performCheck(ctx, opts, bin.Left, bin.Right, node, false)
+			},
+		}
+	},
+})
+
+func performCheck(ctx rule.RuleContext, opts options, leftNode *ast.Node, rightNode *ast.Node, reportNode *ast.Node, isVariableDeclarator bool) {
+	if rightNode == nil {
+		return
+	}
+
+	// Unwrap parentheses on RHS
+	right := ast.SkipParentheses(rightNode)
+
+	// RHS must be a member expression (property access or element access)
+	if right.Kind != ast.KindPropertyAccessExpression && right.Kind != ast.KindElementAccessExpression {
+		return
+	}
+
+	// Skip optional chaining
+	if ast.IsOptionalChain(right) {
+		return
+	}
+
+	// Skip super access and private identifiers
+	var objectNode *ast.Node
+	if right.Kind == ast.KindPropertyAccessExpression {
+		pae := right.AsPropertyAccessExpression()
+		objectNode = pae.Expression
+		if pae.Name() != nil && ast.IsPrivateIdentifier(pae.Name()) {
+			return
+		}
+	} else {
+		eae := right.AsElementAccessExpression()
+		objectNode = eae.Expression
+	}
+
+	if objectNode != nil && ast.SkipParentheses(objectNode).Kind == ast.KindSuperKeyword {
+		return
+	}
+
+	// Determine whether the LHS has a type annotation
+	leftHasTypeAnnotation := hasTypeAnnotation(leftNode)
+
+	// Determine whether to apply fix
+	canFix := !leftHasTypeAnnotation && isVariableDeclarator
+
+	// If LHS has type annotation and enforcement is off, skip
+	if leftHasTypeAnnotation && !opts.EnforceForDeclarationWithTypeAnnotation {
+		return
+	}
+
+	// Get the enabled config for this context
+	var cfg destructuringConfig
+	if isVariableDeclarator {
+		cfg = opts.VariableDeclarator
+	} else {
+		cfg = opts.AssignmentExpression
+	}
+
+	// Check for integer-literal index access (array-like)
+	if isArrayLiteralIntegerIndexAccess(right) {
+		// typescript-eslint uses type info to determine if this is truly iterable
+		if ctx.TypeChecker != nil && objectNode != nil {
+			objType := ctx.TypeChecker.GetTypeAtLocation(objectNode)
+			if !isTypeAnyOrIterableType(objType, ctx.TypeChecker) {
+				// Non-iterable: report as object if enforceForRenamedProperties + object enabled
+				if !opts.EnforceForRenamedProperties || !cfg.Object {
+					return
+				}
+				ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
+				return
+			}
+		}
+		// Iterable or no type checker: report as array
+		if cfg.Array {
+			ctx.ReportNode(reportNode, buildPreferDestructuringMessage("array"))
+		}
+		return
+	}
+
+	// Object destructuring path
+	if !cfg.Object {
+		return
+	}
+
+	if opts.EnforceForRenamedProperties {
+		if canFix && shouldFix(leftNode, right) {
+			reportWithFix(ctx, leftNode, right, reportNode)
+		} else {
+			ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
+		}
+		return
+	}
+
+	// Same-name check: property name must match variable name
+	leftName := getIdentifierName(leftNode)
+	if leftName == "" {
+		return
+	}
+
+	propName, ok := utils.AccessExpressionStaticName(right)
+	if !ok || propName == "" {
+		return
+	}
+
+	if leftName != propName {
+		return
+	}
+
+	if canFix && shouldFix(leftNode, right) {
+		reportWithFix(ctx, leftNode, right, reportNode)
+	} else {
+		ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
+	}
+}
+
+// hasTypeAnnotation checks if the left-hand side node has a type annotation.
+func hasTypeAnnotation(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindIdentifier:
+		parent := node.Parent
+		if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+			return parent.AsVariableDeclaration().Type != nil
+		}
+		return false
+	case ast.KindArrayBindingPattern, ast.KindObjectBindingPattern:
+		parent := node.Parent
+		if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+			return parent.AsVariableDeclaration().Type != nil
+		}
+		return false
+	}
+	return false
+}
+
+// isArrayLiteralIntegerIndexAccess checks if the node is a member expression
+// accessing an integer index (e.g., x[0], x[1]).
+func isArrayLiteralIntegerIndexAccess(node *ast.Node) bool {
+	if node.Kind != ast.KindElementAccessExpression {
+		return false
+	}
+	eae := node.AsElementAccessExpression()
+	if eae.ArgumentExpression == nil {
+		return false
+	}
+	arg := ast.SkipParentheses(eae.ArgumentExpression)
+	if arg.Kind != ast.KindNumericLiteral {
+		return false
+	}
+	val, err := strconv.ParseFloat(arg.Text(), 64)
+	if err != nil {
+		return false
+	}
+	return val == math.Trunc(val) && !math.IsInf(val, 0) && !math.IsNaN(val)
+}
+
+// isTypeAnyOrIterableType checks if the type is any or has [Symbol.iterator].
+// For union types, all members must be any-or-iterable.
+func isTypeAnyOrIterableType(t *checker.Type, tc *checker.Checker) bool {
+	if t == nil {
+		return false
+	}
+	if utils.IsTypeAnyType(t) {
+		return true
+	}
+	if !utils.IsUnionType(t) {
+		return utils.GetWellKnownSymbolPropertyOfType(t, "iterator", tc) != nil
+	}
+	return utils.Every(utils.UnionTypeParts(t), func(member *checker.Type) bool {
+		return isTypeAnyOrIterableType(member, tc)
+	})
+}
+
+// getIdentifierName returns the name of an Identifier node (skipping parens).
+func getIdentifierName(node *ast.Node) string {
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindIdentifier {
+		return n.Text()
+	}
+	return ""
+}
+
+// shouldFix checks if the autofix should be applied.
+// Fix only applies for VariableDeclarator with Identifier LHS, non-computed
+// PropertyAccessExpression RHS, and matching names.
+func shouldFix(leftNode *ast.Node, rightNode *ast.Node) bool {
+	left := ast.SkipParentheses(leftNode)
+	if left.Kind != ast.KindIdentifier {
+		return false
+	}
+	if rightNode.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pae := rightNode.AsPropertyAccessExpression()
+	if pae.Name() == nil || !ast.IsIdentifier(pae.Name()) {
+		return false
+	}
+	return left.Text() == pae.Name().Text()
+}
+
+// reportWithFix reports the diagnostic with an autofix.
+func reportWithFix(ctx rule.RuleContext, leftNode *ast.Node, rightNode *ast.Node, reportNode *ast.Node) {
+	pae := rightNode.AsPropertyAccessExpression()
+	propName := pae.Name().Text()
+	objectExpr := pae.Expression
+
+	// Suppress fix if there are comments outside the object expression that would
+	// be lost by the rewrite. ESLint checks `getCommentsInside(node).length >
+	// getCommentsInside(rightNode.object).length`. We check the two gap regions:
+	// 1. Between the identifier and the object expression (covers `id /* c */ = ...`)
+	// 2. Between the object expression end and the member-expr end (covers `obj /* c */ .prop`)
+	text := ctx.SourceFile.Text()
+	idRange := utils.TrimNodeTextRange(ctx.SourceFile, leftNode)
+	objRange := utils.TrimNodeTextRange(ctx.SourceFile, objectExpr)
+	nodeRange := utils.TrimNodeTextRange(ctx.SourceFile, reportNode)
+
+	if hasCommentInText(text, idRange.End(), objRange.Pos()) ||
+		hasCommentInText(text, objRange.End(), nodeRange.End()) {
+		ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
+		return
+	}
+
+	// Get the inner expression text, stripping outer ParenthesizedExpression.
+	// In ESTree there is no ParenthesizedExpression node, so ESLint's
+	// `sourceCode.getText(rightNode.object)` naturally returns the inner text.
+	// We must replicate this by skipping parens and using the inner range.
+	innerObj := ast.SkipParentheses(objectExpr)
+	innerRange := utils.TrimNodeTextRange(ctx.SourceFile, innerObj)
+
+	// If stripping parens would lose a comment (e.g., `(/* c */ obj)`), suppress fix.
+	if hasCommentInText(text, objRange.Pos(), innerRange.Pos()) ||
+		hasCommentInText(text, innerRange.End(), objRange.End()) {
+		ctx.ReportNode(reportNode, buildPreferDestructuringMessage("object"))
+		return
+	}
+
+	objectText := text[innerRange.Pos():innerRange.End()]
+
+	// Add parens if the inner expression has lower precedence than assignment.
+	// EslintLikePrecedence returns -1 for TS-specific nodes (AsExpression, etc.)
+	// which ESLint never sees; these don't need wrapping since they bind tightly.
+	prec := utils.EslintLikePrecedence(innerObj)
+	if prec >= 0 && prec < precedenceOfAssignmentExpr {
+		objectText = "(" + objectText + ")"
+	}
+
+	replacement := "{" + propName + "} = " + objectText
+	fixRange := core.NewTextRange(idRange.Pos(), nodeRange.End())
+
+	ctx.ReportNodeWithFixes(reportNode, buildPreferDestructuringMessage("object"),
+		rule.RuleFixReplaceRange(fixRange, replacement),
+	)
+}
+
+// hasCommentInText checks whether a `/*` or `//` comment literal exists in the
+// source text between positions start and end. This is a simple text scan that
+// doesn't require scanner integration, and correctly finds comments anywhere in
+// the range (unlike GetCommentsInRange which only scans from the range start).
+func hasCommentInText(text string, start, end int) bool {
+	if start < 0 || end > len(text) || start >= end {
+		return false
+	}
+	s := text[start:end]
+	for i := range len(s) - 1 {
+		if s[i] == '/' && (s[i+1] == '/' || s[i+1] == '*') {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.md
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring.md
@@ -1,0 +1,76 @@
+# prefer-destructuring
+
+## Rule Details
+
+Require destructuring from arrays and/or objects.
+
+This rule extends the base ESLint `prefer-destructuring` rule with TypeScript-specific type awareness.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+var foo = object.foo;
+var bar = array[0];
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+var { foo } = object;
+var [bar] = array;
+```
+
+### Type Annotation Handling
+
+By default, the rule does not report on variable declarations with type annotations, because the auto-fix would remove them:
+
+```typescript
+// This is correct by default (has type annotation)
+const x: string = obj.x;
+```
+
+### Type-Aware Array Detection
+
+The rule uses the TypeScript type checker to determine whether numeric index access (`x[0]`) should be treated as array destructuring or object destructuring:
+
+- If the object type is iterable (has `[Symbol.iterator]`) or `any`, it is treated as array access
+- If the object type is a plain object with numeric keys (e.g., `{ 0: unknown }`), it is treated as object access
+
+```json
+{ "@typescript-eslint/prefer-destructuring": ["error", { "object": true }, { "enforceForRenamedProperties": true }] }
+```
+
+```typescript
+// Correct: x is not iterable, so numeric index is treated as object access
+let x: { 0: unknown };
+let y = x[0];
+```
+
+```typescript
+// Incorrect: x is iterable (array), so numeric index triggers array destructuring
+let x: number[];
+let y = x[0]; // Use array destructuring
+```
+
+### `enforceForDeclarationWithTypeAnnotation`
+
+```json
+{ "@typescript-eslint/prefer-destructuring": ["error", { "object": true }, { "enforceForDeclarationWithTypeAnnotation": true }] }
+```
+
+Examples of **incorrect** code with `{ "enforceForDeclarationWithTypeAnnotation": true }`:
+
+```typescript
+const x: string = obj.x;
+```
+
+Examples of **correct** code with `{ "enforceForDeclarationWithTypeAnnotation": true }`:
+
+```typescript
+const { x }: { x: string } = obj;
+```
+
+## Original Documentation
+
+- [ESLint core rule](https://eslint.org/docs/latest/rules/prefer-destructuring)
+- [TypeScript-ESLint rule](https://typescript-eslint.io/rules/prefer-destructuring)

--- a/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring_test.go
+++ b/internal/plugins/typescript/rules/prefer_destructuring/prefer_destructuring_test.go
@@ -1,0 +1,1162 @@
+package prefer_destructuring
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferDestructuringRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferDestructuringRule, []rule_tester.ValidTestCase{
+		// ---- type annotated (default: skip) ----
+		{Code: "declare const object: { foo: string };\nvar foo: string = object.foo;"},
+		{Code: "declare const array: number[];\nconst bar: number = array[0];"},
+
+		// ---- enforceForDeclarationWithTypeAnnotation: true (valid cases) ----
+		{
+			Code: "declare const object: { foo: string };\nvar { foo } = object;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "declare const object: { foo: string };\nvar { foo }: { foo: number } = object;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "declare const array: number[];\nvar [foo] = array;",
+			Options: []interface{}{
+				map[string]interface{}{"array": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "declare const array: number[];\nvar [foo]: [foo: number] = array;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			// Renamed prop: var name != property name, valid even with enforcement
+			Code: "declare const object: { bar: string };\nvar foo: unknown = object.bar;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "declare const object: { foo: string };\nvar { foo: bar } = object;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "declare const object: { foo: boolean };\nvar { foo: bar }: { foo: boolean } = object;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			// super.foo — always skipped
+			Code: "declare class Foo { foo: string; }\nclass Bar extends Foo {\n  static foo() {\n    var foo: any = super.foo;\n  }\n}",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+
+		// ---- numeric property for iterable / non-iterable ----
+		{Code: "let x: { 0: unknown };\nlet y = x[0];"},
+		{Code: "let x: { 0: unknown };\ny = x[0];"},
+		{Code: "let x: unknown;\nlet y = x[0];"},
+		{Code: "let x: unknown;\ny = x[0];"},
+		{Code: "let x: { 0: unknown } | unknown[];\nlet y = x[0];"},
+		{Code: "let x: { 0: unknown } | unknown[];\ny = x[0];"},
+		{Code: "let x: { 0: unknown } & (() => void);\nlet y = x[0];"},
+		{Code: "let x: { 0: unknown } & (() => void);\ny = x[0];"},
+		{Code: "let x: Record<number, unknown>;\nlet y = x[0];"},
+		{Code: "let x: Record<number, unknown>;\ny = x[0];"},
+		{
+			Code: "let x: { 0: unknown };\nlet { 0: y } = x;",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: { 0: unknown };\n({ 0: y } = x);",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			// Non-iterable + only array enabled → valid
+			Code: "let x: { 0: unknown };\nlet y = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: { 0: unknown };\ny = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			// Per-context: VarDeclarator object=false → valid for let
+			Code: "let x: { 0: unknown };\nlet y = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"AssignmentExpression": map[string]interface{}{"array": true, "object": true},
+					"VariableDeclarator":   map[string]interface{}{"array": true, "object": false},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			// Per-context: AssignExpr object=false → valid for assignment
+			Code: "let x: { 0: unknown };\ny = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"AssignmentExpression": map[string]interface{}{"array": true, "object": false},
+					"VariableDeclarator":   map[string]interface{}{"array": true, "object": true},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		// Non-integer-literal index: x[i] where i is a variable → not array literal access
+		{
+			Code: "let x: Record<number, unknown>;\nlet i: number = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": false},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: Record<number, unknown>;\nlet i: 0 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": false},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: Record<number, unknown>;\nlet i: 0 | 1 | 2 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": false},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: number = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": false},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: 0 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": false},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: 0 | 1 | 2 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": false},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: number = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			// Compound assignment operators should not be reported
+			Code: "let x: { 0: unknown };\ny += x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			// super[0] — always skipped
+			Code: "class Bar { public [0]: unknown; }\nclass Foo extends Bar {\n  static foo() { let y = super[0]; }\n}",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "class Bar { public [0]: unknown; }\nclass Foo extends Bar {\n  static foo() { y = super[0]; }\n}",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+
+		// ---- already destructured ----
+		{Code: "let xs: unknown[] = [1];\nlet [x] = xs;"},
+		{Code: "const obj: { x: unknown } = { x: 1 };\nconst { x } = obj;"},
+		{Code: "var obj: { x: unknown } = { x: 1 };\nvar { x: y } = obj;"},
+		{Code: "let obj: { x: unknown } = { x: 1 };\nlet key: 'x' = 'x';\nlet { [key]: foo } = obj;"},
+		{Code: "const obj: { x: unknown } = { x: 1 };\nlet x: unknown;\n({ x } = obj);"},
+
+		// ---- valid unless enforceForRenamedProperties is true ----
+		{Code: "let obj: { x: unknown } = { x: 1 };\nlet y = obj.x;"},
+		{Code: "var obj: { x: unknown } = { x: 1 };\nvar y: unknown;\ny = obj.x;"},
+		{Code: "const obj: { x: unknown } = { x: 1 };\nconst y = obj['x'];"},
+		{Code: "let obj: Record<string, unknown> = {};\nlet key = 'abc';\nvar y = obj[key];"},
+
+		// ---- shorthand operators (should NOT be reported) ----
+		{Code: "let obj: { x: number } = { x: 1 };\nlet x = 10;\nx += obj.x;"},
+		{Code: "let obj: { x: boolean } = { x: false };\nlet x = true;\nx ||= obj.x;"},
+		{Code: "const xs: number[] = [1];\nlet x = 3;\nx *= xs[0];"},
+		// &&= and ??= operators
+		{Code: "let obj: { x: number } = { x: 1 };\nlet x = 10;\nx &&= obj.x;"},
+		{Code: "let obj: Record<string, number> = { foo: 1 };\nlet x = 10;\nx ??= obj['foo'];"},
+
+		// ---- optional chaining (should NOT be reported) ----
+		{Code: "let xs: unknown[] | undefined;\nlet x = xs?.[0];"},
+		{Code: "let obj: Record<string, unknown> | undefined;\nlet x = obj?.x;"},
+
+		// ---- private identifiers ----
+		{Code: "class C { #foo: string = ''; method() { const foo: unknown = this.#foo; } }"},
+		{Code: "class C { #foo: string = ''; method() { let foo: unknown; foo = this.#foo; } }"},
+		{
+			Code: "class C { #foo: string = ''; method() { const bar: unknown = this.#foo; } }",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "class C { #foo: string = ''; method(another: C) { let bar: unknown; bar = another.#foo; } }",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+		{
+			Code: "class C { #foo: string = ''; method() { const foo: unknown = this.#foo; } }",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+		},
+
+		// ---- ESLint core valid cases ----
+		{Code: "var [foo] = [1];"},
+		{Code: "var { foo } = { foo: 1 };"},
+		{Code: "var foo: any;"},
+		{
+			Code: "var foo = ({ bar: 1 } as any).bar;",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": true}},
+			},
+		},
+		{
+			Code:    "var foo = ({ bar: 1 } as any).bar;",
+			Options: []interface{}{map[string]interface{}{"object": true}},
+		},
+		{
+			Code: "var foo = ({ bar: 1 } as any).bar;",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": true}},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code: "var foo = ({ bar: 1 } as any).bar;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code:    "var { bar: foo } = { bar: 1 } as any;",
+			Options: []interface{}{map[string]interface{}{"object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "var { [bar]: foo } = { bar: 1 } as any;",
+			Options: []interface{}{map[string]interface{}{"object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "var foo = [1][0];",
+			Options: []interface{}{map[string]interface{}{"VariableDeclarator": map[string]interface{}{"array": false}}},
+		},
+		{
+			Code:    "var foo = [1][0];",
+			Options: []interface{}{map[string]interface{}{"array": false}},
+		},
+		{
+			Code: "var foo = ({ foo: 1 } as any).foo;",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": false}},
+			},
+		},
+		{Code: "({ foo } = { foo: 1 } as any);"},
+		{
+			Code: "var foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"array": false}},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code:    "var foo = [1][0];",
+			Options: []interface{}{map[string]interface{}{"array": false}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{Code: "[foo] = [1];"},
+		{Code: "foo += [1][0]"},
+		{Code: "foo += ({ foo: 1 } as any).foo"},
+		{
+			Code: "foo = ({ foo: 1 } as any).foo;",
+			Options: []interface{}{
+				map[string]interface{}{"AssignmentExpression": map[string]interface{}{"object": false}},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "foo = ({ foo: 1 } as any).foo;",
+			Options: []interface{}{
+				map[string]interface{}{"AssignmentExpression": map[string]interface{}{"object": false}},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code: "foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{"AssignmentExpression": map[string]interface{}{"array": false}},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+		},
+		{
+			Code: "foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{"AssignmentExpression": map[string]interface{}{"array": false}},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code: "foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"array": true},
+					"AssignmentExpression": map[string]interface{}{"array": false},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code: "var foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"array": false},
+					"AssignmentExpression": map[string]interface{}{"array": true},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code: "foo = ({ foo: 1 } as any).foo;",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"object": true},
+					"AssignmentExpression": map[string]interface{}{"object": false},
+				},
+			},
+		},
+		{
+			Code: "var foo = ({ foo: 1 } as any).foo;",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"object": false},
+					"AssignmentExpression": map[string]interface{}{"object": true},
+				},
+			},
+		},
+		{Code: "class Foo extends (Object as any) { static foo() {var foo = super.foo} }"},
+		{Code: "foo = ({ bar: 1 } as any)[foo];"},
+		{Code: "var foo = ({ bar: 1 } as any)[foo];"},
+		{
+			Code:    "var {foo: {bar}} = { foo: { bar: 1 } } as any;",
+			Options: []interface{}{map[string]interface{}{"object": true}},
+		},
+		{
+			Code:    "var {bar} = ({ foo: { bar: 1 } } as any).foo;",
+			Options: []interface{}{map[string]interface{}{"object": true}},
+		},
+
+		// ---- optional chaining (ESLint core) ----
+		{Code: "var foo = [1]?.[0];"},
+		{Code: "var foo = ({ foo: 1 } as any)?.foo;"},
+
+		// ---- private identifiers (ESLint core) ----
+		{Code: "class C { #x: number = 0; foo() { const x = this.#x; } }"},
+		{Code: "class C { #x: number = 0; foo() { x = this.#x; } }"},
+		{Code: "class C { #x: number = 0; foo(a: C) { x = a.#x; } }"},
+		{
+			Code:    "class C { #x: number = 0; foo() { const x = this.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "class C { #x: number = 0; foo() { const y = this.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "class C { #x: number = 0; foo() { x = this.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "class C { #x: number = 0; foo() { y = this.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "class C { #x: number = 0; foo(a: C) { x = a.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "class C { #x: number = 0; foo(a: C) { y = a.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+		{
+			Code:    "class C { #x: number = 0; foo() { x = this.a.#x; } }",
+			Options: []interface{}{map[string]interface{}{"array": true, "object": true}, map[string]interface{}{"enforceForRenamedProperties": true}},
+		},
+
+		// ---- ESLint core: computed bracket access, renamed not enforced ----
+		{
+			Code: "let object: Record<string, unknown> = {};\nvar foo = object['bar'];",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": true}},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			Code: "let object: Record<string, unknown> = {};\nvar foo = object[bar];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": false},
+			},
+		},
+		{
+			// object disabled via per-context, bracket string literal
+			Code: "var foo = ({ foo: 1 } as any)['foo'];",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": false}},
+			},
+		},
+		// ---- &&= with array index ----
+		{Code: "const xs: number[] = [1];\nlet x = 3;\nx &&= xs[0];"},
+
+		// ---- using / await using (explicit resource management) ----
+		{Code: "using foo = [1][0];"},
+		{Code: "using foo = ({ foo: 1 } as any).foo;"},
+		{Code: "await using foo = [1][0];"},
+		{Code: "await using foo = ({ foo: 1 } as any).foo;"},
+	}, []rule_tester.InvalidTestCase{
+		// ---- enforceForDeclarationWithTypeAnnotation: true ----
+		{
+			Code: "var foo: string = object.foo;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "var foo: string = array[0];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true},
+				map[string]interface{}{"enforceForDeclarationWithTypeAnnotation": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "var foo: unknown = object.bar;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{
+					"enforceForDeclarationWithTypeAnnotation": true,
+					"enforceForRenamedProperties":             true,
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- numeric property for iterable / non-iterable ----
+		{
+			Code: "let x: [1, 2, 3];\nlet y = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: [1, 2, 3];\ny = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "function* it() { yield 1; }\nlet y = it()[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "function* it() { yield 1; }\ny = it()[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: any;\nlet y = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: any;\ny = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: string[] | { [Symbol.iterator]: unknown };\nlet y = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: string[] | { [Symbol.iterator]: unknown };\ny = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: object & unknown[];\nlet y = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: object & unknown[];\ny = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		// Non-iterable with enforceForRenamedProperties → object
+		{
+			Code: "let x: { 0: string };\nlet y = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: { 0: string };\ny = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: { 0: string };\nlet y = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"AssignmentExpression": map[string]interface{}{"array": false, "object": false},
+					"VariableDeclarator":   map[string]interface{}{"array": false, "object": true},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: { 0: string };\ny = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"AssignmentExpression": map[string]interface{}{"array": false, "object": true},
+					"VariableDeclarator":   map[string]interface{}{"array": false, "object": false},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		// Non-integer-literal index with enforceForRenamedProperties → object
+		{
+			Code: "let x: Record<number, unknown>;\nlet i: number = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: Record<number, unknown>;\nlet i: 0 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: Record<number, unknown>;\nlet i: 0 | 1 | 2 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: number = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: 0 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: unknown[];\nlet i: 0 | 1 | 2 = 0;\ny = x[i];",
+			Options: []interface{}{
+				map[string]interface{}{"array": true, "object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Union of iterable + non-iterable: non-iterable member makes it object
+			Code: "let x: { 0: unknown } | unknown[];\nlet y = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let x: { 0: unknown } | unknown[];\ny = x[0];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- auto fixes (same-name property access) ----
+		{
+			Code:   "let obj = { foo: 'bar' };\nconst foo = obj.foo;",
+			Output: []string{"let obj = { foo: 'bar' };\nconst {foo} = obj;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code:   "const obj = { asdf: { qwer: null } };\nconst qwer = obj.asdf.qwer;",
+			Output: []string{"const obj = { asdf: { qwer: null } };\nconst {qwer} = obj.asdf;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Comment before identifier: fix preserves it
+			Code:   "const obj = { foo: 100 };\nconst /* comment */ foo = obj.foo;",
+			Output: []string{"const obj = { foo: 100 };\nconst /* comment */ {foo} = obj;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		// ---- autofix: parenthesized expression cases ----
+		{
+			Code:   "let x: null = null; let obj = { foo: 1 };\nconst foo = (x, obj).foo;",
+			Output: []string{"let x: null = null; let obj = { foo: 1 };\nconst {foo} = (x, obj);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code:   "const call = (() => null).call;",
+			Output: []string{"const {call} = () => null;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code:   "const obj = { foo: 'bar' };\nlet a: any;\nvar foo = (a = obj).foo;",
+			Output: []string{"const obj = { foo: 'bar' };\nlet a: any;\nvar {foo} = a = obj;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// (a || b).foo → {foo} = a || b
+			Code:   "let a: any; let b: any;\nvar foo = (a || b).foo;",
+			Output: []string{"let a: any; let b: any;\nvar {foo} = a || b;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// (f()).foo → {foo} = f()
+			Code:   "function f(): any { return {}; }\nvar foo = (f()).foo;",
+			Output: []string{"function f(): any { return {}; }\nvar {foo} = f();"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- comment-related fix/no-fix ----
+		{
+			// Comment after identifier before = → suppress fix
+			Code: "var foo /* comment */ = ({ foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Comment between = and expression → suppress fix
+			Code: "var foo = /* comment */ ({ foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- enforceForRenamedProperties: true ----
+		{
+			Code: "let obj = { foo: 'bar' };\nconst x = obj.foo;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let obj = { foo: 'bar' };\nlet x: unknown;\nx = obj.foo;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let obj: Record<string, unknown> = {};\nlet key = 'abc';\nconst x = obj[key];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "let obj: Record<string, unknown> = {};\nlet key = 'abc';\nlet x: unknown;\nx = obj[key];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- ESLint core invalid cases ----
+		{
+			Code:   "var foo = ({ foo: 1 } as any).foo;",
+			Output: []string{"var {foo} = { foo: 1 } as any;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code:   "var foo = ({ bar: { foo: 1 } } as any).bar.foo;",
+			Output: []string{"var {foo} = ({ bar: { foo: 1 } } as any).bar;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "var foobar = ({ bar: 1 } as any).bar;",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": true}},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "var foobar = ({ bar: 1 } as any).bar;",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "var foo = ({ bar: 1 } as any)[bar];",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"object": true}},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "var foo = ({ bar: 1 } as any)[bar];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "var foo = ({ foo: 1 } as any)['foo'];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "foo = ({ foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "foo = ({ foo: 1 } as any)['foo'];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code: "foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{"AssignmentExpression": map[string]interface{}{"array": true}},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "var foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"array": true},
+					"AssignmentExpression": map[string]interface{}{"array": false},
+				},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "var foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"array": true},
+					"AssignmentExpression": map[string]interface{}{"array": false},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"array": false},
+					"AssignmentExpression": map[string]interface{}{"array": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "foo = ({ foo: 1 } as any).foo;",
+			Options: []interface{}{
+				map[string]interface{}{
+					"VariableDeclarator":   map[string]interface{}{"array": true, "object": false},
+					"AssignmentExpression": map[string]interface{}{"object": true},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			Code:   "class Foo extends (Object as any) { static foo() {var bar = super.foo.bar} }",
+			Output: []string{"class Foo extends (Object as any) { static foo() {var {bar} = super.foo} }"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- Options JSON path test (map[string]interface{}) ----
+		{
+			Code:    "var foo = ({ foo: 1 } as any).foo;",
+			Options: map[string]interface{}{"object": true},
+			Output:  []string{"var {foo} = { foo: 1 } as any;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring"},
+			},
+		},
+
+		// ---- Symbol.iterator invalid cases ----
+		{
+			Code: "let x: { [Symbol.iterator]: unknown };\nlet y = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: { [Symbol.iterator]: unknown };\ny = x[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+
+		// ---- Line/Column position assertions ----
+		{
+			Code: "var foo = ({ foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Line: 1, Column: 5},
+			},
+			Output: []string{"var {foo} = { foo: 1 } as any;"},
+		},
+		{
+			Code: "let obj = { foo: 'bar' };\nconst foo = obj.foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Line: 2, Column: 7},
+			},
+			Output: []string{"let obj = { foo: 'bar' };\nconst {foo} = obj;"},
+		},
+		{
+			Code: "foo = ({ foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Line: 1, Column: 1},
+			},
+		},
+
+		// ---- Deeply nested member expression ----
+		{
+			Code:   "const a = { b: { c: { d: 1 } } };\nconst d = a.b.c.d;",
+			Output: []string{"const a = { b: { c: { d: 1 } } };\nconst {d} = a.b.c;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- Parenthesized object on RHS ----
+		{
+			// Multiple parens: ((obj)).foo → {foo} = obj
+			Code:   "const obj: any = {};\nconst foo = ((obj)).foo;",
+			Output: []string{"const obj: any = {};\nconst {foo} = obj;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring"},
+			},
+		},
+
+		// ---- TS type-assertion wrappers ----
+		{
+			// (obj as any).foo → {foo} = obj as any
+			Code:   "const obj = { foo: 1 };\nconst foo = (obj as any).foo;",
+			Output: []string{"const obj = { foo: 1 };\nconst {foo} = obj as any;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring"},
+			},
+		},
+
+		// ---- Element access with string literal key (same name) ----
+		{
+			Code: "const obj: { foo: number } = { foo: 1 };\nconst foo = obj['foo'];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- Default options: var foo = array[0] with iterable type ----
+		{
+			Code: "const array = [1, 2, 3];\nvar foo = array[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "const array = [1, 2, 3];\nfoo = array[0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+
+		// ---- Non-null assertion wrapping (TS-specific) ----
+		{
+			Code:   "const obj: { foo: number } | undefined = { foo: 1 };\nconst foo = obj!.foo;",
+			Output: []string{"const obj: { foo: number } | undefined = { foo: 1 };\nconst {foo} = obj!;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- ESLint core: self-referential computed access ----
+		{
+			Code: "var foo = ({ foo: 1 } as any)[foo];",
+			Options: []interface{}{
+				map[string]interface{}{"object": true},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- ESLint core: per-context VD-only key with enforceForRenamedProperties ----
+		{
+			Code: "var foo = [1][0];",
+			Options: []interface{}{
+				map[string]interface{}{"VariableDeclarator": map[string]interface{}{"array": true}},
+				map[string]interface{}{"enforceForRenamedProperties": true},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+
+		// ---- ESLint core: comment edge cases (fix produced) ----
+		{
+			// Comment before identifier: fix works
+			Code:   "var /* comment */ foo = ({ foo: 1 } as any).foo;",
+			Output: []string{"var /* comment */ {foo} = { foo: 1 } as any;"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Comment inside object expression (function call args): fix works
+			Code:   "function bar(...args: any[]): any { return args; }\nvar foo = bar(/* comment */).foo;",
+			Output: []string{"function bar(...args: any[]): any { return args; }\nvar {foo} = bar(/* comment */);"},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- ESLint core: comment edge cases (fix suppressed) ----
+		{
+			// Line comment between = and expression
+			Code: "var foo = // comment\n({ foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Comment inside parenthesized object
+			Code: "var foo = (/* comment */ { foo: 1 } as any).foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Comment between object and .property
+			Code: "var foo = ({ foo: 1 } as any)// comment\n.foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+		{
+			// Comment between dot and property name
+			Code: "var foo = ({ foo: 1 } as any)./* comment */foo;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use object destructuring."},
+			},
+		},
+
+		// ---- Non-decimal numeric literal indexes (tsgo normalizes to decimal) ----
+		{
+			Code: "let x: number[] = [1, 2, 3];\nlet y = x[0x0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: number[] = [1, 2];\nlet y = x[0b1];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x: number[] = [1, 2, 3];\nlet y = x[0o2];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+		{
+			Code: "let x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];\nlet y = x[1_0];",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "preferDestructuring", Message: "Use array destructuring."},
+			},
+		},
+	})
+}

--- a/internal/rules/no_unneeded_ternary/no_unneeded_ternary.go
+++ b/internal/rules/no_unneeded_ternary/no_unneeded_ternary.go
@@ -80,91 +80,9 @@ func inverseOperatorString(op ast.Kind) (string, bool) {
 	return "", false
 }
 
-// eslintLikePrecedence returns a numeric precedence matching ESLint's
-// astUtils.getPrecedence so behavior parity holds for tsgo nodes that ESLint
-// classifies (e.g. ArrowFunction = 1, ConditionalExpression = 3). Returns -1
-// for TypeScript-only kinds (AsExpression, etc.) so the caller wraps them in
-// parentheses defensively, matching ESLint's behavior on unknown node types.
+// eslintLikePrecedence is a package-local alias for utils.EslintLikePrecedence.
 func eslintLikePrecedence(node *ast.Node) int {
-	switch node.Kind {
-	case ast.KindArrowFunction:
-		return 1
-	case ast.KindYieldExpression:
-		return 1
-	case ast.KindConditionalExpression:
-		return 3
-	case ast.KindBinaryExpression:
-		bin := node.AsBinaryExpression()
-		if bin.OperatorToken == nil {
-			return -1
-		}
-		op := bin.OperatorToken.Kind
-		if op == ast.KindCommaToken {
-			return 0
-		}
-		if ast.IsAssignmentOperator(op) {
-			return 1
-		}
-		switch op {
-		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
-			return 4
-		case ast.KindAmpersandAmpersandToken:
-			return 5
-		case ast.KindBarToken:
-			return 6
-		case ast.KindCaretToken:
-			return 7
-		case ast.KindAmpersandToken:
-			return 8
-		case ast.KindEqualsEqualsToken, ast.KindExclamationEqualsToken,
-			ast.KindEqualsEqualsEqualsToken, ast.KindExclamationEqualsEqualsToken:
-			return 9
-		case ast.KindLessThanToken, ast.KindLessThanEqualsToken,
-			ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken,
-			ast.KindInKeyword, ast.KindInstanceOfKeyword:
-			return 10
-		case ast.KindLessThanLessThanToken, ast.KindGreaterThanGreaterThanToken,
-			ast.KindGreaterThanGreaterThanGreaterThanToken:
-			return 11
-		case ast.KindPlusToken, ast.KindMinusToken:
-			return 12
-		case ast.KindAsteriskToken, ast.KindSlashToken, ast.KindPercentToken:
-			return 13
-		case ast.KindAsteriskAsteriskToken:
-			return 15
-		}
-		return 20
-	case ast.KindPrefixUnaryExpression:
-		op := node.AsPrefixUnaryExpression().Operator
-		if op == ast.KindPlusPlusToken || op == ast.KindMinusMinusToken {
-			return 17
-		}
-		return 16
-	case ast.KindPostfixUnaryExpression:
-		return 17
-	case ast.KindAwaitExpression, ast.KindDeleteExpression,
-		ast.KindVoidExpression, ast.KindTypeOfExpression:
-		return 16
-	case ast.KindCallExpression:
-		return 18
-	case ast.KindNewExpression:
-		return 19
-	case ast.KindIdentifier, ast.KindThisKeyword, ast.KindSuperKeyword,
-		ast.KindNullKeyword, ast.KindTrueKeyword, ast.KindFalseKeyword,
-		ast.KindNumericLiteral, ast.KindStringLiteral, ast.KindBigIntLiteral,
-		ast.KindRegularExpressionLiteral, ast.KindNoSubstitutionTemplateLiteral,
-		ast.KindTemplateExpression, ast.KindArrayLiteralExpression,
-		ast.KindObjectLiteralExpression, ast.KindFunctionExpression,
-		ast.KindClassExpression, ast.KindParenthesizedExpression,
-		ast.KindPropertyAccessExpression, ast.KindElementAccessExpression,
-		ast.KindTaggedTemplateExpression, ast.KindSpreadElement,
-		ast.KindMetaProperty:
-		return 20
-	}
-	// TypeScript-specific (AsExpression, SatisfiesExpression,
-	// TypeAssertionExpression, ...) and any other kind ESLint does not
-	// classify: ESLint returns -1 to force wrapping for safety.
-	return -1
+	return utils.EslintLikePrecedence(node)
 }
 
 // isCoalesceExpression reports whether node (after parens) is a `??`

--- a/internal/utils/ts_eslint.go
+++ b/internal/utils/ts_eslint.go
@@ -692,6 +692,96 @@ func IsHigherPrecedenceThanAwait(node *ast.Node) bool {
 	return nodePrecedence > awaitPrecedence
 }
 
+// EslintLikePrecedence returns a numeric precedence matching ESLint's
+// astUtils.getPrecedence so behavior parity holds for tsgo nodes that ESLint
+// classifies (e.g. ArrowFunction = 1, ConditionalExpression = 3). Returns -1
+// for TypeScript-only kinds (AsExpression, etc.) so the caller wraps them in
+// parentheses defensively, matching ESLint's behavior on unknown node types.
+func EslintLikePrecedence(node *ast.Node) int {
+	if node == nil {
+		return -1
+	}
+	switch node.Kind {
+	case ast.KindArrowFunction:
+		return 1
+	case ast.KindYieldExpression:
+		return 1
+	case ast.KindConditionalExpression:
+		return 3
+	case ast.KindBinaryExpression:
+		bin := node.AsBinaryExpression()
+		if bin.OperatorToken == nil {
+			return -1
+		}
+		op := bin.OperatorToken.Kind
+		if op == ast.KindCommaToken {
+			return 0
+		}
+		if ast.IsAssignmentOperator(op) {
+			return 1
+		}
+		switch op {
+		case ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+			return 4
+		case ast.KindAmpersandAmpersandToken:
+			return 5
+		case ast.KindBarToken:
+			return 6
+		case ast.KindCaretToken:
+			return 7
+		case ast.KindAmpersandToken:
+			return 8
+		case ast.KindEqualsEqualsToken, ast.KindExclamationEqualsToken,
+			ast.KindEqualsEqualsEqualsToken, ast.KindExclamationEqualsEqualsToken:
+			return 9
+		case ast.KindLessThanToken, ast.KindLessThanEqualsToken,
+			ast.KindGreaterThanToken, ast.KindGreaterThanEqualsToken,
+			ast.KindInKeyword, ast.KindInstanceOfKeyword:
+			return 10
+		case ast.KindLessThanLessThanToken, ast.KindGreaterThanGreaterThanToken,
+			ast.KindGreaterThanGreaterThanGreaterThanToken:
+			return 11
+		case ast.KindPlusToken, ast.KindMinusToken:
+			return 12
+		case ast.KindAsteriskToken, ast.KindSlashToken, ast.KindPercentToken:
+			return 13
+		case ast.KindAsteriskAsteriskToken:
+			return 15
+		}
+		return 20
+	case ast.KindPrefixUnaryExpression:
+		op := node.AsPrefixUnaryExpression().Operator
+		if op == ast.KindPlusPlusToken || op == ast.KindMinusMinusToken {
+			return 17
+		}
+		return 16
+	case ast.KindPostfixUnaryExpression:
+		return 17
+	case ast.KindAwaitExpression, ast.KindDeleteExpression,
+		ast.KindVoidExpression, ast.KindTypeOfExpression:
+		return 16
+	case ast.KindCallExpression:
+		return 18
+	case ast.KindNewExpression:
+		return 19
+	case ast.KindIdentifier, ast.KindThisKeyword, ast.KindSuperKeyword,
+		ast.KindNullKeyword, ast.KindTrueKeyword, ast.KindFalseKeyword,
+		ast.KindNumericLiteral, ast.KindStringLiteral, ast.KindBigIntLiteral,
+		ast.KindRegularExpressionLiteral, ast.KindNoSubstitutionTemplateLiteral,
+		ast.KindTemplateExpression, ast.KindArrayLiteralExpression,
+		ast.KindObjectLiteralExpression, ast.KindFunctionExpression,
+		ast.KindClassExpression, ast.KindParenthesizedExpression,
+		ast.KindPropertyAccessExpression, ast.KindElementAccessExpression,
+		ast.KindTaggedTemplateExpression, ast.KindSpreadElement,
+		ast.KindMetaProperty:
+		return 20
+	}
+	// TypeScript-specific (AsExpression, SatisfiesExpression,
+	// TypeAssertionExpression, ...) and any other kind ESLint does not
+	// classify: return -1 to force wrapping for safety.
+	return -1
+}
+
 func IsStrongPrecedenceNode(innerNode *ast.Node) bool {
 	return ast.IsLiteralKind(innerNode.Kind) ||
 		ast.IsBooleanLiteral(innerNode) ||

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -251,7 +251,7 @@ export default defineConfig({
     './tests/typescript-eslint/rules/only-throw-error.test.ts',
     './tests/typescript-eslint/rules/parameter-properties.test.ts',
     './tests/typescript-eslint/rules/prefer-as-const.test.ts',
-    // './tests/typescript-eslint/rules/prefer-destructuring.test.ts',
+    './tests/typescript-eslint/rules/prefer-destructuring.test.ts',
     // './tests/typescript-eslint/rules/prefer-enum-initializers.test.ts',
     // './tests/typescript-eslint/rules/prefer-find.test.ts',
     './tests/typescript-eslint/rules/prefer-for-of.test.ts',

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-destructuring.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/prefer-destructuring.test.ts.snap
@@ -1,0 +1,1132 @@
+// Rstest Snapshot v1
+
+exports[`prefer-destructuring > invalid 1`] = `
+{
+  "code": "var foo: string = object.foo;",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 29,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 2`] = `
+{
+  "code": "var foo: string = array[0];",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 3`] = `
+{
+  "code": "var foo: unknown = object.bar;",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 30,
+          "line": 1,
+        },
+        "start": {
+          "column": 5,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 4`] = `
+{
+  "code": "
+        let x: { [Symbol.iterator]: unknown };
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 5`] = `
+{
+  "code": "
+        let x: { [Symbol.iterator]: unknown };
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 6`] = `
+{
+  "code": "
+        let x: [1, 2, 3];
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 7`] = `
+{
+  "code": "
+        let x: [1, 2, 3];
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 8`] = `
+{
+  "code": "
+        function* it() {
+          yield 1;
+        }
+        let y = it()[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 24,
+          "line": 5,
+        },
+        "start": {
+          "column": 13,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 9`] = `
+{
+  "code": "
+        function* it() {
+          yield 1;
+        }
+        y = it()[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 10`] = `
+{
+  "code": "
+        let x: any;
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 11`] = `
+{
+  "code": "
+        let x: any;
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 12`] = `
+{
+  "code": "
+        let x: string[] | { [Symbol.iterator]: unknown };
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 13`] = `
+{
+  "code": "
+        let x: string[] | { [Symbol.iterator]: unknown };
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 14`] = `
+{
+  "code": "
+        let x: object & unknown[];
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 15`] = `
+{
+  "code": "
+        let x: object & unknown[];
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use array destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 16`] = `
+{
+  "code": "
+        let x: { 0: string };
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 17`] = `
+{
+  "code": "
+        let x: { 0: string };
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 18`] = `
+{
+  "code": "
+        let x: { 0: string };
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 19`] = `
+{
+  "code": "
+        let x: { 0: string };
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 20`] = `
+{
+  "code": "
+        let x: Record<number, unknown>;
+        let i: number = 0;
+        y = x[i];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 21`] = `
+{
+  "code": "
+        let x: Record<number, unknown>;
+        let i: 0 = 0;
+        y = x[i];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 22`] = `
+{
+  "code": "
+        let x: Record<number, unknown>;
+        let i: 0 | 1 | 2 = 0;
+        y = x[i];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 23`] = `
+{
+  "code": "
+        let x: unknown[];
+        let i: number = 0;
+        y = x[i];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 24`] = `
+{
+  "code": "
+        let x: unknown[];
+        let i: 0 = 0;
+        y = x[i];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 25`] = `
+{
+  "code": "
+        let x: unknown[];
+        let i: 0 | 1 | 2 = 0;
+        y = x[i];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 26`] = `
+{
+  "code": "
+        let x: { 0: unknown } | unknown[];
+        let y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 3,
+        },
+        "start": {
+          "column": 13,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 27`] = `
+{
+  "code": "
+        let x: { 0: unknown } | unknown[];
+        y = x[0];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 17,
+          "line": 3,
+        },
+        "start": {
+          "column": 9,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 28`] = `
+{
+  "code": "
+        let obj = { foo: 'bar' };
+        const foo = obj.foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 28,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        let obj = { foo: 'bar' };
+        const {foo} = obj;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 29`] = `
+{
+  "code": "
+        let obj = { foo: 'bar' };
+        var x: null = null;
+        const foo = (x, obj).foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 33,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        let obj = { foo: 'bar' };
+        var x: null = null;
+        const {foo} = (x, obj);
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 30`] = `
+{
+  "code": "const call = (() => null).call;",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 31,
+          "line": 1,
+        },
+        "start": {
+          "column": 7,
+          "line": 1,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "const {call} = () => null;",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 31`] = `
+{
+  "code": "
+        const obj = { foo: 'bar' };
+        let a: any;
+        var foo = (a = obj).foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 32,
+          "line": 4,
+        },
+        "start": {
+          "column": 13,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        const obj = { foo: 'bar' };
+        let a: any;
+        var {foo} = a = obj;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 32`] = `
+{
+  "code": "
+        const obj = { asdf: { qwer: null } };
+        const qwer = obj.asdf.qwer;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 35,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        const obj = { asdf: { qwer: null } };
+        const {qwer} = obj.asdf;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 33`] = `
+{
+  "code": "
+        const obj = { foo: 100 };
+        const /* comment */ foo = obj.foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 42,
+          "line": 3,
+        },
+        "start": {
+          "column": 29,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": "
+        const obj = { foo: 100 };
+        const /* comment */ {foo} = obj;
+      ",
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 34`] = `
+{
+  "code": "
+        let obj = { foo: 'bar' };
+        const x = obj.foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 26,
+          "line": 3,
+        },
+        "start": {
+          "column": 15,
+          "line": 3,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 35`] = `
+{
+  "code": "
+        let obj = { foo: 'bar' };
+        let x: unknown;
+        x = obj.foo;
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 20,
+          "line": 4,
+        },
+        "start": {
+          "column": 9,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 36`] = `
+{
+  "code": "
+        let obj: Record<string, unknown>;
+        let key = 'abc';
+        const x = obj[key];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 27,
+          "line": 4,
+        },
+        "start": {
+          "column": 15,
+          "line": 4,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;
+
+exports[`prefer-destructuring > invalid 37`] = `
+{
+  "code": "
+        let obj: Record<string, unknown>;
+        let key = 'abc';
+        let x: unknown;
+        x = obj[key];
+      ",
+  "diagnostics": [
+    {
+      "message": "Use object destructuring.",
+      "messageId": "preferDestructuring",
+      "range": {
+        "end": {
+          "column": 21,
+          "line": 5,
+        },
+        "start": {
+          "column": 9,
+          "line": 5,
+        },
+      },
+      "ruleName": "@typescript-eslint/prefer-destructuring",
+    },
+  ],
+  "errorCount": 1,
+  "fileCount": 1,
+  "output": null,
+  "ruleCount": 1,
+}
+`;


### PR DESCRIPTION
## Summary

Port the `@typescript-eslint/prefer-destructuring` rule from typescript-eslint to rslint.

This rule enforces destructuring from arrays and/or objects, with TypeScript-aware enhancements:
- Skips variable declarations with type annotations by default (`enforceForDeclarationWithTypeAnnotation` option)
- Uses the TypeScript type checker to classify numeric index access (`x[0]`) as array or object destructuring based on whether the type is iterable
- Provides autofix for simple same-name property access (`var foo = obj.foo` → `var {foo} = obj`)
- Extracts shared `EslintLikePrecedence` to `internal/utils/ts_eslint.go` (previously duplicated in `no_unneeded_ternary`)

## Related Links

- TypeScript-ESLint rule: https://typescript-eslint.io/rules/prefer-destructuring
- ESLint core rule: https://eslint.org/docs/latest/rules/prefer-destructuring

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).