### PR TITLE
feat: port rule react/no-unused-class-component-methods

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -27,6 +27,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_class_component_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_render_return_value"
@@ -76,6 +77,7 @@ func GetAllRules() []rule.Rule {
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
+		no_unused_class_component_methods.NoUnusedClassComponentMethodsRule,
 		no_unused_state.NoUnusedStateRule,
 		no_redundant_should_component_update.NoRedundantShouldComponentUpdateRule,
 		no_render_return_value.NoRenderReturnValueRule,

--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.go
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.go
@@ -153,8 +153,19 @@ func (ci *classInfo) markUsed(name string) {
 // Mirrors upstream's `node.parent.type === 'AssignmentExpression' && node.parent.left === node`.
 // In tsgo, all assignments (`=`, `+=`, `-=`, …) collapse into BinaryExpression
 // with an assignment operator — we gate on that.
+//
+// Parenthesized LHS: ESTree flattens parens, so upstream sees `(this.foo) = 1`
+// as `AssignmentExpression(left: MemberExpression)` directly. tsgo preserves
+// the ParenthesizedExpression wrapper, so we must walk up through any number
+// of paren wrappers before checking the assignment shape — otherwise we'd
+// mis-classify `(this.foo) = 1` (a definition) as a use.
 func isAssignmentTarget(access *ast.Node) bool {
-	parent := access.Parent
+	cur := access
+	parent := cur.Parent
+	for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+		cur = parent
+		parent = parent.Parent
+	}
 	if parent == nil || parent.Kind != ast.KindBinaryExpression {
 		return false
 	}
@@ -162,7 +173,7 @@ func isAssignmentTarget(access *ast.Node) bool {
 	if bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
 		return false
 	}
-	return bin.Left == access
+	return bin.Left == cur
 }
 
 // walkExpressions recursively visits every descendant of `node`, invoking the
@@ -427,23 +438,18 @@ var NoUnusedClassComponentMethodsRule = rule.Rule{
 		pragma := reactutil.GetReactPragma(ctx.Settings)
 		createClass := reactutil.GetReactCreateClass(ctx.Settings)
 
+		runOnClass := func(node *ast.Node) {
+			if !reactutil.ExtendsReactComponent(node, pragma) {
+				return
+			}
+			ci := newClassInfo(true, getClassName(node))
+			processES6Class(ci, node)
+			reportUnused(ctx, ci)
+		}
+
 		return rule.RuleListeners{
-			ast.KindClassDeclaration: func(node *ast.Node) {
-				if !reactutil.ExtendsReactComponent(node, pragma) {
-					return
-				}
-				ci := newClassInfo(true, getClassName(node))
-				processES6Class(ci, node)
-				reportUnused(ctx, ci)
-			},
-			ast.KindClassExpression: func(node *ast.Node) {
-				if !reactutil.ExtendsReactComponent(node, pragma) {
-					return
-				}
-				ci := newClassInfo(true, getClassName(node))
-				processES6Class(ci, node)
-				reportUnused(ctx, ci)
-			},
+			ast.KindClassDeclaration: runOnClass,
+			ast.KindClassExpression:  runOnClass,
 			ast.KindCallExpression: func(node *ast.Node) {
 				call := node.AsCallExpression()
 				if !reactutil.IsCreateClassCall(call, pragma, createClass) {

--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.go
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.go
@@ -1,0 +1,465 @@
+package no_unused_class_component_methods
+
+import (
+	"fmt"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+var lifecycleMethods = map[string]bool{
+	"constructor":                      true,
+	"componentDidCatch":                true,
+	"componentDidMount":                true,
+	"componentDidUpdate":               true,
+	"componentWillMount":               true,
+	"componentWillReceiveProps":        true,
+	"componentWillUnmount":             true,
+	"componentWillUpdate":              true,
+	"getChildContext":                  true,
+	"getSnapshotBeforeUpdate":          true,
+	"render":                           true,
+	"shouldComponentUpdate":            true,
+	"UNSAFE_componentWillMount":        true,
+	"UNSAFE_componentWillReceiveProps": true,
+	"UNSAFE_componentWillUpdate":       true,
+}
+
+var es6Lifecycle = map[string]bool{
+	"state": true,
+}
+
+var es5Lifecycle = map[string]bool{
+	"getInitialState": true,
+	"getDefaultProps": true,
+	"mixins":          true,
+}
+
+// propertyDef records a property definition — the node to report on and the
+// extracted static name.
+type propertyDef struct {
+	node *ast.Node
+	name string
+}
+
+// classInfo tracks a single React component's declared properties and usages.
+type classInfo struct {
+	properties     []*propertyDef
+	usedProperties map[string]bool
+	isClass        bool
+	className      string
+}
+
+func newClassInfo(isClass bool, className string) *classInfo {
+	return &classInfo{
+		usedProperties: make(map[string]bool),
+		isClass:        isClass,
+		className:      className,
+	}
+}
+
+// skipAssertionsAndParens strips parentheses and TS assertion wrappers,
+// matching ESLint's `uncast` which peels TypeCastExpression wrappers.
+func skipAssertionsAndParens(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	return ast.SkipOuterExpressions(node, ast.OEKParentheses|ast.OEKAssertions)
+}
+
+// isThisExpression reports whether `node` (after unwrapping assertions /
+// parens) is a bare `this`.
+func isThisExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return skipAssertionsAndParens(node).Kind == ast.KindThisKeyword
+}
+
+// resolveLiteralKey extracts the static name from a property-key / member-name
+// node, AND the inner node that should be used as the diagnostic position.
+// Mirrors upstream's `isKeyLiteralLike` which accepts:
+//   - Identifier when computed === false
+//   - String / numeric / boolean / null / regex literals (computed or not)
+//   - TemplateLiteral with no expressions (computed or not)
+//
+// Name extraction is delegated to utils.GetStaticPropertyName; this helper's
+// extra job is to surface the reportable inner node (tsgo wraps computed keys
+// in `ComputedPropertyName`; we unwrap so the diagnostic range sits on the
+// literal inside the brackets, matching ESTree-oriented `node.key` positions).
+// PrivateIdentifier (`#foo`) and dynamic computed keys (`[foo]`) are rejected
+// for parity with upstream.
+func resolveLiteralKey(nameNode *ast.Node) (string, *ast.Node) {
+	if nameNode == nil {
+		return "", nil
+	}
+	name, ok := utils.GetStaticPropertyName(nameNode)
+	if !ok {
+		return "", nil
+	}
+	if nameNode.Kind == ast.KindComputedPropertyName {
+		return name, skipAssertionsAndParens(nameNode.AsComputedPropertyName().Expression)
+	}
+	return name, nameNode
+}
+
+// resolveLiteralAccessKey extracts the name from an `X[key]` access key.
+// Upstream's `isKeyLiteralLike(node, node.property)` (with `computed === true`)
+// accepts string / numeric / template-no-expr / boolean / null / regex
+// literals — the same set utils.GetStaticPropertyName handles when wrapped in
+// a ComputedPropertyName. We forward to it by synthesizing the wrapper pattern
+// through the same Kind dispatch.
+func resolveLiteralAccessKey(keyExpr *ast.Node) (string, *ast.Node) {
+	if keyExpr == nil {
+		return "", nil
+	}
+	keyExpr = skipAssertionsAndParens(keyExpr)
+	switch keyExpr.Kind {
+	case ast.KindStringLiteral:
+		return keyExpr.AsStringLiteral().Text, keyExpr
+	case ast.KindNumericLiteral:
+		return utils.NormalizeNumericLiteral(keyExpr.AsNumericLiteral().Text), keyExpr
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return keyExpr.AsNoSubstitutionTemplateLiteral().Text, keyExpr
+	case ast.KindTrueKeyword:
+		return "true", keyExpr
+	case ast.KindFalseKeyword:
+		return "false", keyExpr
+	case ast.KindNullKeyword:
+		return "null", keyExpr
+	}
+	return "", nil
+}
+
+// addProperty records a property definition (its reportable key node and name).
+func (ci *classInfo) addProperty(node *ast.Node, name string) {
+	if node == nil || name == "" {
+		return
+	}
+	ci.properties = append(ci.properties, &propertyDef{node: node, name: name})
+}
+
+// markUsed records a name as used.
+func (ci *classInfo) markUsed(name string) {
+	if name == "" {
+		return
+	}
+	ci.usedProperties[name] = true
+}
+
+// isAssignmentTarget reports whether `access` is the LHS of an assignment.
+// Mirrors upstream's `node.parent.type === 'AssignmentExpression' && node.parent.left === node`.
+// In tsgo, all assignments (`=`, `+=`, `-=`, …) collapse into BinaryExpression
+// with an assignment operator — we gate on that.
+func isAssignmentTarget(access *ast.Node) bool {
+	parent := access.Parent
+	if parent == nil || parent.Kind != ast.KindBinaryExpression {
+		return false
+	}
+	bin := parent.AsBinaryExpression()
+	if bin.OperatorToken == nil || !ast.IsAssignmentOperator(bin.OperatorToken.Kind) {
+		return false
+	}
+	return bin.Left == access
+}
+
+// walkExpressions recursively visits every descendant of `node`, invoking the
+// per-rule handlers for PropertyAccess, ElementAccess, and VariableDeclaration.
+// The walk stops at nested class boundaries to avoid cross-component
+// interference (a nested React class would be visited separately by the
+// top-level ClassDeclaration listener).
+func (ci *classInfo) walkExpressions(node *ast.Node) {
+	if node == nil {
+		return
+	}
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return
+	case ast.KindPropertyAccessExpression:
+		ci.handlePropertyAccess(node)
+	case ast.KindElementAccessExpression:
+		ci.handleElementAccess(node)
+	case ast.KindVariableDeclaration:
+		ci.handleVariableDeclaration(node)
+	}
+	node.ForEachChild(func(child *ast.Node) bool {
+		ci.walkExpressions(child)
+		return false
+	})
+}
+
+// handlePropertyAccess processes `this.X` / `(this).X` expressions.
+func (ci *classInfo) handlePropertyAccess(node *ast.Node) {
+	pa := node.AsPropertyAccessExpression()
+	if !isThisExpression(pa.Expression) {
+		return
+	}
+	nameNode := pa.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return
+	}
+	name := nameNode.AsIdentifier().Text
+	if isAssignmentTarget(node) {
+		ci.addProperty(nameNode, name)
+	} else {
+		ci.markUsed(name)
+	}
+}
+
+// handleElementAccess processes `this['X']` / `this[0]` / `this[`X`]` accesses
+// whose key is a literal-like expression. Dynamic keys are ignored (upstream's
+// `isKeyLiteralLike` check on the key rejects them).
+func (ci *classInfo) handleElementAccess(node *ast.Node) {
+	ea := node.AsElementAccessExpression()
+	if !isThisExpression(ea.Expression) {
+		return
+	}
+	name, inner := resolveLiteralAccessKey(ea.ArgumentExpression)
+	if inner == nil {
+		return
+	}
+	if isAssignmentTarget(node) {
+		ci.addProperty(inner, name)
+	} else {
+		ci.markUsed(name)
+	}
+}
+
+// handleVariableDeclaration processes `const { foo, bar: baz } = this`
+// patterns, marking `foo` and `bar` as used. Mirrors upstream's
+// VariableDeclarator handler. In tsgo, VariableDeclaration is the nearest
+// analog of ESTree's VariableDeclarator.
+func (ci *classInfo) handleVariableDeclaration(node *ast.Node) {
+	vd := node.AsVariableDeclaration()
+	if vd.Initializer == nil {
+		return
+	}
+	if !isThisExpression(vd.Initializer) {
+		return
+	}
+	nameNode := vd.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindObjectBindingPattern {
+		return
+	}
+	bp := nameNode.AsBindingPattern()
+	if bp.Elements == nil {
+		return
+	}
+	for _, elem := range bp.Elements.Nodes {
+		if elem.Kind != ast.KindBindingElement {
+			continue
+		}
+		be := elem.AsBindingElement()
+		// Rest element (`...rest`) has no key — skip. Upstream's filter requires
+		// `prop.type === 'Property'` which excludes RestElement.
+		if be.DotDotDotToken != nil {
+			continue
+		}
+		// Explicit key: `{ foo: local }` — use the property name.
+		if be.PropertyName != nil {
+			name, _ := resolveLiteralKey(be.PropertyName)
+			ci.markUsed(name)
+			continue
+		}
+		// Shorthand: `{ foo }` — the binding name doubles as the key.
+		local := be.Name()
+		if local != nil && local.Kind == ast.KindIdentifier {
+			ci.markUsed(local.AsIdentifier().Text)
+		}
+	}
+}
+
+// processES6Class walks an ES6 class body collecting property definitions and
+// usages. Static members are skipped entirely (upstream's `inStatic` guard).
+func processES6Class(ci *classInfo, classNode *ast.Node) {
+	members := classNode.Members()
+	if members == nil {
+		return
+	}
+	for _, member := range members {
+		if ast.IsStatic(member) {
+			continue
+		}
+		switch member.Kind {
+		case ast.KindPropertyDeclaration:
+			pd := member.AsPropertyDeclaration()
+			if name, keyNode := resolveLiteralKey(pd.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if pd.Initializer != nil {
+				ci.walkExpressions(pd.Initializer)
+			}
+		case ast.KindMethodDeclaration:
+			md := member.AsMethodDeclaration()
+			if name, keyNode := resolveLiteralKey(md.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if md.Body != nil {
+				ci.walkExpressions(md.Body)
+			}
+		case ast.KindGetAccessor:
+			ga := member.AsGetAccessorDeclaration()
+			if name, keyNode := resolveLiteralKey(ga.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if ga.Body != nil {
+				ci.walkExpressions(ga.Body)
+			}
+		case ast.KindSetAccessor:
+			sa := member.AsSetAccessorDeclaration()
+			if name, keyNode := resolveLiteralKey(sa.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if sa.Body != nil {
+				ci.walkExpressions(sa.Body)
+			}
+		case ast.KindConstructor:
+			// The constructor itself has no user-provided key to add (upstream
+			// adds `constructor` then filters it via LIFECYCLE_METHODS — the
+			// net effect is nothing). We only need to walk the body for
+			// `this.X = …` definitions and `this.X` usages.
+			cd := member.AsConstructorDeclaration()
+			if cd.Body != nil {
+				ci.walkExpressions(cd.Body)
+			}
+		}
+	}
+}
+
+// processES5Object walks a createReactClass object literal collecting property
+// definitions and usages.
+func processES5Object(ci *classInfo, obj *ast.Node) {
+	ole := obj.AsObjectLiteralExpression()
+	if ole.Properties == nil {
+		return
+	}
+	for _, prop := range ole.Properties.Nodes {
+		switch prop.Kind {
+		case ast.KindPropertyAssignment:
+			pa := prop.AsPropertyAssignment()
+			if name, keyNode := resolveLiteralKey(pa.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if pa.Initializer != nil {
+				ci.walkExpressions(pa.Initializer)
+			}
+		case ast.KindShorthandPropertyAssignment:
+			spa := prop.AsShorthandPropertyAssignment()
+			if name, keyNode := resolveLiteralKey(spa.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+		case ast.KindMethodDeclaration:
+			md := prop.AsMethodDeclaration()
+			if name, keyNode := resolveLiteralKey(md.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if md.Body != nil {
+				ci.walkExpressions(md.Body)
+			}
+		case ast.KindGetAccessor:
+			ga := prop.AsGetAccessorDeclaration()
+			if name, keyNode := resolveLiteralKey(ga.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if ga.Body != nil {
+				ci.walkExpressions(ga.Body)
+			}
+		case ast.KindSetAccessor:
+			sa := prop.AsSetAccessorDeclaration()
+			if name, keyNode := resolveLiteralKey(sa.Name()); keyNode != nil {
+				ci.addProperty(keyNode, name)
+			}
+			if sa.Body != nil {
+				ci.walkExpressions(sa.Body)
+			}
+		}
+	}
+}
+
+// reportUnused emits a diagnostic for each declared property that was never
+// referenced and is not a recognized lifecycle method / reserved name.
+func reportUnused(ctx rule.RuleContext, ci *classInfo) {
+	for _, pd := range ci.properties {
+		if ci.usedProperties[pd.name] {
+			continue
+		}
+		if lifecycleMethods[pd.name] {
+			continue
+		}
+		if ci.isClass {
+			if es6Lifecycle[pd.name] {
+				continue
+			}
+		} else {
+			if es5Lifecycle[pd.name] {
+				continue
+			}
+		}
+		if ci.className != "" {
+			ctx.ReportNode(pd.node, rule.RuleMessage{
+				Id:          "unusedWithClass",
+				Description: fmt.Sprintf("Unused method or property %q of class %q", pd.name, ci.className),
+			})
+		} else {
+			ctx.ReportNode(pd.node, rule.RuleMessage{
+				Id:          "unused",
+				Description: fmt.Sprintf("Unused method or property %q", pd.name),
+			})
+		}
+	}
+}
+
+// getClassName returns the class's identifier text, or "" for an anonymous
+// class expression.
+func getClassName(classNode *ast.Node) string {
+	name := classNode.Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return name.AsIdentifier().Text
+}
+
+var NoUnusedClassComponentMethodsRule = rule.Rule{
+	Name: "react/no-unused-class-component-methods",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				ci := newClassInfo(true, getClassName(node))
+				processES6Class(ci, node)
+				reportUnused(ctx, ci)
+			},
+			ast.KindClassExpression: func(node *ast.Node) {
+				if !reactutil.ExtendsReactComponent(node, pragma) {
+					return
+				}
+				ci := newClassInfo(true, getClassName(node))
+				processES6Class(ci, node)
+				reportUnused(ctx, ci)
+			},
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				if !reactutil.IsCreateClassCall(call, pragma, createClass) {
+					return
+				}
+				if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+					return
+				}
+				arg := ast.SkipParentheses(call.Arguments.Nodes[0])
+				if arg.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+				ci := newClassInfo(false, "")
+				processES5Object(ci, arg)
+				reportUnused(ctx, ci)
+			},
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.md
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods.md
@@ -1,0 +1,67 @@
+# no-unused-class-component-methods
+
+## Rule Details
+
+Warns you if you have defined a method or property but it is never being used anywhere.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+class Foo extends React.Component {
+  handleClick() {}
+  render() {
+    return null;
+  }
+}
+
+class Foo extends React.Component {
+  action = () => {};
+  render() {
+    return null;
+  }
+}
+
+var Foo = createReactClass({
+  a: 3,
+  render() {
+    return null;
+  },
+});
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+class Foo extends React.Component {
+  handleClick() {}
+  render() {
+    return <button onClick={this.handleClick}>Text</button>;
+  }
+}
+
+class Foo extends React.Component {
+  action = () => {};
+  anotherAction = () => this.action();
+  render() {
+    return <button onClick={this.anotherAction}>Example</button>;
+  }
+}
+
+var Foo = createReactClass({
+  getInitialState() {
+    return { value: 0 };
+  },
+  render() {
+    return <div>{this.state.value}</div>;
+  },
+});
+```
+
+Canonical React lifecycle methods (e.g. `componentDidMount`, `render`,
+`shouldComponentUpdate`) and reserved property names (`state` on ES6 classes;
+`getInitialState`, `getDefaultProps`, `mixins` on `createReactClass`) are
+always ignored, even when unused.
+
+## Original Documentation
+
+- [react/no-unused-class-component-methods](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md)

--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods_test.go
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods_test.go
@@ -1,0 +1,1456 @@
+package no_unused_class_component_methods
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestNoUnusedClassComponentMethodsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedClassComponentMethodsRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: SmockTestForTypeOfNullError — used method + used field ----
+		{Code: `
+        class SmockTestForTypeOfNullError extends React.Component {
+          handleClick() {}
+          foo;
+          render() {
+            let a;
+            return <button disabled onClick={this.handleClick} foo={this.foo}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: handler referenced in JSX event ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass handler referenced in JSX event ----
+		{Code: `
+        var Foo = createReactClass({
+          handleClick() {},
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          },
+        })
+      `, Tsx: true},
+
+		// ---- Upstream: method called from lifecycle method ----
+		{Code: `
+        class Foo extends React.Component {
+          action() {}
+          componentDidMount() {
+            this.action();
+          }
+          render() {
+            return null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass method called from lifecycle ----
+		{Code: `
+        var Foo = createReactClass({
+          action() {},
+          componentDidMount() {
+            this.action();
+          },
+          render() {
+            return null;
+          },
+        })
+      `, Tsx: true},
+
+		// ---- Upstream: method reference aliased locally ----
+		{Code: `
+        class Foo extends React.Component {
+          action() {}
+          componentDidMount() {
+            const action = this.action;
+            action();
+          }
+          render() {
+            return null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: method called and result assigned ----
+		{Code: `
+        class Foo extends React.Component {
+          getValue() {}
+          componentDidMount() {
+            const action = this.getValue();
+          }
+          render() {
+            return null;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class-field arrow handler ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick = () => {}
+          render() {
+            return <button onClick={this.handleClick}>Button</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: method called within JSX expression ----
+		{Code: `
+        class Foo extends React.Component {
+          renderContent() {}
+          render() {
+            return <div>{this.renderContent()}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: method called in nested JSX ----
+		{Code: `
+        class Foo extends React.Component {
+          renderContent() {}
+          render() {
+            return (
+              <div>
+                <div>{this.renderContent()}</div>;
+              </div>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class field object used in JSX ----
+		{Code: `
+        class Foo extends React.Component {
+          property = {}
+          render() {
+            return <div property={this.property}>Example</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow field referenced from another arrow field ----
+		{Code: `
+        class Foo extends React.Component {
+          action = () => {}
+          anotherAction = () => {
+            this.action();
+          }
+          render() {
+            return <button onClick={this.anotherAction}>Example</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow expression-body referencing sibling arrow ----
+		{Code: `
+        class Foo extends React.Component {
+          action = () => {}
+          anotherAction = () => this.action()
+          render() {
+            return <button onClick={this.anotherAction}>Example</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: chained field initializer invokes sibling arrow ----
+		{Code: `
+        class Foo extends React.Component {
+          getValue = () => {}
+          value = this.getValue()
+          render() {
+            return this.value;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: non-Component class is skipped entirely ----
+		{Code: `
+        class Foo {
+          action = () => {}
+          anotherAction = () => this.action()
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: async arrow method reference ----
+		{Code: `
+        class Foo extends React.Component {
+          action = async () => {}
+          render() {
+            return <button onClick={this.action}>Click</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: async method referenced via nested arrow ----
+		{Code: `
+        class Foo extends React.Component {
+          async action() {
+            console.log('error');
+          }
+          render() {
+            return <button onClick={() => this.action()}>Click</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: generator method referenced via nested arrow ----
+		{Code: `
+        class Foo extends React.Component {
+          * action() {
+            console.log('error');
+          }
+          render() {
+            return <button onClick={() => this.action()}>Click</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: async generator method referenced via nested arrow ----
+		{Code: `
+        class Foo extends React.Component {
+          async * action() {
+            console.log('error');
+          }
+          render() {
+            return <button onClick={() => this.action()}>Click</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: function-expression class field referenced via nested arrow ----
+		{Code: `
+        class Foo extends React.Component {
+          action = function() {
+            console.log('error');
+          }
+          render() {
+            return <button onClick={() => this.action()}>Click</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: this.X = ... in constructor (defined + used) ----
+		{Code: `
+        class ClassAssignPropertyInMethodTest extends React.Component {
+          constructor() {
+            this.foo = 3;;
+          }
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: declared class property without initializer ----
+		{Code: `
+        class ClassPropertyTest extends React.Component {
+          foo;
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: class property with initializer ----
+		{Code: `
+        class ClassPropertyTest extends React.Component {
+          foo = a;
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: computed string-literal key with initializer referenced via element access ----
+		{Code: `
+        class Foo extends React.Component {
+          ['foo'] = a;
+          render() {
+            return <SomeComponent foo={this['foo']} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: computed string-literal key without initializer, referenced via element access ----
+		{Code: `
+        class Foo extends React.Component {
+          ['foo'];
+          render() {
+            return <SomeComponent foo={this['foo']} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: computed template-literal key, referenced via element access ----
+		{Code: "\n        class ClassComputedTemplatePropertyTest extends React.Component {\n          [`foo`] = a;\n          render() {\n            return <SomeComponent foo={this[`foo`]} />;\n          }\n        }\n      ", Tsx: true},
+
+		// ---- Upstream: state class field is a lifecycle name (never reported) ----
+		{Code: `
+        class ClassComputedTemplatePropertyTest extends React.Component {
+          state = {}
+          render() {
+            return <div />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: computed string-literal method name, referenced via plain member access ----
+		{Code: `
+        class ClassLiteralComputedMemberTest extends React.Component {
+          ['foo']() {}
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: computed template-literal method name, referenced via plain member access ----
+		{Code: "\n        class ClassComputedTemplateMemberTest extends React.Component {\n          [`foo`]() {}\n          render() {\n            return <SomeComponent foo={this.foo} />;\n          }\n        }\n      ", Tsx: true},
+
+		// ---- Upstream: method referenced via a bare `this.foo;` statement ----
+		{Code: `
+        class ClassUseAssignTest extends React.Component {
+          foo() {}
+          render() {
+            this.foo;
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: method referenced via shorthand destructuring of `this` ----
+		{Code: `
+        class ClassUseAssignTest extends React.Component {
+          foo() {}
+          render() {
+            const { foo } = this;
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: same pattern, different name — destructuring from `this` ----
+		{Code: `
+        class ClassUseDestructuringTest extends React.Component {
+          foo() {}
+          render() {
+            const { foo } = this;
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: destructuring with explicit string key alias ----
+		{Code: `
+        class ClassUseDestructuringTest extends React.Component {
+          ['foo']() {}
+          render() {
+            const { 'foo': bar } = this;
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: fully-computed method key ([foo]) is not tracked ----
+		{Code: `
+        class ClassComputedMemberTest extends React.Component {
+          [foo]() {}
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: every canonical lifecycle method ----
+		{Code: `
+        class ClassWithLifecyleTest extends React.Component {
+          constructor(props) {
+            super(props);
+          }
+          static getDerivedStateFromProps() {}
+          componentWillMount() {}
+          UNSAFE_componentWillMount() {}
+          componentDidMount() {}
+          componentWillReceiveProps() {}
+          UNSAFE_componentWillReceiveProps() {}
+          shouldComponentUpdate() {}
+          componentWillUpdate() {}
+          UNSAFE_componentWillUpdate() {}
+          static getSnapshotBeforeUpdate() {}
+          componentDidUpdate() {}
+          componentDidCatch() {}
+          componentWillUnmount() {}
+          getChildContext() {}
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: every canonical ES5 lifecycle method on createReactClass ----
+		{Code: `
+        var ClassWithLifecyleTest = createReactClass({
+          mixins: [],
+          constructor(props) {
+          },
+          getDefaultProps() {
+            return {}
+          },
+          getInitialState: function() {
+            return {x: 0};
+          },
+          componentWillMount() {},
+          UNSAFE_componentWillMount() {},
+          componentDidMount() {},
+          componentWillReceiveProps() {},
+          UNSAFE_componentWillReceiveProps() {},
+          shouldComponentUpdate() {},
+          componentWillUpdate() {},
+          UNSAFE_componentWillUpdate() {},
+          componentDidUpdate() {},
+          componentDidCatch() {},
+          componentWillUnmount() {},
+          getChildContext() {},
+          render() {
+            return <SomeComponent />;
+          },
+        })
+      `, Tsx: true},
+
+		// ---- rslint: non-React class is ignored regardless of member status ----
+		{Code: `
+        class NotAComponent {
+          handleClick() {}
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: parenthesized `this` still matches (ESTree flattens, tsgo preserves) ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return <button onClick={(this).handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: TS non-null `this!.X` should count as a use ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return <button onClick={this!.handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: TS `as` cast on `this` still counts as a use ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return <button onClick={(this as any).handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: PropertyAccess LHS with inner `this.X.Y = z` does not define X ----
+		// Only direct `this.X = …` (LHS is member of `this`) counts as a definition.
+		// The nested access marks X as USED, not defined.
+		{Code: `
+        class Foo extends React.Component {
+          foo = {}
+          bar() {
+            this.foo.x = 1;
+          }
+          componentDidMount() {
+            this.bar();
+          }
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: method referenced from inside a nested normal function
+		// (lexical `this` does NOT apply, but upstream still counts it) ----
+		{Code: `
+        class Foo extends React.Component {
+          action() {}
+          componentDidMount() {
+            (function() { this.action(); }).call(this);
+          }
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: class-in-class boundary — the inner (non-Component)
+		// class is visited as its own class body; its `this.x` must NOT leak
+		// into the outer classInfo ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          componentDidMount() {
+            class Inner { x() { this.y; } }
+          }
+          render() {
+            return <button onClick={this.handleClick} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: element access with numeric literal key (parity with
+		// upstream isKeyLiteralLike for number literals) ----
+		{Code: `
+        class Foo extends React.Component {
+          [0]() {}
+          render() {
+            return <SomeComponent foo={this[0]} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: destructuring with numeric-literal explicit key ----
+		{Code: `
+        class Foo extends React.Component {
+          [0]() {}
+          render() {
+            const { 0: first } = this;
+            return <SomeComponent foo={first} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: ES5 shorthand property initialized to a variable ----
+		{Code: `
+        var Foo = createReactClass({
+          data: {},
+          render() {
+            return <SomeComponent data={this.data} />;
+          },
+        })
+      `, Tsx: true},
+
+		// ---- rslint: get/set accessor pair — setter references a property
+		// defined via the same class ----
+		{Code: `
+        class Foo extends React.Component {
+          _x = 0
+          get x() { return this._x; }
+          set x(v) { this._x = v; }
+          render() { return <SomeComponent x={this.x} />; }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: extends React.PureComponent (second pragma class name) ----
+		{Code: `
+        class Foo extends React.PureComponent {
+          handleClick() {}
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: bare `Component` base (no pragma prefix, reactutil allows) ----
+		{Code: `
+        class Foo extends Component {
+          handleClick() {}
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: bare `PureComponent` base ----
+		{Code: `
+        class Foo extends PureComponent {
+          handleClick() {}
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: constructor defines via `this.X = …`, render uses via
+		// dotted access — mixed definition paths converge on the same name ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.foo = 1;
+            this.bar = 2;
+          }
+          render() {
+            return <SomeComponent foo={this.foo} bar={this.bar} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: usage via element access with string-literal key —
+		// `this['handleClick']()` must mark `handleClick` as used ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          componentDidMount() {
+            this['handleClick']();
+          }
+          render() { return null; }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: usage via element access with template-literal key ----
+		{Code: "\n        class Foo extends React.Component {\n          handleClick() {}\n          componentDidMount() {\n            this[`handleClick`]();\n          }\n          render() { return null; }\n        }\n      ", Tsx: true},
+
+		// ---- rslint: computed boolean-literal method key is recognized by
+		// both the definition side (computed `[true]`) and the element-access
+		// side (`this[true]`). Upstream treats `String(true) === 'true'`. ----
+		{Code: `
+        class Foo extends React.Component {
+          [true]() {}
+          render() {
+            return <SomeComponent foo={this[true]} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: computed null-literal method key + access parity ----
+		{Code: `
+        class Foo extends React.Component {
+          [null]() {}
+          render() {
+            return <SomeComponent foo={this[null]} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: optional chain `this?.X` must still mark X as used
+		// (tsgo encodes optional chain as a flag on PropertyAccessExpression —
+		// no ChainExpression wrapper to unwrap) ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            const fn = this?.handleClick;
+            return <button onClick={fn}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: optional element-access `this?.['X']` must also count ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            const fn = this?.['handleClick'];
+            return <button onClick={fn}>Text</button>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: nested object destructuring `{ foo: { bar } } = this`
+		// — upstream only marks TOP-LEVEL keys as used (matches the filter
+		// `prop.type === 'Property' && isKeyLiteralLike(prop, prop.key)` +
+		// `addUsedProperty(prop.key)`). The nested `bar` is NOT a direct
+		// property of `this` — it would be `this.foo.bar`. So `foo` is used,
+		// and `bar` is irrelevant to the outer class. ----
+		{Code: `
+        class Foo extends React.Component {
+          foo = { bar: 1 }
+          render() {
+            const { foo: { bar } } = this;
+            return <SomeComponent bar={bar} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: rest pattern `{ foo, ...rest } = this` — rest is not a
+		// Property in ESTree; upstream filter excludes it. `foo` is still
+		// picked up. ----
+		{Code: `
+        class Foo extends React.Component {
+          foo() {}
+          render() {
+            const { foo, ...rest } = this;
+            return <SomeComponent rest={rest} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: createReactClass with getter/setter shorthand ----
+		{Code: `
+        var Foo = createReactClass({
+          get value() { return this._v; },
+          set value(v) { this._v = v; },
+          render() {
+            return <SomeComponent v={this.value} />;
+          },
+        })
+      `, Tsx: true},
+
+		// ---- rslint: createReactClass method referenced via destructuring
+		// from `this` ----
+		{Code: `
+        var Foo = createReactClass({
+          action() {},
+          componentDidMount() {
+            const { action } = this;
+            action();
+          },
+          render() { return null; },
+        })
+      `, Tsx: true},
+
+		// ---- rslint: JSX spread attribute `<C {...this}>` — upstream's
+		// MemberExpression handler only fires on dotted access, not spread.
+		// This is NOT treated as "all members used" — but if no decl is
+		// declared either, it stays valid trivially. Tests the no-crash
+		// property on spread shapes. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <SomeComponent {...this} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: declared method + conditional rendering inside render ----
+		{Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          renderContent(flag) {
+            return flag ? <button onClick={this.handleClick} /> : null;
+          }
+          render() {
+            return this.renderContent(true);
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: declared method used inside a nested arrow inside
+		// render, through multiple JSX layers + conditional expression ----
+		{Code: `
+        class Foo extends React.Component {
+          items = [1, 2, 3]
+          render() {
+            return (
+              <ul>
+                {this.items.map((i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            );
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: static method's body contains `this.X` — should NOT
+		// count as a use because static members are skipped entirely
+		// (upstream's inStatic gate). Instance `foo` stays used from render. ----
+		{Code: `
+        class Foo extends React.Component {
+          foo() {}
+          static init() {
+            // body is skipped — this pattern doesn't mark foo as used.
+          }
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: abstract / declare class member with no body — walker
+		// must not crash when traversing a member whose Body is nil ----
+		{Code: `
+        abstract class Foo extends React.Component {
+          abstract action(): void;
+          render() {
+            return <button onClick={this.action} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: overloaded method signatures — tsgo emits multiple
+		// MethodDeclaration members for overloads; the one with body is the
+		// implementation, others are signature-only (body nil). Must not
+		// crash and must not double-report. ----
+		{Code: `
+        class Foo extends React.Component {
+          action(x: string): void;
+          action(x: number): void;
+          action(x: any): void { console.log(x); }
+          render() {
+            return <button onClick={() => this.action(1)} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: `this.state = {…}` in constructor — `state` is
+		// ES6_LIFECYCLE and always filtered, even when it's only assigned ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            this.state = { x: 0 };
+          }
+          render() { return <div>{this.state.x}</div>; }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: `defaultProps` / `propTypes` as static fields — static
+		// is skipped entirely so they're never reported regardless of name ----
+		{Code: `
+        class Foo extends React.Component {
+          static defaultProps = { x: 0 };
+          static propTypes = {};
+          render() { return <div />; }
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: non-standard lifecycle method on class ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          getDerivedStateFromProps() {}
+          render() {
+            return <div>Example</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "getDerivedStateFromProps" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused class property with empty-object initializer ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          property = {}
+          render() {
+            return <div>Example</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "property" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused method on class ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleClick" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused method on createReactClass ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          handleClick() {},
+          render() {
+            return null;
+          },
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "handleClick"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused property (numeric value) on createReactClass ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          a: 3,
+          render() {
+            return null;
+          },
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "a"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: multiple unused methods reported in source order ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          handleScroll() {}
+          handleClick() {}
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleScroll" of class "Foo"`, Line: 3, Column: 11},
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleClick" of class "Foo"`, Line: 4, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused class-field arrow ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          handleClick = () => {}
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleClick" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused async arrow class field ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          action = async () => {}
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "action" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused async method — position is the identifier, after `async ` ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          async action() {
+            console.log('error');
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "action" of class "Foo"`, Line: 3, Column: 17},
+			},
+		},
+
+		// ---- Upstream: unused generator method — position is the identifier, after `* ` ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          * action() {
+            console.log('error');
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "action" of class "Foo"`, Line: 3, Column: 13},
+			},
+		},
+
+		// ---- Upstream: unused async generator method — position is the identifier, after `async * ` ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          async * action() {
+            console.log('error');
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "action" of class "Foo"`, Line: 3, Column: 19},
+			},
+		},
+
+		// ---- Upstream: getInitialState on ES6 class is not an ES6 lifecycle name → reported ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          getInitialState() {}
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "getInitialState" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: unused `function` class field ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          action = function() {
+            console.log('error');
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "action" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: `this.foo = …` in constructor reported when unused; position is the identifier ----
+		{
+			Code: `
+         class ClassAssignPropertyInMethodTest extends React.Component {
+           constructor() {
+             this.foo = 3;
+           }
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "ClassAssignPropertyInMethodTest"`, Line: 4, Column: 19},
+			},
+		},
+
+		// ---- Upstream: bare class field declaration (no initializer) reported as unused ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           foo;
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 12},
+			},
+		},
+
+		// ---- Upstream: class field with initializer reported as unused ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           foo = a;
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 12},
+			},
+		},
+
+		// ---- Upstream: computed string-literal field (no initializer) reported at the literal ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           ['foo'];
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 13},
+			},
+		},
+
+		// ---- Upstream: computed string-literal field (with initializer) reported at the literal ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           ['foo'] = a;
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 13},
+			},
+		},
+
+		// ---- Upstream: access via a dynamic key (`this[foo]`) does NOT count as use ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           foo = a;
+           render() {
+             return <SomeComponent foo={this[foo]} />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 12},
+			},
+		},
+
+		// ---- Upstream: TS `private` field — position is the identifier, after `private ` ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           private foo;
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 20},
+			},
+		},
+
+		// ---- Upstream: TS `private` method ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           private foo() {}
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 20},
+			},
+		},
+
+		// ---- Upstream: TS `private` field with initializer ----
+		{
+			Code: `
+         class Foo extends React.Component {
+           private foo = 3;
+           render() {
+             return <SomeComponent />;
+           }
+         }
+       `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 20},
+			},
+		},
+
+		// ---- rslint: anonymous ClassExpression — no class name, uses `unused` messageId ----
+		{
+			Code: `
+        const MakeIt = () => class extends React.Component {
+          handleClick() {}
+          render() { return null; }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "handleClick"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint: `this.X` inside a non-constructor method still registers as a definition ----
+		// Mirrors upstream's MemberExpression handler: any `this.X = …` inside any
+		// (non-static) method adds X as a property. Not just constructor.
+		{
+			Code: `
+        class Foo extends React.Component {
+          notInLifecycle() {
+            this.bar = 1;
+          }
+          componentDidMount() {
+            this.notInLifecycle();
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "bar" of class "Foo"`, Line: 4, Column: 18},
+			},
+		},
+
+		// ---- rslint: `this['X'] = …` in constructor — definition reported at
+		// the inner string literal, not the `[` token ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          constructor() {
+            this['bar'] = 1;
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "bar" of class "Foo"`, Line: 4, Column: 18},
+			},
+		},
+
+		// ---- rslint: static member must NOT mask a same-name instance use.
+		// Static `foo` is skipped entirely; instance `foo` is still unused. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static foo = 1;
+          foo() {}
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 4, Column: 11},
+			},
+		},
+
+		// ---- rslint: fully-computed identifier key (`[foo]`) is not tracked
+		// as a definition — but a literal-keyed sibling method still is ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          [foo]() {}
+          bar() {}
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "bar" of class "Foo"`, Line: 4, Column: 11},
+			},
+		},
+
+		// ---- rslint: compound assignment `this.X += …` is treated by upstream
+		// as a DEFINITION (its AssignmentExpression check does not restrict
+		// operator). So a class field `counter` plus a `this.counter += 1`
+		// yields two "unused" reports — since neither assignment counts as a
+		// read, nothing marks `counter` used. This is a known upstream quirk;
+		// lock the behavior in so future refactors cannot silently flip it. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          counter = 0
+          componentDidMount() {
+            this.counter += 1;
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "counter" of class "Foo"`, Line: 3, Column: 11},
+				{MessageId: "unusedWithClass", Message: `Unused method or property "counter" of class "Foo"`, Line: 5, Column: 18},
+			},
+		},
+
+		// ---- rslint: shorthand ES5 ShorthandPropertyAssignment as a property ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          data,
+          render() {
+            return null;
+          },
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "data"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint: extends PureComponent — still a React component; rule
+		// must fire on unused methods ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          handleClick() {}
+          render() {
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleClick" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint: setter body's `this._x = v` is treated as a DEFINITION
+		// (any AssignmentExpression LHS counts). And `set x(v)` is itself a
+		// declared accessor. `render`'s `this.x = v` also counts as another
+		// definition for x. None of these names are ever READ → 3 reports
+		// total. Locks in the "assignment-LHS = definition" semantics plus
+		// its cross-member accumulation behavior. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          set x(v) {
+            this._x = v;
+          }
+          render() {
+            return <SomeComponent set={v => this.x = v} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "x" of class "Foo"`, Line: 3, Column: 15},
+				{MessageId: "unusedWithClass", Message: `Unused method or property "_x" of class "Foo"`, Line: 4, Column: 18},
+				{MessageId: "unusedWithClass", Message: `Unused method or property "x" of class "Foo"`, Line: 7, Column: 50},
+			},
+		},
+
+		// ---- rslint: ES5 PropertyAssignment whose initializer is an arrow
+		// function — the arrow body's `this.foo()` must mark `foo` as used.
+		// Here `foo` IS used that way, but `helper` is unused. ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          foo() {},
+          helper: () => {},
+          componentDidMount: function() { this.foo(); },
+          render() { return null; },
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "helper"`, Line: 4, Column: 11},
+			},
+		},
+
+		// ---- rslint: anonymous ClassExpression extending PureComponent;
+		// uses `unused` messageId (no className) ----
+		{
+			Code: `
+        export default class extends React.PureComponent {
+          handleClick() {}
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "handleClick"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint: multi-line method report position is the IDENTIFIER
+		// (not the method opener). Verifies Line/Column precision on a
+		// member whose name spans across leading modifiers / whitespace. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          async
+          /* comment between modifier and name */
+          handler() {}
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			// tsgo treats the bare `async` on its own line as a standalone
+			// identifier-typed property declaration (not a modifier for the
+			// following method). The "handler" method is therefore a plain
+			// method on the next line; both `async` (the property) and
+			// `handler` (the method) are unused.
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "async" of class "Foo"`, Line: 3, Column: 11},
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handler" of class "Foo"`, Line: 5, Column: 11},
+			},
+		},
+
+		// ---- rslint: JSX spread `<C {...this}>` does NOT count as use for
+		// declared methods. Upstream's MemberExpression handler only fires on
+		// dotted access, not SpreadElement. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return <SomeComponent {...this} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleClick" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint: string-literal property assignment on ES5 ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          "foo-bar": 3,
+          render() { return null; },
+        })
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unused", Message: `Unused method or property "foo-bar"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint: this.X used as a Call callee on a property that was
+		// never declared — no report (nothing to report); but sibling declared
+		// method `foo` stays unused ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          foo() {}
+          render() {
+            this.nonExistent();
+            return null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods_test.go
+++ b/internal/plugins/react/rules/no_unused_class_component_methods/no_unused_class_component_methods_test.go
@@ -373,7 +373,7 @@ func TestNoUnusedClassComponentMethodsRule(t *testing.T) {
 
 		// ---- Upstream: every canonical lifecycle method ----
 		{Code: `
-        class ClassWithLifecyleTest extends React.Component {
+        class ClassWithLifecycleTest extends React.Component {
           constructor(props) {
             super(props);
           }
@@ -399,7 +399,7 @@ func TestNoUnusedClassComponentMethodsRule(t *testing.T) {
 
 		// ---- Upstream: every canonical ES5 lifecycle method on createReactClass ----
 		{Code: `
-        var ClassWithLifecyleTest = createReactClass({
+        var ClassWithLifecycleTest = createReactClass({
           mixins: [],
           constructor(props) {
           },
@@ -814,6 +814,59 @@ func TestNoUnusedClassComponentMethodsRule(t *testing.T) {
           static propTypes = {};
           render() { return <div />; }
         }
+      `, Tsx: true},
+
+		// ---- rslint: parenthesized assignment LHS `(this.foo) = 1` — must
+		// still be classified as a definition (ESTree flattens parens; tsgo
+		// preserves them, so isAssignmentTarget walks up paren wrappers).
+		// Here `foo` is defined this way AND read in render, so no report. ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            (this.foo) = 1;
+          }
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: multi-level parenthesized LHS `((this.foo)) = 1` ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            ((this.foo)) = 1;
+          }
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: parenthesized element-access LHS `(this['foo']) = 1` ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor(props) {
+            super(props);
+            (this['foo']) = 1;
+          }
+          render() {
+            return <SomeComponent foo={this['foo']} />;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- rslint: class expression wrapped in parens `(class extends C {})`
+		// — the listener still fires by Kind, walker is unaffected. ----
+		{Code: `
+        const Made = (class extends React.Component {
+          handleClick() {}
+          render() {
+            return <button onClick={this.handleClick} />;
+          }
+        });
       `, Tsx: true},
 	}, []rule_tester.InvalidTestCase{
 		// ---- Upstream: non-standard lifecycle method on class ----
@@ -1450,6 +1503,70 @@ func TestNoUnusedClassComponentMethodsRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint (negative lock-in): destructuring assignment form
+		// `({ foo } = this)` is NOT a `VariableDeclarator` — upstream's
+		// VariableDeclarator listener does not fire on it, so `foo` is NOT
+		// marked as used. Locks in parity with upstream. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          foo() {}
+          componentDidMount() {
+            let foo;
+            ({ foo } = this);
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "foo" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint (negative lock-in): TS parameter property is NOT
+		// recognized by upstream (no TSParameterProperty listener and no
+		// upstream test case). Locks in 1:1 alignment — `foo` declared via
+		// `constructor(private foo: string)` stays untracked, so a sibling
+		// declared method that's unused is still reported normally. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          constructor(private bar: string) {
+            super();
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "handleClick" of class "Foo"`, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- rslint (negative lock-in): `for (this.foo of arr)` LHS — the
+		// parent is ForOfStatement, not AssignmentExpression. Upstream's
+		// `node.parent.type === 'AssignmentExpression'` check is false, so
+		// `this.foo` is treated as a USE not a definition. Sibling unused
+		// method `bar` is the only report. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          foo: any
+          bar() {}
+          componentDidMount() {
+            for (this.foo of [1, 2, 3]) {}
+          }
+          render() { return null; }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedWithClass", Message: `Unused method or property "bar" of class "Foo"`, Line: 4, Column: 11},
 			},
 		},
 	})

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -117,6 +117,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
+    './tests/eslint-plugin-react/rules/no-unused-class-component-methods.test.ts',
     './tests/eslint-plugin-react/rules/no-unused-state.test.ts',
     './tests/eslint-plugin-react/rules/no-unknown-property.test.ts',
     './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unused-class-component-methods.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unused-class-component-methods.test.ts
@@ -1,0 +1,211 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unused-class-component-methods', {} as never, {
+  valid: [
+    // ---- Handler referenced in JSX event ----
+    {
+      code: `
+        class Foo extends React.Component {
+          handleClick() {}
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          }
+        }
+      `,
+    },
+    // ---- createReactClass handler referenced in JSX event ----
+    {
+      code: `
+        var Foo = createReactClass({
+          handleClick() {},
+          render() {
+            return <button onClick={this.handleClick}>Text</button>;
+          },
+        })
+      `,
+    },
+    // ---- Method called from lifecycle method ----
+    {
+      code: `
+        class Foo extends React.Component {
+          action() {}
+          componentDidMount() {
+            this.action();
+          }
+          render() {
+            return null;
+          }
+        }
+      `,
+    },
+    // ---- Class-field arrow handler ----
+    {
+      code: `
+        class Foo extends React.Component {
+          handleClick = () => {}
+          render() {
+            return <button onClick={this.handleClick}>Button</button>;
+          }
+        }
+      `,
+    },
+    // ---- this.X = ... in constructor (defined + used) ----
+    {
+      code: `
+        class ClassAssignPropertyInMethodTest extends React.Component {
+          constructor() {
+            this.foo = 3;
+          }
+          render() {
+            return <SomeComponent foo={this.foo} />;
+          }
+        }
+      `,
+    },
+    // ---- Computed string-literal key referenced via element access ----
+    {
+      code: `
+        class Foo extends React.Component {
+          ['foo'] = a;
+          render() {
+            return <SomeComponent foo={this['foo']} />;
+          }
+        }
+      `,
+    },
+    // ---- state class field is a lifecycle name (never reported) ----
+    {
+      code: `
+        class ClassComputedTemplatePropertyTest extends React.Component {
+          state = {}
+          render() {
+            return <div />;
+          }
+        }
+      `,
+    },
+    // ---- Destructuring from `this` ----
+    {
+      code: `
+        class ClassUseDestructuringTest extends React.Component {
+          foo() {}
+          render() {
+            const { foo } = this;
+            return <SomeComponent />;
+          }
+        }
+      `,
+    },
+    // ---- Canonical lifecycle methods are always ignored ----
+    {
+      code: `
+        class ClassWithLifecyleTest extends React.Component {
+          constructor(props) {
+            super(props);
+          }
+          static getDerivedStateFromProps() {}
+          componentDidMount() {}
+          shouldComponentUpdate() {}
+          componentDidUpdate() {}
+          componentWillUnmount() {}
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+    },
+    // ---- createReactClass ES5 lifecycle names ----
+    {
+      code: `
+        var ClassWithLifecyleTest = createReactClass({
+          mixins: [],
+          getDefaultProps() { return {} },
+          getInitialState: function() { return {x: 0}; },
+          render() { return <SomeComponent />; },
+        })
+      `,
+    },
+  ],
+  invalid: [
+    // ---- Non-standard lifecycle method on class ----
+    {
+      code: `
+        class Foo extends React.Component {
+          getDerivedStateFromProps() {}
+          render() {
+            return <div>Example</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unusedWithClass' }],
+    },
+    // ---- Unused class field ----
+    {
+      code: `
+        class Foo extends React.Component {
+          property = {}
+          render() {
+            return <div>Example</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unusedWithClass' }],
+    },
+    // ---- Unused method on createReactClass (no className) ----
+    {
+      code: `
+        var Foo = createReactClass({
+          handleClick() {},
+          render() {
+            return null;
+          },
+        })
+      `,
+      errors: [{ messageId: 'unused' }],
+    },
+    // ---- Multiple unused methods reported in source order ----
+    {
+      code: `
+        class Foo extends React.Component {
+          handleScroll() {}
+          handleClick() {}
+          render() {
+            return null;
+          }
+        }
+      `,
+      errors: [
+        { messageId: 'unusedWithClass' },
+        { messageId: 'unusedWithClass' },
+      ],
+    },
+    // ---- Unused `this.foo = …` in constructor ----
+    {
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            this.foo = 3;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unusedWithClass' }],
+    },
+    // ---- TS private method ----
+    {
+      code: `
+        class Foo extends React.Component {
+          private foo() {}
+          render() {
+            return <SomeComponent />;
+          }
+        }
+      `,
+      errors: [{ messageId: 'unusedWithClass' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -95,7 +95,6 @@ ldquo
 libsyncrpc
 lsquo
 lifecycles
-Lifecyle
 lintedfile
 llms
 LOGNAME

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -95,6 +95,7 @@ ldquo
 libsyncrpc
 lsquo
 lifecycles
+Lifecyle
 lintedfile
 llms
 LOGNAME


### PR DESCRIPTION
## Summary

Port the `react/no-unused-class-component-methods` rule from `eslint-plugin-react` to rslint.

The rule warns when a class component declares a method or property that is never referenced anywhere within the component. Canonical React lifecycle methods and reserved names (`state` on ES6 classes; `getInitialState` / `getDefaultProps` / `mixins` on `createReactClass`) are always exempt. Static members are skipped entirely.

Both ES6 class components (`extends React.Component` / `PureComponent` / bare `Component` / `PureComponent`) and ES5 `createReactClass(...)` object-literal components are supported. Definitions are detected from declared members, computed literal keys, and any `this.X = …` / `this['X'] = …` assignment LHS. Usages are detected from `this.X` / `this['X']` access (including `?.`, `as`-cast, and parenthesized-receiver forms) and from `{ foo, bar: baz } = this` destructuring.

The full upstream test suite (33 valid + 23 invalid) is migrated 1:1 with exact `Line` / `Column` / `Message` assertions, plus ~30 rslint-specific edge cases covering tsgo AST quirks (parenthesized / non-null / `as`-cast `this`), TS-specific syntax (`private`, `abstract`, overload signatures), nested traversal boundaries (class-in-class, lexical-`this` in nested functions), and quirk lock-ins (compound-assignment `this.X += …` treated as definition, JSX spread `{...this}` not counted as use, static-vs-instance same-name).

Validated end-to-end against `rsbuild/website` and `rspack/website`: real codebase scans produce zero reports (neither has class components); a fixture file with 9 cases (4 expected to report, 5 expected silent) produces exactly the expected 4 reports with byte-precise positions in both repos.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-class-component-methods.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unused-class-component-methods.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).