### PR TITLE
feat: port rule react/no-unused-state

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -27,6 +27,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_string_refs"
@@ -74,6 +75,7 @@ func GetAllRules() []rule.Rule {
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
+		no_unused_state.NoUnusedStateRule,
 		no_redundant_should_component_update.NoRedundantShouldComponentUpdateRule,
 		no_render_return_value.NoRenderReturnValueRule,
 		no_string_refs.NoStringRefsRule,

--- a/internal/plugins/react/rules/no_unused_state/no_unused_state.go
+++ b/internal/plugins/react/rules/no_unused_state/no_unused_state.go
@@ -1,0 +1,966 @@
+package no_unused_state
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// skipAssertionsAndParens strips parentheses and all TS assertion wrappers
+// (as, satisfies, !, <T>) from an expression, matching ESLint's
+// unwrapTSAsExpression(uncast(node)) pattern.
+func skipAssertionsAndParens(node *ast.Node) *ast.Node {
+	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+}
+
+// getName extracts a static string name from a node. For Identifiers returns
+// the text, for StringLiterals returns the text, for NumericLiterals returns
+// the string representation, for NoSubstitutionTemplateLiterals returns the
+// raw text. Returns "" for everything else.
+func getName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	node = skipAssertionsAndParens(node)
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNumericLiteral:
+		return utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text)
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	case ast.KindTrueKeyword:
+		return "true"
+	case ast.KindFalseKeyword:
+		return "false"
+	}
+	return ""
+}
+
+// isThisExpression checks if a node is a ThisExpression after unwrapping
+// type assertions and parentheses.
+func isThisExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return skipAssertionsAndParens(node).Kind == ast.KindThisKeyword
+}
+
+// isSetStateCall checks if a node is a this.setState(...) call.
+func isSetStateCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := node.AsCallExpression()
+	callee := skipAssertionsAndParens(call.Expression)
+	if callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pa := callee.AsPropertyAccessExpression()
+	if !isThisExpression(pa.Expression) {
+		return false
+	}
+	nameNode := pa.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return false
+	}
+	return nameNode.AsIdentifier().Text == "setState"
+}
+
+// stateField records a state property definition node and its name.
+type stateField struct {
+	node *ast.Node
+	name string
+}
+
+// classInfo tracks state field definitions and usages within a component.
+type classInfo struct {
+	stateFields []*stateField
+	usedFields  map[string]bool
+	aliases     map[string]bool // per-method/function aliases for this.state
+	abandoned   bool
+	typeChecker *checker.Checker // may be nil for plain-JS files
+}
+
+func newClassInfo(tc *checker.Checker) *classInfo {
+	return &classInfo{
+		usedFields:  make(map[string]bool),
+		typeChecker: tc,
+	}
+}
+
+// symbolAt returns the symbol at `node` when the TypeChecker is available,
+// or nil otherwise.
+func (ci *classInfo) symbolAt(node *ast.Node) *ast.Symbol {
+	if ci.typeChecker == nil || node == nil {
+		return nil
+	}
+	return ci.typeChecker.GetSymbolAtLocation(node)
+}
+
+// addStateFields records all named properties from an ObjectLiteralExpression
+// as state field definitions. In ESTree every object member (including
+// shorthand methods and getters/setters) is a Property — we match that by
+// handling all tsgo member kinds that carry a static key.
+func (ci *classInfo) addStateFields(objLit *ast.Node) {
+	if objLit == nil || objLit.Kind != ast.KindObjectLiteralExpression {
+		return
+	}
+	ole := objLit.AsObjectLiteralExpression()
+	if ole.Properties == nil {
+		return
+	}
+	for _, prop := range ole.Properties.Nodes {
+		switch prop.Kind {
+		case ast.KindPropertyAssignment:
+			nameNode := prop.AsPropertyAssignment().Name()
+			if nameNode == nil {
+				continue
+			}
+			if name := getPropertyKeyName(nameNode); name != "" {
+				ci.stateFields = append(ci.stateFields, &stateField{node: prop, name: name})
+			}
+		case ast.KindShorthandPropertyAssignment:
+			nameNode := prop.AsShorthandPropertyAssignment().Name()
+			if nameNode != nil && nameNode.Kind == ast.KindIdentifier {
+				ci.stateFields = append(ci.stateFields, &stateField{node: prop, name: nameNode.AsIdentifier().Text})
+			}
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			// ESTree represents shorthand methods and accessors as Property
+			// nodes; we must track them for parity.
+			nameNode := prop.Name()
+			if nameNode == nil {
+				continue
+			}
+			if name := getPropertyKeyName(nameNode); name != "" {
+				ci.stateFields = append(ci.stateFields, &stateField{node: prop, name: name})
+			}
+		}
+	}
+}
+
+// getPropertyKeyName extracts the static name from a property name node,
+// delegating to utils.GetStaticPropertyName. Returns "" for dynamic keys.
+func getPropertyKeyName(nameNode *ast.Node) string {
+	if nameNode == nil {
+		return ""
+	}
+	name, ok := utils.GetStaticPropertyName(nameNode)
+	if !ok {
+		return ""
+	}
+	return name
+}
+
+// addUsedStateField marks a state field name as used.
+func (ci *classInfo) addUsedStateField(node *ast.Node) {
+	if ci == nil || ci.abandoned {
+		return
+	}
+	name := getName(node)
+	if name != "" {
+		ci.usedFields[name] = true
+	}
+}
+
+// isStateReference checks if a node refers to this.state, an alias, or a
+// lifecycle state parameter.
+func (ci *classInfo) isStateReference(node *ast.Node) bool {
+	if ci == nil || ci.abandoned {
+		return false
+	}
+	node = skipAssertionsAndParens(node)
+
+	// Direct: this.state
+	if node.Kind == ast.KindPropertyAccessExpression {
+		pa := node.AsPropertyAccessExpression()
+		if isThisExpression(pa.Expression) {
+			nameNode := pa.Name()
+			if nameNode != nil && nameNode.Kind == ast.KindIdentifier && nameNode.AsIdentifier().Text == "state" {
+				return true
+			}
+		}
+	}
+
+	// Alias
+	if node.Kind == ast.KindIdentifier && ci.aliases != nil {
+		if ci.aliases[node.AsIdentifier().Text] {
+			return true
+		}
+	}
+
+	// Lifecycle state parameter (shouldComponentUpdate, componentDidUpdate, etc.)
+	return ci.isStateParameterReference(node)
+}
+
+// lifecycleMethodsWithStateParam lists lifecycle methods whose second parameter
+// is the previous/next state object.
+var lifecycleMethodsWithStateParam = map[string]bool{
+	"shouldComponentUpdate":      true,
+	"componentWillUpdate":        true,
+	"UNSAFE_componentWillUpdate": true,
+	"getSnapshotBeforeUpdate":    true,
+	"componentDidUpdate":         true,
+}
+
+// isStateParameterReference checks if an identifier refers to the state
+// parameter of a lifecycle method. When a TypeChecker is available, uses
+// symbol identity for precise matching (handles shadowing correctly);
+// otherwise falls back to name-based matching.
+func (ci *classInfo) isStateParameterReference(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindIdentifier {
+		return false
+	}
+
+	// Try symbol-based matching first (precise, handles shadowing).
+	if ci.typeChecker != nil {
+		useSym := ci.typeChecker.GetSymbolAtLocation(node)
+		if useSym != nil {
+			paramSym := findLifecycleStateParamSymbol(node, ci.typeChecker)
+			return paramSym != nil && useSym == paramSym
+		}
+	}
+
+	// Fallback: name-based matching (no TypeChecker or symbol unavailable).
+	return isStateParameterReferenceByName(node)
+}
+
+// findLifecycleStateParamSymbol walks up from `node` to find the nearest
+// enclosing lifecycle method, and returns the symbol of its 2nd parameter.
+func findLifecycleStateParamSymbol(node *ast.Node, tc *checker.Checker) *ast.Symbol {
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindMethodDeclaration:
+			paramNode := getLifecycleStateParam(p)
+			if paramNode != nil {
+				return tc.GetSymbolAtLocation(paramNode)
+			}
+		case ast.KindFunctionExpression:
+			if p.Parent != nil && p.Parent.Kind == ast.KindPropertyAssignment {
+				paramNode := getES5LifecycleStateParam(p)
+				if paramNode != nil {
+					return tc.GetSymbolAtLocation(paramNode)
+				}
+			}
+		case ast.KindArrowFunction, ast.KindFunctionDeclaration:
+			return nil
+		}
+	}
+	return nil
+}
+
+// getLifecycleStateParam returns the 2nd parameter's name node of a class
+// method if it is a lifecycle method (or static getDerivedStateFromProps).
+func getLifecycleStateParam(method *ast.Node) *ast.Node {
+	md := method.AsMethodDeclaration()
+	nameNode := md.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return nil
+	}
+	methodName := nameNode.AsIdentifier().Text
+	isGDSFP := ast.IsStatic(method) && methodName == "getDerivedStateFromProps"
+	if !isGDSFP && !lifecycleMethodsWithStateParam[methodName] {
+		return nil
+	}
+	params := method.Parameters()
+	if len(params) < 2 {
+		return nil
+	}
+	secondParam := params[1]
+	if secondParam.Kind != ast.KindParameter {
+		return nil
+	}
+	paramName := secondParam.AsParameterDeclaration().Name()
+	if paramName != nil && paramName.Kind == ast.KindIdentifier {
+		return paramName
+	}
+	return nil
+}
+
+// getES5LifecycleStateParam returns the 2nd parameter's name node of an ES5
+// component method (FunctionExpression inside PropertyAssignment).
+func getES5LifecycleStateParam(fn *ast.Node) *ast.Node {
+	pa := fn.Parent.AsPropertyAssignment()
+	keyNode := pa.Name()
+	if keyNode == nil || keyNode.Kind != ast.KindIdentifier {
+		return nil
+	}
+	if !lifecycleMethodsWithStateParam[keyNode.AsIdentifier().Text] {
+		return nil
+	}
+	params := fn.Parameters()
+	if len(params) < 2 {
+		return nil
+	}
+	secondParam := params[1]
+	if secondParam.Kind != ast.KindParameter {
+		return nil
+	}
+	paramName := secondParam.AsParameterDeclaration().Name()
+	if paramName != nil && paramName.Kind == ast.KindIdentifier {
+		return paramName
+	}
+	return nil
+}
+
+// isStateParameterReferenceByName is the name-based fallback for
+// isStateParameterReference when no TypeChecker is available.
+func isStateParameterReferenceByName(node *ast.Node) bool {
+	name := node.AsIdentifier().Text
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindMethodDeclaration:
+			paramNode := getLifecycleStateParam(p)
+			if paramNode != nil && paramNode.AsIdentifier().Text == name {
+				return true
+			}
+		case ast.KindFunctionExpression:
+			if p.Parent != nil && p.Parent.Kind == ast.KindPropertyAssignment {
+				paramNode := getES5LifecycleStateParam(p)
+				if paramNode != nil && paramNode.AsIdentifier().Text == name {
+					return true
+				}
+			}
+		case ast.KindArrowFunction, ast.KindFunctionDeclaration:
+			return false
+		}
+	}
+	return false
+}
+
+// handleStateDestructuring processes an ObjectBindingPattern that destructures
+// this.state, recording used fields and new aliases.
+func (ci *classInfo) handleStateDestructuring(pat *ast.Node) {
+	if pat == nil || pat.Kind != ast.KindObjectBindingPattern {
+		return
+	}
+	bp := pat.AsBindingPattern()
+	if bp.Elements == nil {
+		return
+	}
+	for _, elem := range bp.Elements.Nodes {
+		if elem.Kind != ast.KindBindingElement {
+			continue
+		}
+		be := elem.AsBindingElement()
+		if be.DotDotDotToken != nil {
+			// Rest element — add as alias
+			localName := be.Name()
+			if localName != nil && localName.Kind == ast.KindIdentifier && ci.aliases != nil {
+				ci.aliases[localName.AsIdentifier().Text] = true
+			}
+			continue
+		}
+		// Regular property — mark the key as used
+		if be.PropertyName != nil {
+			ci.addUsedStateField(be.PropertyName)
+		} else {
+			// Shorthand: { foo } — key is same as local name
+			localName := be.Name()
+			ci.addUsedStateField(localName)
+		}
+	}
+}
+
+// handleAssignment processes assignment patterns (both VariableDeclaration and
+// BinaryExpression assignments) to track state aliases and destructuring.
+func (ci *classInfo) handleAssignment(left, right *ast.Node) {
+	if ci == nil || ci.abandoned {
+		return
+	}
+	right = skipAssertionsAndParens(right)
+
+	switch left.Kind {
+	case ast.KindIdentifier:
+		// alias = this.state
+		if ci.isStateReference(right) && ci.aliases != nil {
+			ci.aliases[left.AsIdentifier().Text] = true
+		}
+	case ast.KindObjectBindingPattern:
+		if ci.isStateReference(right) {
+			// const { foo } = this.state
+			ci.handleStateDestructuring(left)
+		} else if isThisExpression(right) {
+			// const { state } = this / const { state: myState } = this
+			bp := left.AsBindingPattern()
+			if bp.Elements == nil {
+				break
+			}
+			for _, elem := range bp.Elements.Nodes {
+				if elem.Kind != ast.KindBindingElement {
+					continue
+				}
+				be := elem.AsBindingElement()
+				if be.DotDotDotToken != nil {
+					continue
+				}
+				// Check if the property name is "state"
+				propName := ""
+				if be.PropertyName != nil {
+					propName = getName(be.PropertyName)
+				} else {
+					propName = getName(be.Name())
+				}
+				if propName != "state" {
+					continue
+				}
+				localName := be.Name()
+				if localName == nil {
+					continue
+				}
+				nameStr := getName(localName)
+				if nameStr != "" && ci.aliases != nil {
+					// const { state: aliasName } = this
+					ci.aliases[nameStr] = true
+				} else if localName.Kind == ast.KindObjectBindingPattern {
+					// const { state: { foo } } = this
+					ci.handleStateDestructuring(localName)
+				}
+			}
+		}
+	}
+}
+
+// walkES6Component walks an ES6 class component body collecting state
+// definitions and usages.
+func walkES6Component(ci *classInfo, classNode *ast.Node) {
+	members := classNode.Members()
+	if members == nil {
+		return
+	}
+
+	for _, member := range members {
+		if ci.abandoned {
+			return
+		}
+		switch member.Kind {
+		case ast.KindPropertyDeclaration:
+			processPropertyDeclaration(ci, member)
+		case ast.KindMethodDeclaration:
+			processMethodDeclaration(ci, member)
+		case ast.KindConstructor:
+			processConstructor(ci, member)
+		case ast.KindGetAccessor, ast.KindSetAccessor:
+			ci.aliases = make(map[string]bool)
+			walkBody(ci, member)
+			ci.aliases = nil
+		}
+	}
+}
+
+// processPropertyDeclaration handles class property declarations like
+// `state = { ... }`, arrow function class methods, and any other initializer
+// that may reference `this.state`.
+//
+// ESLint's visitor model automatically walks ALL descendants of every class
+// member. We must explicitly walk every initializer to match that behavior;
+// skipping non-arrow / non-state initializers causes false positives for
+// patterns like `myProp = this.state.foo`.
+func processPropertyDeclaration(ci *classInfo, member *ast.Node) {
+	pd := member.AsPropertyDeclaration()
+	nameNode := pd.Name()
+	init := skipAssertionsAndParens(pd.Initializer)
+
+	isStatic := ast.IsStatic(member)
+
+	// Check for `state = { ... }` property
+	if !isStatic && nameNode != nil && nameNode.Kind == ast.KindIdentifier &&
+		nameNode.AsIdentifier().Text == "state" && init != nil &&
+		init.Kind == ast.KindObjectLiteralExpression {
+		ci.addStateFields(init)
+	}
+
+	// Handle static getDerivedStateFromProps as class property (arrow function)
+	if isStatic && nameNode != nil && nameNode.Kind == ast.KindIdentifier &&
+		nameNode.AsIdentifier().Text == "getDerivedStateFromProps" &&
+		init != nil && (init.Kind == ast.KindArrowFunction || init.Kind == ast.KindFunctionExpression) {
+		processGDSFPBody(ci, init)
+		return
+	}
+
+	// Walk the initializer for state usage detection.
+	// Non-static arrow functions get their own alias scope (matching ESLint's
+	// ClassProperty enter/exit which creates aliases only for ArrowFE).
+	// All other initializers are walked with the current (nil) alias scope,
+	// which still detects direct `this.state.foo` access.
+	if init == nil {
+		return
+	}
+	if !isStatic && init.Kind == ast.KindArrowFunction {
+		ci.aliases = make(map[string]bool)
+		walkBody(ci, init)
+		ci.aliases = nil
+	} else {
+		walkBody(ci, init)
+	}
+}
+
+// processMethodDeclaration handles class method declarations.
+func processMethodDeclaration(ci *classInfo, member *ast.Node) {
+	ci.aliases = make(map[string]bool)
+	walkBody(ci, member)
+	ci.aliases = nil
+}
+
+// processConstructor handles the class constructor, looking for
+// `this.state = { ... }` assignments.
+func processConstructor(ci *classInfo, member *ast.Node) {
+	ci.aliases = make(map[string]bool)
+	walkBody(ci, member)
+	ci.aliases = nil
+}
+
+// processGDSFPBody processes the body of a getDerivedStateFromProps method,
+// finding accesses on the second parameter (state). Uses TypeChecker symbol
+// identity when available for precise shadowing handling; falls back to
+// name-based matching otherwise.
+func processGDSFPBody(ci *classInfo, fn *ast.Node) {
+	params := fn.Parameters()
+	if len(params) < 2 {
+		return
+	}
+	secondParam := params[1]
+	if secondParam.Kind != ast.KindParameter {
+		return
+	}
+	paramName := secondParam.AsParameterDeclaration().Name()
+	if paramName == nil || paramName.Kind != ast.KindIdentifier {
+		return
+	}
+	stateParamName := paramName.AsIdentifier().Text
+
+	// Resolve the parameter's symbol for precise matching.
+	paramSymbol := ci.symbolAt(paramName)
+
+	// isStateParam reports whether `id` refers to the state parameter.
+	isStateParam := func(id *ast.Node) bool {
+		if id == nil || id.Kind != ast.KindIdentifier {
+			return false
+		}
+		if paramSymbol != nil {
+			idSym := ci.symbolAt(id)
+			if idSym != nil {
+				return idSym == paramSymbol
+			}
+		}
+		// Fallback: name-based matching.
+		return id.AsIdentifier().Text == stateParamName
+	}
+
+	// Walk the body looking for uses of the state parameter
+	var walk func(n *ast.Node)
+	walk = func(n *ast.Node) {
+		if n == nil || ci.abandoned {
+			return
+		}
+		if n.Kind == ast.KindPropertyAccessExpression {
+			pa := n.AsPropertyAccessExpression()
+			obj := skipAssertionsAndParens(pa.Expression)
+			if isStateParam(obj) {
+				ci.addUsedStateField(pa.Name())
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			walk(child)
+			return ci.abandoned
+		})
+	}
+
+	var body *ast.Node
+	switch fn.Kind {
+	case ast.KindArrowFunction:
+		body = fn.AsArrowFunction().Body
+	case ast.KindFunctionExpression:
+		body = fn.AsFunctionExpression().Body
+	case ast.KindMethodDeclaration:
+		body = fn.AsMethodDeclaration().Body
+	}
+	if body != nil {
+		walk(body)
+	}
+}
+
+// walkES5Component walks an ES5 component (createReactClass object literal)
+// collecting state definitions and usages.
+func walkES5Component(ci *classInfo, objLit *ast.Node) {
+	ole := objLit.AsObjectLiteralExpression()
+	if ole.Properties == nil {
+		return
+	}
+
+	for _, prop := range ole.Properties.Nodes {
+		if ci.abandoned {
+			return
+		}
+		if prop.Kind != ast.KindPropertyAssignment && prop.Kind != ast.KindMethodDeclaration &&
+			prop.Kind != ast.KindGetAccessor && prop.Kind != ast.KindSetAccessor {
+			continue
+		}
+
+		// Extract key name via the generic Name() method (works for all member kinds).
+		keyName := ""
+		if nameNode := prop.Name(); nameNode != nil && nameNode.Kind == ast.KindIdentifier {
+			keyName = nameNode.AsIdentifier().Text
+		}
+
+		if keyName == "getInitialState" {
+			processGetInitialState(ci, prop)
+		} else {
+			// ESLint's visitor model walks ALL descendants inside the ES5
+			// object. FunctionExpression values get their own alias scope
+			// (matching ESLint's FunctionExpression handler). Method/accessor
+			// shorthand also gets alias scopes. All other values (arrows,
+			// plain expressions) are walked without aliases but still detect
+			// direct `this.state.foo` access.
+			switch prop.Kind {
+			case ast.KindPropertyAssignment:
+				init := prop.AsPropertyAssignment().Initializer
+				if init != nil && init.Kind == ast.KindFunctionExpression {
+					ci.aliases = make(map[string]bool)
+					walkBody(ci, init)
+					ci.aliases = nil
+				} else if init != nil {
+					walkBody(ci, init)
+				}
+			case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+				ci.aliases = make(map[string]bool)
+				walkBody(ci, prop)
+				ci.aliases = nil
+			}
+		}
+	}
+}
+
+// processGetInitialState handles the getInitialState method in ES5 components.
+func processGetInitialState(ci *classInfo, prop *ast.Node) {
+	var body *ast.Node
+	switch prop.Kind {
+	case ast.KindPropertyAssignment:
+		init := prop.AsPropertyAssignment().Initializer
+		if init == nil || init.Kind != ast.KindFunctionExpression {
+			return
+		}
+		body = init.AsFunctionExpression().Body
+	case ast.KindMethodDeclaration:
+		body = prop.AsMethodDeclaration().Body
+	}
+
+	if body == nil || body.Kind != ast.KindBlock {
+		return
+	}
+
+	block := body.AsBlock()
+	if block.Statements == nil || len(block.Statements.Nodes) == 0 {
+		return
+	}
+	stmts := block.Statements.Nodes
+	lastStmt := stmts[len(stmts)-1]
+	if lastStmt.Kind != ast.KindReturnStatement {
+		return
+	}
+	rs := lastStmt.AsReturnStatement()
+	if rs.Expression == nil {
+		return
+	}
+	retVal := skipAssertionsAndParens(rs.Expression)
+	if retVal.Kind == ast.KindObjectLiteralExpression {
+		ci.addStateFields(retVal)
+	}
+}
+
+// walkBody recursively walks a function/method body processing state-related
+// AST patterns. Stops at nested class boundaries to avoid cross-component
+// interference.
+func walkBody(ci *classInfo, node *ast.Node) {
+	if node == nil || ci.abandoned {
+		return
+	}
+
+	// Skip nested React components
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return
+	}
+
+	processNode(ci, node)
+
+	if ci.abandoned {
+		return
+	}
+
+	node.ForEachChild(func(child *ast.Node) bool {
+		walkBody(ci, child)
+		return ci.abandoned
+	})
+}
+
+// processNode handles a single node during the body walk.
+func processNode(ci *classInfo, node *ast.Node) {
+	switch node.Kind {
+	case ast.KindCallExpression:
+		processCallExpression(ci, node)
+
+	case ast.KindBinaryExpression:
+		processAssignmentExpression(ci, node)
+
+	case ast.KindVariableDeclaration:
+		processVariableDeclarator(ci, node)
+
+	case ast.KindPropertyAccessExpression:
+		processMemberExpression(ci, node)
+
+	case ast.KindElementAccessExpression:
+		processElementAccess(ci, node)
+
+	case ast.KindJsxSpreadAttribute:
+		// If spreading this.state in JSX, give up
+		jsa := node.AsJsxSpreadAttribute()
+		if jsa.Expression != nil && ci.isStateReference(jsa.Expression) {
+			ci.abandoned = true
+		}
+
+	case ast.KindSpreadAssignment:
+		// Object spread: { ...this.state }
+		sa := node.AsSpreadAssignment()
+		if sa.Expression != nil && ci.isStateReference(sa.Expression) {
+			ci.abandoned = true
+		}
+
+	case ast.KindSpreadElement:
+		// Array/call spread: [...this.state]
+		se := node.AsSpreadElement()
+		if se.Expression != nil && ci.isStateReference(se.Expression) {
+			ci.abandoned = true
+		}
+
+	}
+}
+
+// processCallExpression handles this.setState() calls.
+func processCallExpression(ci *classInfo, node *ast.Node) {
+	call := node.AsCallExpression()
+	unwrappedNode := skipAssertionsAndParens(node)
+	if unwrappedNode.Kind != ast.KindCallExpression {
+		return
+	}
+	callExpr := unwrappedNode.AsCallExpression()
+
+	if !isSetStateCall(unwrappedNode) {
+		return
+	}
+
+	if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+		return
+	}
+	firstArg := skipAssertionsAndParens(callExpr.Arguments.Nodes[0])
+
+	switch firstArg.Kind {
+	case ast.KindObjectLiteralExpression:
+		ci.addStateFields(firstArg)
+	case ast.KindArrowFunction:
+		af := firstArg.AsArrowFunction()
+		body := skipAssertionsAndParens(af.Body)
+		if body != nil && body.Kind == ast.KindObjectLiteralExpression {
+			ci.addStateFields(body)
+		}
+		// Add first param as alias for state
+		params := firstArg.Parameters()
+		if len(params) > 0 {
+			firstParam := params[0]
+			if firstParam.Kind == ast.KindParameter {
+				paramName := firstParam.AsParameterDeclaration().Name()
+				if paramName != nil {
+					if paramName.Kind == ast.KindObjectBindingPattern {
+						ci.handleStateDestructuring(paramName)
+					} else if paramName.Kind == ast.KindIdentifier && ci.aliases != nil {
+						ci.aliases[paramName.AsIdentifier().Text] = true
+					}
+				}
+			}
+		}
+	}
+}
+
+// processAssignmentExpression handles assignment expressions like
+// `this.state = {}` and alias assignments.
+func processAssignmentExpression(ci *classInfo, node *ast.Node) {
+	bin := node.AsBinaryExpression()
+	if bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+		return
+	}
+	// Only handle simple assignment (=), not compound (+=, etc.)
+	if bin.OperatorToken.Kind != ast.KindEqualsToken {
+		return
+	}
+
+	left := skipAssertionsAndParens(bin.Left)
+	right := skipAssertionsAndParens(bin.Right)
+
+	// Check for `this.state = { ... }`
+	if left.Kind == ast.KindPropertyAccessExpression {
+		pa := left.AsPropertyAccessExpression()
+		if isThisExpression(pa.Expression) {
+			nameNode := pa.Name()
+			if nameNode != nil && nameNode.Kind == ast.KindIdentifier &&
+				nameNode.AsIdentifier().Text == "state" &&
+				right.Kind == ast.KindObjectLiteralExpression {
+				// Check if we're in a constructor
+				if isInConstructor(node) {
+					ci.addStateFields(right)
+					return
+				}
+			}
+		}
+	}
+
+	// Handle alias assignments: alias = this.state, or destructuring
+	ci.handleAssignment(left, right)
+}
+
+// isInConstructor checks if a node is inside a constructor method.
+func isInConstructor(node *ast.Node) bool {
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindConstructor:
+			return true
+		case ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindFunctionDeclaration:
+			// If we hit a function boundary before constructor, not in constructor
+			// BUT we need to check if this function IS the constructor value
+			if p.Parent != nil && p.Parent.Kind == ast.KindConstructor {
+				return true
+			}
+			return false
+		case ast.KindMethodDeclaration:
+			return false
+		}
+	}
+	return false
+}
+
+// processVariableDeclarator handles variable declarations like
+// `const { foo } = this.state` and `const state = this.state`.
+func processVariableDeclarator(ci *classInfo, node *ast.Node) {
+	vd := node.AsVariableDeclaration()
+	if vd.Initializer == nil {
+		return
+	}
+	ci.handleAssignment(vd.Name(), vd.Initializer)
+}
+
+// processMemberExpression handles property access expressions like
+// `this.state.foo` and `alias.foo`.
+func processMemberExpression(ci *classInfo, node *ast.Node) {
+	pa := node.AsPropertyAccessExpression()
+	obj := skipAssertionsAndParens(pa.Expression)
+
+	if ci.isStateReference(obj) {
+		// Record that we saw this property being accessed
+		ci.addUsedStateField(pa.Name())
+		return
+	}
+
+	// If this.state is used as a call argument (not setState), give up
+	if ci.isStateReference(node) {
+		if node.Parent != nil && node.Parent.Kind == ast.KindCallExpression {
+			ci.abandoned = true
+		}
+	}
+}
+
+// processElementAccess handles element access expressions like
+// `this.state['foo']` and `this.state[expr]`.
+func processElementAccess(ci *classInfo, node *ast.Node) {
+	ea := node.AsElementAccessExpression()
+	obj := skipAssertionsAndParens(ea.Expression)
+
+	if ci.isStateReference(obj) {
+		argExpr := ea.ArgumentExpression
+		if argExpr == nil {
+			return
+		}
+		argExpr = skipAssertionsAndParens(argExpr)
+		// If the access key is a static literal, record the used field.
+		// In ESTree, true/false/null are Literals, so ESLint's
+		// `node.property.type !== 'Literal'` check does NOT give up on them.
+		switch argExpr.Kind {
+		case ast.KindStringLiteral:
+			ci.usedFields[argExpr.AsStringLiteral().Text] = true
+		case ast.KindNumericLiteral:
+			ci.usedFields[utils.NormalizeNumericLiteral(argExpr.AsNumericLiteral().Text)] = true
+		case ast.KindNoSubstitutionTemplateLiteral:
+			ci.usedFields[argExpr.AsNoSubstitutionTemplateLiteral().Text] = true
+		case ast.KindTrueKeyword:
+			ci.usedFields["true"] = true
+		case ast.KindFalseKeyword:
+			ci.usedFields["false"] = true
+		case ast.KindNullKeyword:
+			ci.usedFields["null"] = true
+		default:
+			// Dynamic computed access — give up
+			ci.abandoned = true
+		}
+	}
+}
+
+var NoUnusedStateRule = rule.Rule{
+	Name: "react/no-unused-state",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		processComponent := func(ci *classInfo) {
+			if ci.abandoned {
+				return
+			}
+			for _, field := range ci.stateFields {
+				if !ci.usedFields[field.name] {
+					ctx.ReportNode(field.node, rule.RuleMessage{
+						Id:          "unusedStateField",
+						Description: fmt.Sprintf("Unused state field: '%s'", field.name),
+					})
+				}
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				ci := newClassInfo(ctx.TypeChecker)
+				walkES6Component(ci, node)
+				processComponent(ci)
+			},
+			ast.KindClassExpression: func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				ci := newClassInfo(ctx.TypeChecker)
+				walkES6Component(ci, node)
+				processComponent(ci)
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !reactutil.IsCreateClassCall(call, pragma, createClass) {
+					return
+				}
+				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				arg := ast.SkipParentheses(call.Arguments.Nodes[0])
+				if arg.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				ci := newClassInfo(ctx.TypeChecker)
+				walkES5Component(ci, arg)
+				processComponent(ci)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_unused_state/no_unused_state.md
+++ b/internal/plugins/react/rules/no_unused_state/no_unused_state.md
@@ -1,0 +1,53 @@
+# no-unused-state
+
+## Rule Details
+
+Warns when a React component defines state fields that are never read anywhere in the component. State can be defined via constructor assignments (`this.state = {}`), class property declarations (`state = {}`), `this.setState()` calls, or `getInitialState()` returns in ES5 components.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+class MyComponent extends React.Component {
+  state = { foo: 0 };
+  render() {
+    return <SomeComponent />;
+  }
+}
+```
+
+```javascript
+var MyComponent = createReactClass({
+  getInitialState: function() {
+    return { foo: 0 };
+  },
+  render: function() {
+    return <SomeComponent />;
+  }
+});
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+class MyComponent extends React.Component {
+  state = { foo: 0 };
+  render() {
+    return <SomeComponent foo={this.state.foo} />;
+  }
+}
+```
+
+```javascript
+class MyComponent extends React.Component {
+  state = { foo: 0 };
+  render() {
+    const { foo } = this.state;
+    return <SomeComponent foo={foo} />;
+  }
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react/no-unused-state](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md)
+- [Source code](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unused-state.js)

--- a/internal/plugins/react/rules/no_unused_state/no_unused_state_test.go
+++ b/internal/plugins/react/rules/no_unused_state/no_unused_state_test.go
@@ -1,0 +1,2008 @@
+package no_unused_state
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedStateRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedStateRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: stateless function component ----
+		{Code: `
+        function StatelessFnUnaffectedTest(props) {
+          return <SomeComponent foo={props.foo} />;
+        };
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass without state ----
+		{Code: `
+        var NoStateTest = createReactClass({
+          render: function() {
+            return <SomeComponent />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass without state (shorthand method) ----
+		{Code: `
+        var NoStateMethodTest = createReactClass({
+          render() {
+            return <SomeComponent />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: getInitialState with used state ----
+		{Code: `
+        var GetInitialStateTest = createReactClass({
+          getInitialState: function() {
+            return { foo: 0 };
+          },
+          render: function() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from variable ----
+		{Code: `
+        var ComputedKeyFromVariableTest = createReactClass({
+          getInitialState: function() {
+            return { [foo]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from boolean literal ----
+		{Code: `
+        var ComputedKeyFromBooleanLiteralTest = createReactClass({
+          getInitialState: function() {
+            return { [true]: 0 };
+          },
+          render: function() {
+            return <SomeComponent foo={this.state[true]} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from number literal ----
+		{Code: `
+        var ComputedKeyFromNumberLiteralTest = createReactClass({
+          getInitialState: function() {
+            return { [123]: 0 };
+          },
+          render: function() {
+            return <SomeComponent foo={this.state[123]} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from expression ----
+		{Code: `
+        var ComputedKeyFromExpressionTest = createReactClass({
+          getInitialState: function() {
+            return { [foo + bar]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from binary expression ----
+		{Code: `
+        var ComputedKeyFromBinaryExpressionTest = createReactClass({
+          getInitialState: function() {
+            return { ['foo' + 'bar' * 8]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from string literal ----
+		{Code: `
+        var ComputedKeyFromStringLiteralTest = createReactClass({
+          getInitialState: function() {
+            return { ['foo']: 0 };
+          },
+          render: function() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: computed key from template literal with expression ----
+		{Code: "var ComputedKeyFromTemplateLiteralTest = createReactClass({\n  getInitialState: function() {\n    return { [`foo${bar}`]: 0 };\n  },\n  render: function() {\n    return <SomeComponent />;\n  }\n});", Tsx: true},
+
+		// ---- Upstream: computed key from template literal (no substitution) used ----
+		{Code: "var ComputedKeyFromTemplateLiteralTest = createReactClass({\n  getInitialState: function() {\n    return { [`foo`]: 0 };\n  },\n  render: function() {\n    return <SomeComponent foo={this.state['foo']} />;\n  }\n});", Tsx: true},
+
+		// ---- Upstream: getInitialState shorthand method ----
+		{Code: `
+        var GetInitialStateMethodTest = createReactClass({
+          getInitialState() {
+            return { foo: 0 };
+          },
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState with used state ----
+		{Code: `
+        var SetStateTest = createReactClass({
+          onFooChange(newFoo) {
+            this.setState({ foo: newFoo });
+          },
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: multiple setState with used state ----
+		{Code: `
+        var MultipleSetState = createReactClass({
+          getInitialState() {
+            return { foo: 0 };
+          },
+          update() {
+            this.setState({foo: 1});
+          },
+          render() {
+            return <SomeComponent onClick={this.update} foo={this.state.foo} />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: class component without state ----
+		{Code: `
+        class NoStateTest extends React.Component {
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: constructor state with usage ----
+		{Code: `
+        class CtorStateTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from variable ----
+		{Code: `
+        class ComputedKeyFromVariableTest extends React.Component {
+          constructor() {
+            this.state = { [foo]: 0 };
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from boolean literal ----
+		{Code: `
+        class ComputedKeyFromBooleanLiteralTest extends React.Component {
+          constructor() {
+            this.state = { [false]: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state['false']} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from number literal ----
+		{Code: `
+        class ComputedKeyFromNumberLiteralTest extends React.Component {
+          constructor() {
+            this.state = { [345]: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state[345]} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from expression ----
+		{Code: `
+        class ComputedKeyFromExpressionTest extends React.Component {
+          constructor() {
+            this.state = { [foo + bar]: 0 };
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from binary expression ----
+		{Code: `
+        class ComputedKeyFromBinaryExpressionTest extends React.Component {
+          constructor() {
+            this.state = { [1 + 2 * 8]: 0 };
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from string literal ----
+		{Code: `
+        class ComputedKeyFromStringLiteralTest extends React.Component {
+          constructor() {
+            this.state = { ['foo']: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class computed key from template literal with expression ----
+		{Code: "class ComputedKeyFromTemplateLiteralTest extends React.Component {\n  constructor() {\n    this.state = { [`foo${bar}`]: 0 };\n  }\n  render() {\n    return <SomeComponent />;\n  }\n}", Tsx: true},
+
+		// ---- Upstream: class computed key from template literal used ----
+		{Code: "class ComputedKeyFromTemplateLiteralTest extends React.Component {\n  constructor() {\n    this.state = { [`foo`]: 0 };\n  }\n  render() {\n    return <SomeComponent foo={this.state.foo} />;\n  }\n}", Tsx: true},
+
+		// ---- Upstream: class setState with usage ----
+		{Code: `
+        class SetStateTest extends React.Component {
+          onFooChange(newFoo) {
+            this.setState({ foo: newFoo });
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class property state ----
+		{Code: `
+        class ClassPropertyStateTest extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: optional chaining ----
+		{Code: `
+        class OptionalChaining extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state?.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: variable declaration ----
+		{Code: `
+        class VariableDeclarationTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const foo = this.state.foo;
+            return <SomeComponent foo={foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: destructuring ----
+		{Code: `
+        class DestructuringTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const {foo: myFoo} = this.state;
+            return <SomeComponent foo={myFoo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: shorthand destructuring ----
+		{Code: `
+        class ShorthandDestructuringTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const {foo} = this.state;
+            return <SomeComponent foo={foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: alias declaration ----
+		{Code: `
+        class AliasDeclarationTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const state = this.state;
+            return <SomeComponent foo={state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: alias assignment ----
+		{Code: `
+        class AliasAssignmentTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            let state;
+            state = this.state;
+            return <SomeComponent foo={state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: destructuring alias ----
+		{Code: `
+        class DestructuringAliasTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const {state: myState} = this;
+            return <SomeComponent foo={myState.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: shorthand destructuring alias ----
+		{Code: `
+        class ShorthandDestructuringAliasTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const {state} = this;
+            return <SomeComponent foo={state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: rest property ----
+		{Code: `
+        class RestPropertyTest extends React.Component {
+          constructor() {
+            this.state = {
+              foo: 0,
+              bar: 1,
+            };
+          }
+          render() {
+            const {foo, ...others} = this.state;
+            return <SomeComponent foo={foo} bar={others.bar} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: deep destructuring ----
+		{Code: `
+        class DeepDestructuringTest extends React.Component {
+          state = { foo: 0, bar: 0 };
+          render() {
+            const {state: {foo, ...others}} = this;
+            return <SomeComponent foo={foo} bar={others.bar} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — method argument ----
+		{Code: `
+        class MethodArgFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          consumeFoo(foo) {}
+          render() {
+            this.consumeFoo(this.state.foo);
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — assigned to object ----
+		{Code: `
+        class AssignedToObjectFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const obj = { foo: this.state.foo, bar: 0 };
+            return <SomeComponent bar={obj.bar} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — computed access ----
+		{Code: `
+        class ComputedAccessFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0, bar: 1 };
+          }
+          render() {
+            const bar = 'bar';
+            return <SomeComponent bar={this.state[bar]} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — JSX spread ----
+		{Code: `
+        class JsxSpreadFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent {...this.state} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — aliased JSX spread ----
+		{Code: `
+        class AliasedJsxSpreadFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const state = this.state;
+            return <SomeComponent {...state} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — object spread ----
+		{Code: `
+        class ObjectSpreadFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const attrs = { ...this.state, foo: 1 };
+            return <SomeComponent foo={attrs.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — shadowing ----
+		{Code: `
+        class ShadowingFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const state = this.state;
+            let foo;
+            {
+              const state = { foo: 5 };
+              foo = state.foo;
+            }
+            return <SomeComponent foo={foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: false negative — non-render class method ----
+		{Code: `
+        class NonRenderClassMethodFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0, bar: 0 };
+          }
+          doSomething() {
+            const { foo } = this.state;
+            return this.state.foo;
+          }
+          doSomethingElse() {
+            const { state: { bar }} = this;
+            return bar;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow function class method destructuring false negative ----
+		{Code: `
+        class ArrowFunctionClassMethodDestructuringFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          doSomething = () => {
+            const { state: { foo } } = this;
+            return foo;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow function class method with class property ----
+		{Code: `
+        class ArrowFunctionClassMethodWithClassPropertyTransformFalseNegativeTest extends React.Component {
+          state = { foo: 0 };
+          doSomething = () => {
+            const { state:{ foo } } = this;
+            return foo;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow function deep destructuring ----
+		{Code: `
+        class ArrowFunctionClassMethodDeepDestructuringFalseNegativeTest extends React.Component {
+          state = { foo: { bar: 0 } };
+          doSomething = () => {
+            const { state: { foo: { bar }}} = this;
+            return bar;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow function destructuring assignment ----
+		{Code: `
+        class ArrowFunctionClassMethodDestructuringAssignmentFalseNegativeTest extends React.Component {
+          state = { foo: 0 };
+          doSomething = () => {
+            const { state: { foo: bar }} = this;
+            return bar;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: this.state as an object (call arg) ----
+		{Code: `
+        class ThisStateAsAnObject extends React.Component {
+          state = {
+            active: true
+          };
+          render() {
+            return <div className={classNames('overflowEdgeIndicator', className, this.state)} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: getDerivedStateFromProps ----
+		{Code: `
+        class GetDerivedStateFromPropsTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+            };
+          }
+          static getDerivedStateFromProps(nextProps, otherState) {
+            if (otherState.id === nextProps.id) {
+              return {
+                selected: true,
+              };
+            }
+            return null;
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: componentDidUpdate ----
+		{Code: `
+        class ComponentDidUpdateTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+            };
+          }
+          componentDidUpdate(someProps, someState) {
+            if (someState.id === someProps.id) {
+              doStuff();
+            }
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: shouldComponentUpdate ----
+		{Code: `
+        class ShouldComponentUpdateTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+            };
+          }
+          shouldComponentUpdate(nextProps, nextState) {
+            return nextState.id === nextProps.id;
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: nested scopes in lifecycle ----
+		{Code: `
+        class NestedScopesTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+            };
+          }
+          shouldComponentUpdate(nextProps, nextState) {
+            return (function() {
+              return nextState.id === nextProps.id;
+            })();
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: setState callback with state param ----
+		{Code: `
+        class Foo extends Component {
+          state = {
+            initial: 'foo',
+          }
+          handleChange = () => {
+            this.setState(state => ({
+              current: state.initial
+            }));
+          }
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: constructor state with setState callback ----
+		{Code: `
+        class Foo extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              initial: 'foo',
+            }
+          }
+          handleChange = () => {
+            this.setState(state => ({
+              current: state.initial
+            }));
+          }
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: setState callback with two params ----
+		{Code: `
+        class Foo extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              initial: 'foo',
+            }
+          }
+          handleChange = () => {
+            this.setState((state, props) => ({
+              current: state.initial
+            }));
+          }
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: ES5 setState callback ----
+		{Code: `
+        var Foo = createReactClass({
+          getInitialState: function() {
+            return { initial: 'foo' };
+          },
+          handleChange: function() {
+            this.setState(state => ({
+              current: state.initial
+            }));
+          },
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: ES5 setState callback with two params ----
+		{Code: `
+        var Foo = createReactClass({
+          getInitialState: function() {
+            return { initial: 'foo' };
+          },
+          handleChange: function() {
+            this.setState((state, props) => ({
+              current: state.initial
+            }));
+          },
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: setState destructuring callback ----
+		{Code: `
+        class SetStateDestructuringCallback extends Component {
+          state = {
+              used: 1, unused: 2
+          }
+          handleChange = () => {
+            this.setState(({unused}) => ({
+              used: unused * unused,
+            }));
+          }
+          render() {
+            return <div>{this.state.used}</div>
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: setState callback state condition ----
+		{Code: `
+        class SetStateCallbackStateCondition extends Component {
+          state = {
+              isUsed: true,
+              foo: 'foo'
+          }
+          handleChange = () => {
+            this.setState((prevState) => (prevState.isUsed ? {foo: 'bar', isUsed: false} : {}));
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: setState in regular function expression (no arrow) — don't error ----
+		{Code: `
+        class Foo extends Component {
+          handleChange = function() {
+            this.setState(() => ({ foo: value }));
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: setState with state param in function expression ----
+		{Code: `
+        class Foo extends Component {
+          handleChange = function() {
+            this.setState(state => ({ foo: value }));
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: static handler with setState ----
+		{Code: `
+        class Foo extends Component {
+          static handleChange = () => {
+            this.setState(state => ({ foo: value }));
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: TS as/unknown expressions ----
+		{Code: `
+        class Foo extends Component {
+          state = {
+            thisStateAliasProp,
+            thisStateAliasRestProp,
+            thisDestructStateAliasProp,
+            thisDestructStateAliasRestProp,
+            thisDestructStateDestructRestProp,
+            thisSetStateProp,
+            thisSetStateRestProp,
+          } as unknown
+
+          constructor() {
+            ((this as unknown).state as unknown) = { thisStateProp } as unknown;
+            ((this as unknown).setState as unknown)({ thisStateDestructProp } as unknown);
+            ((this as unknown).setState as unknown)(state => ({ thisDestructStateDestructProp } as unknown));
+          }
+
+          thisStateAlias() {
+            const state = (this as unknown).state as unknown;
+
+            (state as unknown).thisStateAliasProp as unknown;
+            const { ...thisStateAliasRest } = state as unknown;
+            (thisStateAliasRest as unknown).thisStateAliasRestProp as unknown;
+          }
+
+          thisDestructStateAlias() {
+            const { state } = this as unknown;
+
+            (state as unknown).thisDestructStateAliasProp as unknown;
+            const { ...thisDestructStateAliasRest } = state as unknown;
+            (thisDestructStateAliasRest as unknown).thisDestructStateAliasRestProp as unknown;
+          }
+
+          thisSetState() {
+            ((this as unknown).setState as unknown)(state => (state as unknown).thisSetStateProp as unknown);
+            ((this as unknown).setState as unknown)(({ ...thisSetStateRest }) => (thisSetStateRest as unknown).thisSetStateRestProp as unknown);
+          }
+
+          render() {
+            ((this as unknown).state as unknown).thisStateProp as unknown;
+            const { thisStateDestructProp } = (this as unknown).state as unknown;
+            const { state: { thisDestructStateDestructProp, ...thisDestructStateDestructRest } } = this as unknown;
+            (thisDestructStateDestructRest as unknown).thisDestructStateDestructRestProp as unknown;
+
+            return null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: getDerivedStateFromProps as class property (arrow) ----
+		{Code: `
+        class TestNoUnusedState extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: null,
+            };
+          }
+          static getDerivedStateFromProps = (props, state) => {
+            if (state.id !== props.id) {
+              return {
+                id: props.id,
+              };
+            }
+            return null;
+          };
+          render() {
+            return <h1>{this.state.id}</h1>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: getDerivedStateFromProps with destructuring ----
+		{Code: `
+        class Component2 extends React.Component {
+          static getDerivedStateFromProps = ({value, disableAnimation}, {isControlled, isOn}) => {
+            return { isControlled, isOn };
+          };
+          render() {
+            const { isControlled, isOn } = this.state;
+            return <div>{isControlled ? 'controlled' : ''}{isOn ? 'on' : ''}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: cancel button state ----
+		{Code: `
+        class Foo extends React.Component {
+          onCancel = (data) => {
+            console.log('Cancelled', data)
+            this.setState({ status: 'Cancelled. Try again?' })
+          }
+          render() {
+            const { status } = this.state;
+            return <div>{status}</div>
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: non-component class with state ----
+		{Code: `
+        class NotAComponent {
+          state = { foo: 0 };
+          render() {
+            return null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: class expression component ----
+		{Code: `
+        var Hello = class extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        };
+      `, Tsx: true},
+
+		// ---- Edge: nested class — inner component state is independent ----
+		{Code: `
+        class Outer extends React.Component {
+          state = { outerFoo: 0 };
+          render() {
+            class Inner extends React.Component {
+              state = { innerBar: 0 };
+              render() {
+                return <div>{this.state.innerBar}</div>;
+              }
+            }
+            return <div>{this.state.outerFoo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: parenthesized this.state access ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent foo={(this).state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: TS satisfies expression ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 } satisfies { foo: number };
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: lifecycle state param destructured (componentDidUpdate) ----
+		{Code: `
+        class Hello extends Component {
+          constructor(props) {
+            super(props);
+            this.state = { id: 123 };
+          }
+          componentDidUpdate(prevProps, prevState) {
+            const { id } = prevState;
+            console.log(id);
+          }
+          render() {
+            return <h1>{this.state.id}</h1>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: lifecycle state param aliased (shouldComponentUpdate) ----
+		{Code: `
+        class Hello extends Component {
+          constructor(props) {
+            super(props);
+            this.state = { count: 0 };
+          }
+          shouldComponentUpdate(nextProps, nextState) {
+            const s = nextState;
+            return s.count !== this.state.count;
+          }
+          render() {
+            return <div>{this.state.count}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: GDSFP with shadowed state param (TypeChecker resolves correctly) ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { count: 0 };
+          static getDerivedStateFromProps(props, state) {
+            const inner = () => {
+              const state = { local: true };
+              console.log(state.local);
+            };
+            return state.count > 0 ? { count: state.count } : null;
+          }
+          render() {
+            return <div>{this.state.count}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: TS readonly state with generics ----
+		{Code: `
+        interface Props {}
+        interface State {
+          flag: boolean;
+        }
+        class RuleTest extends React.Component<Props, State> {
+          readonly state: State = {
+            flag: false,
+          };
+          static getDerivedStateFromProps = (props: Props, state: State) => {
+            const newState: Partial<State> = {};
+            if (!state.flag) {
+              newState.flag = true;
+            }
+            return newState;
+          };
+        }
+      `, Tsx: true},
+
+		// ---- Edge: non-arrow class property initializer using state (should not false-positive) ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 };
+          myProp = this.state.foo;
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: FunctionExpression class property using state ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 };
+          handleClick = function() {
+            return this.state.foo;
+          }
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: static non-GDSFP arrow using state ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 };
+          static helper = () => {
+            return null;
+          }
+          render() {
+            return <div>{this.state.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: ES5 arrow property value using state ----
+		{Code: `
+        var Hello = createReactClass({
+          getInitialState: function() {
+            return { foo: 0 };
+          },
+          handler: () => this.state.foo,
+          render: function() {
+            return <div />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: this.state[true] / this.state[false] / this.state[null] should not give up ----
+		{Code: `
+        class Hello extends React.Component {
+          constructor() {
+            this.state = { [true]: 0 };
+          }
+          render() {
+            return <div>{this.state[true]}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: ES5 getter using state ----
+		{Code: `
+        var Hello = createReactClass({
+          getInitialState: function() {
+            return { foo: 0 };
+          },
+          get computed() {
+            return this.state.foo;
+          },
+          render: function() {
+            return <div />;
+          }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: this.state['foo'] string element access ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent foo={this.state['foo']} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: getSnapshotBeforeUpdate lifecycle param ----
+		{Code: `
+        class Hello extends Component {
+          constructor(props) {
+            super(props);
+            this.state = { scroll: 0 };
+          }
+          getSnapshotBeforeUpdate(prevProps, prevState) {
+            return prevState.scroll;
+          }
+          render() {
+            return <div>{this.state.scroll}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: UNSAFE_componentWillUpdate lifecycle param ----
+		{Code: `
+        class Hello extends Component {
+          constructor(props) {
+            super(props);
+            this.state = { val: 0 };
+          }
+          UNSAFE_componentWillUpdate(nextProps, nextState) {
+            console.log(nextState.val);
+          }
+          render() {
+            return <div>{this.state.val}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: constructor assigns non-object to this.state (should not track) ----
+		{Code: `
+        class Hello extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = getInitialState();
+          }
+          render() {
+            return <div>{this.state.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: state used only in non-render method ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { token: 'abc' };
+          fetchData() {
+            fetch('/api', { headers: { auth: this.state.token } });
+          }
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: multiple independent components in same file ----
+		{Code: `
+        class CompA extends React.Component {
+          state = { a: 1 };
+          render() { return <div>{this.state.a}</div>; }
+        }
+        class CompB extends React.Component {
+          state = { b: 2 };
+          render() { return <div>{this.state.b}</div>; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: setState arrow return field used ----
+		{Code: `
+        class Hello extends Component {
+          handleChange = () => {
+            this.setState(state => ({
+              derived: state.count + 1
+            }));
+          }
+          render() {
+            return <div>{this.state.derived}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: state used in ternary expression ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { loading: false };
+          render() {
+            return this.state.loading ? <div>Loading</div> : <div>Done</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: state used in logical expression ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { error: null };
+          render() {
+            return <div>{this.state.error && <span>Error</span>}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: state used in template literal ----
+		{Code: "class Hello extends React.Component {\n  state = { name: '' };\n  render() {\n    return <div>{`Hello ${this.state.name}`}</div>;\n  }\n}", Tsx: true},
+
+		// ---- Edge: state alias in arrow class property does NOT leak to other methods ----
+		{Code: `
+        class Hello extends React.Component {
+          state = { foo: 0, bar: 1 };
+          method1 = () => {
+            const s = this.state;
+            return s.foo;
+          }
+          method2() {
+            return this.state.bar;
+          }
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: unused getInitialState ----
+		{
+			Code: `
+        var UnusedGetInitialStateTest = createReactClass({
+          getInitialState: function() {
+            return { foo: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 22},
+			},
+		},
+
+		// ---- Upstream: unused computed string literal key ----
+		{
+			Code: `
+        var UnusedComputedStringLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { ['foo']: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 22},
+			},
+		},
+
+		// ---- Upstream: unused computed template literal key ----
+		{
+			Code: "var UnusedComputedTemplateLiteralKeyStateTest = createReactClass({\n  getInitialState: function() {\n    return { [`foo`]: 0 };\n  },\n  render: function() {\n    return <SomeComponent />;\n  }\n})",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 3, Column: 14},
+			},
+		},
+
+		// ---- Upstream: unused computed number literal key ----
+		{
+			Code: `
+        var UnusedComputedNumberLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { [123]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: '123'", Line: 4, Column: 22},
+			},
+		},
+
+		// ---- Upstream: unused computed boolean literal key ----
+		{
+			Code: `
+        var UnusedComputedBooleanLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { [true]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'true'", Line: 4, Column: 22},
+			},
+		},
+
+		// ---- Upstream: unused getInitialState (shorthand) ----
+		{
+			Code: `
+        var UnusedGetInitialStateMethodTest = createReactClass({
+          getInitialState() {
+            return { foo: 0 };
+          },
+          render() {
+            return <SomeComponent />;
+          }
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 22},
+			},
+		},
+
+		// ---- Upstream: unused setState ----
+		{
+			Code: `
+        var UnusedSetStateTest = createReactClass({
+          onFooChange(newFoo) {
+            this.setState({ foo: newFoo });
+          },
+          render() {
+            return <SomeComponent />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 29},
+			},
+		},
+
+		// ---- Upstream: unused class constructor state ----
+		{
+			Code: `
+        class UnusedCtorStateTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 28},
+			},
+		},
+
+		// ---- Upstream: unused class setState ----
+		{
+			Code: `
+        class UnusedSetStateTest extends React.Component {
+          onFooChange(newFoo) {
+            this.setState({ foo: newFoo });
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 29},
+			},
+		},
+
+		// ---- Upstream: unused class property state ----
+		{
+			Code: `
+        class UnusedClassPropertyStateTest extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Upstream: unused computed string literal key (class) ----
+		{
+			Code: `
+        class UnusedComputedStringLiteralKeyStateTest extends React.Component {
+          state = { ['foo']: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Upstream: unused computed template literal key (class) ----
+		{
+			Code: "class UnusedComputedTemplateLiteralKeyStateTest extends React.Component {\n  state = { [`foo`]: 0 };\n  render() {\n    return <SomeComponent />;\n  }\n}",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 2, Column: 13},
+			},
+		},
+
+		// ---- Upstream: unused computed boolean literal key (class) ----
+		{
+			Code: `
+        class UnusedComputedBooleanLiteralKeyStateTest extends React.Component {
+          state = { [true]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'true'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Upstream: unused computed number literal key (class) ----
+		{
+			Code: `
+        class UnusedComputedNumberLiteralKeyStateTest extends React.Component {
+          state = { [123]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: '123'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Upstream: unused state when props are spread ----
+		{
+			Code: `
+        class UnusedStateWhenPropsAreSpreadTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent {...this.props} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 28},
+			},
+		},
+
+		// ---- Upstream: alias out of scope ----
+		{
+			Code: `
+        class AliasOutOfScopeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const state = this.state;
+            return <SomeComponent />;
+          }
+          someMethod() {
+            const outOfScope = state.foo;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 28},
+			},
+		},
+
+		// ---- Upstream: multiple errors ----
+		{
+			Code: `
+        class MultipleErrorsTest extends React.Component {
+          constructor() {
+            this.state = {
+              foo: 0,
+              bar: 1,
+              baz: 2,
+              qux: 3,
+            };
+          }
+          render() {
+            let {state} = this;
+            return <SomeComponent baz={state.baz} qux={state.qux} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 5, Column: 15},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'bar'", Line: 6, Column: 15},
+			},
+		},
+
+		// ---- Upstream: multiple errors for same key ----
+		{
+			Code: `
+        class MultipleErrorsForSameKeyTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          onFooChange(newFoo) {
+            this.setState({ foo: newFoo });
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 28},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 7, Column: 29},
+			},
+		},
+
+		// ---- Upstream: unused rest property field ----
+		{
+			Code: `
+        class UnusedRestPropertyFieldTest extends React.Component {
+          constructor() {
+            this.state = {
+              foo: 0,
+              bar: 1,
+            };
+          }
+          render() {
+            const {bar, ...others} = this.state;
+            return <SomeComponent bar={bar} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Upstream: unused state with arrow function method ----
+		{
+			Code: `
+        class UnusedStateArrowFunctionMethodTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          doSomething = () => {
+            return null;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 28},
+			},
+		},
+
+		// ---- Upstream: unused deep destructuring ----
+		{
+			Code: `
+        class UnusedDeepDestructuringTest extends React.Component {
+          state = { foo: 0, bar: 0 };
+          render() {
+            const {state: {foo}} = this;
+            return <SomeComponent foo={foo} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'bar'", Line: 3, Column: 29},
+			},
+		},
+
+		// ---- Upstream: fake prevState variable ----
+		{
+			Code: `
+        class FakePrevStateVariableTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+              foo: 456
+            };
+          }
+          componentDidUpdate(someProps, someState) {
+            if (someState.id === someProps.id) {
+              const prevState = { foo: 789 };
+              console.log(prevState.foo);
+            }
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 7, Column: 15},
+			},
+		},
+
+		// ---- Upstream: state parameter in non-lifecycle method ----
+		{
+			Code: `
+        class UseStateParameterOfNonLifecycleTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              foo: 123,
+            };
+          }
+          nonLifecycle(someProps, someState) {
+            doStuff(someState.foo)
+          }
+          render() {
+            return (
+              <SomeComponent />
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 6, Column: 15},
+			},
+		},
+
+		// ---- Upstream: missing state parameter ----
+		{
+			Code: `
+        class MissingStateParameterTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123
+            };
+          }
+          componentDidUpdate(someProps) {
+            const prevState = { id: 456 };
+            console.log(prevState.id);
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'id'", Line: 6, Column: 15},
+			},
+		},
+
+		// ---- Upstream: setState with unused initial ----
+		{
+			Code: `
+        class Foo extends Component {
+          state = {
+            initial: 'foo',
+          }
+          handleChange = () => {
+            this.setState(() => ({
+              current: 'hi'
+            }));
+          }
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'initial'", Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: wrapped class expression ----
+		{
+			Code: `
+        wrap(class NotWorking extends React.Component {
+            state = {
+                dummy: null
+            };
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'dummy'", Line: 4, Column: 17},
+			},
+		},
+
+		// ---- Upstream: TS unused state fields ----
+		{
+			Code: `
+        class Foo extends Component {
+          state = {
+            thisStateAliasPropUnused,
+            thisStateAliasRestPropUnused,
+            thisDestructStateAliasPropUnused,
+            thisDestructStateAliasRestPropUnused,
+            thisDestructStateDestructRestPropUnused,
+            thisSetStatePropUnused,
+            thisSetStateRestPropUnused,
+          } as unknown
+
+          constructor() {
+            ((this as unknown).state as unknown) = { thisStatePropUnused } as unknown;
+            ((this as unknown).setState as unknown)({ thisStateDestructPropUnused } as unknown);
+            ((this as unknown).setState as unknown)(state => ({ thisDestructStateDestructPropUnused } as unknown));
+          }
+
+          thisStateAlias() {
+            const state = (this as unknown).state as unknown;
+
+            (state as unknown).thisStateAliasProp as unknown;
+            const { ...thisStateAliasRest } = state as unknown;
+            (thisStateAliasRest as unknown).thisStateAliasRestProp as unknown;
+          }
+
+          thisDestructStateAlias() {
+            const { state } = this as unknown;
+
+            (state as unknown).thisDestructStateAliasProp as unknown;
+            const { ...thisDestructStateAliasRest } = state as unknown;
+            (thisDestructStateAliasRest as unknown).thisDestructStateAliasRestProp as unknown;
+          }
+
+          thisSetState() {
+            ((this as unknown).setState as unknown)(state => (state as unknown).thisSetStateProp as unknown);
+            ((this as unknown).setState as unknown)(({ ...thisSetStateRest }) => (thisSetStateRest as unknown).thisSetStateRestProp as unknown);
+          }
+
+          render() {
+            ((this as unknown).state as unknown).thisStateProp as unknown;
+            const { thisStateDestructProp } = (this as unknown).state as unknown;
+            const { state: { thisDestructStateDestructProp, ...thisDestructStateDestructRest } } = this as unknown;
+            (thisDestructStateDestructRest as unknown).thisDestructStateDestructRestProp as unknown;
+
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisStateAliasPropUnused'", Line: 4, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisStateAliasRestPropUnused'", Line: 5, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisDestructStateAliasPropUnused'", Line: 6, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisDestructStateAliasRestPropUnused'", Line: 7, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisDestructStateDestructRestPropUnused'", Line: 8, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisSetStatePropUnused'", Line: 9, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisSetStateRestPropUnused'", Line: 10, Column: 13},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisStatePropUnused'", Line: 14, Column: 54},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisStateDestructPropUnused'", Line: 15, Column: 55},
+				{MessageId: "unusedStateField", Message: "Unused state field: 'thisDestructStateDestructPropUnused'", Line: 16, Column: 65},
+			},
+		},
+
+		// ---- Upstream: unused computed float literal key ----
+		{
+			Code: `
+        class UnusedComputedFloatLiteralKeyStateTest extends React.Component {
+          state = { [123.12]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: '123.12'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Edge: nested class — inner unused state is independent ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          state = { outerFoo: 0 };
+          render() {
+            return <div>{this.state.outerFoo}</div>;
+          }
+        }
+        class Inner extends React.Component {
+          state = { innerBar: 0 };
+          render() {
+            return <div />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'innerBar'", Line: 9, Column: 21},
+			},
+		},
+
+		// ---- Edge: parenthesized this.state assignment in constructor ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          constructor() {
+            (this).state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 4, Column: 30},
+			},
+		},
+
+		// ---- Edge: method shorthand in state object is tracked ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          state = { handler() { return 1; } };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'handler'", Line: 3, Column: 21},
+			},
+		},
+
+		// ---- Edge: setState arrow-defined field unused ----
+		{
+			Code: `
+        class Hello extends Component {
+          handleChange = () => {
+            this.setState(state => ({
+              derived: state.count + 1
+            }));
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'derived'", Line: 5, Column: 15},
+			},
+		},
+
+		// ---- Edge: ES5 partially used state ----
+		{
+			Code: `
+        var Hello = createReactClass({
+          getInitialState: function() {
+            return { used: 0, unused: 1 };
+          },
+          render: function() {
+            return <SomeComponent foo={this.state.used} />;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'unused'", Line: 4, Column: 31},
+			},
+		},
+
+		// ---- Edge: multiple components, only one with unused state ----
+		{
+			Code: `
+        class CompA extends React.Component {
+          state = { a: 1 };
+          render() { return <div>{this.state.a}</div>; }
+        }
+        class CompB extends React.Component {
+          state = { b: 2 };
+          render() { return <div />; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'b'", Line: 7, Column: 21},
+			},
+		},
+
+		// ---- Edge: alias does not leak across methods ----
+		{
+			Code: `
+        class Hello extends React.Component {
+          state = { foo: 0 };
+          methodA() {
+            const s = this.state;
+          }
+          methodB() {
+            const out = s.foo;
+          }
+          render() {
+            return <div />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedStateField", Message: "Unused state field: 'foo'", Line: 3, Column: 21},
+			},
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -116,6 +116,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
+    './tests/eslint-plugin-react/rules/no-unused-state.test.ts',
     './tests/eslint-plugin-react/rules/no-unknown-property.test.ts',
     './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/prefer-es6-class.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unused-state.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unused-state.test.ts
@@ -1,0 +1,385 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unused-state', {} as never, {
+  valid: [
+    // ---- Stateless function component ----
+    {
+      code: `
+        function StatelessFnUnaffectedTest(props) {
+          return <SomeComponent foo={props.foo} />;
+        };
+      `,
+    },
+    // ---- createReactClass without state ----
+    {
+      code: `
+        var NoStateTest = createReactClass({
+          render: function() {
+            return <SomeComponent />;
+          }
+        });
+      `,
+    },
+    // ---- getInitialState with used state ----
+    {
+      code: `
+        var GetInitialStateTest = createReactClass({
+          getInitialState: function() {
+            return { foo: 0 };
+          },
+          render: function() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        });
+      `,
+    },
+    // ---- Computed key from variable ----
+    {
+      code: `
+        var ComputedKeyFromVariableTest = createReactClass({
+          getInitialState: function() {
+            return { [foo]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        });
+      `,
+    },
+    // ---- Class component without state ----
+    {
+      code: `
+        class NoStateTest extends React.Component {
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+    },
+    // ---- Constructor state with usage ----
+    {
+      code: `
+        class CtorStateTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- Class property state ----
+    {
+      code: `
+        class ClassPropertyStateTest extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent foo={this.state.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- Optional chaining ----
+    {
+      code: `
+        class OptionalChaining extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent foo={this.state?.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- Destructuring ----
+    {
+      code: `
+        class DestructuringTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const {foo: myFoo} = this.state;
+            return <SomeComponent foo={myFoo} />;
+          }
+        }
+      `,
+    },
+    // ---- Alias declaration ----
+    {
+      code: `
+        class AliasDeclarationTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const state = this.state;
+            return <SomeComponent foo={state.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- Shorthand destructuring alias ----
+    {
+      code: `
+        class ShorthandDestructuringAliasTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const {state} = this;
+            return <SomeComponent foo={state.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- Rest property ----
+    {
+      code: `
+        class RestPropertyTest extends React.Component {
+          constructor() {
+            this.state = {
+              foo: 0,
+              bar: 1,
+            };
+          }
+          render() {
+            const {foo, ...others} = this.state;
+            return <SomeComponent foo={foo} bar={others.bar} />;
+          }
+        }
+      `,
+    },
+    // ---- JSX spread (gives up) ----
+    {
+      code: `
+        class JsxSpreadFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent {...this.state} />;
+          }
+        }
+      `,
+    },
+    // ---- Object spread (gives up) ----
+    {
+      code: `
+        class ObjectSpreadFalseNegativeTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            const attrs = { ...this.state, foo: 1 };
+            return <SomeComponent foo={attrs.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- getDerivedStateFromProps ----
+    {
+      code: `
+        class GetDerivedStateFromPropsTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+            };
+          }
+          static getDerivedStateFromProps(nextProps, otherState) {
+            if (otherState.id === nextProps.id) {
+              return {
+                selected: true,
+              };
+            }
+            return null;
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `,
+    },
+    // ---- shouldComponentUpdate ----
+    {
+      code: `
+        class ShouldComponentUpdateTest extends Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: 123,
+            };
+          }
+          shouldComponentUpdate(nextProps, nextState) {
+            return nextState.id === nextProps.id;
+          }
+          render() {
+            return (
+              <h1>{this.state.selected ? 'Selected' : 'Not selected'}</h1>
+            );
+          }
+        }
+      `,
+    },
+    // ---- setState callback with state param ----
+    {
+      code: `
+        class Foo extends Component {
+          state = {
+            initial: 'foo',
+          }
+          handleChange = () => {
+            this.setState(state => ({
+              current: state.initial
+            }));
+          }
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        }
+      `,
+    },
+    // ---- getDerivedStateFromProps as class property ----
+    {
+      code: `
+        class TestNoUnusedState extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = {
+              id: null,
+            };
+          }
+          static getDerivedStateFromProps = (props, state) => {
+            if (state.id !== props.id) {
+              return {
+                id: props.id,
+              };
+            }
+            return null;
+          };
+          render() {
+            return <h1>{this.state.id}</h1>;
+          }
+        }
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Unused getInitialState ----
+    {
+      code: `
+        var UnusedGetInitialStateTest = createReactClass({
+          getInitialState: function() {
+            return { foo: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })
+      `,
+      errors: [{ message: "Unused state field: 'foo'" }],
+    },
+    // ---- Unused class constructor state ----
+    {
+      code: `
+        class UnusedCtorStateTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+      errors: [{ message: "Unused state field: 'foo'" }],
+    },
+    // ---- Unused class property state ----
+    {
+      code: `
+        class UnusedClassPropertyStateTest extends React.Component {
+          state = { foo: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+      errors: [{ message: "Unused state field: 'foo'" }],
+    },
+    // ---- Unused setState ----
+    {
+      code: `
+        class UnusedSetStateTest extends React.Component {
+          onFooChange(newFoo) {
+            this.setState({ foo: newFoo });
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+      errors: [{ message: "Unused state field: 'foo'" }],
+    },
+    // ---- Multiple unused fields ----
+    {
+      code: `
+        class MultipleErrorsTest extends React.Component {
+          constructor() {
+            this.state = {
+              foo: 0,
+              bar: 1,
+              baz: 2,
+              qux: 3,
+            };
+          }
+          render() {
+            let {state} = this;
+            return <SomeComponent baz={state.baz} qux={state.qux} />;
+          }
+        }
+      `,
+      errors: [
+        { message: "Unused state field: 'foo'" },
+        { message: "Unused state field: 'bar'" },
+      ],
+    },
+    // ---- Wrapped class expression ----
+    {
+      code: `
+        wrap(class NotWorking extends React.Component {
+            state = {
+                dummy: null
+            };
+        });
+      `,
+      errors: [{ message: "Unused state field: 'dummy'" }],
+    },
+    // ---- setState with unused initial ----
+    {
+      code: `
+        class Foo extends Component {
+          state = {
+            initial: 'foo',
+          }
+          handleChange = () => {
+            this.setState(() => ({
+              current: 'hi'
+            }));
+          }
+          render() {
+            const { current } = this.state;
+            return <div>{current}</div>
+          }
+        }
+      `,
+      errors: [{ message: "Unused state field: 'initial'" }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -62,6 +62,7 @@ fround
 fsys
 funcw
 gcflags
+GDSFP
 getsp
 github
 gnored
@@ -250,6 +251,7 @@ componentwillupdate
 renderable
 Unparseable
 deprec
+destructures
 segs
 setstate
 Setstate


### PR DESCRIPTION
## Summary

Port the `react/no-unused-state` rule from eslint-plugin-react to rslint.

This rule detects state fields defined in React components that are never read. Supports:
- ES6 class components (`extends React.Component` / `PureComponent`) and ES5 `createReactClass`
- State definitions via constructor assignment, class property, `this.setState()`, and `getInitialState()`
- State usage detection via direct access, destructuring, aliasing, rest properties, lifecycle method parameters, and `getDerivedStateFromProps`
- TypeChecker-based symbol resolution for precise parameter matching (with name-based fallback for plain JS)
- TS type assertion transparency (`as`, `satisfies`, `!`, `<T>`)

## Related Links

- eslint-plugin-react rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-state.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unused-state.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).