### PR TITLE
feat: port rule react/prefer-stateless-function

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -38,6 +38,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unknown_property"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_will_update_set_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_es6_class"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/prefer_stateless_function"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/react_in_jsx_scope"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/require_render_return"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/self_closing_comp"
@@ -90,6 +91,7 @@ func GetAllRules() []rule.Rule {
 		no_unknown_property.NoUnknownPropertyRule,
 		no_will_update_set_state.NoWillUpdateSetStateRule,
 		prefer_es6_class.PreferEs6ClassRule,
+		prefer_stateless_function.PreferStatelessFunctionRule,
 		react_in_jsx_scope.ReactInJsxScopeRule,
 		require_render_return.RequireRenderReturnRule,
 		self_closing_comp.SelfClosingCompRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -213,6 +213,50 @@ func isComponentName(name string) bool {
 	return name == "Component" || name == "PureComponent"
 }
 
+// ExtendsReactPureComponent reports whether `classNode` (a ClassDeclaration
+// or ClassExpression) has an `extends` clause referencing `PureComponent` —
+// either as a bare identifier or qualified by the configured pragma (e.g.
+// `React.PureComponent`). Parentheses are skipped. Pass the empty string for
+// pragma to default to `DefaultReactPragma`.
+//
+// Mirrors eslint-plugin-react's `componentUtil.isPureComponent`, which uses
+// the regex `/^(<pragma>\.)?PureComponent$/` over the rendered extends-clause
+// text. Plain `Component` does NOT match (use ExtendsReactComponent for the
+// broader detection).
+func ExtendsReactPureComponent(classNode *ast.Node, pragma string) bool {
+	if classNode == nil {
+		return false
+	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	heritage := ast.GetClassExtendsHeritageElement(classNode)
+	if heritage == nil {
+		return false
+	}
+	hc := heritage.AsExpressionWithTypeArguments()
+	if hc == nil || hc.Expression == nil {
+		return false
+	}
+	expr := ast.SkipParentheses(hc.Expression)
+	switch expr.Kind {
+	case ast.KindIdentifier:
+		return expr.AsIdentifier().Text == "PureComponent"
+	case ast.KindPropertyAccessExpression:
+		pa := expr.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		return name.AsIdentifier().Text == "PureComponent"
+	}
+	return false
+}
+
 // GetJsxTagBaseIdentifier returns the leftmost Identifier of a JSX tag-name
 // node — i.e. the symbol a rule must resolve to classify the tag. Pass the
 // tag-name node obtained from `GetJsxTagName` (or directly from

--- a/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.go
+++ b/internal/plugins/react/rules/no_redundant_should_component_update/no_redundant_should_component_update.go
@@ -8,45 +8,6 @@ import (
 	"github.com/web-infra-dev/rslint/internal/rule"
 )
 
-// extendsPureComponent reports whether `classNode`'s extends clause matches
-// upstream's `componentUtil.isPureComponent` regex
-// `/^(<pragma>\.)?PureComponent$/`. Distinct from
-// `reactutil.ExtendsReactComponent` (which also matches plain `Component`).
-//
-// Parens around the extends expression are skipped — matching ESLint's
-// behavior where `getText(node.superClass)` returns the bare member-expression
-// text (range excludes surrounding parens) and the regex still matches.
-func extendsPureComponent(classNode *ast.Node, pragma string) bool {
-	if classNode == nil {
-		return false
-	}
-	heritage := ast.GetClassExtendsHeritageElement(classNode)
-	if heritage == nil {
-		return false
-	}
-	hc := heritage.AsExpressionWithTypeArguments()
-	if hc == nil || hc.Expression == nil {
-		return false
-	}
-	expr := ast.SkipParentheses(hc.Expression)
-	switch expr.Kind {
-	case ast.KindIdentifier:
-		return expr.AsIdentifier().Text == "PureComponent"
-	case ast.KindPropertyAccessExpression:
-		pa := expr.AsPropertyAccessExpression()
-		obj := ast.SkipParentheses(pa.Expression)
-		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
-			return false
-		}
-		name := pa.Name()
-		if name == nil || name.Kind != ast.KindIdentifier {
-			return false
-		}
-		return name.AsIdentifier().Text == "PureComponent"
-	}
-	return false
-}
-
 // hasShouldComponentUpdate mirrors upstream's
 // `astUtil.getComponentProperties(node).some(p => getPropertyName(p) === 'shouldComponentUpdate')`.
 //
@@ -109,7 +70,7 @@ var NoRedundantShouldComponentUpdateRule = rule.Rule{
 		pragma := reactutil.GetReactPragma(ctx.Settings)
 
 		check := func(node *ast.Node) {
-			if !extendsPureComponent(node, pragma) {
+			if !reactutil.ExtendsReactPureComponent(node, pragma) {
 				return
 			}
 			if !hasShouldComponentUpdate(node.Members()) {

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.go
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.go
@@ -1,0 +1,1092 @@
+package prefer_stateless_function
+
+import (
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Options carries the user-supplied options for this rule.
+type Options struct {
+	IgnorePureComponents bool
+}
+
+func parseOptions(options any) Options {
+	opts := Options{}
+	optsMap := utils.GetOptionsMap(options)
+	if optsMap != nil {
+		if v, ok := optsMap["ignorePureComponents"].(bool); ok {
+			opts.IgnorePureComponents = v
+		}
+	}
+	return opts
+}
+
+// componentFlags accumulates the per-component disqualifiers checked by
+// upstream's `prefer-stateless-function`. A component is reported only when
+// every flag remains false (and the basic ES5/ES6 component shape is met).
+type componentFlags struct {
+	hasOtherProperty     bool
+	useThis              bool
+	useRef               bool
+	invalidReturn        bool
+	hasChildContextTypes bool
+	useDecorators        bool
+	hasSCU               bool
+}
+
+// classKeywordStart returns the start position of the `class` keyword for a
+// ClassDeclaration / ClassExpression, skipping any leading `export` /
+// `export default` modifiers tsgo inlines into the node's modifier list.
+//
+// ESTree wraps `export class …` in `ExportNamedDeclaration` /
+// `ExportDefaultDeclaration` and exposes the inner `ClassDeclaration`
+// starting at the `class` keyword. tsgo flattens this; we recover the same
+// position to match upstream's report range exactly. Decorators / TS
+// `abstract` / `declare` modifiers are PART of the class's range upstream
+// (they are kept on TSESTree's ClassDeclaration), so we stop trimming the
+// moment a non-export/default modifier appears.
+func classKeywordStart(text string, node *ast.Node) int {
+	mods := node.Modifiers()
+	pos := node.Pos()
+	if mods != nil {
+		for _, mod := range mods.Nodes {
+			switch mod.Kind {
+			case ast.KindExportKeyword, ast.KindDefaultKeyword:
+				pos = mod.End()
+			default:
+				return scanner.SkipTrivia(text, mod.Pos())
+			}
+		}
+	}
+	return scanner.SkipTrivia(text, pos)
+}
+
+// hasDecorators reports whether `node` carries one or more `@decorator`
+// modifiers. tsgo inlines decorators into the modifier list (ESTree exposes
+// them via `node.decorators`).
+func hasDecorators(node *ast.Node) bool {
+	mods := node.Modifiers()
+	if mods == nil {
+		return false
+	}
+	for _, mod := range mods.Nodes {
+		if mod.Kind == ast.KindDecorator {
+			return true
+		}
+	}
+	return false
+}
+
+// componentBindingName returns the identifier text the component is bound
+// under — class's own name, parent VariableDeclaration's binding for
+// anonymous ClassExpression, or surrounding `var X = createReactClass({...})`
+// binding for ES5. Returns "" when no static name is available. Used as the
+// fallback identity when no TypeChecker is present (see externalCCT).
+func componentBindingName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text
+		}
+		parent := node.Parent
+		for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+			parent = parent.Parent
+		}
+		if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+			if binding := parent.AsVariableDeclaration().Name(); binding != nil && binding.Kind == ast.KindIdentifier {
+				return binding.AsIdentifier().Text
+			}
+		}
+	case ast.KindObjectLiteralExpression:
+		cur := node
+		for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
+			cur = cur.Parent
+		}
+		if cur.Parent == nil {
+			return ""
+		}
+		switch cur.Parent.Kind {
+		case ast.KindCallExpression, ast.KindNewExpression:
+		default:
+			return ""
+		}
+		vd := cur.Parent.Parent
+		if vd == nil || vd.Kind != ast.KindVariableDeclaration {
+			return ""
+		}
+		if binding := vd.AsVariableDeclaration().Name(); binding != nil && binding.Kind == ast.KindIdentifier {
+			return binding.AsIdentifier().Text
+		}
+	}
+	return ""
+}
+
+// memberName returns the static text of a class-member / object-property key
+// for the allow-list comparisons. Mirrors upstream's `astUtils.getPropertyName`:
+//
+//   - Identifier `foo`            → "foo"
+//   - StringLiteral `"foo"`       → "foo"
+//   - NumericLiteral `0`          → "0" (decimal-normalised)
+//   - Template “ `foo` “        → "foo"
+//   - PrivateIdentifier `#foo`    → "foo" (strip `#`, matching ESTree's
+//     PrivateIdentifier.name semantics that upstream's `getPropertyName`
+//     reads via `nameNode.name`)
+//   - ComputedPropertyName `[…]`  → static text of the inner expression when
+//     it resolves to a literal-like value, "" otherwise
+//
+// Dynamic computed keys (`[expr]`) and shapes without a static name fall
+// through to "" — the allow-list comparisons then all evaluate to false and
+// the property is treated as "other", matching upstream where
+// `getPropertyName` returns `undefined`.
+func memberName(member *ast.Node) string {
+	key := member.Name()
+	if key == nil {
+		return ""
+	}
+	if key.Kind == ast.KindPrivateIdentifier {
+		return strings.TrimPrefix(key.AsPrivateIdentifier().Text, "#")
+	}
+	if name, ok := utils.GetStaticPropertyName(key); ok {
+		return name
+	}
+	return ""
+}
+
+// isUselessConstructor mirrors upstream's `isRedundantSuperCall`. A
+// constructor counts as useless iff:
+//
+//   - body has exactly one statement that is `super(...)`
+//   - every constructor parameter is an Identifier or RestElement (no
+//     destructuring / defaults — those have side effects)
+//   - the super-call args are either `...arguments` or a 1:1 pass-through of
+//     the constructor's parameters (Identifier→Identifier or
+//     RestElement→SpreadElement, same name)
+func isUselessConstructor(member *ast.Node) bool {
+	if member.Kind != ast.KindConstructor {
+		return false
+	}
+	cd := member.AsConstructorDeclaration()
+	if cd.Body == nil {
+		return false
+	}
+	body := cd.Body.AsBlock()
+	if body == nil || body.Statements == nil || len(body.Statements.Nodes) != 1 {
+		return false
+	}
+	stmt := body.Statements.Nodes[0]
+	if stmt.Kind != ast.KindExpressionStatement {
+		return false
+	}
+	expr := ast.SkipParentheses(stmt.AsExpressionStatement().Expression)
+	if expr.Kind != ast.KindCallExpression {
+		return false
+	}
+	call := expr.AsCallExpression()
+	if ast.SkipParentheses(call.Expression).Kind != ast.KindSuperKeyword {
+		return false
+	}
+
+	params := cd.Parameters
+	var paramNodes []*ast.Node
+	if params != nil {
+		paramNodes = params.Nodes
+	}
+	for _, p := range paramNodes {
+		pd := p.AsParameterDeclaration()
+		if pd == nil {
+			return false
+		}
+		if pd.Initializer != nil {
+			return false
+		}
+		nameNode := pd.Name()
+		if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+			return false
+		}
+	}
+
+	var argNodes []*ast.Node
+	if call.Arguments != nil {
+		argNodes = call.Arguments.Nodes
+	}
+
+	if len(argNodes) == 1 {
+		a := ast.SkipParentheses(argNodes[0])
+		if a.Kind == ast.KindSpreadElement {
+			inner := ast.SkipParentheses(a.AsSpreadElement().Expression)
+			if inner.Kind == ast.KindIdentifier && inner.AsIdentifier().Text == "arguments" {
+				return true
+			}
+		}
+	}
+
+	if len(paramNodes) != len(argNodes) {
+		return false
+	}
+	for i, p := range paramNodes {
+		pd := p.AsParameterDeclaration()
+		paramName := pd.Name().AsIdentifier().Text
+		paramIsRest := pd.DotDotDotToken != nil
+		arg := ast.SkipParentheses(argNodes[i])
+		if paramIsRest {
+			if arg.Kind != ast.KindSpreadElement {
+				return false
+			}
+			inner := ast.SkipParentheses(arg.AsSpreadElement().Expression)
+			if inner.Kind != ast.KindIdentifier || inner.AsIdentifier().Text != paramName {
+				return false
+			}
+			continue
+		}
+		if arg.Kind != ast.KindIdentifier || arg.AsIdentifier().Text != paramName {
+			return false
+		}
+	}
+	return true
+}
+
+// isAllowedClassMember reports whether `member` of an ES6 class is part of
+// upstream's allow-list (displayName / propTypes / contextTypes / defaultProps
+// / render / `props` with type annotation / useless constructor). Constructors
+// outside that "useless" niche are NOT allowed — they're counted as "other".
+func isAllowedClassMember(member *ast.Node) bool {
+	if member.Kind == ast.KindConstructor {
+		return isUselessConstructor(member)
+	}
+	name := memberName(member)
+	switch name {
+	case "displayName", "propTypes", "contextTypes", "defaultProps", "render":
+		return true
+	case "props":
+		if member.Kind == ast.KindPropertyDeclaration {
+			pd := member.AsPropertyDeclaration()
+			if pd.Type != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isAllowedES5Property mirrors `isAllowedClassMember` for an ES5
+// createReactClass object literal: the same allow-list, minus useless
+// constructor (no constructor concept) and minus the `props` typeAnnotation
+// branch (no type annotations on object-literal properties in ESLint's model).
+func isAllowedES5Property(prop *ast.Node) bool {
+	name := memberName(prop)
+	switch name {
+	case "displayName", "propTypes", "contextTypes", "defaultProps", "render":
+		return true
+	}
+	return false
+}
+
+// isThisExpression reports whether `node` (after stripping parens) is `this`.
+func isThisExpression(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	return ast.SkipParentheses(node).Kind == ast.KindThisKeyword
+}
+
+// staticAccessName returns the name expressed by a member access on `this`
+// when that name resolves to a static identifier or string literal — matching
+// upstream's `(node.property.name || node.property.value)` pattern.
+//
+//   - `this.foo`        → ("foo", true)        — Identifier key
+//   - `this['foo']`     → ("foo", true)        — string-literal key
+//   - `this[bar]`       → ("bar", true)        — Identifier key (variable)
+//   - `this[0]`         → (any, false)         — numeric / non-name key
+//   - `this[expr]`      → ("", false)          — dynamic key
+//
+// The rationale: upstream's rule treats Identifier-keyed `this[bar]` AS-IF
+// the static name were `bar`, which is the same as `this.bar`. That's why
+// `this[bar]` qualifies as "useThis" (matches upstream test).
+func staticAccessName(node *ast.Node) (string, bool) {
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		pa := node.AsPropertyAccessExpression()
+		nm := pa.Name()
+		if nm == nil || nm.Kind != ast.KindIdentifier {
+			return "", false
+		}
+		return nm.AsIdentifier().Text, true
+	case ast.KindElementAccessExpression:
+		ea := node.AsElementAccessExpression()
+		arg := ast.SkipParentheses(ea.ArgumentExpression)
+		switch arg.Kind {
+		case ast.KindStringLiteral:
+			return arg.AsStringLiteral().Text, true
+		case ast.KindNoSubstitutionTemplateLiteral:
+			return arg.AsNoSubstitutionTemplateLiteral().Text, true
+		case ast.KindIdentifier:
+			return arg.AsIdentifier().Text, true
+		}
+	}
+	return "", false
+}
+
+// componentBoundary reports whether `node` is the start of a separate React
+// component context — its body must be analyzed independently and must not
+// be counted as part of an outer component's body. ClassDeclaration /
+// ClassExpression and createReactClass(...) ObjectLiteralExpressions both
+// qualify. The body walk uses this to stop at nested boundaries.
+func componentBoundary(node *ast.Node, pragma, createClass string) bool {
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return true
+	case ast.KindObjectLiteralExpression:
+		return isES5Component(node, pragma, createClass)
+	}
+	return false
+}
+
+// isES5Component reports whether `obj` (an ObjectLiteralExpression) is an
+// argument of a createReactClass / `<pragma>.createClass` call.
+//
+// Mirrors upstream's `componentUtil.isES5Component` exactly: the check is
+// `node.parent && node.parent.callee` followed by a callee identity match.
+// Two notable consequences we preserve for parity:
+//
+//   - BOTH `CallExpression` and `NewExpression` parents qualify, because
+//     `.callee` exists on both ESTree kinds. `new createReactClass({...})`
+//     is non-idiomatic but syntactically valid and upstream registers it.
+//   - The check does NOT verify which argument position `obj` occupies —
+//     any ObjectLiteralExpression whose direct parent is a createClass call
+//     qualifies, even non-first arguments. This matches upstream's
+//     permissive behavior; in practice non-first-arg uses are vanishingly
+//     rare and would still be filtered out by the rule's other gates
+//     (hasOtherProperty etc.).
+//
+// Pass empty strings for pragma / createClass to default to
+// `DefaultReactPragma` / `DefaultReactCreateClass`.
+func isES5Component(obj *ast.Node, pragma, createClass string) bool {
+	if obj == nil || obj.Kind != ast.KindObjectLiteralExpression {
+		return false
+	}
+	cur := obj
+	for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
+		cur = cur.Parent
+	}
+	parent := cur.Parent
+	if parent == nil {
+		return false
+	}
+	var callee *ast.Node
+	switch parent.Kind {
+	case ast.KindCallExpression:
+		callee = parent.AsCallExpression().Expression
+	case ast.KindNewExpression:
+		callee = parent.AsNewExpression().Expression
+	default:
+		return false
+	}
+	return isCreateClassCallee(callee, pragma, createClass)
+}
+
+// isCreateClassCallee mirrors `reactutil.IsCreateClassCall` but operates on a
+// callee node directly so the same logic is shared between Call- and
+// New-expression code paths. Parentheses are skipped on both the callee
+// itself and the pragma identifier.
+func isCreateClassCallee(callee *ast.Node, pragma, createClass string) bool {
+	if callee == nil {
+		return false
+	}
+	if pragma == "" {
+		pragma = reactutil.DefaultReactPragma
+	}
+	if createClass == "" {
+		createClass = reactutil.DefaultReactCreateClass
+	}
+	callee = ast.SkipParentheses(callee)
+	switch callee.Kind {
+	case ast.KindIdentifier:
+		return callee.AsIdentifier().Text == createClass
+	case ast.KindPropertyAccessExpression:
+		pa := callee.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pa.Expression)
+		if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != pragma {
+			return false
+		}
+		name := pa.Name()
+		if name == nil || name.Kind != ast.KindIdentifier {
+			return false
+		}
+		return name.AsIdentifier().Text == createClass
+	}
+	return false
+}
+
+// flagsAnalyzer walks a component body and accumulates the disqualifier flags.
+// The walk stops at nested component boundaries (ClassDeclaration /
+// ClassExpression / createReactClass object arg) so a nested component's
+// `this.X`, JSX refs, or invalid render returns don't pollute the outer one.
+type flagsAnalyzer struct {
+	flags       *componentFlags
+	pragma      string
+	createClass string
+	allowNull   bool
+}
+
+// analyzeBody walks the body of a class/object member.
+func (a *flagsAnalyzer) analyzeBody(body *ast.Node) {
+	if body == nil {
+		return
+	}
+	a.walk(body)
+}
+
+// walk visits every descendant of `node` until it hits a nested component
+// boundary. Per-kind handlers route to the right flag; ReturnStatement is
+// handled inline because its render-scope membership is decided per-statement
+// via `returnIsInsideRender`.
+func (a *flagsAnalyzer) walk(node *ast.Node) {
+	if node == nil {
+		return
+	}
+	if componentBoundary(node, a.pragma, a.createClass) {
+		return
+	}
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression, ast.KindElementAccessExpression:
+		a.handleMemberAccess(node)
+	case ast.KindVariableDeclaration:
+		a.handleVariableDeclaration(node)
+	case ast.KindJsxAttribute:
+		a.handleJsxAttribute(node)
+	case ast.KindReturnStatement:
+		if returnIsInsideRender(node) {
+			a.handleReturnStatement(node)
+		}
+	}
+	// Recurse — a method's body may contain nested arrow functions whose JSX
+	// or `this` accesses still belong to the enclosing component.
+	node.ForEachChild(func(child *ast.Node) bool {
+		a.walk(child)
+		return false
+	})
+}
+
+// returnIsInsideRender mirrors upstream's scope-walk that finds the nearest
+// enclosing `MethodDefinition` or `Property` whose key.name is "render".
+//
+// Upstream walks ESLint scope chain; we approximate by walking AST parents
+// and treating each FunctionLike encountered the same way. The intent (per
+// upstream) is to handle BOTH ES6 `render() {…}` and ES5
+// `render: function(){}` / shorthand methods. A subtle consequence — also
+// present in upstream — is that ANY object literal whose property is named
+// `render` qualifies, even when the object is unrelated to React (e.g. a
+// nested config object inside a non-render method). We mirror this exactly:
+// it is upstream's intentional `Property` arm that produces this side
+// effect.
+//
+// The walk stops at the first FunctionLike whose parent is a recognized
+// method-style container (the equivalent of ESLint's `scope.block.parent`
+// match). FunctionExpression / ArrowFunction / FunctionDeclaration whose
+// parent is NOT a property-assignment container do NOT terminate the walk —
+// upstream's `scope.upper` continues past them, so we do too. This covers
+// inline `<div onClick={function(){return X;}}/>` patterns where the
+// enclosing render container is several scopes up.
+func returnIsInsideRender(node *ast.Node) bool {
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+			// Direct class-body or object-shorthand method. tsgo represents
+			// these as the FunctionLike node itself (no FunctionExpression
+			// wrapper), so this is the analog of upstream's
+			// `scope.block.parent === MethodDefinition` (class body) or
+			// `... === Property && method:true` (object shorthand) match.
+			return memberName(p) == "render"
+		case ast.KindConstructor:
+			// Constructor has no `key.name === 'render'` — upstream's
+			// `blockNode.key.name === 'render'` returns false.
+			return false
+		case ast.KindFunctionExpression, ast.KindArrowFunction, ast.KindFunctionDeclaration:
+			// Only counts as a method-style container when the FunctionLike
+			// is the value of an object-literal PropertyAssignment
+			// (ESTree's `Property` with non-method `value: FunctionExpression`).
+			// Other parents (PropertyDeclaration class-field, ReturnStatement
+			// for a returned closure, JsxExpression for inline event
+			// handlers, …) keep the scope walk going outward — match
+			// upstream's `scope.upper` continuation.
+			if p.Parent != nil && p.Parent.Kind == ast.KindPropertyAssignment {
+				key := p.Parent.AsPropertyAssignment().Name()
+				if key != nil && key.Kind == ast.KindIdentifier {
+					return key.AsIdentifier().Text == "render"
+				}
+				return false
+			}
+		}
+	}
+	return false
+}
+
+func (a *flagsAnalyzer) handleMemberAccess(node *ast.Node) {
+	var receiver *ast.Node
+	switch node.Kind {
+	case ast.KindPropertyAccessExpression:
+		receiver = node.AsPropertyAccessExpression().Expression
+	case ast.KindElementAccessExpression:
+		receiver = node.AsElementAccessExpression().Expression
+	}
+	if !isThisExpression(receiver) {
+		return
+	}
+	name, ok := staticAccessName(node)
+	if !ok {
+		// Dynamic computed key (e.g. `this[expr]`): upstream's
+		// `(node.property.name || node.property.value)` falls back to
+		// undefined, which is neither "props" nor "context", so it
+		// flips markThisAsUsed.
+		a.flags.useThis = true
+		return
+	}
+	if name == "props" || name == "context" {
+		// markPropsOrContextAsUsed — does NOT disqualify.
+		return
+	}
+	a.flags.useThis = true
+}
+
+func (a *flagsAnalyzer) handleVariableDeclaration(node *ast.Node) {
+	vd := node.AsVariableDeclaration()
+	if vd.Initializer == nil || !isThisExpression(vd.Initializer) {
+		return
+	}
+	nameNode := vd.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindObjectBindingPattern {
+		return
+	}
+	bp := nameNode.AsBindingPattern()
+	if bp.Elements == nil {
+		return
+	}
+	useThis := false
+	for _, elem := range bp.Elements.Nodes {
+		if elem.Kind != ast.KindBindingElement {
+			continue
+		}
+		be := elem.AsBindingElement()
+		// Rest binding (`...rest = this`): upstream's
+		// `astUtil.getPropertyName(RestElement)` returns null/undefined; the
+		// `name !== 'props' && name !== 'context'` predicate evaluates to
+		// `true`, so a rest binding flips useThis the same way any non-
+		// allowed key would. (We previously mistakenly skipped these — the
+		// effect was that `let { ...rest } = this` failed to mark useThis
+		// and the component slipped through as a "should be pure"
+		// candidate.)
+		if be.DotDotDotToken != nil {
+			useThis = true
+			break
+		}
+		var keyName string
+		if be.PropertyName != nil {
+			keyName = staticBindingKeyName(be.PropertyName)
+		} else {
+			local := be.Name()
+			if local != nil && local.Kind == ast.KindIdentifier {
+				keyName = local.AsIdentifier().Text
+			}
+		}
+		if keyName != "props" && keyName != "context" {
+			useThis = true
+			break
+		}
+	}
+	if useThis {
+		a.flags.useThis = true
+	}
+}
+
+// staticBindingKeyName returns the static text of an ObjectBindingPattern
+// property name (`{ foo: localBinding }` → "foo"). Returns "" for dynamic
+// computed keys, mirroring upstream's `getPropertyName` undefined fallthrough.
+func staticBindingKeyName(node *ast.Node) string {
+	switch node.Kind {
+	case ast.KindIdentifier:
+		return node.AsIdentifier().Text
+	case ast.KindStringLiteral:
+		return node.AsStringLiteral().Text
+	case ast.KindNumericLiteral:
+		return utils.NormalizeNumericLiteral(node.AsNumericLiteral().Text)
+	case ast.KindNoSubstitutionTemplateLiteral:
+		return node.AsNoSubstitutionTemplateLiteral().Text
+	case ast.KindComputedPropertyName:
+		// `{ [expr]: x }` — only matches when expr resolves statically to a
+		// recognised name; otherwise leave empty so the property is treated
+		// as "useThis"-disqualifying.
+		inner := ast.SkipParentheses(node.AsComputedPropertyName().Expression)
+		return staticBindingKeyName(inner)
+	}
+	return ""
+}
+
+func (a *flagsAnalyzer) handleJsxAttribute(node *ast.Node) {
+	attr := node.AsJsxAttribute()
+	if attr == nil {
+		return
+	}
+	nameNode := attr.Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return
+	}
+	if nameNode.AsIdentifier().Text == "ref" {
+		a.flags.useRef = true
+	}
+}
+
+func (a *flagsAnalyzer) handleReturnStatement(node *ast.Node) {
+	rs := node.AsReturnStatement()
+	// strict mirrors upstream's `!allowNull` argument to `isReturningJSX`:
+	// when null is NOT allowed (React < 15), conditional / logical branches
+	// must ALL be JSX; when null IS allowed, ANY branch being JSX qualifies
+	// the return. This is critical — `return cond ? <jsx/> : null` flips
+	// classification across the React 15 boundary, gating multiple upstream
+	// tests.
+	strict := !a.allowNull
+	isReturningJSX := isJSXLike(rs.Expression, strict)
+	isReturningNull := rs.Expression != nil && isReturnNullOrFalse(rs.Expression)
+	if a.allowNull {
+		if isReturningJSX || isReturningNull {
+			return
+		}
+		a.flags.invalidReturn = true
+		return
+	}
+	if isReturningJSX {
+		return
+	}
+	a.flags.invalidReturn = true
+}
+
+// isJSXLike reports whether `expr` is JSX or contains JSX along all/any
+// branches of a ternary or short-circuiting logical expression. Mirrors
+// upstream's `jsxUtil.isJSX` + `isReturning` recursion: in strict mode,
+// EVERY branch must be JSX (AND); in non-strict mode, ANY branch suffices
+// (OR). The Comma operator always uses the right-hand side (sequence value).
+func isJSXLike(expr *ast.Node, strict bool) bool {
+	if expr == nil {
+		return false
+	}
+	expr = ast.SkipParentheses(expr)
+	switch expr.Kind {
+	case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
+		return true
+	case ast.KindConditionalExpression:
+		ce := expr.AsConditionalExpression()
+		l := isJSXLike(ce.WhenTrue, strict)
+		r := isJSXLike(ce.WhenFalse, strict)
+		if strict {
+			return l && r
+		}
+		return l || r
+	case ast.KindBinaryExpression:
+		bin := expr.AsBinaryExpression()
+		if bin.OperatorToken == nil {
+			return false
+		}
+		switch bin.OperatorToken.Kind {
+		case ast.KindCommaToken:
+			return isJSXLike(bin.Right, strict)
+		case ast.KindAmpersandAmpersandToken,
+			ast.KindBarBarToken,
+			ast.KindQuestionQuestionToken:
+			l := isJSXLike(bin.Left, strict)
+			r := isJSXLike(bin.Right, strict)
+			if strict {
+				return l && r
+			}
+			return l || r
+		}
+	}
+	return false
+}
+
+// isReturnNullOrFalse mirrors upstream's
+// `node.argument.value === null || node.argument.value === false` check on
+// the return argument. The argument may be parenthesized; in tsgo `null` is
+// `KindNullKeyword`, `false` is `KindFalseKeyword`.
+func isReturnNullOrFalse(expr *ast.Node) bool {
+	expr = ast.SkipParentheses(expr)
+	switch expr.Kind {
+	case ast.KindNullKeyword, ast.KindFalseKeyword:
+		return true
+	}
+	return false
+}
+
+// externalCCT records who has had `.childContextTypes` declared on them via
+// an external assignment / access. We index by Symbol when a TypeChecker is
+// available (precise — handles `const C = Foo; C.childContextTypes = {...}`
+// alias patterns the way upstream's `getRelatedComponent` does via scope
+// resolution), and fall back to base-identifier name when the checker is nil
+// (gap files in the program; same degradation pattern other rules use).
+type externalCCT struct {
+	bySymbol map[*ast.Symbol]bool
+	byName   map[string]bool
+}
+
+func (e *externalCCT) hasSymbol(sym *ast.Symbol) bool {
+	return sym != nil && e.bySymbol[sym]
+}
+
+func (e *externalCCT) hasName(name string) bool {
+	return name != "" && e.byName[name]
+}
+
+// collectExternalChildContextTypes scans the source file for
+// `*.childContextTypes` member access (anywhere — not gated on assignment)
+// and records each receiver's base symbol (precise) and base name (fallback).
+//
+// Mirrors upstream's `MemberExpression` listener + `getRelatedComponent`:
+// upstream uses ESLint's scope manager to map a member-expression receiver
+// back to its variable binding, then to the binding's RHS. tsgo's checker
+// gives us the same answer — and crucially handles cross-binding aliases
+// like `const C = Foo` that the previous AST-only `leftmostIdentifierName`
+// could not follow.
+func collectExternalChildContextTypes(sf *ast.SourceFile, tc *checker.Checker) externalCCT {
+	out := externalCCT{
+		bySymbol: map[*ast.Symbol]bool{},
+		byName:   map[string]bool{},
+	}
+	var visit ast.Visitor
+	visit = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if n.Kind == ast.KindPropertyAccessExpression {
+			pa := n.AsPropertyAccessExpression()
+			receiver := ast.SkipParentheses(pa.Expression)
+			if receiver.Kind != ast.KindThisKeyword {
+				name := pa.Name()
+				if name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "childContextTypes" {
+					base := leftmostIdentifier(receiver)
+					if base != nil {
+						out.byName[base.AsIdentifier().Text] = true
+						if tc != nil {
+							if sym := resolveBindingSymbol(tc, base); sym != nil {
+								out.bySymbol[sym] = true
+							}
+						}
+					}
+				}
+			}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	sf.Node.ForEachChild(visit)
+	return out
+}
+
+// leftmostIdentifier walks a receiver expression to its leftmost Identifier
+// node, peeling parentheses and PropertyAccessExpression wrappers. Returns
+// nil for receivers that don't terminate in a bare Identifier (`this.X`,
+// `getFoo().X`, `Foo['x'].X`, …) — same conservative skip upstream's
+// `getRelatedComponent` does for those shapes.
+func leftmostIdentifier(node *ast.Node) *ast.Node {
+	for node != nil {
+		node = ast.SkipParentheses(node)
+		switch node.Kind {
+		case ast.KindIdentifier:
+			return node
+		case ast.KindPropertyAccessExpression:
+			node = node.AsPropertyAccessExpression().Expression
+		default:
+			return nil
+		}
+	}
+	return nil
+}
+
+// resolveBindingSymbol returns the symbol an Identifier ultimately binds to,
+// transparently following local `const X = Y` aliases and import-alias
+// indirections. This mirrors upstream's reliance on
+// `variableUtil.getVariableFromContext` + walking
+// `variableInScope.references` — both of those resolve through aliasing.
+//
+// Returns nil when no TypeChecker is available (gap files in the program
+// have a nil checker — see linter scheduling). We bound the alias chain
+// length to avoid pathological / cyclic inputs.
+func resolveBindingSymbol(tc *checker.Checker, ident *ast.Node) *ast.Symbol {
+	if tc == nil || ident == nil {
+		return nil
+	}
+	sym := tc.GetSymbolAtLocation(ident)
+	for i := 0; i < 16 && sym != nil; i++ {
+		// Resolve import / export aliases first.
+		if sym.Flags&ast.SymbolFlagsAlias != 0 {
+			aliased := tc.GetAliasedSymbol(sym)
+			if aliased == nil || aliased == sym {
+				return sym
+			}
+			sym = aliased
+			continue
+		}
+		// Follow `const X = Y` (Identifier-only) chains.
+		if len(sym.Declarations) == 0 {
+			return sym
+		}
+		decl := sym.Declarations[0]
+		if decl.Kind != ast.KindVariableDeclaration {
+			return sym
+		}
+		init := decl.AsVariableDeclaration().Initializer
+		if init == nil {
+			return sym
+		}
+		init = ast.SkipParentheses(init)
+		if init.Kind != ast.KindIdentifier {
+			return sym
+		}
+		next := tc.GetSymbolAtLocation(init)
+		if next == nil || next == sym {
+			return sym
+		}
+		sym = next
+	}
+	return sym
+}
+
+// componentBindingSymbol returns the symbol identifying a component's binding:
+//
+//   - Named ClassDeclaration / ClassExpression — the class's own Identifier
+//     symbol.
+//   - Anonymous ClassExpression assigned via `var Foo = class …` — the
+//     parent VariableDeclaration's binding Identifier symbol.
+//   - createReactClass(...) ObjectLiteralExpression in `var Foo = createReactClass({...})`
+//     — the surrounding VariableDeclaration's binding Identifier symbol.
+//
+// Returns nil when the component has no binding name available, or when no
+// TypeChecker is present.
+func componentBindingSymbol(tc *checker.Checker, node *ast.Node) *ast.Symbol {
+	if tc == nil || node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier {
+			if sym := tc.GetSymbolAtLocation(name); sym != nil {
+				return sym
+			}
+		}
+		// Anonymous ClassExpression — look at the enclosing VariableDeclaration.
+		parent := node.Parent
+		for parent != nil && parent.Kind == ast.KindParenthesizedExpression {
+			parent = parent.Parent
+		}
+		if parent != nil && parent.Kind == ast.KindVariableDeclaration {
+			if name := parent.AsVariableDeclaration().Name(); name != nil && name.Kind == ast.KindIdentifier {
+				return tc.GetSymbolAtLocation(name)
+			}
+		}
+	case ast.KindObjectLiteralExpression:
+		// ES5 createReactClass — the object literal's symbol-bearing handle is
+		// the surrounding `var Foo = ...` binding. The createClass call may
+		// be either `createReactClass({...})` (CallExpression) or the rare
+		// `new createReactClass({...})` (NewExpression); both parent kinds
+		// are accepted to mirror upstream `componentUtil.isES5Component`.
+		cur := node
+		for cur.Parent != nil && cur.Parent.Kind == ast.KindParenthesizedExpression {
+			cur = cur.Parent
+		}
+		if cur.Parent == nil {
+			return nil
+		}
+		switch cur.Parent.Kind {
+		case ast.KindCallExpression, ast.KindNewExpression:
+		default:
+			return nil
+		}
+		vd := cur.Parent.Parent
+		if vd == nil || vd.Kind != ast.KindVariableDeclaration {
+			return nil
+		}
+		if name := vd.AsVariableDeclaration().Name(); name != nil && name.Kind == ast.KindIdentifier {
+			return tc.GetSymbolAtLocation(name)
+		}
+	}
+	return nil
+}
+
+// analyzeES6Class fills `flags` for an ES6 class component. Each member's
+// allow-list status is checked, and each method/property body is walked for
+// `this.X` / VariableDeclaration / JSXAttribute / ReturnStatement features.
+//
+// Static members are still walked: upstream's getComponentProperties returns
+// every body member regardless of `static`. A `static childContextTypes = {}`
+// is therefore counted as an "other property", not via the external
+// hasChildContextTypes path.
+func analyzeES6Class(classNode *ast.Node, flags *componentFlags, pragma, createClass string, allowNull bool) {
+	if hasDecorators(classNode) {
+		flags.useDecorators = true
+	}
+	a := &flagsAnalyzer{flags: flags, pragma: pragma, createClass: createClass, allowNull: allowNull}
+	members := classNode.Members()
+	for _, member := range members {
+		if !isAllowedClassMember(member) {
+			flags.hasOtherProperty = true
+		}
+		switch member.Kind {
+		case ast.KindMethodDeclaration:
+			a.analyzeBody(member.AsMethodDeclaration().Body)
+		case ast.KindGetAccessor:
+			a.analyzeBody(member.AsGetAccessorDeclaration().Body)
+		case ast.KindSetAccessor:
+			a.analyzeBody(member.AsSetAccessorDeclaration().Body)
+		case ast.KindConstructor:
+			a.analyzeBody(member.AsConstructorDeclaration().Body)
+		case ast.KindPropertyDeclaration:
+			pd := member.AsPropertyDeclaration()
+			if pd.Initializer != nil {
+				a.walk(pd.Initializer)
+			}
+		}
+	}
+}
+
+// analyzeES5Object fills `flags` for an ES5 createReactClass object literal.
+func analyzeES5Object(obj *ast.Node, flags *componentFlags, pragma, createClass string, allowNull bool) {
+	a := &flagsAnalyzer{flags: flags, pragma: pragma, createClass: createClass, allowNull: allowNull}
+	ole := obj.AsObjectLiteralExpression()
+	if ole.Properties == nil {
+		return
+	}
+	for _, prop := range ole.Properties.Nodes {
+		if !isAllowedES5Property(prop) {
+			flags.hasOtherProperty = true
+		}
+		switch prop.Kind {
+		case ast.KindPropertyAssignment:
+			pa := prop.AsPropertyAssignment()
+			if pa.Initializer != nil {
+				// Walk RHS so nested arrow / function bodies still get JSX
+				// `ref` attribute and `this.X` accesses recorded.
+				a.walk(pa.Initializer)
+			}
+		case ast.KindShorthandPropertyAssignment:
+			// Nothing to walk — shorthand initializer is just an identifier
+			// reference.
+		case ast.KindMethodDeclaration:
+			a.analyzeBody(prop.AsMethodDeclaration().Body)
+		case ast.KindGetAccessor:
+			a.analyzeBody(prop.AsGetAccessorDeclaration().Body)
+		case ast.KindSetAccessor:
+			a.analyzeBody(prop.AsSetAccessorDeclaration().Body)
+		}
+	}
+}
+
+var PreferStatelessFunctionRule = rule.Rule{
+	Name: "react/prefer-stateless-function",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		opts := parseOptions(options)
+		pragma := reactutil.GetReactPragma(ctx.Settings)
+		createClass := reactutil.GetReactCreateClass(ctx.Settings)
+
+		// React >= 15 lets stateless components return null. Default version
+		// is "latest" (see reactutil.ParseReactVersion), so allowNull defaults
+		// to true. Older settings (< 15.0.0) flip it.
+		allowNull := !reactutil.ReactVersionLessThan(ctx.Settings, 15, 0, 0)
+
+		// Use TypeChecker when present for symbol-precise resolution of
+		// `<binding>.childContextTypes` references — required to honor
+		// upstream's `getRelatedComponent` semantics for cross-binding
+		// aliases (e.g. `const C = Foo; C.childContextTypes = {...}`).
+		// On gap files (no TypeChecker), fall back to the leftmost
+		// identifier name — covers the common unaliased pattern.
+		externalCCT := collectExternalChildContextTypes(ctx.SourceFile, ctx.TypeChecker)
+
+		// hasExternalCCT bridges the two indices: it returns true when an
+		// external `.childContextTypes` declaration was observed for the
+		// given component, preferring symbol-precise matching when
+		// TypeChecker is available and falling back to name match otherwise.
+		hasExternalCCT := func(componentNode *ast.Node) bool {
+			if ctx.TypeChecker != nil {
+				if sym := componentBindingSymbol(ctx.TypeChecker, componentNode); sym != nil {
+					return externalCCT.hasSymbol(sym)
+				}
+				// TypeChecker available but binding has no symbol — fall
+				// through to name-based check (e.g. anonymous class
+				// expression with no var binding).
+			}
+			return externalCCT.hasName(componentBindingName(componentNode))
+		}
+
+		runOnClass := func(node *ast.Node) {
+			if !reactutil.ExtendsReactComponent(node, pragma) {
+				return
+			}
+			flags := &componentFlags{}
+			if opts.IgnorePureComponents && reactutil.ExtendsReactPureComponent(node, pragma) {
+				flags.hasSCU = true
+			}
+			analyzeES6Class(node, flags, pragma, createClass, allowNull)
+			if hasExternalCCT(node) {
+				flags.hasChildContextTypes = true
+			}
+			if shouldReport(flags) {
+				// Report at the `class` keyword, not at any preceding
+				// `export` / `export default` modifier. ESTree separates
+				// `ExportNamedDeclaration` / `ExportDefaultDeclaration` from
+				// the inner `ClassDeclaration` node, so upstream's
+				// `report({ node: component.node })` lands on `class …`.
+				// tsgo inlines `export` into the ClassDeclaration's modifier
+				// list, so we trim it back out to match upstream's report
+				// position.
+				start := classKeywordStart(ctx.SourceFile.Text(), node)
+				ctx.ReportRange(core.NewTextRange(start, node.End()), rule.RuleMessage{
+					Id:          "componentShouldBePure",
+					Description: "Component should be written as a pure function",
+				})
+			}
+		}
+
+		return rule.RuleListeners{
+			ast.KindClassDeclaration: runOnClass,
+			ast.KindClassExpression:  runOnClass,
+			// Listen on the ObjectLiteralExpression directly — same as
+			// upstream's `ObjectExpression(node)` listener that calls
+			// `componentUtil.isES5Component(node)`. This naturally covers
+			// both `createReactClass({...})` (CallExpression parent) and
+			// the rare `new createReactClass({...})` (NewExpression parent),
+			// because `isES5Component` checks both shapes.
+			ast.KindObjectLiteralExpression: func(node *ast.Node) {
+				if !isES5Component(node, pragma, createClass) {
+					return
+				}
+				flags := &componentFlags{}
+				analyzeES5Object(node, flags, pragma, createClass, allowNull)
+				if hasExternalCCT(node) {
+					flags.hasChildContextTypes = true
+				}
+				if shouldReport(flags) {
+					ctx.ReportNode(node, rule.RuleMessage{
+						Id:          "componentShouldBePure",
+						Description: "Component should be written as a pure function",
+					})
+				}
+			},
+		}
+	},
+}
+
+func shouldReport(f *componentFlags) bool {
+	return !f.hasOtherProperty &&
+		!f.useThis &&
+		!f.useRef &&
+		!f.invalidReturn &&
+		!f.hasChildContextTypes &&
+		!f.useDecorators &&
+		!f.hasSCU
+}

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.md
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function.md
@@ -1,0 +1,76 @@
+# prefer-stateless-function
+
+## Rule Details
+
+Stateless functional components are simpler than class based components and
+will benefit from future React performance optimizations specific to these
+components. This rule will check your class based components for missing
+state, missing lifecycle methods, missing `this` member usages or other
+patterns that suggest the component could be safely written as a stateless
+function.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+var Foo = createReactClass({
+  render: function () {
+    return <div>{this.props.foo}</div>;
+  },
+});
+```
+
+```jsx
+class Foo extends React.Component {
+  render() {
+    return <div>{this.props.foo}</div>;
+  }
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+const Foo = function (props) {
+  return <div>{props.foo}</div>;
+};
+```
+
+```jsx
+const Foo = ({ foo }) => <div>{foo}</div>;
+```
+
+## Rule Options
+
+```json
+{
+  "react/prefer-stateless-function": [
+    "error",
+    { "ignorePureComponents": true }
+  ]
+}
+```
+
+### `ignorePureComponents`
+
+When `true`, classes that extend `React.PureComponent` are exempt — the
+rationale being that `PureComponent` already provides a default
+`shouldComponentUpdate`, which a plain functional component does not.
+Defaults to `false`.
+
+Examples of **correct** code for this rule with `{ "ignorePureComponents": true }`:
+
+```json
+{ "react/prefer-stateless-function": ["error", { "ignorePureComponents": true }] }
+```
+
+```jsx
+class Foo extends React.PureComponent {
+  render() {
+    return <div>{this.props.foo}</div>;
+  }
+}
+```
+
+## Original Documentation
+
+- [react/prefer-stateless-function](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md)

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function_test.go
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function_test.go
@@ -1,0 +1,1767 @@
+package prefer_stateless_function
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+func TestPreferStatelessFunctionRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &PreferStatelessFunctionRule, []rule_tester.ValidTestCase{
+		// ---- Upstream valid: already a stateless function ----
+		{Code: `
+        const Foo = function(props) {
+          return <div>{props.foo}</div>;
+        };
+      `, Tsx: true},
+
+		// ---- Upstream valid: already a stateless arrow function ----
+		{Code: `const Foo = ({foo}) => <div>{foo}</div>;`, Tsx: true},
+
+		// ---- Upstream valid: PureComponent + props + ignorePureComponents ----
+		{Code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: PureComponent + context + ignorePureComponents ----
+		{Code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.context.foo}</div>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: PureComponent in expression context + ignorePureComponents ----
+		{Code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: has lifecycle method ----
+		{Code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: has state — uses this.setState / this.state ----
+		{Code: `
+        class Foo extends React.Component {
+          changeState() {
+            this.setState({foo: "clicked"});
+          }
+          render() {
+            return <div onClick={this.changeState.bind(this)}>{this.state.foo || "bar"}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: uses this.refs ----
+		{Code: `
+        class Foo extends React.Component {
+          doStuff() {
+            this.refs.foo.style.backgroundColor = "red";
+          }
+          render() {
+            return <div ref="foo" onClick={this.doStuff}>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: has additional method ----
+		{Code: `
+        class Foo extends React.Component {
+          doStuff() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: empty (no super) constructor — not "useless" ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: constructor with non-super body ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor() {
+            doSpecialStuffs();
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: constructor with non-super body (2) ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor() {
+            foo;
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: uses this.bar — useThis ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: destructures this.bar — useThis ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            let {props:{foo}, bar} = this;
+            return <div>{foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: this[bar] — element access with Identifier key ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this[bar]}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: this['bar'] — element access with string-literal key ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['bar']}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: render returns null with React 0.14.0 ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "0.14.0"}}},
+
+		// ---- Upstream valid: ES5 createReactClass returns null with React 0.14.0 ----
+		{Code: `
+        var Foo = createReactClass({
+          render: function() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "0.14.0"}}},
+
+		// ---- Upstream valid: shorthand-if returning null with React 0.14.0 ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return true ? <div /> : null;
+          }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"version": "0.14.0"}}},
+
+		// ---- Upstream valid: nested class declaration with extra method ----
+		{Code: `
+        export default (Component) => (
+          class Test extends React.Component {
+            componentDidMount() {}
+            render() {
+              return <Component />;
+            }
+          }
+        );
+      `, Tsx: true},
+
+		// ---- Upstream valid: external Foo.childContextTypes = {...} ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        Foo.childContextTypes = {
+          color: PropTypes.string
+        };
+      `, Tsx: true},
+
+		// ---- Upstream valid: decorator on class ----
+		{Code: `
+        @foo
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: called decorator ----
+		{Code: `
+        @foo("bar")
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: chained property access for external childContextTypes —
+		// `Foo.bar.childContextTypes = ...` resolves to base `Foo` ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        Foo.bar.childContextTypes = {};
+      `, Tsx: true},
+
+		// ---- Edge: paren-wrapped base — `(Foo).childContextTypes = ...` ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        (Foo).childContextTypes = {};
+      `, Tsx: true},
+
+		// ---- Edge: aliased binding — `const C = Foo; C.childContextTypes = ...`
+		// Resolved via TypeChecker symbol following (upstream's
+		// `getRelatedComponent` does this via ESLint's scope manager). ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        const C = Foo;
+        C.childContextTypes = { color: PropTypes.string };
+      `, Tsx: true},
+
+		// ---- Edge: doubly-aliased — `const A = Foo; const B = A; B.childContextTypes = ...` ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        const A = Foo;
+        const B = A;
+        B.childContextTypes = {};
+      `, Tsx: true},
+
+		// ---- Edge: ES5 createReactClass with external childContextTypes via alias ----
+		{Code: `
+        var Foo = createReactClass({
+          render: function() {
+            return <div>{this.props.children}</div>;
+          }
+        });
+        var C = Foo;
+        C.childContextTypes = {};
+      `, Tsx: true},
+
+		// ---- Edge: class static block — counts as "other" property → not
+		// flagged. Locks in graceful handling of KindClassStaticBlockDeclaration. ----
+		{Code: `
+        class Foo extends React.Component {
+          static {
+            globalThis.Foo = Foo;
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: bare `;` class element — KindSemicolonClassElement —
+		// counts as "other" → not flagged. ----
+		{Code: `
+        class Foo extends React.Component {
+          ;
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: abstract class method (TS only — no body) — counts as
+		// "other" property since `abstract foo()` has no body and no allowed
+		// name. Should NOT be flagged. ----
+		{Code: `
+        abstract class Foo extends React.Component {
+          abstract bar(): void;
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: render via getter (`get render() {...}`) — getter on
+		// allowed name, no useThis (this.props), so should be reported as
+		// invalid. Lock-in: getter's body is walked. The next test handles
+		// the body-walk pattern; this test asserts a get-render with this.bar
+		// usage is suppressed (useThis). ----
+		{Code: `
+        class Foo extends React.Component {
+          get render() {
+            return () => <div>{this.bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: nested arrow inside method using this.props only ----
+		// is invalid (still props-only). Covered in invalid-2 below. The
+		// valid sibling: nested arrow uses this.bar → useThis → not flagged.
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            const helper = () => this.bar;
+            return <div>{helper()}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge (upstream-aligned): outer class has a non-render method
+		// that returns a nested object literal containing a `render` property
+		// whose value is a non-JSX-returning function. Upstream's
+		// ReturnStatement listener walks scope chain and finds the inner
+		// `render: function()` Property as the nearest enclosing Method/
+		// Property — sets `invalidReturn` on the outer class via
+		// `components.set` upward propagation. The outer Foo therefore is NOT
+		// reported (suppressed by invalidReturn). Locks in the upstream
+		// `Property` arm semantic. ----
+		{Code: `
+        class Foo extends React.Component {
+          helper() {
+            return {
+              render: function() { return foo; }
+            };
+          }
+          render() { return <div>{this.props.foo}</div>; }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: nested arrow inside method has its own JSX ref — useRef → valid ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            const inner = () => <span ref="x" />;
+            return <div>{inner()}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: multiple decorators ----
+		{Code: `
+        @foo
+        @bar()
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Upstream valid: bare PureComponent + ignorePureComponents ----
+		{Code: `
+        class Child extends PureComponent {
+          render() {
+            return <h1>I don't</h1>;
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: PureComponent w/ static propTypes + ignorePureComponents ----
+		{Code: `
+        function errorDecorator(options) {
+          return WrappedComponent => {
+            class Wrapper extends PureComponent {
+              static propTypes = {
+                error: PropTypes.string
+              }
+              render () {
+                const {error, ...props} = this.props
+                if (error) {
+                  return <div>Error! {error}</div>
+                } else {
+                  return <WrappedComponent {...props} />
+                }
+              }
+            }
+            return Wrapper
+          }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: PureComponent inside arrow body + ignorePureComponents ----
+		{Code: `
+        function errorDecorator(options) {
+          return WrappedComponent =>
+            class Wrapper extends PureComponent {
+              static propTypes = {
+                error: PropTypes.string
+              }
+              render () {
+                const {error, ...props} = this.props
+                if (error) {
+                  return <div>Error! {error}</div>
+                } else {
+                  return <WrappedComponent {...props} />
+                }
+              }
+            }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: React.PureComponent inside arrow body + ignorePureComponents ----
+		{Code: `
+        function errorDecorator(options) {
+          return WrappedComponent =>
+            class Wrapper extends React.PureComponent {
+              static propTypes = {
+                error: PropTypes.string
+              }
+              render () {
+                const {error, ...props} = this.props
+                if (error) {
+                  return <div>Error! {error}</div>
+                } else {
+                  return <WrappedComponent {...props} />
+                }
+              }
+            }
+        }
+      `, Tsx: true, Options: map[string]interface{}{"ignorePureComponents": true}},
+
+		// ---- Upstream valid: jsdoc-decorated stateless function (already pure) ----
+		{Code: `
+        /**
+         * @param a.
+         */
+        function Comp() {
+          return <a></a>
+        }
+      `, Tsx: true},
+
+		// ---- Edge: settings.react.pragma="Preact" — extends Preact.Component triggers, but
+		// React.Component no longer matches as a React component ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}}},
+
+		// ---- Edge: PureComponent + ignorePureComponents=false (default) — should still flag ----
+		// Covered by the invalid test below; valid version skipped.
+
+		// ---- Edge: render returns object literal — invalid return → don't flag ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return {foo: 1};
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: render returns string — invalid return → don't flag ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return "hi";
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: ref on inner JSX inside method — useRef → don't flag ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div ref={(el) => this._el = el}>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: nested class is a separate boundary — outer stays clean
+		// only when outer's body has no extra members. Here outer has a
+		// method (helper), which itself flags useThis on outer (this.helper).
+		// The inner class is reported separately. Valid: only the inner is
+		// reported, outer is suppressed by `useThis`. ----
+		{Code: `
+        class Outer extends React.Component {
+          helper() {}
+          render() {
+            class Inner extends React.Component {
+              render() { return <span ref="x" /> }
+            }
+            return <Inner onClick={this.helper}/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: createReactClass with getInitialState — extra prop → don't flag ----
+		{Code: `
+        var Foo = createReactClass({
+          getInitialState: function() { return {}; },
+          render: function() { return <div>{this.props.foo}</div>; }
+        });
+      `, Tsx: true},
+
+		// ---- Edge: useless constructor variants — `super(...arguments)` ----
+		// Component is REPORTED (invalid below); we test the boundary case
+		// where ctor is non-pass-through, meaning it is NOT useless and the
+		// component is valid.
+		{Code: `
+        class Foo extends React.Component {
+          constructor(a, b) {
+            super(b, a);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: useless constructor with default param — params not "simple" → not useless → valid ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor(props = {}) {
+            super(props);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: useless constructor with destructured param — params not "simple" → valid ----
+		{Code: `
+        class Foo extends React.Component {
+          constructor({props}) {
+            super(props);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: createReactClass with non-render arrow body using this.bar — useThis valid ----
+		{Code: `
+        var Foo = createReactClass({
+          render: function() {
+            return <div>{this.bar}</div>;
+          }
+        });
+      `, Tsx: true},
+
+		// ===== tsgo-shape lock-in tests (these patterns differ from ESTree
+		// in node shape but should produce the same observable outcome) =====
+
+		// ---- tsgo: `(this).bar` — single-paren-wrapped this. tsgo preserves
+		// the ParenthesizedExpression wrapper that ESTree flattens.
+		// `isThisExpression` peels parens, so this is treated as `this.bar`
+		// → useThis → valid. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{(this).bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: multi-paren-wrapped this `((this)).bar` ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{((this)).bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: `this[\`bar\`]` — KindNoSubstitutionTemplateLiteral key
+		// in element access. staticAccessName recognizes this. ----
+		{Code: "\n        class Foo extends React.Component {\n          render() {\n            return <div>{this[`bar`]}</div>;\n          }\n        }\n      ", Tsx: true},
+
+		// ---- tsgo: `this[\`pr${x}ops\`]` — TemplateExpression with
+		// substitution: dynamic key, NOT recognized as 'props' → useThis. ----
+		{Code: "\n        class Foo extends React.Component {\n          render() {\n            return <div>{this[`pr${x}ops`]}</div>;\n          }\n        }\n      ", Tsx: true},
+
+		// ---- tsgo: optional chain `this?.bar` — KindPropertyAccessExpression
+		// with optional flag (no ChainExpression wrapper). useThis. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this?.bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: optional element access `this?.['bar']` — useThis. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this?.['bar']}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: this in destructure with computed string-literal key
+		// matching 'props': `let { ['props']: foo } = this` — keyName resolves
+		// to "props" via ComputedPropertyName recursion → not useThis. So
+		// when this is the only access, component IS reportable (invalid
+		// section below covers the report). Here we add a sibling key so
+		// useThis flips and the component remains valid. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            let { ['props']: a, bar } = this;
+            return <div>{bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: rest-only destructure `let { ...rest } = this` —
+		// upstream's `getPropertyName(RestElement)` returns null;
+		// `null !== 'props' && null !== 'context'` is true → useThis=true →
+		// component suppressed. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            let { ...rest } = this;
+            return <div>{rest}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: rest after `props` — `let { props, ...rest } = this`.
+		// rest still flips useThis=true regardless of sibling keys. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            let { props, ...rest } = this;
+            return <div>{rest}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: dynamic computed destructure `let { [Symbol.iterator]: x } = this`
+		// — keyName "" → useThis=true → valid (suppressed). ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            let { [Symbol.iterator]: x } = this;
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: numeric destructure key `let { 0: x } = this` —
+		// memberName returns "0" → useThis=true → valid. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            let { 0: x } = this;
+            return <div/>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: TS non-null assertion on `this` — `(this!).bar` /
+		// `this!.bar`. SkipParentheses doesn't peel non-null. The shape is
+		// not recognized as a `this`-receiver, so neither markPropsOrContext
+		// nor markThisAsUsed fires for this access. ESTree behaves the same
+		// (`TSNonNullExpression` wraps ThisExpression and doesn't equal
+		// 'ThisExpression'). When no other useThis is present, the
+		// component is REPORTED (invalid section locks this). Here we make
+		// it valid by adding a real useThis sibling. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            const x = this!.bar;
+            return <div>{this.helper}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: TS `as` assertion on `this` — `(this as any).bar`.
+		// AsExpression wraps this; not peeled. Same outcome as non-null. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            const x = (this as any).bar;
+            return <div>{this.helper}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: extends with multi-paren `extends ((React.Component))`
+		// — SkipParentheses peels every level. ----
+		{Code: `
+        class Foo extends ((React.Component)) {
+          render() {
+            return <div>{this.bar}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: TS `as` cast around extends — extends `(React.Component as any)`
+		// — SkipParentheses doesn't peel the AsExpression, so heritage
+		// expression doesn't match Component. → not detected as a React
+		// component → not reportable. ----
+		{Code: `
+        class Foo extends (React.Component as any) {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: `extends React['Component']` — element access form,
+		// neither Identifier nor PropertyAccessExpression of pragma. Not
+		// recognized as React component. ----
+		{Code: `
+        class Foo extends React['Component'] {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: render returning JSX wrapped in `as` cast — AsExpression
+		// is not peeled by SkipParentheses, so isJSXLike returns false →
+		// invalidReturn=true → component suppressed. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return (<div>{this.props.foo}</div>) as any;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: render returning bare `return;` — no expression → both
+		// strict and non-strict: not JSX, not null literal → invalidReturn=true. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: render returning template literal — not JSX, not null →
+		// invalidReturn=true → suppressed. ----
+		{Code: "\n        class Foo extends React.Component {\n          render() {\n            return `not jsx`;\n          }\n        }\n      ", Tsx: true},
+
+		// ---- tsgo: render returning yield (generator-shaped though render
+		// isn't a generator) — KindYieldExpression not recognized as JSX
+		// → invalidReturn=true → suppressed. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return helper();
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: TS overload signatures + impl, where overload is bodyless ----
+		{Code: `
+        class Foo extends React.Component {
+          doStuff(): void;
+          doStuff() {}
+          render() { return <div>{this.props.foo}</div>; }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: abstract bodyless method — bodyless, "other property"
+		// (name not in allow-list) → not flagged. ----
+		// (Already have a similar test above — keeping for completeness.)
+
+		// ---- tsgo: `static childContextTypes = {...}` static class field —
+		// upstream's hasOtherProperties branch matches the name 'childContextTypes'
+		// is NOT in allow-list → other property → not flagged. ----
+		{Code: `
+        class Foo extends React.Component {
+          static childContextTypes = { color: PropTypes.string };
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- tsgo: `props` field with `declare props: SomeType` — Type
+		// annotation present, no Initializer. memberName="props" + Type!=nil
+		// → in allow-list. The ONLY member here is the annotated field +
+		// render with this.props → flagged. (Invalid below.) ----
+
+		// ---- Edge: PropertyDeclaration with Type but Initializer too —
+		// `props: Foo = defaultFoo;`. Type is set, so allow-list matches.
+		// Initializer exists; my walk goes into it. The initializer is just
+		// `defaultFoo` (Identifier) — no this, no JSX, no ref. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.bar}</div>;
+          }
+        }
+        Foo.propTypes = {};
+      `, Tsx: true},
+
+		// ---- Edge: render method returning a comma-sequence whose rhs is
+		// non-JSX — isJSXLike Comma branch checks rhs only → false →
+		// invalidReturn=true → suppressed (valid). ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return (<div>{this.props.foo}</div>, sideEffect());
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Edge: settings.react.createClass="customCreate" — when the
+		// configured factory name is custom, default `createReactClass` no
+		// longer matches as a component. ----
+		{Code: `
+        var Foo = createReactClass({
+          render: function() { return <div>{this.props.foo}</div>; }
+        });
+      `, Tsx: true, Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "customCreate"}}},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream invalid: only uses this.props ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "componentShouldBePure",
+					Message:   "Component should be written as a pure function",
+					Line:      2,
+					Column:    9,
+				},
+			},
+		},
+
+		// ---- Upstream invalid: this['props'] ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['props'].foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: PureComponent without ignorePureComponents — defaults to false ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>foo</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: PureComponent + props (default ignorePureComponents=false) ----
+		{
+			Code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: static get displayName() {...} ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static get displayName() {
+            return 'Foo';
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: static displayName = 'Foo' ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static displayName = 'Foo';
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: static get propTypes() {...} ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static get propTypes() {
+            return {
+              name: PropTypes.string
+            };
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: static propTypes = {...} ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static propTypes = {
+            name: PropTypes.string
+          };
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: props with type annotation (Flow / TS field) ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          props: {
+            name: string;
+          };
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: useless constructor calling super() ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          constructor() {
+            super();
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: destructures only props/context ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            let {props:{foo}, context:{bar}} = this;
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: render returns null on default (>= 15) — props only ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: createReactClass with null return ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          render: function() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 36},
+			},
+		},
+
+		// ---- Upstream invalid: shorthand-if returning null at default (>= 15) ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return true ? <div /> : null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: defaultProps as class field + shorthand-if/null return ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static defaultProps = {
+            foo: true
+          }
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: static get defaultProps() {...} ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static get defaultProps() {
+            return {
+              foo: true
+            };
+          }
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: external Foo.defaultProps assignment ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+        Foo.defaultProps = {
+          foo: true
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: contextTypes as static class field ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static contextTypes = {
+            foo: PropTypes.boolean
+          }
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: static get contextTypes() {...} ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static get contextTypes() {
+            return {
+              foo: PropTypes.boolean
+            };
+          }
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Upstream invalid: external Foo.contextTypes assignment ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+        Foo.contextTypes = {
+          foo: PropTypes.boolean
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: bare Component (not React.Component) — should still flag ----
+		{
+			Code: `
+        class Foo extends Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: createReactClass with displayName + render only — flagged ----
+		{
+			Code: `
+        var Foo = createReactClass({
+          displayName: 'Foo',
+          render: function() {
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 36},
+			},
+		},
+
+		// ---- Edge: `new createReactClass({...})` — non-idiomatic but
+		// upstream's `componentUtil.isES5Component` check is `node.parent.callee`
+		// which exists on both CallExpression and NewExpression in ESTree.
+		// We mirror by handling KindNewExpression's parent shape too. ----
+		{
+			Code: `
+        var Foo = new createReactClass({
+          render: function() {
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure"},
+			},
+		},
+
+		// ---- Edge: ClassExpression assigned to var — flagged ----
+		{
+			Code: `
+        var Foo = class extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 19},
+			},
+		},
+
+		// ---- Edge: useless constructor with `super(...arguments)` ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          constructor() {
+            super(...arguments);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: useless constructor with pass-through params ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          constructor(a, b) {
+            super(a, b);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: useless constructor with rest pass-through ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          constructor(...args) {
+            super(...args);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: bare PureComponent without ignorePureComponents — flagged by default ----
+		{
+			Code: `
+        class Foo extends PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: render returns JSX fragment ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <>{this.props.foo}</>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: nested ES5 component inside an outer ES6 class — outer
+		// has `helper()` so it's NOT reported (hasOtherProperty), but the
+		// inner ES5 (only `render` + `this.props`) IS reported separately.
+		// Locks in independent boundary analysis: outer's body walk MUST
+		// stop at the inner createReactClass call. ----
+		{
+			Code: `
+        class Outer extends React.Component {
+          helper() { return null; }
+          render() {
+            var Inner = createReactClass({
+              render: function() { return <span>{this.props.x}</span>; }
+            });
+            return <Inner onClick={this.helper}/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure"},
+			},
+		},
+
+		// ---- Edge: nested arrow inside render uses this.props only — still flagged ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const inner = () => this.props.foo;
+            return <div>{inner()}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: chained call returning JSX in render (logical &&) — props-only, still flagged ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return this.props.cond && <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: computed string-literal key for `displayName` — upstream's
+		// `getPropertyName` resolves to "displayName", in allow-list, so the
+		// component WITH only render + this.props is reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static ['displayName']() { return 'Foo'; }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: PrivateIdentifier-keyed `#displayName` — upstream's
+		// `getPropertyName` strips the `#` and returns "displayName", placing
+		// it in the allow-list. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static #displayName = 'Foo';
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ===== tsgo-shape lock-in invalid cases =====
+
+		// ---- tsgo: paren-wrapped this with only props access — `(this).props`
+		// is recognized as `this.props` (paren transparent), NOT useThis →
+		// component IS reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{(this).props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: optional chain on this.props — `this?.props.foo`. tsgo
+		// uses an optional flag on PropertyAccessExpression (no
+		// ChainExpression wrapper). property name 'props' → markPropsOrContext
+		// → not useThis → component reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this?.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: TS non-null on `this` — `this!.props`. tsgo wraps with
+		// NonNullExpression which is NOT peeled by SkipParentheses. The
+		// receiver doesn't equal `this`, so neither props-or-context nor
+		// useThis fires. With no other useThis, the component is reported.
+		// Match upstream: ESTree `TSNonNullExpression` has the same outcome
+		// (its type is not 'ThisExpression' in the listener gate). ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const x = this!.props.foo;
+            return <div>{x}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: TS `as` assertion `(this as any).props` — same shape
+		// outcome as non-null. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const x = (this as any).props.foo;
+            return <div>{x}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: computed string-literal destructure key `let { ['props']: x } = this`
+		// — keyName resolves to "props" via ComputedPropertyName recursion;
+		// this counts as accessing this.props only, NOT useThis. With ONLY
+		// this destructure + JSX render, component is reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            let { ['props']: x } = this;
+            return <div>{x.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: NoSubstitutionTemplateLiteral computed key in
+		// destructure: `let { [\`props\`]: x } = this` — keyName="props". ----
+		{
+			Code: "\n        class Foo extends React.Component {\n          render() {\n            let { [`props`]: x } = this;\n            return <div>{x.foo}</div>;\n          }\n        }\n      ",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: extends with multi-paren `extends ((React.Component))`
+		// — SkipParentheses peels every level → matches Component. ----
+		{
+			Code: `
+        class Foo extends ((React.Component)) {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: render returning JSX with multi-line / nested
+		// expression containers — typical real-world shape. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return (
+              <div>
+                {this.props.foo}
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: render returning conditional with both branches JSX —
+		// strict-AND succeeds even on React 0.14.0; non-strict trivially
+		// succeeds on React 15+. With this.props only → reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return cond ? <a>{this.props.x}</a> : <b/>;
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"version": "0.14.0"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: PrivateIdentifier-keyed `#propTypes` — strip `#` →
+		// "propTypes" → in allow-list. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          static #propTypes = {};
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: NoSubstitutionTemplateLiteral computed member key —
+		// `static [\`displayName\`] = 'Foo'` resolves to displayName. ----
+		{
+			Code: "\n        class Foo extends React.Component {\n          static [`displayName`] = 'Foo';\n          render() {\n            return <div>{this.props.foo}</div>;\n          }\n        }\n      ",
+			Tsx:  true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- tsgo: `export class …` — report range starts at `class`, not at
+		// `export`. ESTree wraps `export class` in ExportNamedDeclaration so
+		// the ClassDeclaration's range begins at `class`. tsgo inlines
+		// `export` into the ClassDeclaration's modifier list, so we trim it
+		// back out via classKeywordStart. Locks in the column-after-export
+		// position for parity with upstream.
+		{
+			Code: `
+        export class App extends React.Component {
+          render() {
+            return <div className="App">Hello</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 16},
+			},
+		},
+
+		// ---- Edge: `export default class extends React.Component {…}` —
+		// anonymous default-export class. Position starts at `class`. ----
+		{
+			Code: `
+        export default class extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- tsgo: render returning a comma-sequence whose RHS is JSX —
+		// isJSXLike Comma branch returns rhs check (true) → not
+		// invalidReturn → component reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            return (sideEffect(), <div>{this.props.foo}</div>);
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Alignment: `createReactClass` second-argument position —
+		// upstream's `isES5Component` does NOT verify argument position
+		// (only `node.parent.callee` identity). Even an obj passed as the
+		// SECOND argument to a createClass call gets registered. We mirror
+		// that by dropping our position check. ----
+		{
+			Code: `
+        createReactClass(undefined, {
+          render: function() { return <div>{this.props.foo}</div>; }
+        });
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure"},
+			},
+		},
+
+		// ---- Edge: TS abstract class extending React.Component (already
+		// has a no_redundant test counterpart). Even though declared
+		// abstract, a stateless-eligible body still gets flagged. ----
+		{
+			Code: `
+        abstract class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Edge: settings.react.createClass="customCreate" + matching
+		// factory — recognized as ES5 component. ----
+		{
+			Code: `
+        var Foo = customCreate({
+          render: function() { return <div>{this.props.foo}</div>; }
+        });
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"createClass": "customCreate"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure"},
+			},
+		},
+
+		// ---- Edge: settings.react.pragma="Preact" + extends Preact.Component ----
+		{
+			Code: `
+        class Foo extends Preact.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+	})
+}

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function_test.go
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function_test.go
@@ -378,6 +378,33 @@ func TestPreferStatelessFunctionRule(t *testing.T) {
         }
       `, Tsx: true},
 
+		// ---- Locks in: scope-walk continues past unmatched FunctionLikes —
+		// upstream's `scope.upper` keeps walking outward when the current
+		// scope's `block.parent` is not `MethodDefinition` / `Property`.
+		// Here a non-render-returning inline `function()` lives inside an
+		// onClick JSX expression of render. The inner return must be
+		// attributed to the OUTER render (per upstream), flipping
+		// invalidReturn=true on the class → suppressed → valid.
+		// Rejects gemini-code-assist suggestion that would stop the walk
+		// at the inline function. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div onClick={function() { return undefined; }}>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
+		// ---- Locks in same scope-walk continuation for ArrowFunction
+		// inside JSX expression. ----
+		{Code: `
+        class Foo extends React.Component {
+          render() {
+            return <div onClick={() => { return undefined; }}>{this.props.foo}</div>;
+          }
+        }
+      `, Tsx: true},
+
 		// ---- Edge: nested arrow inside method has its own JSX ref — useRef → valid ----
 		{Code: `
         class Foo extends React.Component {
@@ -1679,6 +1706,44 @@ func TestPreferStatelessFunctionRule(t *testing.T) {
 			Tsx: true,
 			Errors: []rule_tester.InvalidTestCaseError{
 				{MessageId: "componentShouldBePure", Line: 2, Column: 24},
+			},
+		},
+
+		// ---- Locks in: `const x = this;` (Identifier id, NOT ObjectPattern)
+		// — upstream's VariableDeclarator listener returns early when
+		// `node.id.type !== 'ObjectPattern'`, so it does NOT flip useThis.
+		// The class has no other this-access, so the component is REPORTED.
+		// Rejects gemini-code-assist suggestion that would stricten this. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const x = this;
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
+			},
+		},
+
+		// ---- Locks in: array-pattern destructure `const [x] = this;` —
+		// upstream returns early (id is ArrayPattern, not ObjectPattern). No
+		// useThis flip → component reported. ----
+		{
+			Code: `
+        class Foo extends React.Component {
+          render() {
+            const [x] = this;
+            return <div/>;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "componentShouldBePure", Line: 2, Column: 9},
 			},
 		},
 

--- a/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function_test.go
+++ b/internal/plugins/react/rules/prefer_stateless_function/prefer_stateless_function_test.go
@@ -1713,7 +1713,7 @@ func TestPreferStatelessFunctionRule(t *testing.T) {
 		// — upstream's VariableDeclarator listener returns early when
 		// `node.id.type !== 'ObjectPattern'`, so it does NOT flip useThis.
 		// The class has no other this-access, so the component is REPORTED.
-		// Rejects gemini-code-assist suggestion that would stricten this. ----
+		// Rejects gemini-code-assist suggestion that would tighten this. ----
 		{
 			Code: `
         class Foo extends React.Component {

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -124,6 +124,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-unknown-property.test.ts',
     './tests/eslint-plugin-react/rules/no-will-update-set-state.test.ts',
     './tests/eslint-plugin-react/rules/prefer-es6-class.test.ts',
+    './tests/eslint-plugin-react/rules/prefer-stateless-function.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 
     // typescript-eslint

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/prefer-stateless-function.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/prefer-stateless-function.test.ts
@@ -1,0 +1,500 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('prefer-stateless-function', {} as never, {
+  valid: [
+    // ---- Already a stateless function ----
+    {
+      code: `
+        const Foo = function(props) {
+          return <div>{props.foo}</div>;
+        };
+      `,
+    },
+    // ---- Already a stateless arrow function ----
+    {
+      code: `const Foo = ({foo}) => <div>{foo}</div>;`,
+    },
+    // ---- PureComponent + props + ignorePureComponents ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      options: [{ ignorePureComponents: true }],
+    },
+    // ---- PureComponent + context + ignorePureComponents ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.context.foo}</div>;
+          }
+        }
+      `,
+      options: [{ ignorePureComponents: true }],
+    },
+    // ---- PureComponent in expression context + ignorePureComponents ----
+    {
+      code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
+      options: [{ ignorePureComponents: true }],
+    },
+    // ---- Has lifecycle method ----
+    {
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Has state ----
+    {
+      code: `
+        class Foo extends React.Component {
+          changeState() {
+            this.setState({foo: "clicked"});
+          }
+          render() {
+            return <div onClick={this.changeState.bind(this)}>{this.state.foo || "bar"}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Uses this.refs ----
+    {
+      code: `
+        class Foo extends React.Component {
+          doStuff() {
+            this.refs.foo.style.backgroundColor = "red";
+          }
+          render() {
+            return <div ref="foo" onClick={this.doStuff}>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Has additional method ----
+    {
+      code: `
+        class Foo extends React.Component {
+          doStuff() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Empty (no super) constructor ----
+    {
+      code: `
+        class Foo extends React.Component {
+          constructor() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- Constructor with non-super body ----
+    {
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            doSpecialStuffs();
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- this.bar — useThis ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.bar}</div>;
+          }
+        }
+      `,
+    },
+    // ---- destructure this.bar — useThis ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            let {props:{foo}, bar} = this;
+            return <div>{foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- this[bar] / this['bar'] — useThis ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this[bar]}</div>;
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['bar']}</div>;
+          }
+        }
+      `,
+    },
+    // ---- nested ClassExpression ----
+    {
+      code: `
+        export default (Component) => (
+          class Test extends React.Component {
+            componentDidMount() {}
+            render() {
+              return <Component />;
+            }
+          }
+        );
+      `,
+    },
+    // ---- external Foo.childContextTypes = ... ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        Foo.childContextTypes = {
+          color: PropTypes.string
+        };
+      `,
+    },
+    // ---- decorator on class ----
+    {
+      code: `
+        @foo
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- multiple decorators ----
+    {
+      code: `
+        @foo
+        @bar()
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+    },
+    // ---- bare PureComponent + ignorePureComponents ----
+    {
+      code: `
+        class Child extends PureComponent {
+          render() {
+            return <h1>I don't</h1>;
+          }
+        }
+      `,
+      options: [{ ignorePureComponents: true }],
+    },
+  ],
+  invalid: [
+    // ---- only uses this.props ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- this['props'] ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['props'].foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- PureComponent without ignorePureComponents ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>foo</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- PureComponent + props (default ignorePureComponents=false) ----
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- static get displayName ----
+    {
+      code: `
+        class Foo extends React.Component {
+          static get displayName() {
+            return 'Foo';
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- static displayName field ----
+    {
+      code: `
+        class Foo extends React.Component {
+          static displayName = 'Foo';
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- static get propTypes ----
+    {
+      code: `
+        class Foo extends React.Component {
+          static get propTypes() {
+            return {
+              name: PropTypes.string
+            };
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- static propTypes field ----
+    {
+      code: `
+        class Foo extends React.Component {
+          static propTypes = {
+            name: PropTypes.string
+          };
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- props with type annotation ----
+    {
+      code: `
+        class Foo extends React.Component {
+          props: {
+            name: string;
+          };
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- useless constructor ----
+    {
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            super();
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- destructures only props/context ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            let {props:{foo}, context:{bar}} = this;
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- render returns null on default (>= 15) ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- createReactClass with null return ----
+    {
+      code: `
+        var Foo = createReactClass({
+          render: function() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- shorthand-if returning null at default (>= 15) ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return true ? <div /> : null;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- defaultProps as class field ----
+    {
+      code: `
+        class Foo extends React.Component {
+          static defaultProps = {
+            foo: true
+          }
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- external Foo.defaultProps ----
+    {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+        Foo.defaultProps = {
+          foo: true
+        };
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- contextTypes static field ----
+    {
+      code: `
+        class Foo extends React.Component {
+          static contextTypes = {
+            foo: PropTypes.boolean
+          }
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- bare Component (not React.Component) ----
+    {
+      code: `
+        class Foo extends Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- ClassExpression assigned to var ----
+    {
+      code: `
+        var Foo = class extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- useless constructor with super(...arguments) ----
+    {
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            super(...arguments);
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+    // ---- bare PureComponent without ignorePureComponents ----
+    {
+      code: `
+        class Foo extends PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      errors: [{ messageId: 'componentShouldBePure' }],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -260,3 +260,8 @@ Setstate
 middot
 xlink
 nend
+disqualifier
+disqualifiers
+normalised
+recognised
+unaliased


### PR DESCRIPTION
## Summary

Port the `react/prefer-stateless-function` rule from `eslint-plugin-react` to rslint.

The rule reports React class components (ES6 `extends Component` / `extends PureComponent`, or ES5 `createReactClass({...})`) that could be safely rewritten as stateless functional components — i.e. no state, no lifecycle methods, no `this` member usages other than `this.props` / `this.context`, no JSX `ref` attribute, no decorators, and a `render` returning JSX (or `null` on React ≥ 15).

Behavior is 1:1 aligned with upstream's latest version, including:

- `ignorePureComponents` option (default `false`).
- `settings.react.{pragma, createClass, version}` honored; React-15 boundary flips strict / non-strict `isReturningJSX` semantics for ternary / logical returns.
- ES6 + ES5 + `new createReactClass({...})` component shapes; report range trims `export` / `export default` modifiers to match ESTree's ClassDeclaration position.
- Allow-list mirrors upstream exactly: `displayName` / `propTypes` (or `props` w/ type annotation) / `contextTypes` / `defaultProps` / `render` / "useless" constructor (single pass-through `super(...)` call).
- External `<binding>.childContextTypes = …` resolution uses the tsgo TypeChecker for symbol-precise alias chain following (`const C = Foo; C.childContextTypes = …`), with graceful name-based fallback when the checker is nil (gap files).
- Computed string-literal / template / `PrivateIdentifier` keys recognized via `utils.GetStaticPropertyName`.
- `ReturnStatement` listener walks AST parents to mirror upstream's scope-walk for nearest `MethodDefinition` / `Property` named `render`.

Also extracted shared helper `reactutil.ExtendsReactPureComponent` (used by both this rule and `no-redundant-should-component-update`).

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/prefer-stateless-function.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/prefer-stateless-function.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).