### PR TITLE
fix: align `no-redundant-type-constituents` with ESLint implementation

### DIFF
--- a/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
+++ b/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents.go
@@ -45,6 +45,22 @@ func isNodeInsideReturnType(node *ast.Node) bool {
 	return ast.IsFunctionLike(node.Parent)
 }
 
+// Mirrors typescript-eslint `describeLiteralType`: error type with alias drives `errorTypeOverrides`; otherwise treat as plain `any`.
+func errorTypeAliasName(typePart typeFlagsWithNodeOrType) (string, bool) {
+	if typePart.t == nil || !utils.IsIntrinsicErrorType(typePart.t) {
+		return "", false
+	}
+	alias := checker.Type_alias(typePart.t)
+	if alias == nil {
+		return "", false
+	}
+	sym := alias.Symbol()
+	if sym == nil {
+		return "", false
+	}
+	return sym.Name, true
+}
+
 type typeFlagsWithNodeOrType struct {
 	flags checker.TypeFlags
 	// either node or t must be non-nil
@@ -77,15 +93,17 @@ func (t *typeFlagsWithNodeOrType) ToString(typeChecker *checker.Checker) string 
 			switch literal.Kind {
 			case ast.KindTemplateLiteralType, ast.KindNoSubstitutionTemplateLiteral:
 				return "template literal type"
-			case ast.KindStringLiteral, ast.KindNumericLiteral, ast.KindBigIntLiteral:
+			case ast.KindStringLiteral:
+				return fmt.Sprintf("%q", literal.Text())
+			case ast.KindNumericLiteral, ast.KindBigIntLiteral:
 				return literal.Text()
+			case ast.KindTrueKeyword:
+				return "true"
+			case ast.KindFalseKeyword:
+				return "false"
 			}
 		}
 		return "literal type"
-	}
-
-	if utils.IsTypeFlagSet(t.t, checker.TypeFlagsStringLiteral) {
-		return fmt.Sprintf("%q", typeChecker.TypeToString(t.t))
 	}
 
 	return typeChecker.TypeToString(t.t)
@@ -176,11 +194,10 @@ var NoRedundantTypeConstituentsRule = rule.CreateRule(rule.Rule{
 
 			switch typePart.flags {
 			case checker.TypeFlagsAny:
-				typeName := typePart.ToString(ctx.TypeChecker)
-				if typeName == "any" {
-					message = buildOverridesMessage(typeName, "intersection")
+				if aliasName, ok := errorTypeAliasName(typePart); ok {
+					message = buildErrorTypeOverridesMessage(aliasName, "intersection")
 				} else {
-					message = buildErrorTypeOverridesMessage(typeName, "intersection")
+					message = buildOverridesMessage("any", "intersection")
 				}
 			case checker.TypeFlagsNever:
 				message = buildOverridesMessage(typePart.ToString(ctx.TypeChecker), "intersection")
@@ -332,11 +349,10 @@ var NoRedundantTypeConstituentsRule = rule.CreateRule(rule.Rule{
 
 					switch typePart.flags {
 					case checker.TypeFlagsAny:
-						typeName := typePart.ToString(ctx.TypeChecker)
-						if typeName == "any" {
-							message = buildOverridesMessage(typeName, "union")
+						if aliasName, ok := errorTypeAliasName(typePart); ok {
+							message = buildErrorTypeOverridesMessage(aliasName, "union")
 						} else {
-							message = buildErrorTypeOverridesMessage(typeName, "union")
+							message = buildOverridesMessage("any", "union")
 						}
 					case checker.TypeFlagsUnknown:
 						message = buildOverridesMessage(typePart.ToString(ctx.TypeChecker), "union")

--- a/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
+++ b/internal/plugins/typescript/rules/no_redundant_type_constituents/no_redundant_type_constituents_test.go
@@ -649,5 +649,190 @@ func TestNoRedundantTypeConstituentsRule(t *testing.T) {
 				},
 			},
 		},
+		// Message-text assertions — pin exact output against typescript-eslint
+		// reference. These guard rendering of the {{literal}}/{{typeName}}
+		// substitutions (string-literal quoting, alias-name extraction, etc.).
+		{
+			Code: "type T = number | any;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "overrides",
+					Message:   "'any' overrides all other types in this union type.",
+					Column:    19,
+				},
+			},
+		},
+		{
+			Code: `
+        type B = any;
+        type T = B | number;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "overrides",
+					Message:   "'any' overrides all other types in this union type.",
+					Column:    18,
+				},
+			},
+		},
+		{
+			Code: "type ErrorTypes = NotKnown | 0;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "errorTypeOverrides",
+					Message:   "'NotKnown' is an 'error' type that acts as 'any' and overrides all other types in this union type.",
+					Column:    19,
+				},
+			},
+		},
+		{
+			Code: "type ErrorTypes = NotKnown & 0;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "errorTypeOverrides",
+					Message:   "'NotKnown' is an 'error' type that acts as 'any' and overrides all other types in this intersection type.",
+					Column:    19,
+				},
+			},
+		},
+		{
+			Code: "type T = number | unknown;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "overrides",
+					Message:   "'unknown' overrides all other types in this union type.",
+					Column:    19,
+				},
+			},
+		},
+		{
+			Code: "type T = number | never;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "overridden",
+					Message:   "'never' is overridden by other types in this union type.",
+					Column:    19,
+				},
+			},
+		},
+		{
+			Code: "type T = '' | string;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   `"" is overridden by string in this union type.`,
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: `
+        type B = 'b';
+        type T = B | string;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   `"b" is overridden by string in this union type.`,
+					Column:    18,
+				},
+			},
+		},
+		{
+			Code: "type T = 0n | bigint;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   "0n is overridden by bigint in this union type.",
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "type T = -1n | bigint;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   "-1n is overridden by bigint in this union type.",
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "type T = number | 0;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   "0 is overridden by number in this union type.",
+					Column:    19,
+				},
+			},
+		},
+		{
+			Code: "type T = '' & string;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "primitiveOverridden",
+					Message:   `string is overridden by the "" in this intersection type.`,
+					Column:    15,
+				},
+			},
+		},
+		{
+			Code: `
+        type B = '';
+        type T = B & string;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "primitiveOverridden",
+					Message:   `string is overridden by the "" in this intersection type.`,
+					Column:    22,
+				},
+			},
+		},
+		{
+			Code: `
+        type B = -1n;
+        type T = B | bigint;
+      `,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   "-1n is overridden by bigint in this union type.",
+					Column:    18,
+				},
+			},
+		},
+		{
+			Code: "type T = false | boolean;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   "false is overridden by boolean in this union type.",
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "type T = true | boolean;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "literalOverridden",
+					Message:   "true is overridden by boolean in this union type.",
+					Column:    10,
+				},
+			},
+		},
+		{
+			Code: "type T = false & boolean;",
+			Errors: []rule_tester.InvalidTestCaseError{
+				{
+					MessageId: "primitiveOverridden",
+					Message:   "boolean is overridden by the false in this intersection type.",
+					Column:    18,
+				},
+			},
+		},
 	})
 }

--- a/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-redundant-type-constituents.test.ts.snap
+++ b/packages/rslint-test-tools/tests/typescript-eslint/rules/__snapshots__/no-redundant-type-constituents.test.ts.snap
@@ -514,7 +514,7 @@ exports[`no-redundant-type-constituents > invalid 20`] = `
   "code": "type T = '' | string;",
   "diagnostics": [
     {
-      "message": " is overridden by string in this union type.",
+      "message": """ is overridden by string in this union type.",
       "messageId": "literalOverridden",
       "range": {
         "end": {
@@ -543,7 +543,7 @@ exports[`no-redundant-type-constituents > invalid 21`] = `
       ",
   "diagnostics": [
     {
-      "message": ""\\"b\\"" is overridden by string in this union type.",
+      "message": ""b" is overridden by string in this union type.",
       "messageId": "literalOverridden",
       "range": {
         "end": {
@@ -731,7 +731,7 @@ exports[`no-redundant-type-constituents > invalid 28`] = `
       ",
   "diagnostics": [
     {
-      "message": "literal type is overridden by boolean in this union type.",
+      "message": "false is overridden by boolean in this union type.",
       "messageId": "literalOverridden",
       "range": {
         "end": {
@@ -757,7 +757,7 @@ exports[`no-redundant-type-constituents > invalid 29`] = `
   "code": "type T = false | boolean;",
   "diagnostics": [
     {
-      "message": "literal type is overridden by boolean in this union type.",
+      "message": "false is overridden by boolean in this union type.",
       "messageId": "literalOverridden",
       "range": {
         "end": {
@@ -783,7 +783,7 @@ exports[`no-redundant-type-constituents > invalid 30`] = `
   "code": "type T = true | boolean;",
   "diagnostics": [
     {
-      "message": "literal type is overridden by boolean in this union type.",
+      "message": "true is overridden by boolean in this union type.",
       "messageId": "literalOverridden",
       "range": {
         "end": {
@@ -809,7 +809,7 @@ exports[`no-redundant-type-constituents > invalid 31`] = `
   "code": "type T = false & boolean;",
   "diagnostics": [
     {
-      "message": "boolean is overridden by the literal type in this intersection type.",
+      "message": "boolean is overridden by the false in this intersection type.",
       "messageId": "primitiveOverridden",
       "range": {
         "end": {
@@ -893,7 +893,7 @@ exports[`no-redundant-type-constituents > invalid 34`] = `
   "code": "type T = true & boolean;",
   "diagnostics": [
     {
-      "message": "boolean is overridden by the literal type in this intersection type.",
+      "message": "boolean is overridden by the true in this intersection type.",
       "messageId": "primitiveOverridden",
       "range": {
         "end": {
@@ -1156,7 +1156,7 @@ exports[`no-redundant-type-constituents > invalid 44`] = `
   "code": "type T = '' & string;",
   "diagnostics": [
     {
-      "message": "string is overridden by the  in this intersection type.",
+      "message": "string is overridden by the "" in this intersection type.",
       "messageId": "primitiveOverridden",
       "range": {
         "end": {
@@ -1266,7 +1266,7 @@ exports[`no-redundant-type-constituents > invalid 48`] = `
       ",
   "diagnostics": [
     {
-      "message": ""\\"a\\"" | "\\"b\\"" is overridden by the string in this intersection type.",
+      "message": ""a" | "b" is overridden by the string in this intersection type.",
       "messageId": "primitiveOverridden",
       "range": {
         "end": {


### PR DESCRIPTION
## Summary

Aligns `@typescript-eslint/no-redundant-type-constituents` with the typescript-eslint reference implementation by fixing three rendering / classification divergences:

1. **Error-type vs real `any` classification.** The previous implementation used the brittle `TypeToString == "any"` string check to decide between the `errorTypeOverrides` and `overrides` messages. It is now driven by `utils.IsIntrinsicErrorType(t)` plus `checker.Type_alias(t).Symbol().Name`, mirroring typescript-eslint's `describeLiteralType` (`isIntrinsicErrorType(type) && type.aliasSymbol`).
2. **String-literal double-quoting on the type-path.** `TypeChecker.TypeToString` already returns the JSON-quoted form for string-literal types (e.g. `"b"`); the previous code wrapped it again with `%q`, producing `"\"b\""`. The redundant wrapping is removed; the node-path now applies `%q` to the raw `literal.Text()`.
3. **Boolean literal rendering.** Node-path rendering of `KindTrueKeyword` / `KindFalseKeyword` was missing, so `false`/`true` fell through to the `"literal type"` placeholder. Added the two missing branches.

Verified end-to-end against typescript-eslint:

- All Go unit tests pass (existing 60+ cases plus added message-text assertions covering string/bigint/boolean literals and error-type cases).
- typescript-eslint fixture suite passes (snapshots updated).
- Real-project diff on rsbuild + rspack: 2 reports + 0 reports respectively, message text and locations identical to original ESLint.

## Related Links

N/A

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).