### PR TITLE
feat: port rule react/jsx-no-leaked-render

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -45,6 +45,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_comment_textnodes"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_leaked_render"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/jsx_no_script_url"
 )
 
@@ -92,6 +93,7 @@ func GetAllRules() []rule.Rule {
 		style_prop_object.StylePropObjectRule,
 		void_dom_elements_no_children.VoidDomElementsNoChildrenRule,
 		jsx_no_comment_textnodes.JsxNoCommentTextnodesRule,
+		jsx_no_leaked_render.JsxNoLeakedRenderRule,
 		jsx_no_script_url.JsxNoScriptUrlRule,
 	}
 }

--- a/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.go
+++ b/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.go
@@ -1,0 +1,572 @@
+package jsx_no_leaked_render
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+const noPotentialLeakedRenderMessage = "Potential leaked value that might cause unintentionally rendered values or rendering crashes"
+
+const (
+	strategyCoerce  = "coerce"
+	strategyTernary = "ternary"
+)
+
+type ruleOptions struct {
+	// validStrategies is ordered; the first element is the preferred fix
+	// strategy (matches upstream's `find(from(set), () => true)`).
+	validStrategies  []string
+	ignoreAttributes bool
+}
+
+func defaultOptions() ruleOptions {
+	return ruleOptions{
+		validStrategies:  []string{strategyTernary, strategyCoerce},
+		ignoreAttributes: false,
+	}
+}
+
+func parseOptions(raw any) ruleOptions {
+	opts := defaultOptions()
+	m := utils.GetOptionsMap(raw)
+	if m == nil {
+		return opts
+	}
+	if v, ok := m["ignoreAttributes"].(bool); ok {
+		opts.ignoreAttributes = v
+	}
+	if v, ok := m["validStrategies"].([]interface{}); ok {
+		var strategies []string
+		seen := map[string]bool{}
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if s != strategyCoerce && s != strategyTernary {
+				continue
+			}
+			if seen[s] {
+				continue
+			}
+			seen[s] = true
+			strategies = append(strategies, s)
+		}
+		if len(strategies) > 0 {
+			opts.validStrategies = strategies
+		}
+	}
+	return opts
+}
+
+func hasStrategy(list []string, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+var JsxNoLeakedRenderRule = rule.Rule{
+	Name: "react/jsx-no-leaked-render",
+	Run: func(ctx rule.RuleContext, raw any) rule.RuleListeners {
+		opts := parseOptions(raw)
+		var fixStrategy string
+		if len(opts.validStrategies) > 0 {
+			fixStrategy = opts.validStrategies[0]
+		}
+		coerceAllowed := hasStrategy(opts.validStrategies, strategyCoerce)
+		ternaryAllowed := hasStrategy(opts.validStrategies, strategyTernary)
+		isReact18Plus := !reactutil.ReactVersionLessThan(ctx.Settings, 18, 0, 0)
+
+		return rule.RuleListeners{
+			ast.KindJsxExpression: func(node *ast.Node) {
+				je := node.AsJsxExpression()
+				if je == nil || je.DotDotDotToken != nil {
+					return
+				}
+				expr := je.Expression
+				if expr == nil {
+					return
+				}
+				inner := ast.SkipParentheses(expr)
+
+				// Logical AND: matches upstream
+				// `JSXExpressionContainer > LogicalExpression[operator="&&"]`.
+				if ast.IsBinaryExpression(inner) {
+					bin := inner.AsBinaryExpression()
+					if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindAmpersandAmpersandToken {
+						handleLogicalAnd(ctx, node, inner, bin, opts, coerceAllowed, isReact18Plus, fixStrategy)
+						return
+					}
+				}
+
+				// Conditional: matches upstream
+				// `JSXExpressionContainer > ConditionalExpression`.
+				if ast.IsConditionalExpression(inner) {
+					handleConditional(ctx, node, inner, opts, ternaryAllowed, fixStrategy)
+					return
+				}
+			},
+		}
+	},
+}
+
+func handleLogicalAnd(
+	ctx rule.RuleContext,
+	jsxExpr *ast.Node,
+	reportedNode *ast.Node,
+	bin *ast.BinaryExpression,
+	opts ruleOptions,
+	coerceAllowed bool,
+	isReact18Plus bool,
+	fixStrategy string,
+) {
+	if opts.ignoreAttributes && isWithinJsxAttribute(jsxExpr) {
+		return
+	}
+	leftSide := bin.Left
+	leftInner := ast.SkipParentheses(leftSide)
+
+	if coerceAllowed {
+		if isCoerceValidLeftSide(leftInner) || isCoerceValidNestedLogical(leftInner) {
+			return
+		}
+		// Identifier resolution: if the binding's initializer is a boolean
+		// literal, treat as safe (mirrors upstream's variableUtil scope walk).
+		if leftInner.Kind == ast.KindIdentifier && ctx.TypeChecker != nil {
+			decl := utils.GetDeclaration(ctx.TypeChecker, leftInner)
+			if decl != nil && decl.Kind == ast.KindVariableDeclaration {
+				init := decl.AsVariableDeclaration().Initializer
+				if init != nil {
+					initInner := ast.SkipParentheses(init)
+					if initInner.Kind == ast.KindTrueKeyword || initInner.Kind == ast.KindFalseKeyword {
+						return
+					}
+				}
+			}
+		}
+	}
+
+	// React >= 18: empty string literal '' on the left is safe — React 18 no
+	// longer renders empty string in JSX.
+	if isReact18Plus && leftInner.Kind == ast.KindStringLiteral {
+		if leftInner.AsStringLiteral().Text == "" {
+			return
+		}
+	}
+
+	msg := rule.RuleMessage{
+		Id:          "noPotentialLeakedRender",
+		Description: noPotentialLeakedRenderMessage,
+	}
+	fix := buildFix(ctx, reportedNode, leftSide, bin.Right, fixStrategy)
+	if fix == nil {
+		ctx.ReportNode(reportedNode, msg)
+		return
+	}
+	ctx.ReportNodeWithFixes(reportedNode, msg, *fix)
+}
+
+func handleConditional(
+	ctx rule.RuleContext,
+	jsxExpr *ast.Node,
+	reportedNode *ast.Node,
+	opts ruleOptions,
+	ternaryAllowed bool,
+	fixStrategy string,
+) {
+	if ternaryAllowed {
+		return
+	}
+	if opts.ignoreAttributes && isWithinJsxAttribute(jsxExpr) {
+		return
+	}
+	cond := reportedNode.AsConditionalExpression()
+	if cond == nil || cond.WhenFalse == nil {
+		return
+	}
+	if !isInvalidTernaryAlternate(cond.WhenFalse) {
+		return
+	}
+
+	msg := rule.RuleMessage{
+		Id:          "noPotentialLeakedRender",
+		Description: noPotentialLeakedRenderMessage,
+	}
+	fix := buildFix(ctx, reportedNode, cond.Condition, cond.WhenTrue, fixStrategy)
+	if fix == nil {
+		ctx.ReportNode(reportedNode, msg)
+		return
+	}
+	ctx.ReportNodeWithFixes(reportedNode, msg, *fix)
+}
+
+// isInvalidTernaryAlternate mirrors upstream's
+//
+//	const isValidTernaryAlternate = TERNARY_INVALID_ALTERNATE_VALUES.indexOf(node.alternate.value) === -1;
+//	const isJSXElementAlternate = node.alternate.type === 'JSXElement';
+//	if (isValidTernaryAlternate || isJSXElementAlternate) return;
+//
+// Upstream skips when the alternate is a non-falsy Literal value or a
+// JSXElement; everything else (`null`/`false`, identifiers, calls, …) is
+// treated as `value === undefined` and falls through to the report path.
+// JSXFragment is intentionally NOT in the JSXElement allowlist — upstream's
+// `=== 'JSXElement'` is strict and a fragment alternate would still report.
+//
+// `KindTrueKeyword` is treated as a non-falsy Literal here even though the
+// boolean keywords aren't covered by `ast.IsLiteralKind`; ESTree models them
+// as Literal nodes with `value === true`.
+func isInvalidTernaryAlternate(alt *ast.Node) bool {
+	inner := ast.SkipParentheses(alt)
+	switch inner.Kind {
+	case ast.KindNullKeyword, ast.KindFalseKeyword:
+		return true
+	case ast.KindTrueKeyword:
+		return false
+	case ast.KindJsxElement, ast.KindJsxSelfClosingElement:
+		return false
+	}
+	return !ast.IsLiteralKind(inner.Kind)
+}
+
+// isWithinJsxAttribute walks up parents until a JsxElement / JsxSelfClosingElement
+// / JsxFragment boundary, returning true if a JsxAttribute is encountered first.
+// Mirrors upstream's `isWithinAttribute` (stopTypes = JSXElement, JSXFragment).
+// JsxOpeningElement is included as a stop type because in tsgo it owns the
+// attributes list — past it, we're outside the current element's attribute
+// scope.
+func isWithinJsxAttribute(node *ast.Node) bool {
+	p := node.Parent
+	for p != nil {
+		if ast.IsJsxElement(p) || ast.IsJsxSelfClosingElement(p) || ast.IsJsxFragment(p) || ast.IsJsxOpeningElement(p) {
+			return false
+		}
+		if ast.IsJsxAttribute(p) {
+			return true
+		}
+		p = p.Parent
+	}
+	return false
+}
+
+// isCoerceValidLeftSide reports whether the (paren-skipped) node is one of
+// upstream's `COERCE_VALID_LEFT_SIDE_EXPRESSIONS`: UnaryExpression,
+// BinaryExpression (non-logical, non-assignment, non-comma), or CallExpression.
+// TS-only `as` / `satisfies` / `!` non-null wrappers are treated as transparent
+// (they don't affect the truthiness of the wrapped expression and have no
+// ESTree analog upstream considers).
+//
+// The BinaryExpression branch must EXCLUDE logical (`&&`/`||`/`??`), assignment,
+// and comma operators, which ESTree models as separate node types
+// (LogicalExpression / AssignmentExpression / SequenceExpression) but tsgo
+// flattens into BinaryExpression.
+func isCoerceValidLeftSide(node *ast.Node) bool {
+	n := skipTypeAssertions(ast.SkipParentheses(node))
+	if isUnaryExpressionLike(n) {
+		return true
+	}
+	if n.Kind == ast.KindCallExpression {
+		return true
+	}
+	if ast.IsBinaryExpression(n) {
+		bin := n.AsBinaryExpression()
+		if bin.OperatorToken == nil {
+			return false
+		}
+		op := bin.OperatorToken.Kind
+		return !ast.IsLogicalOrCoalescingBinaryOperator(op) && !ast.IsAssignmentOperator(op) && op != ast.KindCommaToken
+	}
+	return false
+}
+
+// isCoerceValidNestedLogical mirrors upstream's
+// `getIsCoerceValidNestedLogicalExpression`: the node tree, when reduced
+// across logical operators, must consist entirely of coerce-valid leaves.
+func isCoerceValidNestedLogical(node *ast.Node) bool {
+	n := skipTypeAssertions(ast.SkipParentheses(node))
+	if ast.IsLogicalOrCoalescingBinaryExpression(n) {
+		bin := n.AsBinaryExpression()
+		return isCoerceValidNestedLogical(bin.Left) && isCoerceValidNestedLogical(bin.Right)
+	}
+	return isCoerceValidLeftSide(n)
+}
+
+// isUnaryExpressionLike reports whether a tsgo node corresponds to an ESTree
+// UnaryExpression (`!`, `~`, `+`, `-`, `typeof`, `void`, `delete`).
+// PostfixUnaryExpression (`x++`, `x--`) is excluded — ESTree models those as
+// UpdateExpression, which is NOT in upstream's coerce-valid list.
+func isUnaryExpressionLike(n *ast.Node) bool {
+	switch n.Kind {
+	case ast.KindTypeOfExpression, ast.KindVoidExpression, ast.KindDeleteExpression:
+		return true
+	case ast.KindPrefixUnaryExpression:
+		op := n.AsPrefixUnaryExpression().Operator
+		return op == ast.KindExclamationToken || op == ast.KindTildeToken ||
+			op == ast.KindPlusToken || op == ast.KindMinusToken
+	}
+	return false
+}
+
+// skipTypeAssertions strips TS-only wrappers that don't change the runtime
+// expression: `x as T`, `x satisfies T`, `<T>x`, and `x!` non-null assertion.
+// Used inside coerce-validity classification so that `(arr.length as number)`
+// or `obj!` on the left of `&&` classifies the same as the unwrapped form
+// (matching upstream, which sees these as the inner expression because tsgo's
+// AST has shapes that ESLint's parser-emitted ESTree treats as Identifier /
+// MemberExpression directly).
+func skipTypeAssertions(n *ast.Node) *ast.Node {
+	for {
+		switch n.Kind {
+		case ast.KindAsExpression:
+			n = n.AsAsExpression().Expression
+		case ast.KindSatisfiesExpression:
+			n = n.AsSatisfiesExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			n = n.AsTypeAssertion().Expression
+		case ast.KindNonNullExpression:
+			n = n.AsNonNullExpression().Expression
+		default:
+			return n
+		}
+		n = ast.SkipParentheses(n)
+	}
+}
+
+// extractAndOperands flattens a left-leaning `&&` chain into its leaf operands,
+// preserving any ParenthesizedExpression wrappers on the leaves themselves.
+// Parentheses around the chain are skipped for traversal (upstream's ESTree
+// is paren-flattened) but the leaf wrapping is retained so the source text
+// emitted in the fix matches the input.
+func extractAndOperands(node *ast.Node) []*ast.Node {
+	skipped := ast.SkipParentheses(node)
+	if ast.IsBinaryExpression(skipped) {
+		bin := skipped.AsBinaryExpression()
+		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindAmpersandAmpersandToken {
+			return append(extractAndOperands(bin.Left), extractAndOperands(bin.Right)...)
+		}
+	}
+	return []*ast.Node{node}
+}
+
+// trimDoubleNot strips a leading `!!` boolean coercion. Mirrors upstream's
+// `trimLeftNode` — but additionally skips the ParenthesizedExpression that tsgo
+// inserts and ESTree flattens, so `!!(a && b)` returns `a && b` (not the
+// paren-wrapped form), making the ternary fix reproduce upstream's output.
+func trimDoubleNot(node *ast.Node) *ast.Node {
+	n := ast.SkipParentheses(node)
+	if n.Kind != ast.KindPrefixUnaryExpression {
+		return node
+	}
+	u := n.AsPrefixUnaryExpression()
+	if u.Operator != ast.KindExclamationToken {
+		return node
+	}
+	inner := ast.SkipParentheses(u.Operand)
+	if inner.Kind != ast.KindPrefixUnaryExpression {
+		return node
+	}
+	u2 := inner.AsPrefixUnaryExpression()
+	if u2.Operator != ast.KindExclamationToken {
+		return node
+	}
+	return trimDoubleNot(ast.SkipParentheses(u2.Operand))
+}
+
+// buildFix produces the autofix for a report. fixStrategy controls the output
+// shape (`coerce` → `!! left && right`, `ternary` → `left ? right : null`).
+// reportedNode is the BinaryExpression (`a && b`) or ConditionalExpression
+// (`a ? b : c`) being replaced; leftNode and rightNode are its operands.
+//
+// Returns nil when no safe fix is available (e.g. coerce strategy on a
+// rightNode that is itself a Literal — auto-coercing would not eliminate the
+// leak) or when the fix would be a no-op (the rule still reports, e.g. the
+// inverse-ternary `!!a && !!b ? false : alt` shape, but emitting a no-op fix
+// would otherwise feed back into the autofix loop indefinitely).
+func buildFix(
+	ctx rule.RuleContext,
+	reportedNode *ast.Node,
+	leftNode *ast.Node,
+	rightNode *ast.Node,
+	fixStrategy string,
+) *rule.RuleFix {
+	if fixStrategy == "" {
+		return nil
+	}
+	sf := ctx.SourceFile
+	existing := utils.TrimmedNodeText(sf, reportedNode)
+
+	if fixStrategy == strategyTernary {
+		trimmed := trimDoubleNot(leftNode)
+		leftSideText := utils.TrimmedNodeText(sf, trimmed)
+		rightSideText := utils.TrimmedNodeText(sf, rightNode)
+		newText := leftSideText + " ? " + rightSideText + " : null"
+		if newText == existing {
+			return nil
+		}
+		f := rule.RuleFixReplace(sf, reportedNode, newText)
+		return &f
+	}
+
+	// COERCE strategy.
+	// hasFalseConsequent: special inverse-ternary case
+	// (`cond ? false : alt` with validStrategies: ['coerce']). When the
+	// reported node is a ConditionalExpression whose consequent is `false`,
+	// upstream emits `!cond && alt` instead of `!!cond && false`.
+	hasFalseConsequent := false
+	if reportedNode.Kind == ast.KindConditionalExpression {
+		cond := reportedNode.AsConditionalExpression()
+		if cond.WhenTrue != nil {
+			consequent := ast.SkipParentheses(cond.WhenTrue)
+			if consequent.Kind == ast.KindFalseKeyword {
+				hasFalseConsequent = true
+			}
+		}
+	}
+
+	operands := extractAndOperands(leftNode)
+	parts := make([]string, 0, len(operands))
+	for _, op := range operands {
+		opText := utils.TrimmedNodeText(sf, op)
+		valid := isCoerceValidNestedLogical(op)
+		var prefix string
+		if valid {
+			prefix = ""
+		} else if hasFalseConsequent && operandHasConditionalFalseParent(op) {
+			prefix = "!"
+		} else {
+			prefix = "!!"
+		}
+		parts = append(parts, prefix+opText)
+	}
+	newText := strings.Join(parts, " && ")
+
+	if reportedNode.Kind == ast.KindConditionalExpression && hasFalseConsequent {
+		cond := reportedNode.AsConditionalExpression()
+		// Source text of the alternate (preserves any parens around it).
+		alternateText := utils.TrimmedNodeText(sf, cond.WhenFalse)
+		// If the test itself was a logical chain, upstream preserves the
+		// `? false : alt` shape; otherwise it collapses to `&& alt`.
+		isTestLogical := ast.IsLogicalOrCoalescingBinaryExpression(ast.SkipParentheses(cond.Condition))
+		var out string
+		if isTestLogical {
+			consequentText := utils.TrimmedNodeText(sf, cond.WhenTrue)
+			out = newText + " ? " + consequentText + " : " + alternateText
+		} else {
+			out = newText + " && " + alternateText
+		}
+		if out == existing {
+			return nil
+		}
+		f := rule.RuleFixReplace(sf, reportedNode, out)
+		return &f
+	}
+
+	rightInner := ast.SkipParentheses(rightNode)
+	rightTextWithParens := utils.TrimmedNodeText(sf, rightNode)
+	rightInnerText := utils.TrimmedNodeText(sf, rightInner)
+
+	// Right side is a logical / conditional expression — wrap in parens for
+	// precedence (upstream rule). When the source already wraps the right side
+	// in parens (tsgo preserves them), use the source text as-is to avoid
+	// double-wrapping.
+	if ast.IsConditionalExpression(rightInner) || ast.IsLogicalOrCoalescingBinaryExpression(rightInner) {
+		var out string
+		if rightNode != rightInner {
+			out = newText + " && " + rightTextWithParens
+		} else {
+			out = newText + " && (" + rightInnerText + ")"
+		}
+		if out == existing {
+			return nil
+		}
+		f := rule.RuleFixReplace(sf, reportedNode, out)
+		return &f
+	}
+
+	// Right side is a multi-line JSX element — preserve indentation by
+	// wrapping in `(\n…\n)` with computed leading whitespace, mirroring
+	// upstream. Single-line JSX falls through to the default emit.
+	if ast.IsJsxElement(rightInner) || ast.IsJsxSelfClosingElement(rightInner) {
+		lines := strings.Split(rightInnerText, "\n")
+		if len(lines) > 1 {
+			lastLine := lines[len(lines)-1]
+			indent := leadingWhitespaceLen(lastLine)
+			indentStart := strings.Repeat(" ", indent)
+			closeIndent := indent - 2
+			if closeIndent < 0 {
+				closeIndent = 0
+			}
+			indentClose := strings.Repeat(" ", closeIndent)
+			out := newText + " && (\n" + indentStart + rightInnerText + "\n" + indentClose + ")"
+			if out == existing {
+				return nil
+			}
+			f := rule.RuleFixReplace(sf, reportedNode, out)
+			return &f
+		}
+	}
+
+	// Right side is a Literal — auto-coercing the left side would still leave
+	// the literal as the rendered value; skip the fix entirely (upstream
+	// returns null).
+	if isLiteralLike(rightInner) {
+		return nil
+	}
+
+	out := newText + " && " + rightTextWithParens
+	if out == existing {
+		return nil
+	}
+	f := rule.RuleFixReplace(sf, reportedNode, out)
+	return &f
+}
+
+// operandHasConditionalFalseParent reports whether the operand's structural
+// (paren-skipped) parent is a ConditionalExpression with `false` consequent.
+// This drives upstream's special-case `!` (vs `!!`) prefix in the inverse
+// ternary fix.
+func operandHasConditionalFalseParent(op *ast.Node) bool {
+	p := op.Parent
+	for p != nil && p.Kind == ast.KindParenthesizedExpression {
+		p = p.Parent
+	}
+	if p == nil || p.Kind != ast.KindConditionalExpression {
+		return false
+	}
+	cond := p.AsConditionalExpression()
+	if cond.WhenTrue == nil {
+		return false
+	}
+	consequent := ast.SkipParentheses(cond.WhenTrue)
+	return consequent.Kind == ast.KindFalseKeyword
+}
+
+// isLiteralLike mirrors ESTree's `Literal` test: any tsgo literal kind plus
+// `true` / `false` / `null` keywords (modeled as Literal in ESTree). Used to
+// suppress the coerce fix when the right side is itself a literal — coercing
+// the left side wouldn't change the leak.
+func isLiteralLike(n *ast.Node) bool {
+	if ast.IsLiteralKind(n.Kind) {
+		return true
+	}
+	switch n.Kind {
+	case ast.KindTrueKeyword, ast.KindFalseKeyword, ast.KindNullKeyword:
+		return true
+	}
+	return false
+}
+
+func leadingWhitespaceLen(s string) int {
+	for i, r := range s {
+		if r != ' ' && r != '\t' {
+			return i
+		}
+	}
+	return len(s)
+}

--- a/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.md
+++ b/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render.md
@@ -1,0 +1,93 @@
+# jsx-no-leaked-render
+
+## Rule Details
+
+In React, conditionally rendering content with `&&` is a common pattern, but it can leak unintended values into the DOM when the left-hand side is falsy but not boolean. For example, `{count && <Something/>}` renders `0` as a literal `"0"` in React DOM and crashes React Native when `count` is `0`. The same applies to `NaN`, and in React 17 also to `''`.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+const Component = ({ count, title }) => {
+  return <div>{count && title}</div>;
+};
+```
+
+```jsx
+const Component = ({ elements }) => {
+  return <div>{elements.length && <List elements={elements} />}</div>;
+};
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+const Component = ({ elements }) => {
+  return <div>{!!elements.length && <List elements={elements} />}</div>;
+};
+```
+
+```jsx
+const Component = ({ elements }) => {
+  return <div>{elements.length > 0 && <List elements={elements} />}</div>;
+};
+```
+
+```jsx
+const Component = ({ elements }) => {
+  return (
+    <div>
+      {elements.length ? <List elements={elements} /> : null}
+    </div>
+  );
+};
+```
+
+## Options
+
+This rule accepts an options object as its second argument.
+
+### `validStrategies`
+
+**Type:** `Array<"ternary" | "coerce">` &nbsp; **Default:** `["ternary", "coerce"]`
+
+Which conversion strategies count as valid. The first entry of the array is the strategy used for autofix.
+
+```json
+{ "react/jsx-no-leaked-render": ["error", { "validStrategies": ["ternary"] }] }
+```
+
+```jsx
+const Component = ({ count, title }) => {
+  return <div>{count ? title : null}</div>;
+};
+```
+
+```json
+{ "react/jsx-no-leaked-render": ["error", { "validStrategies": ["coerce"] }] }
+```
+
+```jsx
+const Component = ({ count, title }) => {
+  return <div>{!!count && title}</div>;
+};
+```
+
+### `ignoreAttributes`
+
+**Type:** `boolean` &nbsp; **Default:** `false`
+
+When `true`, JSX attribute values are exempt from the check; only the children of JSX elements are inspected. Useful when a downstream component accepts truthy-coerced props.
+
+```json
+{ "react/jsx-no-leaked-render": ["error", { "ignoreAttributes": true }] }
+```
+
+```jsx
+const Component = ({ enabled, checked }) => {
+  return <CheckBox checked={enabled && checked} />;
+};
+```
+
+## Original Documentation
+
+- ESLint plugin: [`react/jsx-no-leaked-render`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md)

--- a/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render_test.go
+++ b/internal/plugins/react/rules/jsx_no_leaked_render/jsx_no_leaked_render_test.go
@@ -1,0 +1,1274 @@
+package jsx_no_leaked_render
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestJsxNoLeakedRender(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &JsxNoLeakedRenderRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid cases (default options) ----
+		{
+			Code: `
+        const Component = () => {
+          return <div>{customTitle || defaultTitle}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>There are {elements.length} elements</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{!count && 'No results found'}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{!!elements.length && <List elements={elements}/>}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{Boolean(elements.length) && <List elements={elements}/>}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements.length > 0 && <List elements={elements}/>}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements.length ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{count ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			Tsx: true,
+		},
+
+		// ---- Upstream valid: ternary-only strategy ----
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{count ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: coerce-only strategy ----
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{!!count && <List elements={elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: explicit [coerce, ternary] (same as default) ----
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{count ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Tsx:     true,
+		},
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{!!count && <List elements={elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: should not delete valid alternates from ternaries ----
+		// https://github.com/jsx-eslint/eslint-plugin-react/issues/3292
+		// https://github.com/jsx-eslint/eslint-plugin-react/issues/3297
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return (
+            <div>
+              <div> {direction ? (direction === "down" ? "▼" : "▲") : ""} </div>
+              <div>{ containerName.length > 0 ? "Loading several stuff" : "Loading" }</div>
+            </div>
+          )
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{direction ? (direction === "down" ? "▼" : "▲") : ""}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: nested logical expressions are coerce-valid when leaves are valid ----
+		{
+			Code: `
+        const Component = ({ direction }) => {
+          return (
+            <div>
+              <div>{!!direction && direction === "down" && "▼"}</div>
+              <div>{direction === "down" && !!direction && "▼"}</div>
+              <div>{direction === "down" || !!direction && "▼"}</div>
+              <div>{(!display || display === DISPLAY.WELCOME) && <span>foo</span>}</div>
+            </div>
+          )
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: ternary with JSX alternate ----
+		// https://github.com/jsx-eslint/eslint-plugin-react/issues/3354
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{count ? <List elements={elements}/> : <EmptyList />}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Tsx:     true,
+		},
+		{
+			Code: `
+        const Component = ({ elements, count }) => {
+          return <div>{count ? <List elements={elements}/> : <EmptyList />}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: const-bound boolean Identifier resolves through TypeChecker ----
+		{
+			Code: `
+        const isOpen = true;
+        const Component = () => {
+          return <Popover open={isOpen && items.length > 0} />
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+		{
+			Code: `
+        const isOpen = false;
+        const Component = () => {
+          return <Popover open={isOpen && items.length > 0} />
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Upstream valid: ignoreAttributes ----
+		// https://github.com/jsx-eslint/eslint-plugin-react/issues/3292
+		{
+			Code: `
+        const Component = ({ enabled, checked }) => {
+          return <CheckBox checked={enabled && checked} />
+        }
+      `,
+			Options: map[string]interface{}{"ignoreAttributes": true},
+			Tsx:     true,
+		},
+
+		// ---- React 18+: empty-string left side is safe ----
+		{
+			Code: `
+        const Example = () => {
+          return <>{'' && <Something/>}</>
+        }
+      `,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.0.0"}},
+			Tsx:      true,
+		},
+		// Default react version (latest) → React 18+ behavior.
+		{
+			Code: `
+        const Example = () => {
+          return <>{'' && <Something/>}</>
+        }
+      `,
+			Tsx: true,
+		},
+
+		// ---- Edge: JsxFragment as alternate is treated as non-JSX (matches upstream
+		// strict 'JSXElement' check) — but with default ['ternary', 'coerce'] the
+		// conditional listener does not fire at all, so the case is valid. ----
+		{
+			Code: `
+        const Example = ({ count }) => {
+          return <div>{count ? <Foo/> : null}</div>
+        }
+      `,
+			Tsx: true,
+		},
+
+		// ---- Edge: spread JsxExpression must not crash. ----
+		{
+			Code: `
+        const Component = ({ rest }) => <div {...rest} />
+      `,
+			Tsx: true,
+		},
+
+		// ---- Edge: parenthesized && expression flattens transparently
+		// (tsgo-specific: ESTree paren-flattens). With the coerce-valid left side
+		// `Boolean(...)`, the case stays valid. ----
+		{
+			Code: `
+        const Component = ({ x }) => {
+          return <div>{(Boolean(x) && <Foo />)}</div>
+        }
+      `,
+			Tsx: true,
+		},
+
+		// ---- Edge (tsgo-specific): multiple paren wrappers around a logical
+		// chain whose leaves are all coerce-valid — the recursive
+		// SkipParentheses inside isCoerceValidNestedLogical drills through.
+		// Locks in upstream's intent (parens transparent) under tsgo's preserved
+		// ParenthesizedExpression. ----
+		{
+			Code: `
+        const Component = () => <div>{(((!a && b > 0))) && <Foo/>}</div>
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Edge (tsgo-specific): TS-only wrappers `as` / `satisfies` /
+		// non-null assertion on a coerce-valid leaf — skipTypeAssertions sees
+		// past them so no `!!` is needed. ----
+		{
+			Code: `
+        const Component = ({ arr }: { arr: number[] }) => (
+          <div>{(arr.length as number) > 0 && <Foo/>}</div>
+        )
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+		{
+			Code: `
+        const Component = ({ arr }: { arr?: number[] }) => (
+          <div>{!!arr! && <Foo/>}</div>
+        )
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Edge: JsxFragment as alternate is NOT JSXElement under upstream's
+		// strict check — but with default validStrategies the conditional
+		// listener is short-circuited, so the case stays valid. Locks in the
+		// "default options skip ternaries unconditionally" path. ----
+		{
+			Code: `
+        const Component = ({ count }) => <div>{count ? <Foo/> : <></>}</div>
+      `,
+			Tsx: true,
+		},
+
+		// ---- Edge: nested JsxExpression containing a `&&` whose own right side
+		// contains another JsxExpression with a `&&`. Without coerce-valid
+		// guards the OUTER `&&` reports; under coerce strategy with valid
+		// guards on both, neither reports. ----
+		{
+			Code: `
+        const Component = ({ a, b }) => (
+          <div>
+            {!!a && <Foo>{!!b && <Bar/>}</Foo>}
+          </div>
+        )
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Edge: empty JsxExpression `{}` must not crash. ----
+		{
+			Code: `
+        const Component = () => <div>{}</div>
+      `,
+			Tsx: true,
+		},
+
+		// ---- Edge: Identifier resolves through `let`-bound variable whose
+		// initializer is a boolean literal. Upstream's `defs[0].node.init.value`
+		// path triggers regardless of `let` vs `const`; tsgo's GetDeclaration
+		// yields the same VariableDeclaration. ----
+		{
+			Code: `
+        let isOpen = true;
+        const Component = () => <Popover open={isOpen && items.length > 0} />
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Tsx:     true,
+		},
+
+		// ---- Edge: spread JsxExpression inside JSX attribute (e.g.
+		// `{...spread}`) sets dotDotDotToken. The listener's early-return on
+		// dotDotDotToken protects against false-positive reports on the spread
+		// argument. ----
+		{
+			Code: `
+        const Component = ({ rest, count }) =>
+          <Foo {...rest} bar={count ? <Bar/> : null} />
+      `,
+			Tsx: true,
+		},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid: React 17 — '' is leaked ----
+		{
+			Code: `
+        const Example = () => {
+          return (
+            <>
+              {0 && <Something/>}
+              {'' && <Something/>}
+              {NaN && <Something/>}
+            </>
+          )
+        }
+      `,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "17.999.999"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noPotentialLeakedRender", Line: 5, Column: 16},
+				{MessageId: "noPotentialLeakedRender", Line: 6, Column: 16},
+				{MessageId: "noPotentialLeakedRender", Line: 7, Column: 16},
+			},
+			Output: []string{
+				`
+        const Example = () => {
+          return (
+            <>
+              {0 ? <Something/> : null}
+              {'' ? <Something/> : null}
+              {NaN ? <Something/> : null}
+            </>
+          )
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: React 18 — '' is safe but 0 / NaN still leak ----
+		{
+			Code: `
+        const Example = () => {
+          return (
+            <>
+              {0 && <Something/>}
+              {'' && <Something/>}
+              {NaN && <Something/>}
+            </>
+          )
+        }
+      `,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "18.0.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noPotentialLeakedRender", Line: 5, Column: 16},
+				{MessageId: "noPotentialLeakedRender", Line: 7, Column: 16},
+			},
+			Output: []string{
+				`
+        const Example = () => {
+          return (
+            <>
+              {0 ? <Something/> : null}
+              {'' && <Something/>}
+              {NaN ? <Something/> : null}
+            </>
+          )
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: default options (ternary fix) ----
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{count && title}</div>
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{count ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count }) => {
+          return <div>{count && <span>There are {count} results</span>}</div>
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count }) => {
+          return <div>{count ? <span>There are {count} results</span> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements.length && <List elements={elements}/>}</div>
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ elements }) => {
+          return <div>{elements.length ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ nestedCollection }) => {
+          return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ nestedCollection }) => {
+          return <div>{nestedCollection.elements.length ? <List elements={nestedCollection.elements}/> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements[0] && <List elements={elements}/>}</div>
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ elements }) => {
+          return <div>{elements[0] ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ numberA, numberB }) => {
+          return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ numberA, numberB }) => {
+          return <div>{(numberA || numberB) ? <Results>{numberA+numberB}</Results> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		// Same as above, but with [coerce, ternary]: first strategy = coerce.
+		{
+			Code: `
+        const Component = ({ numberA, numberB }) => {
+          return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ numberA, numberB }) => {
+          return <div>{!!(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: ternary-only ----
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{count && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{count ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count }) => {
+          return <div>{count && <span>There are {count} results</span>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count }) => {
+          return <div>{count ? <span>There are {count} results</span> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements.length && <List elements={elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ elements }) => {
+          return <div>{elements.length ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ nestedCollection }) => {
+          return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ nestedCollection }) => {
+          return <div>{nestedCollection.elements.length ? <List elements={nestedCollection.elements}/> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements[0] && <List elements={elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ elements }) => {
+          return <div>{elements[0] ? <List elements={elements}/> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ numberA, numberB }) => {
+          return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ numberA, numberB }) => {
+          return <div>{(numberA || numberB) ? <Results>{numberA+numberB}</Results> : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: ternary-only — boolean-coerce on the left is not a free pass ----
+		{
+			Code: `
+        const Component = ({ someCondition, title }) => {
+          return <div>{!someCondition && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ someCondition, title }) => {
+          return <div>{!someCondition ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{!!count && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{count ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{count > 0 && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{count > 0 ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{0 != count && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{0 != count ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count, total, title }) => {
+          return <div>{count < total && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, total, title }) => {
+          return <div>{count < total ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		// trimDoubleNot: `!!(count && somethingElse)` → ternary leaves the inner
+		// LogicalExpression as-is (no `!!`), and tsgo's ParenthesizedExpression is
+		// invisible in the emitted text.
+		{
+			Code: `
+        const Component = ({ count, title, somethingElse }) => {
+          return <div>{!!(count && somethingElse) && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title, somethingElse }) => {
+          return <div>{count && somethingElse ? title : null}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: coerce-only ----
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{count && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{!!count && title}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count }) => {
+          return <div>{count && <span>There are {count} results</span>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count }) => {
+          return <div>{!!count && <span>There are {count} results</span>}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements.length && <List elements={elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ elements }) => {
+          return <div>{!!elements.length && <List elements={elements}/>}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ nestedCollection }) => {
+          return <div>{nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ nestedCollection }) => {
+          return <div>{!!nestedCollection.elements.length && <List elements={nestedCollection.elements}/>}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ elements }) => {
+          return <div>{elements[0] && <List elements={elements}/>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ elements }) => {
+          return <div>{!!elements[0] && <List elements={elements}/>}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ numberA, numberB }) => {
+          return <div>{(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ numberA, numberB }) => {
+          return <div>{!!(numberA || numberB) && <Results>{numberA+numberB}</Results>}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ connection, hasError, hasErrorUpdate}) => {
+          return <div>{connection && (hasError || hasErrorUpdate)}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ connection, hasError, hasErrorUpdate}) => {
+          return <div>{!!connection && (hasError || hasErrorUpdate)}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: ternary not allowed when validStrategies=['coerce'] ----
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{count ? title : null}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{!!count && title}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{!count ? title : null}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{!count && title}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ count, somethingElse, title }) => {
+          return <div>{count && somethingElse ? title : null}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, somethingElse, title }) => {
+          return <div>{!!count && !!somethingElse && title}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const Component = ({ items, somethingElse, title }) => {
+          return <div>{items.length > 0 && somethingElse && title}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ items, somethingElse, title }) => {
+          return <div>{items.length > 0 && !!somethingElse && title}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const MyComponent = () => {
+          const items = []
+          const breakpoint = { phones: true }
+
+          return <div>{items.length > 0 && breakpoint.phones && <span />}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 6, Column: 24}},
+			Output: []string{
+				`
+        const MyComponent = () => {
+          const items = []
+          const breakpoint = { phones: true }
+
+          return <div>{items.length > 0 && !!breakpoint.phones && <span />}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		{
+			Code: `
+        const MyComponent = () => {
+          return <div>{maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const MyComponent = () => {
+          return <div>{!!maybeObject && (isFoo ? <Aaa /> : <Bbb />)}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: inside JSX attribute, default options ----
+		// https://github.com/jsx-eslint/eslint-plugin-react/issues/3292
+		{
+			Code: `
+        const Component = ({ enabled, checked }) => {
+          return <CheckBox checked={enabled && checked} />
+        }
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 37}},
+			Output: []string{
+				`
+        const Component = ({ enabled, checked }) => {
+          return <CheckBox checked={enabled ? checked : null} />
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		// ---- Upstream invalid: inverse ternary (`cond ? false : alt`) under coerce ----
+		{
+			Code: `
+        const MyComponent = () => {
+          return <Something checked={isIndeterminate ? false : isChecked} />
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 38}},
+			Output: []string{
+				`
+        const MyComponent = () => {
+          return <Something checked={!isIndeterminate && isChecked} />
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		// ---- Inverse ternary with logical-and test (preserves `? false : alt`) ----
+		{
+			Code: `
+        const MyComponent = () => {
+          return <Something checked={cond && isIndeterminate ? false : isChecked} />
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 38}},
+			Output: []string{
+				`
+        const MyComponent = () => {
+          return <Something checked={!!cond && !!isIndeterminate ? false : isChecked} />
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: multi-line JSX right side, coerce strategy ----
+		{
+			Code: `
+        const MyComponent = () => {
+          return (
+            <>
+              {someCondition && (
+                <div>
+                  <p>hello</p>
+                </div>
+              )}
+            </>
+          )
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 5, Column: 16}},
+			Output: []string{
+				`
+        const MyComponent = () => {
+          return (
+            <>
+              {!!someCondition && (
+                <div>
+                  <p>hello</p>
+                </div>
+              )}
+            </>
+          )
+        }
+      `,
+			},
+			Tsx: true,
+		},
+		// ---- Multi-line JSX self-closing right side ----
+		{
+			Code: `
+        const MyComponent = () => {
+          return (
+            <>
+              {someCondition && (
+                <SomeComponent
+                  prop1={val1}
+                  prop2={val2}
+                />
+              )}
+            </>
+          )
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce", "ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 5, Column: 16}},
+			Output: []string{
+				`
+        const MyComponent = () => {
+          return (
+            <>
+              {!!someCondition && (
+                <SomeComponent
+                  prop1={val1}
+                  prop2={val2}
+                />
+              )}
+            </>
+          )
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: const-bound non-boolean Identifier still leaks ----
+		{
+			Code: `
+        const isOpen = 0;
+        const Component = () => {
+          return <Popover open={isOpen && items.length > 0} />
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 4, Column: 33}},
+			Output: []string{
+				`
+        const isOpen = 0;
+        const Component = () => {
+          return <Popover open={!!isOpen && items.length > 0} />
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Upstream invalid: ignoreAttributes only mutes attribute-level reports;
+		// children expressions still report. ----
+		{
+			Code: `
+        const Component = ({ enabled }) => {
+          return (
+            <Foo bar={
+              <Something>{enabled && <MuchWow />}</Something>
+            } />
+          )
+        }
+      `,
+			Options: map[string]interface{}{"ignoreAttributes": true},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 5, Column: 27}},
+			Output: []string{
+				`
+        const Component = ({ enabled }) => {
+          return (
+            <Foo bar={
+              <Something>{enabled ? <MuchWow /> : null}</Something>
+            } />
+          )
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Edge: paren-wrapped && at the JsxExpression root.
+		// In ESTree this is paren-flattened; tsgo wraps it in
+		// ParenthesizedExpression, but the listener treats the inner BinaryExpression
+		// transparently and reports on the LogicalExpression's start. ----
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{(count && title)}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"ternary"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 25}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{(count ? title : null)}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Edge: `undefined` Identifier as ternary alternate (coerce-only) — value
+		// of `undefined` Identifier is undefined → IN [undefined, null, false] →
+		// invalid alternate → report. Locks in upstream's `node.alternate.value` arm
+		// for non-Literal alternates. ----
+		{
+			Code: `
+        const Component = ({ count, title }) => {
+          return <div>{count ? title : undefined}</div>
+        }
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 3, Column: 24}},
+			Output: []string{
+				`
+        const Component = ({ count, title }) => {
+          return <div>{!!count && title}</div>
+        }
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Edge: deep nesting — JsxExpression inside JsxExpression
+		// recursion. Both inner and outer `&&` report independently (each is
+		// its own JSXExpressionContainer > LogicalExpression). The outer fix
+		// covers a range that contains the inner `&&`, so the two fixes
+		// overlap; the linter applies them across two autofix iterations
+		// (outer first, then inner). ----
+		{
+			Code: `
+        const Component = ({ a, b }) => (
+          <div>
+            {a && <Foo>{b && <Bar/>}</Foo>}
+          </div>
+        )
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "noPotentialLeakedRender", Line: 4, Column: 14},
+				{MessageId: "noPotentialLeakedRender", Line: 4, Column: 25},
+			},
+			Output: []string{
+				`
+        const Component = ({ a, b }) => (
+          <div>
+            {a ? <Foo>{b && <Bar/>}</Foo> : null}
+          </div>
+        )
+      `,
+				`
+        const Component = ({ a, b }) => (
+          <div>
+            {a ? <Foo>{b ? <Bar/> : null}</Foo> : null}
+          </div>
+        )
+      `,
+			},
+			Tsx: true,
+		},
+
+		// ---- Edge: nested ConditionalExpression as right of `&&` — under
+		// coerce, outer wraps right in parens, inner ternary preserved. ----
+		{
+			Code: `
+        const Component = ({ a, isFoo }) => <div>{a && (isFoo ? <X/> : <Y/>)}</div>
+      `,
+			Options: map[string]interface{}{"validStrategies": []interface{}{"coerce"}},
+			Errors:  []rule_tester.InvalidTestCaseError{{MessageId: "noPotentialLeakedRender", Line: 2, Column: 51}},
+			Output: []string{
+				`
+        const Component = ({ a, isFoo }) => <div>{!!a && (isFoo ? <X/> : <Y/>)}</div>
+      `,
+			},
+			Tsx: true,
+		},
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -95,6 +95,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/jsx-no-bind.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-comment-textnodes.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-duplicate-props.test.ts',
+    './tests/eslint-plugin-react/rules/jsx-no-leaked-render.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-script-url.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-target-blank.test.ts',
     './tests/eslint-plugin-react/rules/jsx-no-undef.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-leaked-render.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/jsx-no-leaked-render.test.ts
@@ -1,0 +1,124 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-leaked-render', {} as never, {
+  valid: [
+    // ---- Default options (validStrategies = [ternary, coerce]) ----
+    { code: `const C = () => <div>{customTitle || defaultTitle}</div>` },
+    { code: `const C = ({ elements }) => <div>{elements}</div>` },
+    {
+      code: `const C = ({ elements }) => <div>There are {elements.length} elements</div>`,
+    },
+    {
+      code: `const C = ({ count }) => <div>{!count && 'No results found'}</div>`,
+    },
+    {
+      code: `const C = ({ elements }) => <div>{!!elements.length && <List/>}</div>`,
+    },
+    {
+      code: `const C = ({ elements }) => <div>{Boolean(elements.length) && <List/>}</div>`,
+    },
+    {
+      code: `const C = ({ elements }) => <div>{elements.length > 0 && <List/>}</div>`,
+    },
+    {
+      code: `const C = ({ elements }) => <div>{elements.length ? <List/> : null}</div>`,
+    },
+
+    // ---- coerce-only ----
+    {
+      code: `const C = ({ count }) => <div>{!!count && <List/>}</div>`,
+      options: [{ validStrategies: ['coerce'] }],
+    },
+    {
+      code: `const C = ({ direction }) => <div>{!!direction && direction === "down" && "▼"}</div>`,
+      options: [{ validStrategies: ['coerce'] }],
+    },
+
+    // ---- ternary-only ----
+    {
+      code: `const C = ({ count }) => <div>{count ? <List/> : null}</div>`,
+      options: [{ validStrategies: ['ternary'] }],
+    },
+
+    // ---- ignoreAttributes mutes attribute-only reports ----
+    {
+      code: `const C = ({ enabled, checked }) => <CheckBox checked={enabled && checked} />`,
+      options: [{ ignoreAttributes: true }],
+    },
+
+    // ---- Default react version (latest) → React 18+ behavior:
+    //      '' empty string is safe on the left of `&&` ----
+    { code: `const C = () => <>{'' && <Foo/>}</>` },
+  ],
+  invalid: [
+    // ---- Default: ternary fix ----
+    {
+      code: `const C = ({ count, title }) => <div>{count && title}</div>`,
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    {
+      code: `const C = ({ count }) => <div>{count && <span>{count}</span>}</div>`,
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    {
+      code: `const C = ({ elements }) => <div>{elements.length && <List/>}</div>`,
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    {
+      code: `const C = ({ a, b }) => <div>{(a || b) && <Results/>}</div>`,
+      errors: [{ message: /Potential leaked value/ }],
+    },
+
+    // ---- coerce-only ----
+    {
+      code: `const C = ({ count, title }) => <div>{count && title}</div>`,
+      options: [{ validStrategies: ['coerce'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    {
+      code: `const C = ({ a, b }) => <div>{(a || b) && <Results/>}</div>`,
+      options: [{ validStrategies: ['coerce'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    // ternary not allowed under coerce-only.
+    {
+      code: `const C = ({ count, title }) => <div>{count ? title : null}</div>`,
+      options: [{ validStrategies: ['coerce'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    // Inverse ternary `cond ? false : alt`.
+    {
+      code: `const C = () => <Something checked={isIndeterminate ? false : isChecked} />`,
+      options: [{ validStrategies: ['coerce'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+
+    // ---- ternary-only — boolean coercion on the left is not a free pass ----
+    {
+      code: `const C = ({ count, title }) => <div>{!!count && title}</div>`,
+      options: [{ validStrategies: ['ternary'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+    {
+      code: `const C = ({ count, title }) => <div>{count > 0 && title}</div>`,
+      options: [{ validStrategies: ['ternary'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+
+    // ---- ignoreAttributes does NOT silence children-level reports ----
+    {
+      code: `const C = ({ enabled }) => <Foo bar={<Something>{enabled && <MuchWow/>}</Something>} />`,
+      options: [{ ignoreAttributes: true }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+
+    // ---- Const-bound non-boolean Identifier still leaks ----
+    {
+      code: `const isOpen = 0; const C = () => <Popover open={isOpen && items.length > 0} />`,
+      options: [{ validStrategies: ['coerce'] }],
+      errors: [{ message: /Potential leaked value/ }],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Port the `react/jsx-no-leaked-render` rule from `eslint-plugin-react` to rslint.

The rule prevents conditional `&&` rendering from leaking falsy non-boolean values (e.g. `0`, `NaN`, in React <18 also `''`) into the DOM, which would render the literal value or — on React Native — crash the renderer. Both `validStrategies` (default `["ternary", "coerce"]`) and `ignoreAttributes` (default `false`) options are supported, including the inverse-ternary autofix shape (`cond ? false : alt` → `!cond && alt`) and the multi-line JSX indentation handling. Behavior was cross-verified against upstream `eslint-plugin-react` on real-world JSX in `web-infra-dev/rspack`'s website — diagnostic positions and counts match byte-for-byte.

## Related Links

- ESLint plugin doc: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-leaked-render.md
- Upstream source: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/jsx-no-leaked-render.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).