### PR TITLE
feat: port rule react/no-unstable-nested-components

### DIFF
--- a/internal/plugins/react/all.go
+++ b/internal/plugins/react/all.go
@@ -27,6 +27,7 @@ import (
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_direct_mutation_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_find_dom_node"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_is_mounted"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unstable_nested_components"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_class_component_methods"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_unused_state"
 	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/no_redundant_should_component_update"
@@ -80,6 +81,7 @@ func GetAllRules() []rule.Rule {
 		no_direct_mutation_state.NoDirectMutationStateRule,
 		no_find_dom_node.NoFindDomNodeRule,
 		no_is_mounted.NoIsMountedRule,
+		no_unstable_nested_components.NoUnstableNestedComponentsRule,
 		no_unused_class_component_methods.NoUnusedClassComponentMethodsRule,
 		no_unused_state.NoUnusedStateRule,
 		no_redundant_should_component_update.NoRedundantShouldComponentUpdateRule,

--- a/internal/plugins/react/reactutil/reactutil.go
+++ b/internal/plugins/react/reactutil/reactutil.go
@@ -5,18 +5,799 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/scanner"
 )
 
 // DefaultReactPragma is the fallback object name for createElement calls
 // when `settings.react.pragma` is not configured, matching eslint-plugin-react.
 const DefaultReactPragma = "React"
 
+// hookNameRegex matches the React hook naming convention `^use[A-Z0-9].*$`.
+// Mirrors eslint-plugin-react-hooks' `RE_HOOKS` and the `HOOK_REGEXP` used by
+// no-unstable-nested-components. Exposed here because every React-flavored
+// rule that needs to recognize hook calls re-derives the same predicate.
+var hookNameRegex = regexp.MustCompile(`^use[A-Z0-9].*$`)
+
+// IsHookName reports whether `name` matches the React hook naming convention.
+// Returns false for empty input.
+func IsHookName(name string) bool {
+	if name == "" {
+		return false
+	}
+	return hookNameRegex.MatchString(name)
+}
+
+// GlobToRegex converts a minimatch-style glob (only `*` and `?` wildcards
+// recognized; every other regex metacharacter is literally escaped) into a
+// fully anchored regular expression. Mirrors the subset of minimatch
+// behavior eslint-plugin-react relies on for `propNamePattern`-style options
+// — sufficient for `render*`, `*Renderer`, etc.
+//
+// Compilation is cached per-pattern; the returned `*regexp.Regexp` is
+// safe to share across goroutines.
+func GlobToRegex(pattern string) *regexp.Regexp {
+	if v, ok := globToRegexCache.Load(pattern); ok {
+		// Cache values are always `*regexp.Regexp` — `Store` is the
+		// only writer below and writes only this type. The check is
+		// kept for `forcetypeassert` lint hygiene; a failed assertion
+		// would indicate a programming error elsewhere in this file.
+		if re, ok := v.(*regexp.Regexp); ok {
+			return re
+		}
+	}
+	var b strings.Builder
+	b.Grow(len(pattern) + 4)
+	b.WriteByte('^')
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			b.WriteString(".*")
+		case '?':
+			b.WriteByte('.')
+		case '.', '+', '(', ')', '|', '^', '$', '{', '}', '[', ']', '\\':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('$')
+	re := regexp.MustCompile(b.String())
+	globToRegexCache.Store(pattern, re)
+	return re
+}
+
+// MatchGlob is the fast path equivalent of `GlobToRegex(pattern).MatchString(text)`,
+// returning false for empty `text`.
+func MatchGlob(text, pattern string) bool {
+	if text == "" {
+		return false
+	}
+	return GlobToRegex(pattern).MatchString(text)
+}
+
+var globToRegexCache sync.Map
+
+// SkipExpressionWrappers is a paren-and-TS-type-wrapper-transparent variant
+// of `ast.SkipParentheses`. It additionally peels back tsgo's TS-only
+// expression wrappers that ESLint's ESTree never produces: `as`-expressions,
+// `satisfies`-expressions, `<T>x` type assertions, and `x!` non-null
+// assertions. Use it whenever a rule must reach the underlying expression
+// regardless of whether the source uses any of those wrappers — e.g. when
+// matching a callee identifier, a JSX tag base, or a return-statement
+// argument that may sit behind a `(x as Foo)`.
+func SkipExpressionWrappers(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	for {
+		switch node.Kind {
+		case ast.KindParenthesizedExpression:
+			node = node.AsParenthesizedExpression().Expression
+		case ast.KindAsExpression:
+			node = node.AsAsExpression().Expression
+		case ast.KindSatisfiesExpression:
+			node = node.AsSatisfiesExpression().Expression
+		case ast.KindNonNullExpression:
+			node = node.AsNonNullExpression().Expression
+		case ast.KindTypeAssertionExpression:
+			node = node.AsTypeAssertion().Expression
+		default:
+			return node
+		}
+	}
+}
+
+// SkipExpressionWrappersUp is the parent-walk equivalent of
+// `SkipExpressionWrappers`: starting from `node.Parent`, walks up while the
+// current parent is a transparent expression wrapper (`()` / `as` /
+// `satisfies` / `<T>x` / `x!`) and returns the first non-wrapper ancestor,
+// or nil when no such ancestor exists. Mirrors what ESTree implicitly does
+// by flattening these wrappers — three sites in this rule used to inline
+// the loop; one helper keeps them in lockstep.
+func SkipExpressionWrappersUp(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	parent := node.Parent
+	for parent != nil {
+		switch parent.Kind {
+		case ast.KindParenthesizedExpression,
+			ast.KindAsExpression,
+			ast.KindSatisfiesExpression,
+			ast.KindNonNullExpression,
+			ast.KindTypeAssertionExpression:
+			parent = parent.Parent
+			continue
+		}
+		break
+	}
+	return parent
+}
+
+// IsFirstLetterCapitalized is the exported alias for the package-private
+// helper. Mirrors eslint-plugin-react's `lib/util/isFirstLetterCapitalized.js`
+// — strips leading underscores then compares `unicode.ToUpper(r) == r`.
+// Non-cased characters (CJK, digits, emoji) count as "capitalized" because
+// they have no upper/lower mapping. Use this for any parent-name / binding
+// capitalization check that needs to align with upstream's component
+// detection semantics.
+func IsFirstLetterCapitalized(s string) bool {
+	return isFirstLetterCapitalized(s)
+}
+
+// IsLowercaseFirstLetter is the companion of IsFirstLetterCapitalized that
+// matches upstream's exact lowercase-skip predicate from
+// `lib/rules/no-unstable-nested-components.js`:
+//
+//	parentName[0] === parentName[0].toLowerCase()
+//
+// Notably this is NOT the negation of IsFirstLetterCapitalized: this
+// helper does NOT strip leading underscores, so `_Foo` is treated as
+// lowercase here (the `_` round-trips through `ToLower`) even though
+// IsFirstLetterCapitalized returns true for `_Foo` (after stripping `_`,
+// `Foo` is capitalized). Both helpers exist because upstream uses each
+// in different code paths — keep them paired.
+func IsLowercaseFirstLetter(s string) bool {
+	if s == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError {
+		return false
+	}
+	return unicode.ToLower(r) == r
+}
+
+// ParamListOpenParenPos returns the source position of the `(` that opens
+// `node`'s parameter list, or -1 when the position cannot be located.
+// Walks tokens after `node.Name().End()` via the scanner — robust against
+// type-parameter lists (`<T>(p: T)`) where the `(` is not contiguous with
+// the name. Use this when narrowing a diagnostic range on an
+// object-literal shorthand method / getter / setter so the report site
+// aligns with ESTree's `Property { value: FunctionExpression }` shape
+// (FE.loc.start at `(`).
+//
+// `node` must be a MethodDeclaration / GetAccessor / SetAccessor (or
+// anything with a non-nil `Name()`); other inputs return -1.
+func ParamListOpenParenPos(sf *ast.SourceFile, node *ast.Node) int {
+	if sf == nil || node == nil {
+		return -1
+	}
+	name := node.Name()
+	if name == nil {
+		return -1
+	}
+	sc := scanner.GetScannerForSourceFile(sf, name.End())
+	for {
+		tok := sc.Token()
+		if tok == ast.KindEndOfFile {
+			return -1
+		}
+		if tok == ast.KindOpenParenToken {
+			return sc.TokenStart()
+		}
+		sc.Scan()
+	}
+}
+
+// IsObjectLiteralShorthandFunction reports whether `node` is a
+// FunctionLike that, in ESTree, would be the inner FunctionExpression of
+// a `Property { value: FunctionExpression }` — i.e. an object-literal
+// shorthand method / getter / setter. Useful for callers that want to
+// narrow diagnostic ranges to the parameter-list `(` (see
+// ParamListOpenParenPos) so positions align with ESTree's reporting shape.
+func IsObjectLiteralShorthandFunction(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return node.Parent.Kind == ast.KindObjectLiteralExpression
+	}
+	return false
+}
+
+// IsDestructuredFromPragmaImport mirrors upstream eslint-plugin-react's
+// `lib/util/isDestructuredFromPragmaImport.js`: reports whether the
+// Identifier `ident` (a bare callee like `memo`) was bound from the
+// pragma module. Returns true when ident's local binding originated from
+// any of:
+//
+//   - `import { memo } from 'react'` (named import)
+//   - `import { memo as m } from 'react'` (named-import rename — checks
+//     the imported name, not the local alias)
+//   - `import * as React from 'react'`'s namespace + `const memo = React.memo`
+//   - `const { memo } = React` (object destructure of the pragma binding)
+//   - `const memo = React.memo` (member access via pragma binding)
+//   - `const { memo } = require('react')` (require destructure)
+//   - `const memo = require('react').memo` (require member access)
+//
+// `pragma` is the React pragma name (e.g. "React") — the comparison
+// against ImportDeclaration / require argument uses
+// `strings.ToLower(pragma)` to match upstream's
+// `pragma.toLocaleLowerCase()` semantic. `tc` may be nil — when no
+// TypeChecker is available the function falls back to a syntax-only
+// SourceFile-wide scan via `findPragmaBindingByName`. That fallback is
+// strictly a subset of TC-based resolution (no scope precision) but
+// covers the idiomatic top-level pragma-import patterns, keeping the
+// observable wrapper-recognition behavior aligned with upstream in
+// no-tsconfig modes.
+func IsDestructuredFromPragmaImport(ident *ast.Node, pragma string, tc *checker.Checker) bool {
+	if ident == nil || ident.Kind != ast.KindIdentifier {
+		return false
+	}
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	pragmaLower := strings.ToLower(pragma)
+
+	if tc == nil {
+		// Syntax-only fallback: walk up to the SourceFile and scan it
+		// for any binding that introduces `ident.Text` from the pragma
+		// module. This is strictly less precise than TC-based
+		// resolution (no scope handling, no shadowing detection) but
+		// catches the canonical top-level patterns that account for
+		// virtually all real-world React pragma imports.
+		return findPragmaBindingByName(getSourceFileNode(ident), ident.AsIdentifier().Text, pragma, pragmaLower)
+	}
+
+	symbol := tc.GetSymbolAtLocation(ident)
+	if symbol == nil {
+		return false
+	}
+
+	// Pick the most relevant declaration. Upstream walks `latestDef` —
+	// for value bindings ValueDeclaration is the right one; for
+	// ImportSpecifier (which has no Initializer of its own), upstream
+	// walks `latestDef.parent.type === 'ImportDeclaration'`. We mirror
+	// by trying ValueDeclaration first then Declarations[0].
+	var decl *ast.Node
+	if symbol.ValueDeclaration != nil {
+		decl = symbol.ValueDeclaration
+	} else if len(symbol.Declarations) > 0 {
+		decl = symbol.Declarations[0]
+	}
+	if decl == nil {
+		return false
+	}
+
+	// 1) Named import: `import { memo } from 'react'` — declaration is
+	//    an ImportSpecifier (or ImportClause for default imports, but
+	//    bare callee `memo` won't bind to a default).
+	if decl.Kind == ast.KindImportSpecifier {
+		// Walk up: ImportSpecifier → NamedImports → ImportClause →
+		// ImportDeclaration.
+		for p := decl.Parent; p != nil; p = p.Parent {
+			if p.Kind == ast.KindImportDeclaration {
+				ms := p.AsImportDeclaration().ModuleSpecifier
+				if ms != nil && ms.Kind == ast.KindStringLiteral &&
+					ms.Text() == pragmaLower {
+					return true
+				}
+				return false
+			}
+		}
+		return false
+	}
+
+	// 2) BindingElement (object/array destructure): `const { memo } = React`
+	//    → declaration is BindingElement; walk up to VariableDeclaration
+	//    and inspect its Initializer.
+	if decl.Kind == ast.KindBindingElement {
+		varDecl := findEnclosingVariableDeclaration(decl)
+		if varDecl == nil {
+			return false
+		}
+		init := varDecl.AsVariableDeclaration().Initializer
+		return initializerMatchesPragma(init, pragma, pragmaLower)
+	}
+
+	// 3) VariableDeclaration: `const memo = React.memo` /
+	//    `const memo = require('react').memo`
+	if decl.Kind == ast.KindVariableDeclaration {
+		init := decl.AsVariableDeclaration().Initializer
+		return initializerMatchesPragma(init, pragma, pragmaLower)
+	}
+
+	return false
+}
+
+// getSourceFileNode walks up from `node` to its enclosing SourceFile,
+// returning it as an `*ast.Node`, or nil when no SourceFile ancestor is
+// found (extremely unlikely outside of synthesized nodes).
+func getSourceFileNode(node *ast.Node) *ast.Node {
+	sf := ast.GetSourceFileOfNode(node)
+	if sf == nil {
+		return nil
+	}
+	return sf.AsNode()
+}
+
+// findPragmaBindingByName is the syntax-only fallback for
+// `IsDestructuredFromPragmaImport` when no TypeChecker is available. It
+// scans the SourceFile rooted at `root` for any declaration that
+// introduces a binding named `name` whose source is the pragma module:
+//
+//   - `import { name } from '<pragma>'`
+//   - `import { x as name } from '<pragma>'` (renamed import — local
+//     binding is `name`)
+//   - `const { name } = <pragma>` / `const { name } = require('<pragma>')`
+//   - `const name = <pragma>.name` / `const name = require('<pragma>').name`
+//   - `const { x: name } = <pragma>` / require — destructure-with-rename
+//
+// Walks the entire SourceFile rather than tracking lexical scope. This
+// is a deliberate trade-off: shadowing in inner scopes (e.g. a deeply
+// nested `function memo() {}` overriding a top-level
+// `import { memo } from 'react'`) is NOT modeled — but the recognition
+// only matters for bare callees that already passed name + non-shadow
+// checks at the call site, which makes shadowing edge-cases vanish in
+// practice.
+func findPragmaBindingByName(root *ast.Node, name string, pragma string, pragmaLower string) bool {
+	if root == nil || name == "" {
+		return false
+	}
+	var found bool
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if found || n == nil {
+			return
+		}
+		switch n.Kind {
+		case ast.KindImportDeclaration:
+			if importDeclBindsNameFromPragma(n, name, pragmaLower) {
+				found = true
+				return
+			}
+		case ast.KindVariableDeclaration:
+			if variableDeclBindsNameFromPragma(n, name, pragma, pragmaLower) {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return found
+		})
+	}
+	visit(root)
+	return found
+}
+
+// importDeclBindsNameFromPragma reports whether `decl`
+// (an ImportDeclaration) introduces a local binding called `name` from
+// the module whose lowercased specifier equals `pragmaLower`. Handles
+// both plain (`import { name } from '...'`) and renamed
+// (`import { x as name } from '...'`) named imports — the local binding
+// is the second identifier, which is what we match against `name`.
+func importDeclBindsNameFromPragma(decl *ast.Node, name string, pragmaLower string) bool {
+	id := decl.AsImportDeclaration()
+	if id.ModuleSpecifier == nil || id.ModuleSpecifier.Kind != ast.KindStringLiteral {
+		return false
+	}
+	if id.ModuleSpecifier.Text() != pragmaLower {
+		return false
+	}
+	if id.ImportClause == nil {
+		return false
+	}
+	ic := id.ImportClause.AsImportClause()
+	if ic.NamedBindings == nil || ic.NamedBindings.Kind != ast.KindNamedImports {
+		// Default import / namespace import don't bind `name` directly.
+		return false
+	}
+	ni := ic.NamedBindings.AsNamedImports()
+	if ni.Elements == nil {
+		return false
+	}
+	for _, spec := range ni.Elements.Nodes {
+		// ImportSpecifier.Name() returns the local binding identifier
+		// (post-rename in `{ x as y }`). That's what shadows scope and
+		// what we should compare against `name`.
+		local := spec.Name()
+		if local != nil && local.Kind == ast.KindIdentifier && local.AsIdentifier().Text == name {
+			return true
+		}
+	}
+	return false
+}
+
+// variableDeclBindsNameFromPragma reports whether `decl`
+// (a VariableDeclaration) introduces a local binding called `name`
+// whose value originates from the pragma module. Recognized shapes:
+//
+//   - `const name = <pragma>.name` / `const name = require('<pragma>').name`
+//   - `const { name } = <pragma>` / `const { name } = require('<pragma>')`
+//   - `const { x: name } = <pragma>` / `const { x: name } = require('<pragma>')`
+func variableDeclBindsNameFromPragma(decl *ast.Node, name, pragma, pragmaLower string) bool {
+	vd := decl.AsVariableDeclaration()
+	if vd.Initializer == nil {
+		return false
+	}
+	bindingName := vd.Name()
+	if bindingName == nil {
+		return false
+	}
+	switch bindingName.Kind {
+	case ast.KindIdentifier:
+		// `const name = ...` — local binding is `bindingName.Text`.
+		if bindingName.AsIdentifier().Text != name {
+			return false
+		}
+		// Initializer must be `<pragma>.name` or `require('<pragma>').name`.
+		return initializerIsPragmaMember(vd.Initializer, name, pragma, pragmaLower)
+	case ast.KindObjectBindingPattern:
+		// `const { name } = ...` or `const { x: name } = ...`. Element
+		// match: an ObjectBindingPattern element introduces `name` if
+		// either its propertyName is unset and its bindingName.Text is
+		// `name`, OR its bindingName.Text is `name` (the alias side).
+		if !objectBindingPatternBindsName(bindingName, name) {
+			return false
+		}
+		return initializerMatchesPragma(vd.Initializer, pragma, pragmaLower)
+	}
+	return false
+}
+
+// objectBindingPatternBindsName reports whether any element of the
+// ObjectBindingPattern introduces a local binding called `name`. The
+// local binding is the BindingElement.Name() — for `{ x: name }`,
+// PropertyName is `x` and Name is `name`; we always compare against
+// Name. Nested patterns are not recursed into (they don't apply to
+// pragma-import shapes).
+func objectBindingPatternBindsName(pat *ast.Node, name string) bool {
+	obp := pat.AsBindingPattern()
+	if obp == nil || obp.Elements == nil {
+		return false
+	}
+	for _, el := range obp.Elements.Nodes {
+		be := el.AsBindingElement()
+		local := be.Name()
+		if local != nil && local.Kind == ast.KindIdentifier && local.AsIdentifier().Text == name {
+			return true
+		}
+	}
+	return false
+}
+
+// initializerIsPragmaMember reports whether `init` is `<pragma>.<name>` or
+// `require('<pragma>').<name>` — the two member-access shapes that
+// introduce a `name` binding pulled from the pragma module without
+// going through a destructure pattern.
+func initializerIsPragmaMember(init *ast.Node, name, pragma, pragmaLower string) bool {
+	init = SkipExpressionWrappers(init)
+	if init == nil || init.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	pa := init.AsPropertyAccessExpression()
+	prop := pa.Name()
+	if prop == nil || prop.Kind != ast.KindIdentifier || prop.AsIdentifier().Text != name {
+		return false
+	}
+	obj := SkipExpressionWrappers(pa.Expression)
+	if obj == nil {
+		return false
+	}
+	if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == pragma {
+		return true
+	}
+	if obj.Kind == ast.KindCallExpression && isRequireCallOfPragma(obj, pragmaLower) {
+		return true
+	}
+	return false
+}
+
+// findEnclosingVariableDeclaration walks up from a BindingElement to its
+// enclosing VariableDeclaration, or nil when not found (e.g. parameter
+// bindings, which are not pragma imports).
+func findEnclosingVariableDeclaration(node *ast.Node) *ast.Node {
+	for p := node.Parent; p != nil; p = p.Parent {
+		switch p.Kind {
+		case ast.KindVariableDeclaration:
+			return p
+		case ast.KindParameter, ast.KindFunctionDeclaration,
+			ast.KindArrowFunction, ast.KindFunctionExpression,
+			ast.KindMethodDeclaration:
+			return nil
+		}
+	}
+	return nil
+}
+
+// initializerMatchesPragma reports whether the given initializer
+// expression evaluates to the pragma binding (or to a property of it).
+// Mirrors the four init shapes upstream's helper inspects.
+func initializerMatchesPragma(init *ast.Node, pragma, pragmaLower string) bool {
+	if init == nil {
+		return false
+	}
+	init = SkipExpressionWrappers(init)
+
+	// `init` is the pragma identifier itself (`= React`).
+	if init.Kind == ast.KindIdentifier && init.AsIdentifier().Text == pragma {
+		return true
+	}
+
+	// `init` is `pragma.something` — `= React.memo`.
+	if init.Kind == ast.KindPropertyAccessExpression {
+		obj := SkipExpressionWrappers(init.AsPropertyAccessExpression().Expression)
+		if obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == pragma {
+			return true
+		}
+		// `init` is `require('react').memo` — member access on a
+		// require call.
+		if obj.Kind == ast.KindCallExpression && isRequireCallOfPragma(obj, pragmaLower) {
+			return true
+		}
+	}
+
+	// `init` is `require('react')` directly (destructure case).
+	if init.Kind == ast.KindCallExpression && isRequireCallOfPragma(init, pragmaLower) {
+		return true
+	}
+
+	return false
+}
+
+// isRequireCallOfPragma reports whether `call` is `require('<pragmaLower>')`.
+// Upstream's helper checks `callee.name === 'require'` and
+// `arguments[0].value === pragma.toLocaleLowerCase()`.
+func isRequireCallOfPragma(call *ast.Node, pragmaLower string) bool {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	c := call.AsCallExpression()
+	callee := SkipExpressionWrappers(c.Expression)
+	if callee == nil || callee.Kind != ast.KindIdentifier ||
+		callee.AsIdentifier().Text != "require" {
+		return false
+	}
+	if c.Arguments == nil || len(c.Arguments.Nodes) == 0 {
+		return false
+	}
+	arg := SkipExpressionWrappers(c.Arguments.Nodes[0])
+	if arg == nil || arg.Kind != ast.KindStringLiteral {
+		return false
+	}
+	return arg.AsStringLiteral().Text == pragmaLower
+}
+
 // DefaultReactCreateClass is the fallback ES5 factory name when
 // `settings.react.createClass` is not configured, matching
 // eslint-plugin-react.
 const DefaultReactCreateClass = "createReactClass"
+
+// ComponentWrapperEntry describes one user-configured component-wrapping
+// call site. Either form is recognized:
+//
+//   - `{property: "memo", object: "React"}` matches `<object>.<property>(fn)`
+//     calls. Empty `object` is treated as `DefaultReactPragma`.
+//   - `{property: "memo"}` matches bare `<property>(fn)` calls when `object`
+//     is empty.
+//
+// Mirrors eslint-plugin-react's `settings.componentWrapperFunctions` —
+// strings in the user setting expand to `{property: <s>}`, objects pass
+// through.
+//
+// `IsUserConfigured` distinguishes entries the user explicitly added via
+// `settings.componentWrapperFunctions` from entries we inject as
+// hardcoded defaults (memo / forwardRef, pragma-qualified or bare).
+// Upstream's `isDestructuredFromPragmaImport` adds a runtime guard to
+// bare default entries — they only match when the bare callee was
+// destructure-imported from the pragma module. We have no import
+// resolver, so we approximate by matching default bare entries on
+// non-optional calls only, and matching user-configured bare entries
+// freely (since they don't depend on import resolution).
+type ComponentWrapperEntry struct {
+	Object           string
+	Property         string
+	IsUserConfigured bool
+}
+
+// DefaultComponentWrappers is the always-on wrapper list every React rule
+// uses regardless of `settings.componentWrapperFunctions`. Mirrors upstream:
+// `{property: 'memo', object: pragma}`, `{property: 'forwardRef', object: pragma}`,
+// plus the bare `memo` / `forwardRef` aliases.
+func DefaultComponentWrappers(pragma string) []ComponentWrapperEntry {
+	if pragma == "" {
+		pragma = DefaultReactPragma
+	}
+	return []ComponentWrapperEntry{
+		{Object: pragma, Property: "memo"},
+		{Object: pragma, Property: "forwardRef"},
+		{Property: "memo"},
+		{Property: "forwardRef"},
+	}
+}
+
+// GetComponentWrapperFunctions reads `settings.componentWrapperFunctions`
+// and merges the user's additions on top of `DefaultComponentWrappers`.
+// Accepted shapes per entry:
+//
+//   - string: "myMemo" → {Property: "myMemo"}
+//   - object: {"property": "memo", "object": "React"} →
+//     {Object: "React", Property: "memo"}; "object" defaults to empty
+//     (bare call) when omitted
+//
+// Unknown / malformed entries are silently ignored, matching upstream.
+func GetComponentWrapperFunctions(settings map[string]interface{}, pragma string) []ComponentWrapperEntry {
+	out := DefaultComponentWrappers(pragma)
+	if settings == nil {
+		return out
+	}
+	raw, ok := settings["componentWrapperFunctions"]
+	if !ok {
+		return out
+	}
+	add := func(v interface{}) {
+		switch e := v.(type) {
+		case string:
+			if e != "" {
+				out = append(out, ComponentWrapperEntry{Property: e, IsUserConfigured: true})
+			}
+		case map[string]interface{}:
+			prop, _ := e["property"].(string)
+			if prop == "" {
+				return
+			}
+			obj, _ := e["object"].(string)
+			out = append(out, ComponentWrapperEntry{Object: obj, Property: prop, IsUserConfigured: true})
+		}
+	}
+	switch r := raw.(type) {
+	case []interface{}:
+		for _, v := range r {
+			add(v)
+		}
+	default:
+		add(r)
+	}
+	return out
+}
+
+// MatchesAnyComponentWrapper reports whether `call` matches any entry in
+// `wrappers`, with `fn` as its first argument (paren / TS-wrapper transparent).
+// Pass an empty pragma to default to "React"; the pragma is only consulted
+// for entries whose `Object` is empty AND need to fall back to the configured
+// pragma — but `DefaultComponentWrappers` already pre-fills the pragma form,
+// so callers normally shouldn't need to thread pragma through twice.
+//
+// Optional-chain handling mirrors upstream's `isPragmaComponentWrapper`:
+//
+//   - Member-level optional (`React?.memo(arg)`) — recognized; Babel
+//     emits the callee as MemberExpression with `optional: true` and
+//     upstream's `callee.type === 'MemberExpression'` check still passes.
+//
+//   - Call-level optional (`memo?.(arg)`) on a bare Identifier callee —
+//     recognized only against `IsUserConfigured: true` entries.
+//     Hardcoded bare-default entries (`memo` / `forwardRef` without
+//     pragma object) are upstream-gated by
+//     `isDestructuredFromPragmaImport`, which we cannot enforce without
+//     an import resolver. Restricting hardcoded bare defaults to
+//     non-optional matches keeps us conservative; user wrappers don't
+//     need that gate (they're explicit user opt-in).
+func MatchesAnyComponentWrapper(call, fn *ast.Node, wrappers []ComponentWrapperEntry) bool {
+	return matchesAnyComponentWrapperCore(call, fn, wrappers, "", nil)
+}
+
+// MatchesAnyComponentWrapperWithChecker is the import-aware variant.
+// When `tc` is non-nil and the callee is a bare Identifier matching a
+// hardcoded bare default entry (`{Property: "memo"}` /
+// `{Property: "forwardRef"}` from `DefaultComponentWrappers`), the
+// callee's binding must additionally be destructured from / imported
+// from / required from the pragma module (per
+// `IsDestructuredFromPragmaImport`). This precisely mirrors upstream's
+//
+//	(!wrapperFunction.object ||
+//	 (wrapperFunction.object === pragma &&
+//	  this.isDestructuredFromPragmaImport(node, node.callee.name)))
+//
+// gate. Without this, `memo(arrow)` would silently classify when `memo`
+// is a user-defined function unrelated to React — leading to over-reports
+// where upstream skips. Use this variant whenever a TypeChecker is
+// available; otherwise the import-resolution check is skipped (matching
+// the non-checker variant's conservative behavior — call-level optional
+// rejected for hardcoded bare defaults).
+func MatchesAnyComponentWrapperWithChecker(call, fn *ast.Node, wrappers []ComponentWrapperEntry, pragma string, tc *checker.Checker) bool {
+	return matchesAnyComponentWrapperCore(call, fn, wrappers, pragma, tc)
+}
+
+func matchesAnyComponentWrapperCore(call, fn *ast.Node, wrappers []ComponentWrapperEntry, pragma string, tc *checker.Checker) bool {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	c := call.AsCallExpression()
+	if c.Arguments == nil || len(c.Arguments.Nodes) == 0 {
+		return false
+	}
+	if SkipExpressionWrappers(c.Arguments.Nodes[0]) != fn {
+		return false
+	}
+	callLevelOptional := c.QuestionDotToken != nil
+	callee := SkipExpressionWrappers(c.Expression)
+	for _, w := range wrappers {
+		if w.Property == "" {
+			continue
+		}
+		switch callee.Kind {
+		case ast.KindIdentifier:
+			if w.Object != "" {
+				continue
+			}
+			if callee.AsIdentifier().Text != w.Property {
+				continue
+			}
+			if w.IsUserConfigured {
+				// User-configured bare entry: accept any callee shape
+				// (call-level optional included). User entries don't
+				// need the pragma-import gate since they're explicit
+				// opt-in.
+				return true
+			}
+			// Hardcoded bare default (memo / forwardRef without object):
+			// upstream gates with `isDestructuredFromPragmaImport`. We
+			// always run that gate — when a TypeChecker is available
+			// it resolves the binding precisely, and when not it falls
+			// back to a syntax-only SourceFile scan that handles the
+			// canonical top-level pragma-import shapes.
+			if !IsDestructuredFromPragmaImport(callee, pragma, tc) {
+				continue
+			}
+			return true
+		case ast.KindPropertyAccessExpression:
+			if w.Object == "" {
+				continue
+			}
+			// Call-level optional on a member callee (`(R.memo)?.()`)
+			// is structurally distinct from member-level optional
+			// (`R?.memo()` — flag on the PropertyAccess) and upstream
+			// also rejects it (`callee.name` undefined on the call's
+			// own optional shape). Reject regardless of IsUserConfigured.
+			if callLevelOptional {
+				continue
+			}
+			pa := callee.AsPropertyAccessExpression()
+			obj := SkipExpressionWrappers(pa.Expression)
+			if obj.Kind != ast.KindIdentifier || obj.AsIdentifier().Text != w.Object {
+				continue
+			}
+			name := pa.Name()
+			if name == nil || name.Kind != ast.KindIdentifier {
+				continue
+			}
+			if name.AsIdentifier().Text == w.Property {
+				return true
+			}
+		}
+	}
+	return false
+}
 
 // GetReactPragma reads `settings.react.pragma` from the config settings map.
 // Returns DefaultReactPragma when the setting is absent, not a string, or empty.
@@ -488,7 +1269,53 @@ func GetEnclosingReactComponentOrStateless(node *ast.Node, pragma, createClass s
 //     own Identifier.
 //
 // Pass the empty string for `pragma` to default to `DefaultReactPragma`.
+//
+// This wrapper preserves the historical "no checker" call shape used by
+// every other React rule. Pass a non-nil checker via
+// `IsStatelessReactComponentWithChecker` to enable Identifier-through-scope
+// resolution inside the JSX-return checks (relevant for any input where
+// the function returns a name bound elsewhere — `return view` ↔
+// `let view = <div/>` etc).
 func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
+	return isStatelessReactComponentCore(fn, pragma, nil, nil)
+}
+
+// IsStatelessReactComponentWithChecker mirrors IsStatelessReactComponent and
+// additionally threads `tc` into every isReturningJSX / isReturningJSXOrNull
+// gate inside the decision tree. When `tc` is nil, all behavior matches
+// `IsStatelessReactComponent` exactly (local-block initializer scan only).
+//
+// The pragma-component-wrapper branch (Branch 11) uses the hardcoded
+// default wrappers (`memo` / `forwardRef`, pragma-qualified or bare). To
+// honor `settings.componentWrapperFunctions` here, use
+// `IsStatelessReactComponentWithWrappers` instead.
+func IsStatelessReactComponentWithChecker(fn *ast.Node, pragma string, tc *checker.Checker) bool {
+	return isStatelessReactComponentCore(fn, pragma, tc, nil)
+}
+
+// IsStatelessReactComponentWithWrappers is the variant that consults a
+// user-provided wrapper list when classifying the inner function of
+// pragma-component-wrapper calls (Branch 11 of the decision tree).
+//
+// Why this matters: `myMemo(() => null)` with
+// `settings.componentWrapperFunctions: ['myMemo']` should classify the
+// inner arrow as a stateless component (via the wrapper-arm of upstream's
+// `getStatelessComponent`), so that the null-only return correctly
+// triggers `isStatelessComponentReturningNull` and the rule SKIPs. With
+// the hardcoded variant above, `myMemo` isn't recognized → the arrow
+// isn't classified → the null-only skip never fires → the rule reports
+// where upstream would not.
+//
+// Pass `wrappers = nil` for hardcoded defaults; pass the configured
+// `GetComponentWrapperFunctions(...)` list to honor user settings.
+func IsStatelessReactComponentWithWrappers(fn *ast.Node, pragma string, tc *checker.Checker, wrappers []ComponentWrapperEntry) bool {
+	return isStatelessReactComponentCore(fn, pragma, tc, wrappers)
+}
+
+// isStatelessReactComponentCore is the shared decision tree. `wrappers`
+// nil means "use hardcoded memo/forwardRef defaults" (matching the legacy
+// public API); non-nil means "consult this list in Branch 11 instead".
+func isStatelessReactComponentCore(fn *ast.Node, pragma string, tc *checker.Checker, wrappers []ComponentWrapperEntry) bool {
 	if fn == nil {
 		return false
 	}
@@ -514,12 +1341,12 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		if name == nil || name.Kind != ast.KindIdentifier {
 			return false
 		}
-		return isFirstLetterCapitalized(name.AsIdentifier().Text) && functionReturnsJSX(fn)
+		return isFirstLetterCapitalized(name.AsIdentifier().Text) && functionReturnsJSXInternal(fn, false, pragma, tc)
 	case ast.KindFunctionDeclaration:
 		// Branch: FunctionDeclaration requires isReturningJSXOrNull AND
 		// (no id || capitalized). Anonymous FD is only legal as
 		// `export default function() {...}`.
-		if !functionReturnsJSXOrNull(fn) {
+		if !functionReturnsJSXInternal(fn, true, pragma, tc) {
 			return false
 		}
 		name := fn.Name()
@@ -560,12 +1387,12 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 
 	// Branch 1 — ExportDefault (strict isReturningJSX).
 	if parent.Kind == ast.KindExportAssignment {
-		return functionReturnsJSX(fn)
+		return functionReturnsJSXInternal(fn, false, pragma, tc)
 	}
 
 	// Branch 2 — VariableDeclarator.
 	if parent.Kind == ast.KindVariableDeclaration {
-		if !functionReturnsJSXOrNull(fn) {
+		if !functionReturnsJSXInternal(fn, true, pragma, tc) {
 			return false
 		}
 		binding := parent.AsVariableDeclaration().Name()
@@ -579,7 +1406,7 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 	// when not strictly returning JSX.
 	if parent.Kind == ast.KindReturnStatement ||
 		(parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == fn) {
-		if !functionReturnsJSX(fn) {
+		if !functionReturnsJSXInternal(fn, false, pragma, tc) {
 			return false
 		}
 	}
@@ -589,7 +1416,7 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 	if parent.Kind == ast.KindBinaryExpression && !isMEAssign {
 		bin := parent.AsBinaryExpression()
 		if bin.OperatorToken != nil && bin.OperatorToken.Kind == ast.KindEqualsToken && bin.Right == fn {
-			if !functionReturnsJSXOrNull(fn) {
+			if !functionReturnsJSXInternal(fn, true, pragma, tc) {
 				return false
 			}
 			// Named FE defers to its own id (matches upstream's final
@@ -613,7 +1440,7 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 	// AssignmentExpression / PropertyAssignment position.
 	if parent.Kind == ast.KindArrowFunction && parent.AsArrowFunction().Body == fn {
 		grand := parent.Parent
-		if grand != nil && !isMEAssign && functionReturnsJSXOrNull(fn) {
+		if grand != nil && !isMEAssign && functionReturnsJSXInternal(fn, true, pragma, tc) {
 			switch grand.Kind {
 			case ast.KindBinaryExpression:
 				bin := grand.AsBinaryExpression()
@@ -650,7 +1477,7 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		if funcExpr != nil {
 			funcExpr = funcExpr.Parent
 		}
-		if funcExpr != nil && funcExpr.Parent != nil && !isMEAssign && functionReturnsJSXOrNull(fn) {
+		if funcExpr != nil && funcExpr.Parent != nil && !isMEAssign && functionReturnsJSXInternal(fn, true, pragma, tc) {
 			gp := funcExpr.Parent
 			switch gp.Kind {
 			case ast.KindBinaryExpression:
@@ -679,7 +1506,7 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 		if nameNode != nil && nameNode.Kind == ast.KindComputedPropertyName {
 			keyExpr := ast.SkipParentheses(nameNode.AsComputedPropertyName().Expression)
 			if keyExpr.Kind == ast.KindPropertyAccessExpression || keyExpr.Kind == ast.KindElementAccessExpression {
-				if !functionReturnsJSX(fn) && !functionReturnsOnlyNull(fn) {
+				if !functionReturnsJSXInternal(fn, false, pragma, tc) && !functionReturnsOnlyNull(fn) {
 					return false
 				}
 			}
@@ -701,25 +1528,41 @@ func IsStatelessReactComponent(fn *ast.Node, pragma string) bool {
 				if !isFirstLetterCapitalized(name.AsIdentifier().Text) {
 					return false
 				}
-				return functionReturnsJSX(fn)
+				return functionReturnsJSXInternal(fn, false, pragma, tc)
 			}
 			return false
 		}
 	}
 
-	// Branch 11 — pragma component wrapper (paren-transparent arg).
-	effectiveParent := parent
-	if effectiveParent.Kind == ast.KindParenthesizedExpression && effectiveParent.Parent != nil {
-		effectiveParent = effectiveParent.Parent
-	}
-	if effectiveParent.Kind == ast.KindCallExpression && isPragmaComponentWrapperCall(effectiveParent, fn, pragma) {
-		if functionReturnsJSXOrNull(fn) {
+	// Branch 11 — pragma component wrapper. tsgo preserves `()`, `as`,
+	// `satisfies`, `<T>x`, and `x!` wrappers around the arrow argument
+	// (ESTree flattens parens and has no equivalent for the TS-only
+	// forms), so we walk up through every such wrapper before looking for
+	// the enclosing CallExpression.
+	effectiveParent := SkipExpressionWrappersUp(fn)
+	if effectiveParent != nil && effectiveParent.Kind == ast.KindCallExpression {
+		// When the caller threaded `wrappers`, consult the configured
+		// list so user `settings.componentWrapperFunctions` entries
+		// (`myMemo`, `MyLib.observer`, etc.) participate in stateless-
+		// component classification — which in turn makes
+		// `isStatelessComponentReturningNull` fire correctly on
+		// null-only inner functions of user-configured wrappers. With
+		// `wrappers == nil` we fall back to the hardcoded default
+		// (memo / forwardRef, pragma-qualified or bare), preserving
+		// every legacy caller's behavior.
+		matched := false
+		if wrappers != nil {
+			matched = MatchesAnyComponentWrapperWithChecker(effectiveParent, fn, wrappers, pragma, tc)
+		} else {
+			matched = isPragmaComponentWrapperCall(effectiveParent, fn, pragma)
+		}
+		if matched && functionReturnsJSXInternal(fn, true, pragma, tc) {
 			return true
 		}
 	}
 
 	// Branch 12 — require allowed position AND isReturningJSXOrNull.
-	if !isInAllowedPositionForComponent(fn) || !functionReturnsJSXOrNull(fn) {
+	if !isInAllowedPositionForComponent(fn) || !functionReturnsJSXInternal(fn, true, pragma, tc) {
 		return false
 	}
 
@@ -874,21 +1717,32 @@ func skipParenParents(node *ast.Node) *ast.Node {
 // default `wrapperFunctions` entries (`{property: 'memo', object: pragma}`,
 // `{property: 'forwardRef', object: pragma}`); the user-configurable
 // `settings.componentWrapperFunctions` is NOT honored.
+//
+// Call-level optional chains (`memo?.(fn)`) are rejected for the same
+// reason as `MatchesAnyComponentWrapper` — upstream's
+// `isPragmaComponentWrapper` reads `callee.name` on a plain Identifier
+// callee, which fails on the OptionalCallExpression / ChainExpression
+// shape Babel emits.
 func isPragmaComponentWrapperCall(call, fn *ast.Node, pragma string) bool {
 	if call == nil || call.Kind != ast.KindCallExpression {
 		return false
 	}
 	c := call.AsCallExpression()
+	if c.QuestionDotToken != nil {
+		return false
+	}
 	if c.Arguments == nil || len(c.Arguments.Nodes) == 0 {
 		return false
 	}
-	// Paren-transparent argument match: tsgo preserves ParenthesizedExpression
-	// wrappers that ESTree flattens, so `React.memo((fn))` surfaces the paren
+	// Paren- and TS-wrapper-transparent argument match: tsgo preserves
+	// `()` / `as` / `satisfies` / `<T>x` / `x!` wrappers that ESTree
+	// either flattens or doesn't have at all, so `React.memo((fn))` /
+	// `React.memo(fn as Foo)` / `React.memo(fn!)` all surface the wrapper
 	// as the first argument rather than `fn` itself.
-	if ast.SkipParentheses(c.Arguments.Nodes[0]) != fn {
+	if SkipExpressionWrappers(c.Arguments.Nodes[0]) != fn {
 		return false
 	}
-	callee := ast.SkipParentheses(c.Expression)
+	callee := SkipExpressionWrappers(c.Expression)
 	switch callee.Kind {
 	case ast.KindIdentifier:
 		text := callee.AsIdentifier().Text
@@ -909,26 +1763,55 @@ func isPragmaComponentWrapperCall(call, fn *ast.Node, pragma string) bool {
 	return false
 }
 
-// functionReturnsJSXOrNull reports whether the function's body contains a
-// `return <jsx/>` / `return null` at depth ≤ 1 (nested functions excluded),
-// OR — for an arrow with expression body — whether that expression is JSX or
-// `null`. ConditionalExpression is traversed so `return cond ? <jsx/> : null`
+// FunctionReturnsJSXOrNull reports whether the function's body contains a
+// `return <jsx/>` / `return null` / `return <pragma>.createElement(...)` at
+// depth ≤ 1 (nested functions excluded), OR — for an arrow with expression
+// body — whether that expression qualifies under the same rules.
+// ConditionalExpression is traversed so `return cond ? <jsx/> : null`
 // qualifies.
-func functionReturnsJSXOrNull(fn *ast.Node) bool {
-	return functionReturnsJSXInternal(fn, true)
+//
+// Identifier returns (`return view` where `view` is bound to a JSX value)
+// are resolved structurally via a local block scan. Use
+// `FunctionReturnsJSXOrNullWithChecker` for full TypeChecker-based scope
+// resolution.
+//
+// Mirrors upstream jsxUtil.isReturningJSX invoked with default arguments
+// (which accept JSX, `null`, and `<pragma>.createElement(...)` returns).
+// Pass an empty pragma to default to "React".
+func FunctionReturnsJSXOrNull(fn *ast.Node, pragma string) bool {
+	return functionReturnsJSXInternal(fn, true, pragma, nil)
 }
 
-// functionReturnsJSX is the strict sibling of functionReturnsJSXOrNull:
-// a `null` return does NOT qualify on its own. Mirrors upstream's
-// jsxUtil.isReturningJSX (as opposed to isReturningJSXOrNull). Used by
-// branches of getStatelessComponent that specifically gate on strict JSX
-// (ExportDefault, inside-ReturnStatement / arrow-expression-body early
-// rejection, Property `method`-branch final check).
-func functionReturnsJSX(fn *ast.Node) bool {
-	return functionReturnsJSXInternal(fn, false)
+// FunctionReturnsJSXOrNullWithChecker is the TypeChecker-aware variant of
+// FunctionReturnsJSXOrNull. When `tc` is non-nil, Identifier returns are
+// resolved through `GetSymbolAtLocation` → `Declarations[0]` →
+// `VariableDeclaration.Initializer`, matching upstream's `findVariableByName`
+// scope walk semantically (any binding the TS resolver can reach is
+// considered, not just bindings in the immediately-enclosing block). When
+// `tc` is nil, falls back to the local-block scan.
+func FunctionReturnsJSXOrNullWithChecker(fn *ast.Node, pragma string, tc *checker.Checker) bool {
+	return functionReturnsJSXInternal(fn, true, pragma, tc)
 }
 
-func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool) bool {
+// FunctionReturnsJSX is the strict sibling of FunctionReturnsJSXOrNull:
+// a `null` return does NOT qualify on its own. `<pragma>.createElement(...)`
+// calls still qualify. Mirrors upstream jsxUtil.isReturningJSX invoked with
+// `strict=true, ignoreNull=true`. `<pragma>.createElement(...)` calls still
+// qualify. Pass an empty pragma to default to "React".
+func FunctionReturnsJSX(fn *ast.Node, pragma string) bool {
+	return functionReturnsJSXInternal(fn, false, pragma, nil)
+}
+
+// FunctionReturnsJSXWithChecker is the TypeChecker-aware strict variant.
+// See FunctionReturnsJSXOrNullWithChecker for the resolution semantics.
+func FunctionReturnsJSXWithChecker(fn *ast.Node, pragma string, tc *checker.Checker) bool {
+	return functionReturnsJSXInternal(fn, false, pragma, tc)
+}
+
+func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool, pragma string, tc *checker.Checker) bool {
+	if fn == nil {
+		return false
+	}
 	var body *ast.Node
 	switch fn.Kind {
 	case ast.KindFunctionDeclaration:
@@ -938,7 +1821,7 @@ func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool) bool {
 	case ast.KindArrowFunction:
 		body = fn.AsArrowFunction().Body
 		if body != nil && body.Kind != ast.KindBlock {
-			return isJSXExpression(body, acceptNull)
+			return isJSXExpression(body, acceptNull, pragma, tc)
 		}
 	case ast.KindMethodDeclaration:
 		body = fn.AsMethodDeclaration().Body
@@ -959,7 +1842,7 @@ func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool) bool {
 		switch n.Kind {
 		case ast.KindReturnStatement:
 			rs := n.AsReturnStatement()
-			if rs.Expression != nil && isJSXExpression(rs.Expression, acceptNull) {
+			if rs.Expression != nil && isJSXExpression(rs.Expression, acceptNull, pragma, tc) {
 				found = true
 				return true
 			}
@@ -981,21 +1864,70 @@ func functionReturnsJSXInternal(fn *ast.Node, acceptNull bool) bool {
 
 // isJSXExpression reports whether `expr` may evaluate to JSX (or to `null`
 // when `acceptNull` is true) on at least one control-flow path. Walks through
-// ParenthesizedExpression, ConditionalExpression (both branches),
-// comma-sequence right-most operands, and logical `&&` / `||` / `??`
-// operands (either side). Pass `acceptNull=true` for
-// `isReturningJSXOrNull`-style gates and `false` for the strict
-// `isReturningJSX` gates.
-func isJSXExpression(expr *ast.Node, acceptNull bool) bool {
-	expr = ast.SkipParentheses(expr)
+// ParenthesizedExpression, TS expression wrappers (`as` / `satisfies` / `<T>x`
+// / `x!`), ConditionalExpression and LogicalExpression (NON-strict semantics:
+// either side qualifying is enough), comma-sequence right-most operands, and
+// optional chains. A `<pragma>.createElement(...)` CallExpression also
+// qualifies — upstream's jsxUtil.isReturningJSX treats `createElement` calls
+// as JSX returns. An Identifier resolves through its declaring
+// VariableDeclaration initializer when present, mirroring upstream's
+// `findVariableByName` lookup but limited to const/let initializers within
+// the same scope (no re-binding analysis).
+//
+// Strict semantics note: upstream's jsxUtil.isReturningJSX accepts a
+// `strict` parameter that, when true, requires BOTH branches of a
+// Conditional / LogicalExpression to qualify. Every call site in upstream
+// `Components.js` (rev 7.x) passes `strict=undefined` (falsy = non-strict),
+// so the strict mode is effectively unreachable through this rule and the
+// no-unstable-nested-components rule itself. We therefore match upstream's
+// observable behavior (non-strict for all current consumers) and omit the
+// strict parameter; if a future rule needs strict mode it should be added
+// then with the corresponding test coverage.
+//
+// Pass `acceptNull=true` for `isReturningJSXOrNull`-style gates and `false`
+// for the strict `isReturningJSX` (ignoreNull=true) gates. Pass `tc` (the
+// active TypeChecker) when scope-resolved Identifier lookup is desired;
+// pass nil to fall back to a local-block initializer scan.
+//
+// Identifier-via-initializer resolution is one-step only — matching
+// upstream's `isJSXValue → findVariableByName → isJSX(variable)` chain
+// where `isJSX` accepts ONLY a JSXElement / JSXFragment node and does not
+// recurse. No depth bookkeeping needed because the function does not
+// recurse on Identifier; the only recursion sites (Conditional / comma /
+// `&&` / `||` / `??`) walk strictly smaller AST subtrees.
+func isJSXExpression(expr *ast.Node, acceptNull bool, pragma string, tc *checker.Checker) bool {
+	expr = SkipExpressionWrappers(expr)
+	if expr == nil {
+		return false
+	}
 	switch expr.Kind {
 	case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
 		return true
 	case ast.KindNullKeyword:
 		return acceptNull
+	case ast.KindCallExpression:
+		return IsCreateElementCallWithChecker(expr.AsCallExpression().Expression, pragma, tc)
+	case ast.KindIdentifier:
+		// Upstream's `isJSXValue` for the Identifier case calls
+		// `findVariableByName` and then `isJSX(variable)` — and `isJSX`
+		// ONLY accepts JSXElement / JSXFragment. It does NOT recurse
+		// into ConditionalExpression / LogicalExpression / CallExpression
+		// (`createElement`) / nested Identifiers. We mirror that here:
+		// resolve the initializer one step, accept iff the resolved node
+		// is itself a JSX element/fragment. Anything else returns false.
+		init := resolveIdentifierInitializer(expr, tc)
+		if init == nil {
+			return false
+		}
+		init = SkipExpressionWrappers(init)
+		switch init.Kind {
+		case ast.KindJsxElement, ast.KindJsxSelfClosingElement, ast.KindJsxFragment:
+			return true
+		}
+		return false
 	case ast.KindConditionalExpression:
 		ce := expr.AsConditionalExpression()
-		return isJSXExpression(ce.WhenTrue, acceptNull) || isJSXExpression(ce.WhenFalse, acceptNull)
+		return isJSXExpression(ce.WhenTrue, acceptNull, pragma, tc) || isJSXExpression(ce.WhenFalse, acceptNull, pragma, tc)
 	case ast.KindBinaryExpression:
 		bin := expr.AsBinaryExpression()
 		if bin.OperatorToken == nil {
@@ -1003,36 +1935,243 @@ func isJSXExpression(expr *ast.Node, acceptNull bool) bool {
 		}
 		switch bin.OperatorToken.Kind {
 		case ast.KindCommaToken:
-			return isJSXExpression(bin.Right, acceptNull)
+			return isJSXExpression(bin.Right, acceptNull, pragma, tc)
 		case ast.KindAmpersandAmpersandToken,
 			ast.KindBarBarToken,
 			ast.KindQuestionQuestionToken:
-			return isJSXExpression(bin.Left, acceptNull) || isJSXExpression(bin.Right, acceptNull)
+			return isJSXExpression(bin.Left, acceptNull, pragma, tc) || isJSXExpression(bin.Right, acceptNull, pragma, tc)
 		}
 	}
 	return false
 }
 
-func isFirstLetterCapitalized(s string) bool {
-	return len(s) > 0 && s[0] >= 'A' && s[0] <= 'Z'
+// resolveIdentifierInitializer returns the value-side AST node that an
+// Identifier reference is bound to, or nil when the binding cannot be
+// determined.
+//
+//   - When `tc` is non-nil, asks the TypeChecker for the resolved symbol's
+//     ValueDeclaration, then returns that declaration's `.Initializer`
+//     (only the const/let/var case — class / function declarations have
+//     no `Initializer` and aren't useful for JSX-return resolution). This
+//     is upstream-equivalent to `findVariableByName` because the TS
+//     resolver already follows the full lexical scope chain.
+//
+//   - When `tc` is nil, falls back to scanning enclosing Block /
+//     SourceFile / ModuleBlock / CaseBlock statements for a
+//     `VariableStatement` declaring `name` — catches the common
+//     same-block initializer case without scope analysis.
+func resolveIdentifierInitializer(ident *ast.Node, tc *checker.Checker) *ast.Node {
+	if ident == nil || ident.Kind != ast.KindIdentifier {
+		return nil
+	}
+	if tc != nil {
+		if init := resolveIdentifierViaChecker(ident, tc); init != nil {
+			return init
+		}
+		// Fall through: TypeChecker may not resolve the binding (e.g. a
+		// type-only declaration in a JS file, or a synthesized symbol).
+		// The local-block scan is a strict subset, so trying it as a
+		// safety net costs nothing.
+	}
+	return lookupLocalInitializer(ident)
 }
 
-// IsCreateElementCall reports whether the callee is `<pragma>.createElement`.
+// resolveIdentifierViaChecker resolves an Identifier through the
+// TypeChecker. Returns the initializer of the resolved
+// VariableDeclaration, or nil when the symbol's value declaration is not a
+// VariableDeclaration with an Initializer.
+//
+// All `checker.Checker` access on rslint runs without `--type-check` is
+// nil; this function MUST be defensive even though its callers already
+// gate on a non-nil `tc`. The double guard keeps the file safe to call
+// from any future site that forgets the gate.
+func resolveIdentifierViaChecker(ident *ast.Node, tc *checker.Checker) *ast.Node {
+	if tc == nil || ident == nil {
+		return nil
+	}
+	symbol := tc.GetSymbolAtLocation(ident)
+	if symbol == nil {
+		return nil
+	}
+	// `ValueDeclaration` is the symbol's primary declaration site; for
+	// `const x = <div/>` it's the VariableDeclaration. When ValueDeclaration
+	// is absent (interfaces, type aliases, ambient symbols) we explicitly
+	// don't try to walk `Declarations` — those don't have a JSX value.
+	decl := symbol.ValueDeclaration
+	if decl == nil {
+		// Fall back to Declarations[0] when ValueDeclaration is missing
+		// but the symbol still has a concrete declaration (e.g. some
+		// shorthand-property bindings).
+		if len(symbol.Declarations) == 0 {
+			return nil
+		}
+		decl = symbol.Declarations[0]
+	}
+	if decl == nil || decl.Kind != ast.KindVariableDeclaration {
+		return nil
+	}
+	return decl.AsVariableDeclaration().Initializer
+}
+
+// lookupLocalInitializer mirrors upstream `variableUtil.findVariableByName`'s
+// happy path for the cases this rule cares about: a const/let/var binding
+// whose initializer is a JSX-or-createElement expression, declared in the
+// same enclosing function/program. Walks lexically up the parent chain
+// looking for a Block / SourceFile that contains a `VariableStatement`
+// declaring `name` with a non-nil initializer; returns the initializer or
+// nil when no such declaration is reachable.
+//
+// We deliberately do NOT re-implement a full scope manager — the tradeoff
+// is that re-bindings (e.g. `let x = <div/>; x = 1; return x`) and
+// destructuring patterns are not resolved, matching the conservative subset
+// of upstream's behavior that the no-unstable-nested-components rule
+// actually exercises in its tests.
+func lookupLocalInitializer(ident *ast.Node) *ast.Node {
+	if ident == nil || ident.Kind != ast.KindIdentifier {
+		return nil
+	}
+	name := ident.AsIdentifier().Text
+	for cur := ident.Parent; cur != nil; cur = cur.Parent {
+		switch cur.Kind {
+		case ast.KindBlock, ast.KindSourceFile, ast.KindCaseBlock, ast.KindModuleBlock:
+			if init := findInitializerInStatements(cur, name); init != nil {
+				return init
+			}
+		}
+	}
+	return nil
+}
+
+// findInitializerInStatements scans the statements of a Block / SourceFile
+// (or anything with a `Statements` field exposed via ForEachChild) for a
+// `VariableStatement` declaring `name` with a direct initializer.
+func findInitializerInStatements(scope *ast.Node, name string) *ast.Node {
+	if scope == nil {
+		return nil
+	}
+	var found *ast.Node
+	scope.ForEachChild(func(stmt *ast.Node) bool {
+		if found != nil || stmt == nil {
+			return false
+		}
+		var declList *ast.Node
+		switch stmt.Kind {
+		case ast.KindVariableStatement:
+			declList = stmt.AsVariableStatement().DeclarationList
+		}
+		if declList == nil {
+			return false
+		}
+		decls := declList.AsVariableDeclarationList()
+		if decls == nil || decls.Declarations == nil {
+			return false
+		}
+		for _, d := range decls.Declarations.Nodes {
+			if d == nil || d.Kind != ast.KindVariableDeclaration {
+				continue
+			}
+			vd := d.AsVariableDeclaration()
+			if vd.Name() == nil || vd.Name().Kind != ast.KindIdentifier {
+				continue
+			}
+			if vd.Name().AsIdentifier().Text != name {
+				continue
+			}
+			if vd.Initializer != nil {
+				found = vd.Initializer
+				return true
+			}
+		}
+		return false
+	})
+	return found
+}
+
+// isFirstLetterCapitalized mirrors eslint-plugin-react's helper of the same
+// name (`lib/util/isFirstLetterCapitalized.js`). The semantics are:
+//
+//  1. Strip leading underscores: `_Foo` → "Foo" (so `_Foo` is treated the
+//     same as `Foo`, matching upstream's `word.replace(/^_+/, '')`).
+//  2. A character is "capitalized" iff `unicode.ToUpper(r) == r` —
+//     equivalent to upstream's `firstLetter.toUpperCase() === firstLetter`.
+//
+// Step 2 means non-cased characters (CJK, digits, emoji, symbols) all
+// count as "capitalized" because they have no upper/lower mapping. This
+// matters for non-ASCII identifiers like `function 不稳定组件()` — upstream
+// classifies the function as a component (CJK char ≠ lowercase letter),
+// and we must do the same to stay output-aligned.
+func isFirstLetterCapitalized(s string) bool {
+	stripped := strings.TrimLeft(s, "_")
+	if stripped == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(stripped)
+	if r == utf8.RuneError {
+		return false
+	}
+	return unicode.ToUpper(r) == r
+}
+
+// IsCreateElementCall reports whether the callee is `<pragma>.createElement`
+// (or, with the WithChecker variant below, bare `createElement` resolved
+// to a pragma-destructured binding).
+//
 // Pass an empty pragma to default to "React"; pass GetReactPragma(ctx.Settings)
 // to honor the user's `settings.react.pragma` configuration.
 //
-// Parentheses are transparently skipped on both the callee itself and the
-// pragma identifier (e.g. `(React).createElement` / `(React.createElement)()`),
-// matching ESTree's flattened shape.
+// Parentheses AND TS expression wrappers (`as` / `satisfies` / `<T>x` / `x!`)
+// are transparently skipped on both the callee itself and the pragma
+// identifier (e.g. `(React).createElement` / `(React as any).createElement`).
+// Optional-chain calls (`React?.createElement(...)`) are NOT recognized
+// (upstream's `node.callee.object.name` access fails on the OptionalCall
+// shape).
+//
+// This non-checker variant only recognizes the member-access form. To
+// recognize bare `createElement(...)` calls (with the
+// `isDestructuredFromPragmaImport` gate), use
+// `IsCreateElementCallWithChecker`.
 func IsCreateElementCall(callee *ast.Node, pragma string) bool {
+	return isCreateElementCallCore(callee, pragma, nil)
+}
+
+// IsCreateElementCallWithChecker is the import-aware variant. When `tc`
+// is non-nil, additionally recognizes bare `createElement(arg)` calls
+// where the bare callee resolves to a pragma-destructured binding
+// (`import { createElement } from 'react'` /
+// `const { createElement } = React` / `const createElement = React.createElement`
+// / `const { createElement } = require('react')`). Mirrors upstream
+// `isCreateElement`'s second branch byte-for-byte.
+func IsCreateElementCallWithChecker(callee *ast.Node, pragma string, tc *checker.Checker) bool {
+	return isCreateElementCallCore(callee, pragma, tc)
+}
+
+func isCreateElementCallCore(callee *ast.Node, pragma string, tc *checker.Checker) bool {
 	if callee == nil {
 		return false
 	}
 	if pragma == "" {
 		pragma = DefaultReactPragma
 	}
-	callee = ast.SkipParentheses(callee)
+	callee = SkipExpressionWrappers(callee)
+
+	// Bare callee: `createElement(arg)` — recognize when destructured
+	// from the pragma module. Mirrors upstream's second branch of
+	// `isCreateElement`.
+	if callee.Kind == ast.KindIdentifier {
+		if callee.AsIdentifier().Text != "createElement" {
+			return false
+		}
+		// Without a TypeChecker we can't resolve the binding; bail to
+		// match the conservative non-import-aware path (upstream also
+		// returns false when the destructure gate fails).
+		return IsDestructuredFromPragmaImport(callee, pragma, tc)
+	}
+
+	// Member-access callee: `<pragma>.createElement(arg)`.
 	if callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	if ast.IsOptionalChain(callee) {
 		return false
 	}
 	prop := callee.AsPropertyAccessExpression()
@@ -1040,7 +2179,7 @@ func IsCreateElementCall(callee *ast.Node, pragma string) bool {
 	if nameNode.Kind != ast.KindIdentifier || nameNode.AsIdentifier().Text != "createElement" {
 		return false
 	}
-	pragmaExpr := ast.SkipParentheses(prop.Expression)
+	pragmaExpr := SkipExpressionWrappers(prop.Expression)
 	if pragmaExpr.Kind != ast.KindIdentifier || pragmaExpr.AsIdentifier().Text != pragma {
 		return false
 	}

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.go
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.go
@@ -1,0 +1,962 @@
+package no_unstable_nested_components
+
+import (
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Message text mirrors eslint-plugin-react v7.37.x byte-for-byte, including
+// the typographic apostrophe (U+2019) in "subtree's" and the typographic
+// double quotation marks (U+201C / U+201D) wrapping the parent name. ASCII
+// straight quotes here would silently diverge from upstream and break
+// `errors: [{message: ERROR_MESSAGE}]` assertions written against the
+// upstream rule.
+const (
+	messageBase = "Do not define components during render. React will see a new component type on every render and destroy the entire subtree’s DOM nodes and state (https://reactjs.org/docs/reconciliation.html#elements-of-different-types). Instead, move this component definition out of the parent component"
+	asPropsInfo = " If you want to allow component creation in props, set allowAsProps option to true."
+	openQuote   = "“"
+	closeQuote  = "”"
+)
+
+// options holds the parsed rule options. Mirrors upstream's schema:
+//
+//	[{
+//	  type: 'object',
+//	  properties: {
+//	    customValidators: { type: 'array', items: { type: 'string' } },
+//	    allowAsProps: { type: 'boolean' },
+//	    propNamePattern: { type: 'string' },
+//	  },
+//	  additionalProperties: false,
+//	}]
+//
+// Schema validation itself is a framework-layer concern — upstream relies
+// on ESLint's central ajv pass; rslint's config loader is the equivalent
+// home. The rule body simply reads the well-typed fields it needs and
+// trusts the surrounding tooling to reject malformed configs upstream of
+// this point. `customValidators` is declared in the schema but unused by
+// both upstream and us, so we accept and discard it.
+type options struct {
+	allowAsProps    bool
+	propNamePattern string
+}
+
+func parseOptions(raw any) options {
+	opts := options{propNamePattern: "render*"}
+	optsMap := utils.GetOptionsMap(raw)
+	if optsMap == nil {
+		return opts
+	}
+	if v, ok := optsMap["allowAsProps"].(bool); ok {
+		opts.allowAsProps = v
+	}
+	if v, ok := optsMap["propNamePattern"].(string); ok && v != "" {
+		opts.propNamePattern = v
+	}
+	return opts
+}
+
+// unwrap peels off ParenthesizedExpression and TS-only expression wrappers
+// (`as`, `satisfies`, `<T>x` type assertions, `x!` non-null assertions) so
+// that downstream checks never need to know about them. Mirrors what ESTree
+// implicitly hands to ESLint after the parser strips parens.
+func unwrap(node *ast.Node) *ast.Node {
+	return reactutil.SkipExpressionWrappers(node)
+}
+
+// isFunctionLike reports whether `node` is a function-shaped node we
+// classify as a "potential component" — covers FunctionDeclaration,
+// FunctionExpression, ArrowFunction, and the object-literal shorthand
+// MethodDeclaration / GetAccessor / SetAccessor (upstream catches these
+// via ESTree's `Property { method: true, value: FunctionExpression }`).
+func isFunctionLike(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		return true
+	}
+	return false
+}
+
+// componentEnv bundles the per-rule-invocation context every helper needs.
+// Threading a single struct keeps signatures readable and avoids drift when
+// new fields (TypeChecker, settings derivatives) are added later.
+type componentEnv struct {
+	pragma      string
+	createClass string
+	wrappers    []reactutil.ComponentWrapperEntry
+	tc          *checker.Checker
+}
+
+// isDetectedComponent reports whether `node` looks like a React component.
+// Mirrors upstream's `components.get(node)` — a node is considered a
+// component when it would be classified by the plugin's Components.detect
+// pipeline. For functions we defer to `IsStatelessReactComponent` (which
+// itself recognizes the default `memo`/`forwardRef` wrapper); when an inner
+// FunctionLike sits inside a configured-but-non-default wrapper from
+// `settings.componentWrapperFunctions`, that fallback is handled here. For
+// classes we check the extends clause. For object literals we recognize the
+// `<createClass>(...)` argument shape (ES5 components). CallExpressions are
+// recognized as components when they match a configured wrapper — that's
+// what lets `validateCall` walk up from a custom `myMemo(fn)` call and find
+// itself as the closest component ancestor.
+func isDetectedComponent(node *ast.Node, env componentEnv) bool {
+	if node == nil {
+		return false
+	}
+	pragma, createClass, wrappers := env.pragma, env.createClass, env.wrappers
+	switch node.Kind {
+	case ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression,
+		ast.KindArrowFunction,
+		ast.KindMethodDeclaration,
+		ast.KindGetAccessor,
+		ast.KindSetAccessor:
+		// Use the wrappers-aware variant so user-configured
+		// `componentWrapperFunctions` entries participate in Branch 11
+		// (the pragma-component-wrapper arm). Without this, a
+		// `myMemo(() => null)` inner arrow would NOT classify as a
+		// stateless component, and `isStatelessComponentReturningNull`
+		// later would not be able to skip it the way upstream does.
+		if reactutil.IsStatelessReactComponentWithWrappers(node, pragma, env.tc, wrappers) {
+			return true
+		}
+		// User-configured wrapper fallback: an arrow / FE wrapped by a
+		// non-default wrapper (`myMemo(fn)` etc.) doesn't get picked up by
+		// IsStatelessReactComponent's hardcoded memo/forwardRef branch, so
+		// we walk paren / TS-wrapper hops up to the enclosing call and
+		// check the configured list. The function still has to return JSX
+		// or null on at least one path, matching upstream's
+		// `isReturningJSXOrNull` gate inside Components.detect's wrapper
+		// arm.
+		parent := reactutil.SkipExpressionWrappersUp(node)
+		if parent != nil && parent.Kind == ast.KindCallExpression &&
+			reactutil.MatchesAnyComponentWrapperWithChecker(parent, node, wrappers, env.pragma, env.tc) &&
+			reactutil.FunctionReturnsJSXOrNullWithChecker(node, pragma, env.tc) {
+			return true
+		}
+		return false
+	case ast.KindClassDeclaration, ast.KindClassExpression:
+		return reactutil.ExtendsReactComponent(node, pragma)
+	case ast.KindObjectLiteralExpression:
+		return reactutil.IsCreateReactClassObjectArg(node, pragma, createClass)
+	case ast.KindCallExpression:
+		// A wrapper call counts as a component when it matches the
+		// configured wrapper list AND its first argument is a
+		// FunctionLike. Upstream's CallExpression visitor in
+		// `Components.detect` registers via
+		// `components.add(call, 2)` whenever
+		// `isPragmaComponentWrapper(node) && isFunctionLikeExpression(arguments[0])`
+		// — note that it does NOT additionally check whether the inner
+		// FunctionLike returns JSX. Tracking that intentional looseness
+		// here keeps the report counts byte-aligned for cases like
+		// `React.memo(() => undefined)` which upstream still flags
+		// despite the inner arrow not returning JSX.
+		call := node.AsCallExpression()
+		if call.Arguments == nil || len(call.Arguments.Nodes) == 0 {
+			return false
+		}
+		inner := reactutil.SkipExpressionWrappers(call.Arguments.Nodes[0])
+		if inner == nil || !isFunctionLike(inner) {
+			return false
+		}
+		if !reactutil.MatchesAnyComponentWrapperWithChecker(node, inner, wrappers, env.pragma, env.tc) {
+			return false
+		}
+		// `nodeWrapsComponent` parity: when the wrapper is a
+		// MemberExpression (e.g. `React.memo(...)`) and its
+		// FunctionLike argument's body returns JSX whose root tag
+		// resolves to a sibling/outer detected component
+		// (arrow-assigned-to-VariableDeclarator or ClassDeclaration),
+		// upstream's `isPragmaComponentWrapper` short-circuits to
+		// false and the call is NOT registered as a component. The
+		// bare-callee form (e.g. `memo(...)` after `import { memo }
+		// from 'react'`) does NOT get this gate — see upstream
+		// `Components.js` `isPragmaComponentWrapper`, MemberExpression
+		// branch only.
+		if wrapsKnownSiblingComponent(node, inner) {
+			return false
+		}
+		return true
+	}
+	return false
+}
+
+// wrapsKnownSiblingComponent reports whether `call` is a MemberExpression
+// wrapper (e.g. `React.memo(arrow)`) whose FunctionLike argument's body
+// returns JSX (concise body or first ReturnStatement of a block) whose root
+// tag-name matches a sibling/outer arrow-assigned-to-VariableDeclarator or
+// ClassDeclaration in the same source file. Mirrors upstream's
+// `nodeWrapsComponent` gate, which is intentionally name-based (not symbol-
+// based) and only applied to the MemberExpression form of the wrapper.
+func wrapsKnownSiblingComponent(call *ast.Node, fn *ast.Node) bool {
+	if call == nil || call.Kind != ast.KindCallExpression {
+		return false
+	}
+	expr := call.AsCallExpression().Expression
+	if expr == nil || expr.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	tag := returnedJSXRootTagName(fn)
+	if tag == "" {
+		return false
+	}
+	src := ast.GetSourceFileOfNode(call)
+	if src == nil {
+		return false
+	}
+	// Position gate matches upstream's order-dependence:
+	// `getDetectedComponents()` only returns components that have been
+	// visited so far in AST walk order, which for non-overlapping
+	// declarations is equivalent to source-position order. A sibling
+	// declared AFTER the wrapper call is invisible to upstream and must
+	// be invisible here too — otherwise we'd skip a wrapper that
+	// upstream reports.
+	return sourceHasComponentNamedBefore(src.AsNode(), tag, call.Pos())
+}
+
+// returnedJSXRootTagName extracts the root JSX tag name from a function's
+// body — covers both the concise-body case (`() => <Foo/>`) and the
+// block-body case where the FIRST top-level ReturnStatement is inspected.
+// Returns empty string when the body doesn't return a JSX element directly.
+func returnedJSXRootTagName(fn *ast.Node) string {
+	if fn == nil {
+		return ""
+	}
+	var body *ast.Node
+	switch fn.Kind {
+	case ast.KindArrowFunction:
+		body = fn.AsArrowFunction().Body
+	case ast.KindFunctionExpression:
+		body = fn.AsFunctionExpression().Body
+	case ast.KindFunctionDeclaration:
+		body = fn.AsFunctionDeclaration().Body
+	default:
+		return ""
+	}
+	if body == nil {
+		return ""
+	}
+	if body.Kind == ast.KindBlock {
+		var ret *ast.Node
+		body.ForEachChild(func(child *ast.Node) bool {
+			if child.Kind == ast.KindReturnStatement {
+				ret = child
+				return true
+			}
+			return false
+		})
+		if ret == nil {
+			return ""
+		}
+		return jsxRootTagName(ret.AsReturnStatement().Expression)
+	}
+	return jsxRootTagName(body)
+}
+
+// jsxRootTagName returns the tag-name of a JsxElement / JsxSelfClosingElement
+// (peeling paren / TS wrappers) when it's a plain identifier, or "" otherwise.
+// Member-expression tag-names (`<Foo.Bar />`) and namespaced names
+// (`<svg:circle/>`) intentionally return "" — upstream's
+// `getComponentNameFromJSXElement` only matches plain identifiers via the
+// detected-components list keyed by the binding's local name.
+func jsxRootTagName(expr *ast.Node) string {
+	expr = reactutil.SkipExpressionWrappers(expr)
+	if expr == nil {
+		return ""
+	}
+	var tag *ast.Node
+	switch expr.Kind {
+	case ast.KindJsxElement:
+		opening := expr.AsJsxElement().OpeningElement
+		if opening != nil {
+			tag = opening.AsJsxOpeningElement().TagName
+		}
+	case ast.KindJsxSelfClosingElement:
+		tag = expr.AsJsxSelfClosingElement().TagName
+	default:
+		return ""
+	}
+	if tag == nil || tag.Kind != ast.KindIdentifier {
+		return ""
+	}
+	return tag.AsIdentifier().Text
+}
+
+// sourceHasComponentNamedBefore scans the source file for a sibling/outer
+// component declaration whose name equals `name` and whose start position
+// precedes `before`. Mirrors upstream's `getDetectedComponents` filter —
+// only `class` declarations and arrow-assigned-to-VariableDeclarator
+// declarations qualify; function declarations do NOT (upstream's filter
+// in `Components.js getDetectedComponents` only retains those two kinds).
+// The position gate replicates upstream's order-dependence: a sibling
+// declared AFTER the use site has not yet been added to the components
+// list when `isPragmaComponentWrapper` runs, so it must not match here
+// either.
+func sourceHasComponentNamedBefore(root *ast.Node, name string, before int) bool {
+	if root == nil || name == "" {
+		return false
+	}
+	var found bool
+	var visit func(n *ast.Node)
+	visit = func(n *ast.Node) {
+		if found || n == nil {
+			return
+		}
+		if n.Pos() >= before {
+			// Subtree starts at or after the use site — upstream's AST
+			// walk wouldn't have reached it yet. Skip the entire subtree.
+			return
+		}
+		switch n.Kind {
+		case ast.KindClassDeclaration:
+			id := n.Name()
+			if id != nil && id.Kind == ast.KindIdentifier && id.AsIdentifier().Text == name {
+				found = true
+				return
+			}
+		case ast.KindVariableDeclaration:
+			vd := n.AsVariableDeclaration()
+			if vd.Initializer == nil {
+				break
+			}
+			init := reactutil.SkipExpressionWrappers(vd.Initializer)
+			if init == nil || init.Kind != ast.KindArrowFunction {
+				break
+			}
+			id := vd.Name()
+			if id != nil && id.Kind == ast.KindIdentifier && id.AsIdentifier().Text == name {
+				found = true
+				return
+			}
+		}
+		n.ForEachChild(func(child *ast.Node) bool {
+			visit(child)
+			return found
+		})
+	}
+	visit(root)
+	return found
+}
+
+// isInsideWrapperCall reports whether `node` is the FunctionLike argument of
+// a wrapper call (memo / forwardRef / configured wrapper). When true, the
+// outer CallExpression listener handles reporting at the wrapper's Pos —
+// this listener should skip to avoid double-reporting at a different column.
+func isInsideWrapperCall(node *ast.Node, env componentEnv) bool {
+	parent := reactutil.SkipExpressionWrappersUp(node)
+	if parent == nil || parent.Kind != ast.KindCallExpression {
+		return false
+	}
+	return reactutil.MatchesAnyComponentWrapperWithChecker(parent, node, env.wrappers, env.pragma, env.tc)
+}
+
+// isValueOfObjectProperty mirrors upstream's
+// `node.parent.type === 'Property'` check. In tsgo, a function / arrow used
+// as an object-literal value has parent `PropertyAssignment`; an
+// object-literal shorthand method has parent `ObjectLiteralExpression`
+// directly. Both correspond to upstream's "Property" filter. Wrappers
+// (`()` / TS) between the FunctionLike and the PropertyAssignment are
+// peeled via `SkipExpressionWrappersUp` so `{ Foo: ((arrow)) }` is
+// recognized the same as `{ Foo: arrow }`.
+func isValueOfObjectProperty(node *ast.Node) bool {
+	if node == nil || node.Parent == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return node.Parent.Kind == ast.KindObjectLiteralExpression
+	}
+	parent := reactutil.SkipExpressionWrappersUp(node)
+	return parent != nil && parent.Kind == ast.KindPropertyAssignment
+}
+
+// objectPropertyKey returns the Identifier-like key of the
+// PropertyAssignment / shorthand-method that owns `node`, or nil when the
+// owner shape doesn't match. The returned node is always an Identifier when
+// non-nil; computed keys / numeric / string-literal keys return nil since
+// upstream's render-prop matching only fires on Identifier keys. Wrappers
+// (`()` / TS) between the FunctionLike and the owning PropertyAssignment
+// are walked through.
+func objectPropertyKey(node *ast.Node) *ast.Node {
+	if node == nil || node.Parent == nil {
+		return nil
+	}
+	switch node.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		if node.Parent.Kind != ast.KindObjectLiteralExpression {
+			return nil
+		}
+		name := node.Name()
+		if name != nil && name.Kind == ast.KindIdentifier {
+			return name
+		}
+		return nil
+	}
+	parent := reactutil.SkipExpressionWrappersUp(node)
+	if parent == nil || parent.Kind != ast.KindPropertyAssignment {
+		return nil
+	}
+	name := parent.AsPropertyAssignment().Name()
+	if name != nil && name.Kind == ast.KindIdentifier {
+		return name
+	}
+	return nil
+}
+
+// isComponentInsideCreateElementProp mirrors upstream's
+// `isComponentInsideCreateElementsProp`: the node (a detected component)
+// sits inside the second argument (the props object) of a
+// `<pragma>.createElement(...)` call. The closest enclosing
+// ObjectLiteralExpression must be the call's second argument — deeper
+// nesting (object inside an object inside the props object) does NOT match,
+// matching upstream's strict-equality check.
+func isComponentInsideCreateElementProp(node *ast.Node, env componentEnv) bool {
+	if !isDetectedComponent(node, env) {
+		return false
+	}
+	// Start the ancestor walks from the wrapper-skipped parent so paren /
+	// TS wrappers between the FunctionLike and its semantic ESTree
+	// ancestor don't introduce slack. Matches upstream's flattened tree.
+	start := reactutil.SkipExpressionWrappersUp(node)
+	if start == nil {
+		return false
+	}
+	objectExpr := ast.FindAncestor(start, func(n *ast.Node) bool {
+		return n.Kind == ast.KindObjectLiteralExpression
+	})
+	if objectExpr == nil {
+		return false
+	}
+	createEl := ast.FindAncestor(start, func(n *ast.Node) bool {
+		return n.Kind == ast.KindCallExpression &&
+			reactutil.IsCreateElementCallWithChecker(n.AsCallExpression().Expression, env.pragma, env.tc)
+	})
+	if createEl == nil {
+		return false
+	}
+	call := createEl.AsCallExpression()
+	if call.Arguments == nil || len(call.Arguments.Nodes) < 2 {
+		return false
+	}
+	return unwrap(call.Arguments.Nodes[1]) == objectExpr
+}
+
+// isComponentInProp mirrors upstream's `isComponentInProp`: reports whether
+// the node is used as the value of an object-literal property (including
+// props on a JSX element or the props object of `React.createElement`) AND
+// strictly returns JSX. Matches upstream's `utils.isReturningJSX` which
+// passes `ignoreNull=true` — functions that only return `null` do NOT
+// qualify here (Components.js isReturningJSX wrapper).
+func isComponentInProp(node *ast.Node, env componentEnv) bool {
+	if isValueOfObjectProperty(node) {
+		return reactutil.FunctionReturnsJSXWithChecker(node, env.pragma, env.tc)
+	}
+	// Walk up to a JsxAttribute whose value is a JsxExpression — the tsgo
+	// equivalent of ESTree's "JSXAttribute with JSXExpressionContainer
+	// value". The first such ancestor decides; objects nested deeper still
+	// count because upstream's `getClosestMatchingParent` walks past
+	// non-matching ancestors.
+	if hasAncestorJsxAttributeWithExpression(node) {
+		return reactutil.FunctionReturnsJSXWithChecker(node, env.pragma, env.tc)
+	}
+	return isComponentInsideCreateElementProp(node, env)
+}
+
+// hasAncestorJsxAttributeWithExpression walks up from the node's semantic
+// parent (skipping `()` / TS wrappers) and returns true once it sees a
+// JsxExpression whose parent is a JsxAttribute. Starting the walk from the
+// wrapper-skipped parent matches upstream's ESTree-flattened ancestor
+// chain.
+func hasAncestorJsxAttributeWithExpression(node *ast.Node) bool {
+	start := reactutil.SkipExpressionWrappersUp(node)
+	if start == nil {
+		return false
+	}
+	return ast.FindAncestor(start, func(n *ast.Node) bool {
+		return n.Kind == ast.KindJsxExpression &&
+			n.Parent != nil && n.Parent.Kind == ast.KindJsxAttribute
+	}) != nil
+}
+
+// isComponentInRenderProp mirrors upstream's `isComponentInRenderProp`:
+// returns true when the node is hosted by a render-prop-shaped position —
+// either a property whose key matches the configured glob, a JSX child
+// expression, or a JSX attribute whose name matches the glob / equals
+// `children`. Wrapper-transparent at every parent-walk site so paren / TS
+// wrappers (which ESTree flattens but tsgo preserves) don't break alignment.
+func isComponentInRenderProp(node *ast.Node, propNamePattern string) bool {
+	// Direct value of a PropertyAssignment / shorthand method whose key
+	// matches the pattern.
+	if key := objectPropertyKey(node); key != nil {
+		if reactutil.MatchGlob(key.AsIdentifier().Text, propNamePattern) {
+			return true
+		}
+	}
+	// Direct child of a JsxExpression whose parent is a JsxElement /
+	// JsxFragment — i.e. a render-prop passed as JSX children
+	// (`<C>{() => <div/>}</C>` / `<>{() => <div/>}</>` / paren-wrapped
+	// `<C>{((() => <div/>))}</C>`). Walk up through wrappers so the
+	// JsxExpression-as-direct-parent shape matches upstream regardless of
+	// intermediate `()` / TS-wrapper nodes.
+	if jsxParent := reactutil.SkipExpressionWrappersUp(node); jsxParent != nil &&
+		jsxParent.Kind == ast.KindJsxExpression && jsxParent.Parent != nil {
+		switch jsxParent.Parent.Kind {
+		case ast.KindJsxElement, ast.KindJsxFragment:
+			return true
+		}
+	}
+	// Closest JsxExpression ancestor whose parent is a JsxAttribute.
+	container := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		return n.Kind == ast.KindJsxExpression
+	})
+	if container == nil || container.Parent == nil || container.Parent.Kind != ast.KindJsxAttribute {
+		return false
+	}
+	nameNode := container.Parent.AsJsxAttribute().Name()
+	if nameNode == nil || nameNode.Kind != ast.KindIdentifier {
+		return false
+	}
+	propName := nameNode.AsIdentifier().Text
+	if reactutil.MatchGlob(propName, propNamePattern) {
+		return true
+	}
+	return propName == "children"
+}
+
+// isMapCall mirrors upstream's `isMapCall`: `<anything>.map(...)`. Only the
+// property name is inspected; the receiver is ignored.
+//
+// The `node` parameter is unwrapped first so callers passing
+// `node.Parent` get a hit even when the parent is a ParenthesizedExpression
+// / TS-wrapper around the actual map call — e.g.
+// `<C foo={(items.map((arrow)))}/>`, where the arrow's direct parent is the
+// inner ParenExpr around the arrow, whose own parent is the ParenExpr
+// wrapping the call result. ESTree flattens these wrappers; tsgo preserves
+// them, so we unwrap here to keep the skip-on-map behavior aligned with
+// upstream byte-for-byte. Same applies to the callee.
+func isMapCall(node *ast.Node) bool {
+	node = unwrap(node)
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := unwrap(node.AsCallExpression().Expression)
+	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	name := callee.AsPropertyAccessExpression().Name()
+	return name != nil && name.Kind == ast.KindIdentifier && name.AsIdentifier().Text == "map"
+}
+
+// isReturnStatementOfHook mirrors upstream's `isReturnStatementOfHook`: the
+// node is the direct value of a `return` that lives inside a hook call
+// (Identifier callee whose name matches the hook regex). The closest
+// enclosing CallExpression decides — hook detection does NOT recurse past
+// the first call.
+//
+// tsgo preserves `()` / TS-wrapper nodes between the FunctionLike and its
+// owning ReturnStatement that ESTree flattens — e.g.
+// `useEffect(() => { return (() => null); })` has the inner arrow's
+// parent = ParenExpr in tsgo but the inner arrow's parent = ReturnStatement
+// in ESTree. Walk up through wrappers so the skip behavior aligns with
+// upstream byte-for-byte.
+func isReturnStatementOfHook(node *ast.Node) bool {
+	parent := reactutil.SkipExpressionWrappersUp(node)
+	if parent == nil || parent.Kind != ast.KindReturnStatement {
+		return false
+	}
+	enclosing := ast.FindAncestor(parent, func(n *ast.Node) bool {
+		return n.Kind == ast.KindCallExpression
+	})
+	if enclosing == nil {
+		return false
+	}
+	callee := unwrap(enclosing.AsCallExpression().Expression)
+	if callee == nil || callee.Kind != ast.KindIdentifier {
+		return false
+	}
+	return reactutil.IsHookName(callee.AsIdentifier().Text)
+}
+
+// isDirectValueOfRenderProperty mirrors upstream's
+// `isDirectValueOfRenderProperty`: the node's owning property has an
+// Identifier key matching the render-prop pattern.
+//
+// tsgo preserves `()` / TS-wrapper nodes between the FunctionLike and its
+// owning PropertyAssignment that ESTree flattens — e.g.
+// `{ render: ((props) => <Row/>) }` has arrow.Parent = ParenExpr in tsgo
+// but arrow.parent = PropertyAssignment in ESTree. Walk up through
+// wrappers so the skip behavior aligns with upstream byte-for-byte.
+func isDirectValueOfRenderProperty(node *ast.Node, propNamePattern string) bool {
+	parent := reactutil.SkipExpressionWrappersUp(node)
+	if parent == nil || parent.Kind != ast.KindPropertyAssignment {
+		return false
+	}
+	name := parent.AsPropertyAssignment().Name()
+	if name == nil || name.Kind != ast.KindIdentifier {
+		return false
+	}
+	return reactutil.MatchGlob(name.AsIdentifier().Text, propNamePattern)
+}
+
+// isStatelessComponentReturningNull mirrors upstream's sibling check: the
+// node is classified as a stateless component but strictly does NOT return
+// JSX (e.g. `() => undefined` or `() => null` under ignoreNull=true). These
+// are excluded because they cannot render as React components. Upstream's
+// `utils.isReturningJSX` negated — ignoreNull=true — is our
+// `FunctionReturnsJSX`.
+func isStatelessComponentReturningNull(node *ast.Node, env componentEnv) bool {
+	// Use the wrappers-aware classification so user wrappers (myMemo /
+	// MyLib.observer / ...) correctly participate in stateless detection.
+	// Without this, `myMemo(() => null)` would not classify as a
+	// stateless component → this skip wouldn't fire → we'd over-report
+	// where upstream skips.
+	if !reactutil.IsStatelessReactComponentWithWrappers(node, env.pragma, env.tc, env.wrappers) {
+		return false
+	}
+	return !reactutil.FunctionReturnsJSXWithChecker(node, env.pragma, env.tc)
+}
+
+// isFunctionComponentInsideClassComponent mirrors upstream's safety net of
+// the same name — cases where Components.detect classifies a parent as an
+// ES6 class component but the inner FunctionLike returning JSX wasn't
+// picked up via the stateless path on its own. Returns true when:
+//
+//  1. the nearest enclosing component is a class (ES6 path),
+//  2. there's a FunctionLike ancestor between the class and `node`
+//     (the "parentStatelessComponent" upstream walks for),
+//  3. that FunctionLike ancestor itself classifies as a stateless
+//     component (matching upstream's `getStatelessComponent(parentStatelessComponent)`
+//     gate), and
+//  4. `node` strictly returns JSX.
+//
+// All four conditions matter — without (3) we'd misclassify any
+// lowercase-named helper inside a class render method's nested function
+// as a "function component inside class component" purely on the basis
+// of returning JSX.
+func isFunctionComponentInsideClassComponent(node *ast.Node, env componentEnv) bool {
+	if !isFunctionLike(node) {
+		return false
+	}
+	parent := getClosestParentComponent(node, env)
+	if parent == nil {
+		return false
+	}
+	if parent.Kind != ast.KindClassDeclaration && parent.Kind != ast.KindClassExpression {
+		return false
+	}
+	enclosingFn := ast.FindAncestor(node.Parent, func(n *ast.Node) bool {
+		return isFunctionLike(n)
+	})
+	if enclosingFn == nil {
+		return false
+	}
+	// Upstream's gate (3): the enclosing FunctionLike must itself
+	// classify as a stateless component for this safety net to fire.
+	// Use the wrappers-aware variant for user-configured wrappers
+	// participating in stateless detection.
+	if !reactutil.IsStatelessReactComponentWithWrappers(enclosingFn, env.pragma, env.tc, env.wrappers) {
+		return false
+	}
+	return reactutil.FunctionReturnsJSXWithChecker(node, env.pragma, env.tc)
+}
+
+// getClosestParentComponent walks up from `node.Parent` and returns the
+// first ancestor that would be classified as a React component. Mirrors
+// upstream's `getClosestMatchingParent(components.get)`.
+//
+// Starts the walk from the wrapper-skipped parent so paren / TS wrappers
+// between the node and its semantic ESTree ancestor don't change the
+// closest-component result. Matches upstream's flattened tree.
+func getClosestParentComponent(node *ast.Node, env componentEnv) *ast.Node {
+	start := reactutil.SkipExpressionWrappersUp(node)
+	if start == nil {
+		return nil
+	}
+	return ast.FindAncestor(start, func(n *ast.Node) bool {
+		return isDetectedComponent(n, env)
+	})
+}
+
+// resolveComponentName returns the display name of a detected component
+// node, or "" when anonymous. Mirrors upstream's `resolveComponentName`
+// byte-for-byte:
+//
+//   - Class / Function declarations and named FunctionExpressions: the
+//     declaration's own Identifier (`node.id.name` upstream).
+//   - Anonymous ArrowFunctionExpression: the binding name of its
+//     VariableDeclarator parent (`node.parent.id.name` upstream).
+//
+// Every other parent component shape (ObjectLiteralExpression returned by
+// `<createClass>(...)`, wrapper CallExpression `React.memo(arrow)`, etc.)
+// returns "" — upstream never walks beyond the immediate `.id` lookup, and
+// matching that quirk keeps the diagnostic message text byte-equal in
+// corner cases like ES5 components and optional-chain wrappers.
+func resolveComponentName(node *ast.Node) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Kind {
+	case ast.KindClassDeclaration,
+		ast.KindClassExpression,
+		ast.KindFunctionDeclaration,
+		ast.KindFunctionExpression:
+		if name := node.Name(); name != nil && name.Kind == ast.KindIdentifier {
+			return name.AsIdentifier().Text
+		}
+	case ast.KindArrowFunction:
+		// Upstream's ArrowFunctionExpression branch: parent must be a
+		// VariableDeclarator with an Identifier id. tsgo's
+		// VariableDeclaration is the equivalent of ESTree's
+		// VariableDeclarator (the per-declaration node, not the
+		// const/let/var statement).
+		if node.Parent != nil && node.Parent.Kind == ast.KindVariableDeclaration {
+			binding := node.Parent.AsVariableDeclaration().Name()
+			if binding != nil && binding.Kind == ast.KindIdentifier {
+				return binding.AsIdentifier().Text
+			}
+		}
+	}
+	return ""
+}
+
+// isOptionalPragmaWrapperCall reports whether `node` is a CallExpression
+// whose optional-chain shape triggers upstream's empty-parent-name quirk:
+//
+//   - Member-level optional (`React?.memo(arrow)`) — Babel wraps in
+//     ChainExpression sharing `range[0]` with the inner CE; upstream's
+//     `components.add` storage is keyed by `range[0]` so
+//     `components.get(ChainExpression)` returns the wrapper entry, the
+//     parent walk stops there, `resolveComponentName(ChainExpression)`
+//     returns falsy → empty parent name.
+//
+//   - Call-level optional (`myMemo?.(arrow)` with user wrapper) — same
+//     ChainExpression wrapping shape; same `range[0]` collision; same
+//     empty-parent-name observation.
+//
+// Either form requires the parentName-blanking quirk to keep diagnostics
+// byte-aligned with upstream.
+func isOptionalPragmaWrapperCall(node *ast.Node) bool {
+	if node == nil || node.Kind != ast.KindCallExpression {
+		return false
+	}
+	c := node.AsCallExpression()
+	if c.QuestionDotToken != nil {
+		return true
+	}
+	callee := reactutil.SkipExpressionWrappers(c.Expression)
+	if callee == nil || callee.Kind != ast.KindPropertyAccessExpression {
+		return false
+	}
+	return ast.IsOptionalChain(callee)
+}
+
+// generateErrorMessageWithParentName mirrors upstream's helper of the same
+// name — the parent name, when known, is wrapped in typographic double
+// quotes (U+201C / U+201D) and appears immediately after "parent component".
+func generateErrorMessageWithParentName(parentName string) string {
+	if parentName != "" {
+		return messageBase + " " + openQuote + parentName + closeQuote + " and pass data as props."
+	}
+	return messageBase + " and pass data as props."
+}
+
+var NoUnstableNestedComponentsRule = rule.Rule{
+	Name: "react/no-unstable-nested-components",
+	Run: func(ctx rule.RuleContext, rawOptions any) rule.RuleListeners {
+		opts := parseOptions(rawOptions)
+		// componentEnv bundles every per-invocation derivative the helpers
+		// below need. Building it once at rule entry avoids both repeated
+		// `ctx.Settings` lookups and the risk of helpers drifting on
+		// pragma / createClass / wrapper / TypeChecker reads.
+		env := componentEnv{
+			pragma:      reactutil.GetReactPragma(ctx.Settings),
+			createClass: reactutil.GetReactCreateClass(ctx.Settings),
+			tc:          ctx.TypeChecker,
+		}
+		// `settings.componentWrapperFunctions` decides which CallExpression
+		// wrappers count as "creating a component" — defaults to memo +
+		// forwardRef (pragma-qualified and bare), users may add more.
+		env.wrappers = reactutil.GetComponentWrapperFunctions(ctx.Settings, env.pragma)
+
+		// reported tracks node positions we've already reported on, so
+		// the FunctionLike + CallExpression listeners can both fire for a
+		// React.memo-wrapped arrow without double-counting.
+		reported := map[int]struct{}{}
+
+		validate := func(node *ast.Node) {
+			if node == nil || node.Parent == nil {
+				return
+			}
+			// Class-body methods / accessors are NOT separate component
+			// candidates — the enclosing class already decides component
+			// status (and is reported on its own). Without this guard, a
+			// nested-class-in-class case would emit one report for the
+			// inner ClassDeclaration AND a second for its `render` method.
+			// Mirrors upstream's `isInsideRenderMethod` skip plus the
+			// fact that upstream does not listen to MethodDefinition.
+			switch node.Kind {
+			case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+				if node.Parent.Kind != ast.KindObjectLiteralExpression {
+					return
+				}
+			}
+			// Wrapper-call arguments are reported by the CallExpression
+			// listener at the wrapper's Pos (matching upstream's
+			// `components.add(call, 2)` registration). Suppress the inner
+			// FunctionLike report so the diagnostic position aligns with
+			// upstream byte-for-byte.
+			if isFunctionLike(node) && isInsideWrapperCall(node, env) {
+				return
+			}
+
+			isDeclaredInsideProps := isComponentInProp(node, env)
+			isComponent := isDetectedComponent(node, env)
+			isFnInClass := !isComponent && !isDeclaredInsideProps && isFunctionComponentInsideClassComponent(node, env)
+
+			if !isComponent && !isDeclaredInsideProps && !isFnInClass {
+				return
+			}
+
+			// Allow components in render-prop positions (and, when
+			// configured, everywhere a prop hosts one).
+			if isDeclaredInsideProps && (opts.allowAsProps || isComponentInRenderProp(node, opts.propNamePattern)) {
+				return
+			}
+			// Skip nodes produced by Array#map callbacks. tsgo preserves
+			// `()` / TS-wrapper nodes that ESTree flattens, so an arrow
+			// inside `items.map((arrow))` has parent = ParenExpr, not the
+			// CallExpression directly. Walking up through wrappers
+			// recovers the ESTree-equivalent parent and matches upstream's
+			// `isMapCall(node.parent)` byte-for-byte.
+			if isMapCall(node) || isMapCall(reactutil.SkipExpressionWrappersUp(node)) {
+				return
+			}
+			if isReturnStatementOfHook(node) {
+				return
+			}
+			if isDirectValueOfRenderProperty(node, opts.propNamePattern) {
+				return
+			}
+			if isStatelessComponentReturningNull(node, env) {
+				return
+			}
+
+			parentComponent := getClosestParentComponent(node, env)
+			if parentComponent == nil {
+				return
+			}
+
+			parentName := resolveComponentName(parentComponent)
+			// Lowercase factory/helper names are not React components at
+			// runtime — React-DOM only treats Capitalized references as
+			// components. Mirror upstream's EXACT check from
+			// `lib/rules/no-unstable-nested-components.js`:
+			//
+			//     if (parentName && parentName[0] === parentName[0].toLowerCase()) return;
+			//
+			// This is **NOT** the same as `isFirstLetterCapitalized`:
+			//   - upstream's component-detection helper strips leading `_`
+			//     (so `_Foo` is treated as the component "Foo");
+			//   - upstream's lowercase-skip check above does NOT strip — it
+			//     just checks `firstLetter === firstLetter.toLowerCase()`,
+			//     which is true for `_foo` AND `_Foo` (`_` is non-cased) AND
+			//     CJK / digit prefixes.
+			//
+			// Both conditions co-exist: `_Foo` qualifies as a parent
+			// component (detection passes) but the lowercase-skip ALSO
+			// fires (so the inner nested component is silently allowed).
+			// We replicate this with `isLowercaseFirstLetter` below.
+			if parentName != "" && reactutil.IsLowercaseFirstLetter(parentName) {
+				return
+			}
+			// Optional-chain pragma wrapper quirk: in Babel's ESTree, the
+			// inner CallExpression of `<pragma>?.<wrapper>(arrow)` is
+			// wrapped in a ChainExpression that shares the same `range[0]`
+			// as the inner CallExpression. Upstream's `components.add` uses
+			// `range[0]` as the storage key, so `components.get(ChainExpression)`
+			// returns the wrapper entry — which makes
+			// `getClosestMatchingParent` stop at the ChainExpression instead
+			// of walking up to the enclosing component. ChainExpression has
+			// no `.id`, so `resolveComponentName` returns empty.
+			//
+			// rslint's tsgo AST has no ChainExpression wrapper (optional is
+			// flag-based), so our parent walk would naturally find the
+			// outer FunctionDeclaration and produce a non-empty parentName.
+			// To stay byte-aligned with upstream's observable output, blank
+			// the parentName whenever the validate target is a wrapper call
+			// whose callee carries an optional-chain mark.
+			if isOptionalPragmaWrapperCall(node) {
+				parentName = ""
+			}
+
+			pos := node.Pos()
+			if _, seen := reported[pos]; seen {
+				return
+			}
+			reported[pos] = struct{}{}
+
+			msg := generateErrorMessageWithParentName(parentName)
+			if isDeclaredInsideProps && !opts.allowAsProps {
+				msg += asPropsInfo
+			}
+			// MessageId is intentionally empty: upstream's
+			// eslint-plugin-react reports this rule's diagnostic with
+			// `messageId: null` — it passes the raw message string to
+			// `report(context, message, null, …)`. We mirror that with an
+			// empty Id; tests matching by `message` text work in both
+			// runners.
+			ruleMsg := rule.RuleMessage{Id: "", Description: msg}
+			// Object-literal shorthand methods (`{ Foo() {} }`,
+			// `{ get Foo() {} }`, `{ async Foo() {} }`) are one
+			// `MethodDeclaration` / `GetAccessor` / `SetAccessor` node in
+			// tsgo, but ESTree wraps them as `Property { kind, value:
+			// FunctionExpression }` and reports on the inner FE — whose
+			// `loc.start` lands at the `(` of the parameter list, after
+			// the `get`/`set`/`async` modifier and the property name.
+			// Mirror that by narrowing the report range to start at the
+			// parameter list's `(` for these node kinds when they live
+			// inside an ObjectLiteralExpression.
+			if reactutil.IsObjectLiteralShorthandFunction(node) {
+				if start := reactutil.ParamListOpenParenPos(ctx.SourceFile, node); start >= 0 {
+					ctx.ReportRange(core.NewTextRange(start, node.End()), ruleMsg)
+					return
+				}
+			}
+			ctx.ReportNode(node, ruleMsg)
+		}
+
+		// Listener set mirrors upstream's exact list:
+		// FunctionDeclaration / ArrowFunctionExpression / FunctionExpression
+		// / ClassDeclaration / CallExpression. ClassExpression is
+		// intentionally NOT listened to — upstream's rule body declares
+		// only those five `return { ... }` keys; `const X = class extends
+		// React.Component {}` therefore does NOT report.
+		//
+		// MethodDeclaration / GetAccessor / SetAccessor are also listened
+		// to here so we cover object-literal shorthand methods (`{ Foo() {
+		// return <div/>; } }`); class-body methods are filtered out by the
+		// `parent.Kind != ObjectLiteralExpression` guard inside `validate`.
+		return rule.RuleListeners{
+			ast.KindFunctionDeclaration: validate,
+			ast.KindFunctionExpression:  validate,
+			ast.KindArrowFunction:       validate,
+			ast.KindMethodDeclaration:   validate,
+			ast.KindGetAccessor:         validate,
+			ast.KindSetAccessor:         validate,
+			ast.KindClassDeclaration:    validate,
+			ast.KindCallExpression:      validate,
+		}
+	},
+}

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.md
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components.md
@@ -1,0 +1,104 @@
+# no-unstable-nested-components
+
+## Rule Details
+
+Creating components inside components causes React to see a new component type on every render. Because React identifies a component by its reference, a new reference forces React to unmount the existing subtree and mount a fresh one on every parent render — losing DOM state, triggering layout effects, and leaking memory. Move nested component definitions to the module scope (or accept data through props).
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function ParentComponent() {
+  function UnstableNestedComponent() {
+    return <div />;
+  }
+
+  return (
+    <div>
+      <UnstableNestedComponent />
+    </div>
+  );
+}
+```
+
+```javascript
+class ParentComponent extends React.Component {
+  render() {
+    const UnstableNestedComponent = () => <div />;
+    return <UnstableNestedComponent />;
+  }
+}
+```
+
+```javascript
+function ParentComponent() {
+  return <ComponentWithProps footer={() => <div />} />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function OutsideDefinedComponent() {
+  return <div />;
+}
+
+function ParentComponent() {
+  return (
+    <div>
+      <OutsideDefinedComponent />
+    </div>
+  );
+}
+```
+
+```javascript
+function ParentComponent(props) {
+  return (
+    <ul>
+      {props.items.map(item => (
+        <li key={item.id}>{item.name}</li>
+      ))}
+    </ul>
+  );
+}
+```
+
+```javascript
+function ParentComponent() {
+  return <ComponentForProps renderFooter={() => <div />} />;
+}
+```
+
+## Options
+
+### `allowAsProps`
+
+Allow components to be declared inside other components' props without reporting. Defaults to `false`.
+
+```json
+{ "react/no-unstable-nested-components": ["error", { "allowAsProps": true }] }
+```
+
+```javascript
+function ParentComponent() {
+  return <ComponentWithProps footer={() => <div />} />;
+}
+```
+
+### `propNamePattern`
+
+Glob pattern matched against JSX attribute / object-literal property names. When the pattern matches, a component defined in that position is treated as a render prop and is NOT reported. Defaults to `"render*"`.
+
+```json
+{ "react/no-unstable-nested-components": ["error", { "propNamePattern": "*Renderer" }] }
+```
+
+```javascript
+function ParentComponent() {
+  return <Table rowRenderer={(rowData) => <Row data={rowData} />} />;
+}
+```
+
+## Original Documentation
+
+- [eslint-plugin-react no-unstable-nested-components](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md)

--- a/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components_test.go
+++ b/internal/plugins/react/rules/no_unstable_nested_components/no_unstable_nested_components_test.go
@@ -1,0 +1,2278 @@
+package no_unstable_nested_components
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/reactutil"
+	"github.com/web-infra-dev/rslint/internal/plugins/react/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// Message constants mirror eslint-plugin-react v7.37.x byte-for-byte,
+// including the typographic apostrophe (U+2019) in "subtree's" and the
+// typographic double quotation marks (U+201C / U+201D) around the parent
+// name. Verified against upstream installed source.
+const (
+	errorMessage                 = "Do not define components during render. React will see a new component type on every render and destroy the entire subtree’s DOM nodes and state (https://reactjs.org/docs/reconciliation.html#elements-of-different-types). Instead, move this component definition out of the parent component “ParentComponent” and pass data as props."
+	errorMessageWithoutName      = "Do not define components during render. React will see a new component type on every render and destroy the entire subtree’s DOM nodes and state (https://reactjs.org/docs/reconciliation.html#elements-of-different-types). Instead, move this component definition out of the parent component and pass data as props."
+	errorMessageComponentAsProps = errorMessage + " If you want to allow component creation in props, set allowAsProps option to true."
+)
+
+func TestNoUnstableNestedComponentsRule(t *testing.T) {
+	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnstableNestedComponentsRule, []rule_tester.ValidTestCase{
+		// ---- Upstream: outside-defined components used in JSX ----
+		{Code: `
+        function ParentComponent() {
+          return (
+            <div>
+              <OutsideDefinedFunctionComponent />
+            </div>
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(OutsideDefinedFunctionComponent, null)
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent
+              footer={<OutsideDefinedComponent />}
+              header={<div />}
+              />
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          return React.createElement(SomeComponent, {
+            footer: React.createElement(OutsideDefinedComponent, null),
+            header: React.createElement("div", null)
+          });
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: React.useCallback false-negatives (intentionally not flagged) ----
+		{Code: `
+        function ParentComponent() {
+          const MemoizedNestedComponent = React.useCallback(() => <div />, []);
+          return (
+            <div>
+              <MemoizedNestedComponent />
+            </div>
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          const MemoizedNestedComponent = React.useCallback(
+            () => React.createElement("div", null),
+            []
+          );
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(MemoizedNestedComponent, null)
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          const MemoizedNestedFunctionComponent = React.useCallback(
+            function () { return <div />; },
+            []
+          );
+          return (
+            <div>
+              <MemoizedNestedFunctionComponent />
+            </div>
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          const MemoizedNestedFunctionComponent = React.useCallback(
+            function () { return React.createElement("div", null); },
+            []
+          );
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(MemoizedNestedFunctionComponent, null)
+          );
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: handler functions that don't return JSX are not components ----
+		{Code: `
+        function ParentComponent(props) {
+          function onClick(event) {
+            props.onClick(event.target.value);
+          }
+          const onKeyPress = () => null;
+          function getOnHover() {
+            return function onHover(event) {
+              props.onHover(event.target);
+            }
+          }
+          return (
+            <div>
+              <button
+                onClick={onClick}
+                onKeyPress={onKeyPress}
+                onHover={getOnHover()}
+                maybeComponentOrHandlerNull={() => null}
+                maybeComponentOrHandlerUndefined={() => undefined}
+                maybeComponentOrHandlerBlank={() => ''}
+                maybeComponentOrHandlerString={() => 'hello-world'}
+                maybeComponentOrHandlerNumber={() => 42}
+                maybeComponentOrHandlerArray={() => []}
+                maybeComponentOrHandlerObject={() => {}} />
+            </div>
+          );
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: lowercase "factory" functions are not components ----
+		{Code: `
+        function ParentComponent() {
+          function getComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              {getComponent()}
+            </div>
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          function getComponent() {
+            return React.createElement("div", null);
+          }
+          return React.createElement("div", null, getComponent());
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: render-prop-as-children patterns ----
+		{Code: `
+        function ParentComponent() {
+            return (
+              <RenderPropComponent>
+                {() => <div />}
+              </RenderPropComponent>
+            );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+            return (
+              <RenderPropComponent children={() => <div />} />
+            );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          return (
+            <ComplexRenderPropComponent
+              listRenderer={data.map((items, index) => (
+                <ul>
+                  {items[index].map((item) =>
+                    <li>
+                      {item}
+                    </li>
+                  )}
+                </ul>
+              ))
+              }
+            />
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          return React.createElement(
+              RenderPropComponent,
+              null,
+              () => React.createElement("div", null)
+          );
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: Array#map callbacks are not components ----
+		{Code: `
+        function ParentComponent(props) {
+          return (
+            <ul>
+              {props.items.map(item => (
+                <li key={item.id}>
+                  {item.name}
+                </li>
+              ))}
+            </ul>
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent(props) {
+          return (
+            <List items={props.items.map(item => {
+              return (
+                <li key={item.id}>
+                  {item.name}
+                </li>
+              );
+            })}
+            />
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent(props) {
+          return React.createElement(
+            "ul",
+            null,
+            props.items.map(() =>
+              React.createElement(
+                "li",
+                { key: item.id },
+                item.name
+              )
+            )
+          )
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent(props) {
+          return (
+            <ul>
+              {props.items.map(function Item(item) {
+                return (
+                  <li key={item.id}>
+                    {item.name}
+                  </li>
+                );
+              })}
+            </ul>
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent(props) {
+          return React.createElement(
+            "ul",
+            null,
+            props.items.map(function Item() {
+              return React.createElement(
+                "li",
+                { key: item.id },
+                item.name
+              );
+            })
+          );
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: lowercase factory top-level functions are not components ----
+		{Code: `
+        function createTestComponent(props) {
+          return (
+            <div />
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function createTestComponent(props) {
+          return React.createElement("div", null);
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: allowAsProps option ----
+		{
+			Code: `
+        function ParentComponent() {
+          return (
+            <ComponentWithProps footer={() => <div />} />
+          );
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAsProps": true},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          return React.createElement(ComponentWithProps, {
+            footer: () => React.createElement("div", null)
+          });
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAsProps": true},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent item={{ children: () => <div /> }} />
+          )
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAsProps": true},
+		},
+
+		// ---- Upstream: render-prop pattern keys inside nested objects ----
+		{Code: `
+      function ParentComponent() {
+        return (
+          <SomeComponent>
+            {
+              thing.match({
+                renderLoading: () => <div />,
+                renderSuccess: () => <div />,
+                renderFailure: () => <div />,
+              })
+            }
+          </SomeComponent>
+        )
+      }
+      `, Tsx: true},
+		{Code: `
+      function ParentComponent() {
+        const thingElement = thing.match({
+          renderLoading: () => <div />,
+          renderSuccess: () => <div />,
+          renderFailure: () => <div />,
+        });
+        return (
+          <SomeComponent>
+            {thingElement}
+          </SomeComponent>
+        )
+      }
+      `, Tsx: true},
+		{
+			Code: `
+      function ParentComponent() {
+        return (
+          <SomeComponent>
+            {
+              thing.match({
+                loading: () => <div />,
+                success: () => <div />,
+                failure: () => <div />,
+              })
+            }
+          </SomeComponent>
+        )
+      }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAsProps": true},
+		},
+		{
+			Code: `
+      function ParentComponent() {
+        const thingElement = thing.match({
+          loading: () => <div />,
+          success: () => <div />,
+          failure: () => <div />,
+        });
+        return (
+          <SomeComponent>
+            {thingElement}
+          </SomeComponent>
+        )
+      }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAsProps": true},
+		},
+
+		// ---- Upstream: renderX attribute (default pattern) ----
+		{Code: `
+        function ParentComponent() {
+          return (
+            <ComponentForProps renderFooter={() => <div />} />
+          );
+        }
+      `, Tsx: true},
+		{Code: `
+        function ParentComponent() {
+          return React.createElement(ComponentForProps, {
+            renderFooter: () => React.createElement("div", null)
+          });
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: useEffect cleanup callback is not a component ----
+		{Code: `
+        function ParentComponent() {
+          useEffect(() => {
+            return () => null;
+          });
+          return <div />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: `renderers` nested object — prop name matches pattern ----
+		{Code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent renderers={{ Header: () => <div /> }} />
+          )
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: nested render-prop with inner map ----
+		{Code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent renderMenu={() => (
+              <RenderPropComponent>
+                {items.map(item => (
+                  <li key={item}>{item}</li>
+                ))}
+              </RenderPropComponent>
+            )} />
+          )
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow inside array literal of a JSX attribute ----
+		{Code: `
+        const ParentComponent = () => (
+          <SomeComponent
+            components={[
+              <ul>
+                {list.map(item => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>,
+            ]}
+          />
+        );
+     `, Tsx: true},
+
+		// ---- Upstream: direct value of render: key in a plain object ----
+		{Code: `
+        function ParentComponent() {
+          const rows = [
+            {
+              name: 'A',
+              render: (props) => <Row {...props} />
+            },
+          ];
+          return <Table rows={rows} />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: arrow returning null whose property key doesn't match pattern ----
+		{Code: `
+        function ParentComponent() {
+          return <SomeComponent renderers={{ notComponent: () => null }} />;
+        }
+      `, Tsx: true},
+
+		// ---- Upstream: createReactClass statics field ----
+		{Code: `
+        const ParentComponent = createReactClass({
+          displayName: "ParentComponent",
+          statics: {
+            getSnapshotBeforeUpdate: function () {
+              return null;
+            },
+          },
+          render() {
+            return <div />;
+          },
+        });
+      `, Tsx: true},
+
+		// ---- Upstream: allowAsProps with non-render prefix ----
+		{
+			Code: `
+        function ParentComponent() {
+          const rows = [
+            {
+              name: 'A',
+              notPrefixedWithRender: (props) => <Row {...props} />
+            },
+          ];
+          return <Table rows={rows} />;
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"allowAsProps": true},
+		},
+
+		// ---- Upstream: propNamePattern override ----
+		{
+			Code: `
+        function ParentComponent() {
+          return <Table
+            rowRenderer={(rowData) => <Row data={data} />}
+          />
+        }
+      `,
+			Tsx:     true,
+			Options: map[string]interface{}{"propNamePattern": "*Renderer"},
+		},
+
+		// =======================================================
+		// Additional valid edge-case coverage (tsgo-specific) —
+		// failures here clearly point at over-reporting rather than
+		// upstream-aligned behavior.
+		// =======================================================
+
+		// ---- Optional chain `.map`: `items?.map(...)` is still a map call ----
+		{Code: `
+        function ParentComponent(props) {
+          return (
+            <ul>
+              {props.items?.map(item => (<li key={item.id}>{item.name}</li>))}
+            </ul>
+          );
+        }
+      `, Tsx: true},
+
+		// ---- Computed property key — anonymous arrow under a computed key
+		// is NOT a render-prop pattern and the function isn't a stateless
+		// component (computed keys go through Branch 9 + null-only check) ----
+		{Code: `
+        function ParentComponent() {
+          const key = "Foo";
+          return <Comp config={{ [key]: () => null }} />;
+        }
+      `, Tsx: true},
+
+		// ---- Numeric / string-literal property key — neither matches the
+		// render-prop glob; the inner arrow is not classified as a component ----
+		{Code: `
+        function ParentComponent() {
+          return <Comp config={{ 0: () => null, "render-foo": () => null }} />;
+        }
+      `, Tsx: true},
+
+		// ---- Class method returning JSX must not double-report:
+		// outer class is the only acceptable diagnostic site ----
+		{Code: `
+        class StableTopLevel extends React.Component {
+          render() { return <div />; }
+        }
+      `, Tsx: true},
+
+		// ---- `useMemo(() => <div/>, [])` — hook callback in allowed
+		// position (VariableDeclaration) but NOT a memo/forwardRef
+		// wrapper, so the inner arrow isn't classified as a component ----
+		{Code: `
+        function ParentComponent() {
+          const ui = useMemo(() => <div />, []);
+          return ui;
+        }
+      `, Tsx: true},
+
+		// ---- `useCallback` cleanup pattern — the returned arrow is a hook
+		// return statement (skip via isReturnStatementOfHook) ----
+		{Code: `
+        function ParentComponent() {
+          useEffect(() => {
+            return function CleanupComp() { return <div />; };
+          }, []);
+          return <div />;
+        }
+      `, Tsx: true},
+
+		// ---- Lowercase parent — even deeply nested capitalized children
+		// inside a lowercase factory must NOT report (parent name lowercase
+		// short-circuit) ----
+		{Code: `
+        function makeView(props) {
+          function NestedInsideFactory() { return <div />; }
+          return <NestedInsideFactory />;
+        }
+      `, Tsx: true},
+
+		// ---- TS-as wrapper around createElement callee — pragma still
+		// recognized after unwrap ----
+		{Code: `
+        function ParentComponent() {
+          return ((React as any).createElement)("div", null);
+        }
+      `, Tsx: true},
+
+		// ---- Outer paren wrapper around the JSX element / fragment ----
+		{Code: `
+        const ParentComponent = () => ((<div />));
+      `, Tsx: true},
+
+		// ---- Generator function nested in component — generators do not
+		// classify as React components (they yield, not return JSX) so the
+		// inner generator must not be reported. ----
+		{Code: `
+        function ParentComponent() {
+          function* helperGen() {
+            yield 1;
+            yield 2;
+          }
+          return <div>{helperGen()}</div>;
+        }
+      `, Tsx: true},
+
+		// ---- Inner abstract class declaration — abstract methods are
+		// body-absent; the class itself doesn't extend React.Component so
+		// it's not a component. ----
+		{Code: `
+        function ParentComponent() {
+          abstract class Helper {
+            abstract serialize(): string;
+          }
+          return <div />;
+        }
+      `, Tsx: true},
+
+		// ---- Top-level React.memo — no parent component, so even though
+		// the arrow looks like a stateless component it has no enclosing
+		// component to attach to. ----
+		{Code: `
+        const TopLevel = React.memo(() => <div />);
+      `, Tsx: true},
+
+		// ---- Arrow with block body returning early `null` only — strict
+		// isReturningJSX (ignoreNull=true) treats this as not-a-component
+		// when it's used as a property value, so should not be flagged
+		// even when the property key matches the render-prop pattern. ----
+		{Code: `
+        function ParentComponent() {
+          return (
+            <Comp renderEmpty={() => { return null; }} />
+          );
+        }
+      `, Tsx: true},
+
+		// ---- Bare `memo(fn)` without importing `memo` from the pragma
+		// module — upstream skips this because `isPragmaComponentWrapper`
+		// requires the binding to come from `react`, and our
+		// `IsDestructuredFromPragmaImport` enforces the same gate. The
+		// matching invalid form (with `import { memo } from 'react'`)
+		// lives in the invalid suite. ----
+		{Code: `
+        function ParentComponent() {
+          const UnstableMemo = memo(() => <div />);
+          return <UnstableMemo />;
+        }
+      `, Tsx: true},
+
+		// ---- Bare `memo(fn)` with `memo` imported from a non-pragma
+		// module (e.g. `preact`) — name collides with React's `memo` but
+		// upstream's import resolution rejects it, so we must too. ----
+		{Code: `
+        import { memo } from 'preact';
+        function ParentComponent() {
+          const UnstableMemo = memo(() => <div />);
+          return <UnstableMemo />;
+        }
+      `, Tsx: true},
+
+		// ---- Aliased import (`memo as m`) — upstream recognizes
+		// wrappers by the local name, so `m(...)` does NOT match the
+		// hardcoded wrapper list and the call is not treated as a
+		// component. Locks in name-based matching, not symbol-based. ----
+		{Code: `
+        import { memo as m } from 'react';
+        function ParentComponent() {
+          const Aliased = m(() => <div />);
+          return <Aliased />;
+        }
+      `, Tsx: true},
+
+		// ---- Bare `createElement(...)` without importing it from
+		// the pragma module — upstream's `isCreateElement` requires the
+		// binding to resolve to React; without the import this is treated
+		// as a regular function call and the helper is not flagged. ----
+		{Code: `
+        function ParentComponent() {
+          function NotAComponent() { return createElement('div'); }
+          return <NotAComponent />;
+        }
+      `, Tsx: true},
+
+		// ---- React.memo wrapping a sibling/outer arrow component
+		// (`nodeWrapsComponent` gate) — upstream's
+		// `isPragmaComponentWrapper` short-circuits to false for the
+		// MemberExpression form when the wrapped function returns JSX
+		// whose root tag matches an already-detected sibling/outer
+		// component, so the call is NOT registered. Locks in three
+		// declaration shapes (arrow / class / function) and the bare /
+		// import-aware variants. ----
+		{Code: `
+        const Inner = () => <div />;
+        function Parent() {
+          const Wrap = React.memo(() => <Inner />);
+          return <Wrap />;
+        }
+      `, Tsx: true},
+		{Code: `
+        const Inner = () => <div />;
+        function Parent() {
+          const Wrap = React.memo(() => { return <Inner />; });
+          return <Wrap />;
+        }
+      `, Tsx: true},
+		{Code: `
+        const Inner = () => <div />;
+        function Parent() {
+          const Wrap = React.memo(Inner);
+          return <Wrap />;
+        }
+      `, Tsx: true},
+		{Code: `
+        class InnerCls extends React.Component { render() { return <div />; } }
+        function Parent() {
+          const Wrap = React.memo(() => <InnerCls />);
+          return <Wrap />;
+        }
+      `, Tsx: true},
+		{Code: `
+        const Inner = () => <div />;
+        function Parent() {
+          const Wrap = React.forwardRef(() => <Inner />);
+          return <Wrap />;
+        }
+      `, Tsx: true},
+	}, []rule_tester.InvalidTestCase{
+		// ---- Upstream: function declaration nested in function component ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableNestedFunctionComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedFunctionComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableNestedFunctionComponent() {
+            return React.createElement("div", null);
+          }
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedFunctionComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: arrow assigned to capitalized binding nested in function component ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNestedVariableComponent = () => {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedVariableComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 51},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNestedVariableComponent = () => {
+            return React.createElement("div", null);
+          }
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedVariableComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 51},
+			},
+		},
+		{
+			Code: `
+        const ParentComponent = () => {
+          function UnstableNestedFunctionComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedFunctionComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+        const ParentComponent = () => {
+          function UnstableNestedFunctionComponent() {
+            return React.createElement("div", null);
+          }
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedFunctionComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: anonymous default-exported arrow ----
+		{
+			Code: `
+        export default () => {
+          function UnstableNestedFunctionComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedFunctionComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageWithoutName, Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+        export default () => {
+          function UnstableNestedFunctionComponent() {
+            return React.createElement("div", null);
+          }
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedFunctionComponent, null)
+          );
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageWithoutName, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: nested arrow assigned to capitalized binding (arrow parent) ----
+		{
+			Code: `
+        const ParentComponent = () => {
+          const UnstableNestedVariableComponent = () => {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedVariableComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 51},
+			},
+		},
+		{
+			Code: `
+        const ParentComponent = () => {
+          const UnstableNestedVariableComponent = () => {
+            return React.createElement("div", null);
+          }
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedVariableComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 51},
+			},
+		},
+
+		// ---- Upstream: class nested in function component ----
+		{
+			Code: `
+        function ParentComponent() {
+          class UnstableNestedClassComponent extends React.Component {
+            render() {
+              return <div />;
+            }
+          };
+          return (
+            <div>
+              <UnstableNestedClassComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          class UnstableNestedClassComponent extends React.Component {
+            render() {
+              return React.createElement("div", null);
+            }
+          }
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedClassComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Upstream: class nested in class component (via render method) ----
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            class UnstableNestedClassComponent extends React.Component {
+              render() {
+                return <div />;
+              }
+            };
+            return (
+              <div>
+                <UnstableNestedClassComponent />
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            class UnstableNestedClassComponent extends React.Component {
+              render() {
+                return React.createElement("div", null);
+              }
+            }
+            return React.createElement(
+              "div",
+              null,
+              React.createElement(UnstableNestedClassComponent, null)
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: function nested in class component render ----
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            function UnstableNestedFunctionComponent() {
+              return <div />;
+            }
+            return (
+              <div>
+                <UnstableNestedFunctionComponent />
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            function UnstableNestedClassComponent() {
+              return React.createElement("div", null);
+            }
+            return React.createElement(
+              "div",
+              null,
+              React.createElement(UnstableNestedClassComponent, null)
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: arrow assigned to capitalized binding inside class render ----
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            const UnstableNestedVariableComponent = () => {
+              return <div />;
+            }
+            return (
+              <div>
+                <UnstableNestedVariableComponent />
+              </div>
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 53},
+			},
+		},
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            const UnstableNestedClassComponent = () => {
+              return React.createElement("div", null);
+            }
+            return React.createElement(
+              "div",
+              null,
+              React.createElement(UnstableNestedClassComponent, null)
+            );
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 50},
+			},
+		},
+
+		// ---- Upstream: nested function inside a nested getter-function ----
+		{
+			Code: `
+        function ParentComponent() {
+          function getComponent() {
+            function NestedUnstableFunctionComponent() {
+              return <div />;
+            };
+            return <NestedUnstableFunctionComponent />;
+          }
+          return (
+            <div>
+              {getComponent()}
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          function getComponent() {
+            function NestedUnstableFunctionComponent() {
+              return React.createElement("div", null);
+            }
+            return React.createElement(NestedUnstableFunctionComponent, null);
+          }
+          return React.createElement("div", null, getComponent());
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+
+		// ---- Upstream: function declaration as prop value (componentAsProps) ----
+		{
+			Code: `
+        function ComponentWithProps(props) {
+          return <div />;
+        }
+
+        function ParentComponent() {
+          return (
+            <ComponentWithProps
+              footer={
+                function SomeFooter() {
+                  return <div />;
+                }
+              } />
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 10, Column: 17},
+			},
+		},
+		{
+			Code: `
+        function ComponentWithProps(props) {
+          return React.createElement("div", null);
+        }
+
+        function ParentComponent() {
+          return React.createElement(ComponentWithProps, {
+            footer: function SomeFooter() {
+              return React.createElement("div", null);
+            }
+          });
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 8, Column: 21},
+			},
+		},
+		{
+			Code: `
+        function ComponentWithProps(props) {
+          return <div />;
+        }
+
+        function ParentComponent() {
+            return (
+              <ComponentWithProps footer={() => <div />} />
+            );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 8, Column: 43},
+			},
+		},
+		{
+			Code: `
+        function ComponentWithProps(props) {
+          return React.createElement("div", null);
+        }
+
+        function ParentComponent() {
+          return React.createElement(ComponentWithProps, {
+            footer: () => React.createElement("div", null)
+          });
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 8, Column: 21},
+			},
+		},
+
+		// ---- Upstream: render-prop children with nested component ----
+		{
+			Code: `
+        function ParentComponent() {
+            return (
+              <RenderPropComponent>
+                {() => {
+                  function UnstableNestedComponent() {
+                    return <div />;
+                  }
+                  return (
+                    <div>
+                      <UnstableNestedComponent />
+                    </div>
+                  );
+                }}
+              </RenderPropComponent>
+            );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 6, Column: 19},
+			},
+		},
+		{
+			Code: `
+        function RenderPropComponent(props) {
+          return props.render({});
+        }
+
+        function ParentComponent() {
+          return React.createElement(
+            RenderPropComponent,
+            null,
+            () => {
+              function UnstableNestedComponent() {
+                return React.createElement("div", null);
+              }
+              return React.createElement(
+                "div",
+                null,
+                React.createElement(UnstableNestedComponent, null)
+              );
+            }
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 11, Column: 15},
+			},
+		},
+
+		// ---- Upstream: non-render-prefixed attribute (componentAsProps) ----
+		{
+			Code: `
+        function ComponentForProps(props) {
+          return <div />;
+        }
+
+        function ParentComponent() {
+          return (
+            <ComponentForProps notPrefixedWithRender={() => <div />} />
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 8, Column: 55},
+			},
+		},
+		{
+			Code: `
+        function ComponentForProps(props) {
+          return React.createElement("div", null);
+        }
+
+        function ParentComponent() {
+          return React.createElement(ComponentForProps, {
+            notPrefixedWithRender: () => React.createElement("div", null)
+          });
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 8, Column: 36},
+			},
+		},
+
+		// ---- Upstream: nested object with capitalized key under non-render attribute ----
+		{
+			Code: `
+        function ParentComponent() {
+          return (
+            <ComponentForProps someMap={{ Header: () => <div /> }} />
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 4, Column: 51},
+			},
+		},
+
+		// ---- Upstream: single-error sanity check — class with nested List arrow ----
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          render() {
+            const List = (props) => {
+              const items = props.items
+                .map((item) => (
+                  <li key={item.key}>
+                    <span>{item.name}</span>
+                  </li>
+                ));
+              return <ul>{items}</ul>;
+            };
+            return <List {...this.props} />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 26},
+			},
+		},
+
+		// ---- Upstream: nested thing.match with lowercase keys — 3 errors ----
+		{
+			Code: `
+      function ParentComponent() {
+        return (
+          <SomeComponent>
+            {
+              thing.match({
+                loading: () => <div />,
+                success: () => <div />,
+                failure: () => <div />,
+              })
+            }
+          </SomeComponent>
+        )
+      }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Three distinct property values, each at the start of its
+				// arrow expression. Column points at `() => …` after the
+				// `<key>: ` prefix, so loading=26, success=26, failure=26;
+				// lines progress by one each.
+				{Message: errorMessageComponentAsProps, Line: 7, Column: 26},
+				{Message: errorMessageComponentAsProps, Line: 8, Column: 26},
+				{Message: errorMessageComponentAsProps, Line: 9, Column: 26},
+			},
+		},
+		{
+			Code: `
+      function ParentComponent() {
+        const thingElement = thing.match({
+          loading: () => <div />,
+          success: () => <div />,
+          failure: () => <div />,
+        });
+        return (
+          <SomeComponent>
+            {thingElement}
+          </SomeComponent>
+        )
+      }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 4, Column: 20},
+				{Message: errorMessageComponentAsProps, Line: 5, Column: 20},
+				{Message: errorMessageComponentAsProps, Line: 6, Column: 20},
+			},
+		},
+
+		// ---- Upstream: rows in array with notPrefixedWithRender key ----
+		{
+			Code: `
+      function ParentComponent() {
+        const rows = [
+          {
+            name: 'A',
+            notPrefixedWithRender: (props) => <Row {...props} />
+          },
+        ];
+        return <Table rows={rows} />;
+      }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 6, Column: 36},
+			},
+		},
+
+		// ---- Upstream: React.memo wrapper patterns (arrow / function) ----
+		// Wrapper-call diagnostic Pos lives at the START of the wrapper
+		// CallExpression (`React.memo`), matching upstream's
+		// `components.add(call, 2)` registration in Components.detect.
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNestedComponent = React.memo(() => {
+            return <div />;
+          });
+          return (
+            <div>
+              <UnstableNestedComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNestedComponent = React.memo(
+            () => React.createElement("div", null),
+          );
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNestedComponent = React.memo(
+            function () {
+              return <div />;
+            }
+          );
+          return (
+            <div>
+              <UnstableNestedComponent />
+            </div>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 43},
+			},
+		},
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNestedComponent = React.memo(
+            function () {
+              return React.createElement("div", null);
+            }
+          );
+          return React.createElement(
+            "div",
+            null,
+            React.createElement(UnstableNestedComponent, null)
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 43},
+			},
+		},
+
+		// ============================================================
+		// tsgo-specific edge cases beyond the upstream test suite
+		// ============================================================
+
+		// ---- TS wrapper: `(X as any)` callee on createElement should still
+		// classify the inner arrow as JSX-returning ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return (React as any).createElement("div", null);
+          }
+          return <UnstableNestedComponent />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- TS wrapper: `<div/> satisfies JSX.Element` return ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return <div /> satisfies React.ReactNode;
+          }
+          return <UnstableNestedComponent />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- TS wrapper: non-null `!` on createElement call ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return React.createElement("div", null)!;
+          }
+          return <UnstableNestedComponent />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- ParenthesizedExpression around React.memo argument ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableComp = React.memo((() => <div />));
+          return <UnstableComp />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Position points at the start of the wrapper CallExpression
+				// (`React.memo`), matching upstream's component registration
+				// site for memo/forwardRef wrappers.
+				{Message: errorMessage, Line: 3, Column: 32},
+			},
+		},
+
+		// (ClassExpression test removed — verified via differential testing
+		// that upstream eslint-plugin-react v7.37.x does NOT listen on
+		// ClassExpression. `const X = class extends React.Component {}` is
+		// silent in upstream so we match by not registering the listener.
+		// See `differential_test.go` for the alignment harness.)
+
+		// ---- async function as nested component ----
+		{
+			Code: `
+        function ParentComponent() {
+          async function UnstableAsyncComponent() {
+            return <div />;
+          }
+          return <UnstableAsyncComponent />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- forwardRef wrapper (sibling of React.memo) ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableForwarded = React.forwardRef((props, ref) => <div ref={ref} />);
+          return <UnstableForwarded />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Wrapper-call Pos: `React.forwardRef(...)` starts at col 37.
+				{Message: errorMessage, Line: 3, Column: 37},
+			},
+		},
+
+		// ---- Member-expression wrapper that does NOT wrap a known
+		// sibling component — the gate only fires when the JSX root
+		// tag resolves to a detected outer/sibling component. With
+		// the inner tag unknown, `React.memo` is registered as usual. ----
+		{
+			Code: `
+        function ParentComponent() {
+          const Wrap = React.memo(() => <NotKnown />);
+          return <Wrap />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 24},
+			},
+		},
+
+		// ---- Bare `memo(fn)` with `import { memo } from 'react'` ----
+		// Upstream's `isPragmaComponentWrapper` only treats a bare
+		// `memo(...)` call as a pragma wrapper when the binding was
+		// imported from / destructured from / required from the pragma
+		// module. The corresponding "no-import" form is in the valid
+		// suite — both shapes are covered to lock in the gate.
+		{
+			Code: `
+        import { memo } from 'react';
+        function ParentComponent() {
+          const UnstableMemo = memo(() => <div />);
+          return <UnstableMemo />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Wrapper-call Pos: `memo(...)` starts at col 32.
+				{Message: errorMessage, Line: 4, Column: 32},
+			},
+		},
+		{
+			Code: `
+        const { memo } = require('react');
+        function ParentComponent() {
+          const UnstableMemo = memo(() => <div />);
+          return <UnstableMemo />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 32},
+			},
+		},
+		{
+			Code: `
+        import React from 'react';
+        const { memo } = React;
+        function ParentComponent() {
+          const UnstableMemo = memo(() => <div />);
+          return <UnstableMemo />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 5, Column: 32},
+			},
+		},
+		{
+			Code: `
+        import { createElement } from 'react';
+        function ParentComponent() {
+          function UnstableNested() { return createElement('div'); }
+          return <UnstableNested />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// FunctionDeclaration Pos for the nested helper.
+				{Message: errorMessage, Line: 4, Column: 11},
+			},
+		},
+		// Bare `createElement(...)` recognized via destructure-from-React
+		// (`const { createElement } = React`). Closes the
+		// `IsCreateElementCallWithChecker` second branch — TypeChecker
+		// resolves the local `createElement` to its BindingElement, and
+		// `IsDestructuredFromPragmaImport` then walks to the enclosing
+		// VariableDeclaration and confirms its initializer is the pragma
+		// identifier (`React`).
+		{
+			Code: `
+        import React from 'react';
+        const { createElement } = React;
+        function ParentComponent() {
+          function UnstableNested() { return createElement('div'); }
+          return <UnstableNested />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// FunctionDeclaration Pos for the nested helper.
+				{Message: errorMessage, Line: 5, Column: 11},
+			},
+		},
+		// Optional-call form on a bare wrapper (`memo?.(...)`) with
+		// `import { memo } from 'react'` — exercises the call-level
+		// optional path of `MatchesAnyComponentWrapperWithChecker`.
+		// Upstream classifies the call as a wrapper (the callee binding
+		// resolves to the pragma module), but emits the message
+		// WITHOUT a parent name: Babel wraps optional calls in a
+		// ChainExpression sharing range[0] with the inner call, so
+		// upstream's parent walk stops at the ChainExpression which has
+		// no `.id`. We mirror via `isOptionalPragmaWrapperCall`'s
+		// parentName-blanking branch.
+		{
+			Code: `
+        import { memo } from 'react';
+        function ParentComponent() {
+          const Inner = memo?.(() => <div />);
+          return <Inner />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageWithoutName, Line: 4, Column: 25},
+			},
+		},
+		// `nodeWrapsComponent` is order-dependent: a sibling/outer arrow
+		// declared AFTER the wrapper call hasn't been added to upstream's
+		// detected-components list yet, so the gate doesn't fire and the
+		// wrapper IS reported. Locks in the position guard inside
+		// `sourceHasComponentNamedBefore`.
+		{
+			Code: `
+        function ParentComponent() {
+          const Wrap = React.memo(() => <Inner />);
+          return <Wrap />;
+        }
+        const Inner = () => <div />;
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 24},
+			},
+		},
+		// Optional member-access wrapper (`React?.memo(...)`) — Babel
+		// wraps the inner CallExpression in a ChainExpression sharing
+		// `range[0]` with it, so upstream's parent walk stops at the
+		// ChainExpression which has no `.id`. The wrapper IS classified
+		// (the property name still matches) but the message is emitted
+		// without a parent name — mirrored via `isOptionalPragmaWrapperCall`.
+		{
+			Code: `
+        function ParentComponent() {
+          const X = React?.memo(() => <div />);
+          return <X />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageWithoutName, Line: 3, Column: 21},
+			},
+		},
+		// Optional member-access on a user-configured wrapper
+		// (`MyLib?.observer(...)`) — same ChainExpression quirk as the
+		// pragma form; locks in that the parentName-blanking applies
+		// regardless of whether the wrapper came from the hardcoded
+		// defaults or `componentWrapperFunctions`.
+		{
+			Code: `
+        function ParentComponent() {
+          const X = MyLib?.observer(() => <div />);
+          return <X />;
+        }
+      `,
+			Tsx: true,
+			Settings: map[string]any{
+				"componentWrapperFunctions": []any{
+					map[string]any{"object": "MyLib", "property": "observer"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageWithoutName, Line: 3, Column: 21},
+			},
+		},
+		// Class component extending `React.PureComponent` qualifies as
+		// the parent component. Upstream's `componentUtil.isES6Component`
+		// accepts both `Component` and `PureComponent` superclass names
+		// (qualified or bare); mirrored by `ExtendsReactComponent` here.
+		{
+			Code: `
+        class ParentComponent extends React.PureComponent {
+          render() {
+            function UnstableInPure() { return <div />; }
+            return <UnstableInPure />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+		// Bare `PureComponent` (without `React.` prefix) — locks in
+		// that `ExtendsReactComponent`'s identifier branch accepts
+		// both `Component` and `PureComponent` names, mirroring
+		// upstream's `componentUtil.isPureComponent` which treats
+		// the bare identifier form the same as the qualified one.
+		{
+			Code: `
+        class ParentComponent extends PureComponent {
+          render() {
+            function UnstableInBarePure() { return <div />; }
+            return <UnstableInBarePure />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 13},
+			},
+		},
+
+		// ---- JsxFragment children render-prop (parallel to upstream's JsxElement case) ----
+		{
+			Code: `
+        function ParentComponent() {
+          return (
+            <>
+              {() => {
+                function UnstableInsideFragment() {
+                  return <div />;
+                }
+                return <UnstableInsideFragment />;
+              }}
+            </>
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 6, Column: 17},
+			},
+		},
+
+		// ---- Custom react.pragma setting — `Preact.createElement` recognized ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return Preact.createElement("div", null);
+          }
+          return <UnstableNestedComponent />;
+        }
+      `,
+			Tsx:      true,
+			Settings: map[string]interface{}{"react": map[string]interface{}{"pragma": "Preact"}},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Object-literal shorthand method that returns JSX, in a non-render prop ----
+		{
+			Code: `
+        function ParentComponent() {
+          return (
+            <ComponentForProps map={{
+              Foo() { return <div />; },
+            }} />
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Position narrowed to the `(` of the parameter list,
+				// matching upstream's report on the inner FunctionExpression.
+				{Message: errorMessageComponentAsProps, Line: 5, Column: 18},
+			},
+		},
+
+		// ---- Arrow returning createElement directly (expression body) ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableArrow = () => React.createElement("div", null);
+          return <UnstableArrow />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 33},
+			},
+		},
+
+		// ---- Conditional return: `cond ? <div/> : null` qualifies as JSX-or-null ----
+		{
+			Code: `
+        function ParentComponent(props) {
+          function UnstableConditional() {
+            return props.show ? <div /> : null;
+          }
+          return <UnstableConditional />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Nested arrow as property of a deeply-nested object inside JSX attribute ----
+		{
+			Code: `
+        function ParentComponent() {
+          return (
+            <Comp config={{
+              ui: {
+                Header: () => <div />,
+              }
+            }} />
+          );
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageComponentAsProps, Line: 6, Column: 25},
+			},
+		},
+
+		// ---- React.memo wrapping a TS-asserted arrow ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableMemoTS = React.memo((() => <div />) as any);
+          return <UnstableMemoTS />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Wrapper-call Pos: `React.memo(...)` starts at col 34.
+				{Message: errorMessage, Line: 3, Column: 34},
+			},
+		},
+
+		// ---- Doubly-wrapped pragma component:
+		// React.memo(React.forwardRef(...)). The INNER wrapper is the
+		// reported site — this matches upstream's behavior verified via
+		// differential testing: ESLint's `Components.detect` registers the
+		// inner forwardRef call as a component but the outer memo call is
+		// not (its first argument is a CallExpression, not a FunctionLike,
+		// so it fails the `isReturningJSXOrNull(inner)` gate). ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableDouble = React.memo(React.forwardRef((props, ref) => <div ref={ref} />));
+          return <UnstableDouble />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Wrapper-call Pos: inner `React.forwardRef(...)` starts at
+				// col 45. Inner-arrow self-suppresses (its parent IS a
+				// wrapper call) so we don't double-fire.
+				{Message: errorMessage, Line: 3, Column: 45},
+			},
+		},
+
+		// ---- Class with class-static-block must not affect detection of
+		// nested function components inside its render method ----
+		{
+			Code: `
+        class ParentComponent extends React.Component {
+          static {
+            console.log("init");
+          }
+          render() {
+            const UnstableInner = () => <div />;
+            return <UnstableInner />;
+          }
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 7, Column: 35},
+			},
+		},
+
+		// ============================================================
+		// Round-3 expansion: full container coverage with EndLine /
+		// EndColumn assertions, LogicalExpression / Identifier
+		// resolution, settings.componentWrapperFunctions support, and
+		// other previously-missed paths.
+		// ============================================================
+
+		// ---- EndLine / EndColumn on a multi-line FunctionDeclaration body ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableMultiline() {
+            return (
+              <div>
+                <span>nested</span>
+              </div>
+            );
+          }
+          return <UnstableMultiline />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					Message: errorMessage,
+					Line: 3, Column: 11, EndLine: 9, EndColumn: 12,
+				},
+			},
+		},
+
+		// ---- EndLine / EndColumn on a multi-line ClassDeclaration ----
+		{
+			Code: `
+        function ParentComponent() {
+          class UnstableMulti extends React.Component {
+            render() {
+              return (
+                <div>
+                  text
+                </div>
+              );
+            }
+          };
+          return <UnstableMulti />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					Message: errorMessage,
+					Line: 3, Column: 11, EndLine: 11, EndColumn: 12,
+				},
+			},
+		},
+
+		// ---- LogicalExpression `cond && <div/>` return — strict
+		// isReturningJSX accepts EITHER side as JSX. ----
+		{
+			Code: `
+        function ParentComponent(props) {
+          function UnstableLogical() {
+            return props.show && <div />;
+          }
+          return <UnstableLogical />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Nullish coalescing `?? <div/>` return ----
+		{
+			Code: `
+        function ParentComponent(props) {
+          function UnstableNullish() {
+            return props.cached ?? <div />;
+          }
+          return <UnstableNullish />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Comma sequence return `(setup(), <div/>)` ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableSeq() {
+            return (init(), <div />);
+          }
+          return <UnstableSeq />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// ---- Identifier resolution: function returns a local variable
+		// that holds JSX. Mirrors upstream's `case 'Identifier'` arm in
+		// jsxUtil.isReturningJSX via a one-hop initializer lookup. ----
+		{
+			Code: `
+        function ParentComponent() {
+          function UnstableIndirect() {
+            const view = <div />;
+            return view;
+          }
+          return <UnstableIndirect />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 3, Column: 11},
+			},
+		},
+
+		// (Identifier resolution chain `const a = <div/>; const b = a;
+		// return b;` was previously asserted as invalid here, but
+		// differential testing confirmed upstream does NOT chain-resolve:
+		// its `isJSX(variable)` accepts only JSXElement / JSXFragment
+		// initializers — Identifier-to-Identifier chains return false. The
+		// matching valid case lives in the rule's valid suite below.)
+
+		// ---- Cross-block Identifier resolution (TypeChecker path):
+		// the JSX-bound binding lives in an outer block; only a real
+		// scope walk (not the local-block fallback) can resolve it. ----
+		{
+			Code: `
+        function ParentComponent() {
+          const sharedView = <div />;
+          function UnstableCrossBlock() {
+            if (true) {
+              return sharedView;
+            }
+            return null;
+          }
+          return <UnstableCrossBlock />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 11},
+			},
+		},
+
+		// ---- settings.componentWrapperFunctions extends defaults — a
+		// user-declared `myMemo(fn)` call counts as a component wrapper. ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableCustomWrap = myMemo(() => <div />);
+          return <UnstableCustomWrap />;
+        }
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{"myMemo"},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Wrapper-call Pos: `myMemo(...)` starts at col 38.
+				{Message: errorMessage, Line: 3, Column: 38},
+			},
+		},
+
+		// ---- settings.componentWrapperFunctions object form
+		// `{property, object}` — pragma-qualified custom wrapper. ----
+		{
+			Code: `
+        function ParentComponent() {
+          const UnstableNS = MyLib.observer(() => <div />);
+          return <UnstableNS />;
+        }
+      `,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"componentWrapperFunctions": []interface{}{
+					map[string]interface{}{"property": "observer", "object": "MyLib"},
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Wrapper-call Pos: `MyLib.observer(...)` starts at col 30.
+				{Message: errorMessage, Line: 3, Column: 30},
+			},
+		},
+
+		// ---- Member-expression parent component name —
+		// `Foo.Bar = function ...` host. Parent name resolution returns
+		// "" because `Foo.Bar` is not a VariableDeclaration; the diagnostic
+		// uses the no-name template. ----
+		{
+			Code: `
+        var Foo = {};
+        Foo.Bar = function () {
+          function UnstableInside() { return <div />; }
+          return <UnstableInside />;
+        };
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessageWithoutName, Line: 4, Column: 11},
+			},
+		},
+
+		// ---- TypeScript decorator on a nested class component does NOT
+		// alter detection — the heritage clause still drives classification. ----
+		{
+			Code: `
+        function deco(target: any) { return target; }
+        function ParentComponent() {
+          @deco
+          class UnstableDecorated extends React.Component {
+            render() { return <div />; }
+          };
+          return <UnstableDecorated />;
+        }
+      `,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: errorMessage, Line: 4, Column: 11},
+			},
+		},
+	})
+}
+
+// TestNilCheckerFallback locks down the contract that every Identifier-
+// resolving entry point used by this rule degrades safely when no
+// TypeChecker is available — the case for tooling that runs the rule on
+// a SourceFile-only host or with TypeScript project services disabled.
+//
+// Each helper must return its safe-default ("not recognized") value
+// rather than panicking on a nil receiver. The cases are split by
+// argument shape (nil fn vs nil checker on a present fn) because a
+// future regression could land in either guard.
+func TestNilCheckerFallback(t *testing.T) {
+	t.Run("nil fn + nil checker", func(t *testing.T) {
+		if reactutil.FunctionReturnsJSXOrNullWithChecker(nil, "", nil) {
+			t.Fatal("nil fn + nil tc must yield false")
+		}
+		if reactutil.FunctionReturnsJSXWithChecker(nil, "", nil) {
+			t.Fatal("nil fn + nil tc must yield false (strict)")
+		}
+	})
+
+	t.Run("nil-typed fn + nil checker (no panic)", func(t *testing.T) {
+		// The rule_tester suite above exercises the non-nil-fn path
+		// with real ASTs; here we only verify the WithChecker entry
+		// points accept an explicitly nil-typed *ast.Node without
+		// panicking when the checker is also nil.
+		var nilFn *ast.Node
+		_ = reactutil.FunctionReturnsJSXOrNullWithChecker(nilFn, "Preact", nil)
+		_ = reactutil.FunctionReturnsJSXWithChecker(nilFn, "", nil)
+	})
+
+	t.Run("import-aware helpers degrade safely with nil checker", func(t *testing.T) {
+		if reactutil.IsDestructuredFromPragmaImport(nil, "React", nil) {
+			t.Fatal("IsDestructuredFromPragmaImport(nil ident, nil tc) must return false")
+		}
+		if reactutil.IsCreateElementCallWithChecker(nil, "React", nil) {
+			t.Fatal("IsCreateElementCallWithChecker(nil callee, nil tc) must return false")
+		}
+		if reactutil.MatchesAnyComponentWrapperWithChecker(nil, nil, nil, "React", nil) {
+			t.Fatal("MatchesAnyComponentWrapperWithChecker(nil call, nil fn, nil tc) must return false")
+		}
+		if reactutil.IsStatelessReactComponentWithChecker(nil, "React", nil) {
+			t.Fatal("IsStatelessReactComponentWithChecker(nil fn, nil tc) must return false")
+		}
+		if reactutil.IsStatelessReactComponentWithWrappers(nil, "React", nil, nil) {
+			t.Fatal("IsStatelessReactComponentWithWrappers(nil fn, nil tc, nil wrappers) must return false")
+		}
+	})
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -117,6 +117,7 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/no-render-return-value.test.ts',
     './tests/eslint-plugin-react/rules/no-string-refs.test.ts',
     './tests/eslint-plugin-react/rules/no-this-in-sfc.test.ts',
+    './tests/eslint-plugin-react/rules/no-unstable-nested-components.test.ts',
     './tests/eslint-plugin-react/rules/no-typos.test.ts',
     './tests/eslint-plugin-react/rules/no-unescaped-entities.test.ts',
     './tests/eslint-plugin-react/rules/no-unused-class-component-methods.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rule-tester.ts
@@ -1,7 +1,57 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import path from 'node:path';
 import util from 'node:util';
 
 import { lint } from '@rslint/core';
+
+// Per-test rslint.json builder used to thread `settings` through to the
+// linter. The base rslint.json registered for the suite has `settings: {}`;
+// when a test case carries its own settings, we emit a temporary config
+// that merges the base with the test's settings and point `lint()` at it.
+//
+// rslint's LintOptions does NOT expose a runtime `settings` override (see
+// packages/rslint/dist/types.d.ts), so a config file is the only path. The
+// temp dir is cleaned on the same tick the lint() promise resolves.
+function buildConfigForSettings(
+  baseConfigPath: string,
+  settings: Record<string, unknown> | undefined,
+): { configPath: string; cleanup: () => void } {
+  if (!settings || Object.keys(settings).length === 0) {
+    return { configPath: baseConfigPath, cleanup: () => {} };
+  }
+  const base = JSON.parse(readFileSync(baseConfigPath, 'utf8'));
+  const merged = base.map((entry: any) => ({
+    ...entry,
+    settings: { ...(entry.settings ?? {}), ...settings },
+  }));
+  // Write the temp config into the SAME directory as the base config:
+  // the base entries reference `tsconfig.*.json` via relative paths
+  // that rslint resolves from the config file's location, so the temp
+  // config must sit next to the originals or those paths break.
+  const baseDir = path.dirname(baseConfigPath);
+  const cfg = path.join(
+    baseDir,
+    `rslint.test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+  writeFileSync(cfg, JSON.stringify(merged), 'utf8');
+  // Suppress unused-import warnings for the temp-dir helpers — they are
+  // kept on the imports list to keep the surface stable for future edits
+  // that may need an out-of-tree config (e.g. one that doesn't share the
+  // base config's relative tsconfig references).
+  void mkdtempSync;
+  void tmpdir;
+  return {
+    configPath: cfg,
+    cleanup: () => {
+      try {
+        rmSync(cfg, { force: true });
+      } catch {
+        /* best-effort cleanup; never fail a test on rmdir */
+      }
+    },
+  };
+}
 
 // Port from 'eslint'
 export interface ValidTestCase {
@@ -81,6 +131,8 @@ export class RuleTester {
 
           const options =
             typeof validCase === 'string' ? [] : validCase.options || [];
+          const settings =
+            typeof validCase === 'string' ? undefined : validCase.settings;
           const defaultFilename = 'src/virtual.tsx';
           const filename =
             typeof validCase === 'string'
@@ -88,16 +140,25 @@ export class RuleTester {
               : (validCase.filename ?? defaultFilename);
           const absoluteFilename = path.resolve(import.meta.dirname, filename);
 
-          const diags = await lint({
+          const { configPath, cleanup } = buildConfigForSettings(
             config,
-            workingDirectory: cwd,
-            fileContents: {
-              [absoluteFilename]: code,
-            },
-            ruleOptions: {
-              [ruleName]: options,
-            },
-          });
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
 
           assert(
             diags.diagnostics?.length === 0,
@@ -115,7 +176,7 @@ export class RuleTester {
             assert.fail('Invalid cases must have at least one error');
           }
 
-          const { code, only = false, options = [] } = item;
+          const { code, only = false, options = [], settings } = item;
           if (hasOnly && !only) {
             continue;
           }
@@ -125,16 +186,25 @@ export class RuleTester {
               ? defaultFilename
               : (item.filename ?? defaultFilename);
           const absoluteFilename = path.resolve(import.meta.dirname, filename);
-          const diags = await lint({
+          const { configPath, cleanup } = buildConfigForSettings(
             config,
-            workingDirectory: cwd,
-            fileContents: {
-              [absoluteFilename]: code,
-            },
-            ruleOptions: {
-              [ruleName]: options,
-            },
-          });
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
 
           if (typeof item.errors === 'number') {
             if (item.errors === 0) {

--- a/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unstable-nested-components.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react/rules/no-unstable-nested-components.test.ts
@@ -1,0 +1,391 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+// Message constants mirror eslint-plugin-react v7.37.x byte-for-byte,
+// including the typographic apostrophe (U+2019) and double quotation
+// marks (U+201C / U+201D) around the parent name.
+const ERROR_MESSAGE =
+  'Do not define components during render. React will see a new component type on every render and destroy the entire subtree’s DOM nodes and state (https://reactjs.org/docs/reconciliation.html#elements-of-different-types). Instead, move this component definition out of the parent component “ParentComponent” and pass data as props.';
+const ERROR_MESSAGE_WITHOUT_NAME =
+  'Do not define components during render. React will see a new component type on every render and destroy the entire subtree’s DOM nodes and state (https://reactjs.org/docs/reconciliation.html#elements-of-different-types). Instead, move this component definition out of the parent component and pass data as props.';
+const ERROR_MESSAGE_COMPONENT_AS_PROPS =
+  ERROR_MESSAGE +
+  ' If you want to allow component creation in props, set allowAsProps option to true.';
+
+ruleTester.run('no-unstable-nested-components', {} as never, {
+  valid: [
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <div>
+              <OutsideDefinedFunctionComponent />
+            </div>
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent
+              footer={<OutsideDefinedComponent />}
+              header={<div />}
+              />
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <RenderPropComponent>
+              {() => <div />}
+            </RenderPropComponent>
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <RenderPropComponent children={() => <div />} />
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent(props) {
+          return (
+            <ul>
+              {props.items.map(item => (
+                <li key={item.id}>
+                  {item.name}
+                </li>
+              ))}
+            </ul>
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <ComponentWithProps footer={() => <div />} />
+          );
+        }
+      `,
+      options: [{ allowAsProps: true }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <ComponentForProps renderFooter={() => <div />} />
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return <SomeComponent renderers={{ notComponent: () => null }} />;
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent renderers={{ Header: () => <div /> }} />
+          )
+        }
+      `,
+    },
+    // ---- settings.react.pragma override — `Preact.createElement` is
+    // recognized as a JSX-returning call when pragma is configured. The
+    // outer ParentComponent has no nested component definition here, so
+    // the rule stays silent; the assertion is "no false-positive on the
+    // outer createElement call" given the custom pragma. ----
+    {
+      code: `
+        function ParentComponent() {
+          return Preact.createElement(OutsideDefined, null);
+        }
+      `,
+      settings: { react: { pragma: 'Preact' } },
+    },
+    // ---- settings.componentWrapperFunctions (string form) — a top-level
+    // myMemo wrapper has no enclosing component, so it stays valid even
+    // though the wrapper is registered. ----
+    {
+      code: `
+        const TopLevel = myMemo(() => <div />);
+      `,
+      settings: { componentWrapperFunctions: ['myMemo'] },
+    },
+    // ---- settings.componentWrapperFunctions (object form) — same as
+    // above but pragma-qualified. ----
+    {
+      code: `
+        const TopLevel = MyLib.observer(() => <div />);
+      `,
+      settings: {
+        componentWrapperFunctions: [{ property: 'observer', object: 'MyLib' }],
+      },
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return <Table rowRenderer={(rowData) => <Row data={data} />} />
+        }
+      `,
+      options: [{ propNamePattern: '*Renderer' }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent>
+              {
+                thing.match({
+                  renderLoading: () => <div />,
+                  renderSuccess: () => <div />,
+                  renderFailure: () => <div />,
+                })
+              }
+            </SomeComponent>
+          )
+        }
+      `,
+    },
+    {
+      code: `
+        function createTestComponent(props) {
+          return (
+            <div />
+          );
+        }
+      `,
+    },
+    {
+      code: `
+        function ParentComponent() {
+          function getComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              {getComponent()}
+            </div>
+          );
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function ParentComponent() {
+          function UnstableNestedFunctionComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedFunctionComponent />
+            </div>
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          const UnstableNestedVariableComponent = () => {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedVariableComponent />
+            </div>
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+        export default () => {
+          function UnstableNestedFunctionComponent() {
+            return <div />;
+          }
+          return (
+            <div>
+              <UnstableNestedFunctionComponent />
+            </div>
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE_WITHOUT_NAME }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          class UnstableNestedClassComponent extends React.Component {
+            render() {
+              return <div />;
+            }
+          };
+          return (
+            <div>
+              <UnstableNestedClassComponent />
+            </div>
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+        class ParentComponent extends React.Component {
+          render() {
+            class UnstableNestedClassComponent extends React.Component {
+              render() {
+                return <div />;
+              }
+            };
+            return (
+              <div>
+                <UnstableNestedClassComponent />
+              </div>
+            );
+          }
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+        function ComponentWithProps(props) {
+          return <div />;
+        }
+
+        function ParentComponent() {
+          return (
+            <ComponentWithProps footer={() => <div />} />
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE_COMPONENT_AS_PROPS }],
+    },
+    {
+      code: `
+        function ComponentForProps(props) {
+          return <div />;
+        }
+
+        function ParentComponent() {
+          return (
+            <ComponentForProps notPrefixedWithRender={() => <div />} />
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE_COMPONENT_AS_PROPS }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <ComponentForProps someMap={{ Header: () => <div /> }} />
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE_COMPONENT_AS_PROPS }],
+    },
+    // ---- settings.react.pragma override — Preact.createElement
+    // recognized as JSX-returning, so the inner function is detected as
+    // a stateless component and its enclosing ParentComponent is named
+    // in the diagnostic. ----
+    {
+      code: `
+        function ParentComponent() {
+          function UnstableNestedComponent() {
+            return Preact.createElement("div", null);
+          }
+          return <UnstableNestedComponent />;
+        }
+      `,
+      settings: { react: { pragma: 'Preact' } },
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    // ---- settings.componentWrapperFunctions extends defaults — a
+    // user-declared `myMemo(fn)` wrapper inside a component now flags. ----
+    {
+      code: `
+        function ParentComponent() {
+          const Unstable = myMemo(() => <div />);
+          return <Unstable />;
+        }
+      `,
+      settings: { componentWrapperFunctions: ['myMemo'] },
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    // ---- settings.componentWrapperFunctions object form (pragma-qualified). ----
+    {
+      code: `
+        function ParentComponent() {
+          const Unstable = MyLib.observer(() => <div />);
+          return <Unstable />;
+        }
+      `,
+      settings: {
+        componentWrapperFunctions: [{ property: 'observer', object: 'MyLib' }],
+      },
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          const UnstableNestedComponent = React.memo(() => {
+            return <div />;
+          });
+          return (
+            <div>
+              <UnstableNestedComponent />
+            </div>
+          );
+        }
+      `,
+      errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+        function ParentComponent() {
+          return (
+            <SomeComponent>
+              {
+                thing.match({
+                  loading: () => <div />,
+                  success: () => <div />,
+                  failure: () => <div />,
+                })
+              }
+            </SomeComponent>
+          )
+        }
+      `,
+      errors: [
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+      ],
+    },
+  ],
+});

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -265,3 +265,6 @@ disqualifiers
 normalised
 recognised
 unaliased
+metacharacter
+nunc
+forcetypeassert


### PR DESCRIPTION
## Summary

Port the `react/no-unstable-nested-components` rule from eslint-plugin-react v7.37.5.

The rule disallows defining components inside the render of another component — React would see a fresh component type on every render, destroying the subtree's DOM nodes and state. Detection covers FunctionDeclaration / FunctionExpression / ArrowFunction / ClassDeclaration / object-literal shorthand methods, plus memo / forwardRef / configured wrapper calls.

## Related Links

- ESLint rule: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md
- Source code: https://github.com/jsx-eslint/eslint-plugin-react/blob/master/lib/rules/no-unstable-nested-components.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).