### PR TITLE
fix(no-unused-vars): drop property-name positions from unresolved-ref fallback

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1300,6 +1300,69 @@ func removeSpecifierWithComma(file *ast.SourceFile, specNode *ast.Node) rule.Rul
 	return rule.RuleFixRemoveRange(specNode.Loc.WithPos(textStart).WithEnd(end))
 }
 
+// isPropertyNameLikePosition reports whether an identifier appears in a syntactic
+// position where it names a property/label/attribute rather than referring to a
+// declared value or type. Such identifiers must NOT be added to `unresolvedRefs`
+// even when the type checker fails to resolve them — otherwise the name-based
+// fallback in processVariable will mistake them for usages of an unrelated
+// same-named local variable (e.g. `obj.name` polluting the lookup of an unused
+// local `const name`). See gap-rules report Cases 3/4/5 for `name`,
+// `deployConfigSource`, `isTikTokBiz` on `any`-typed receivers.
+func isPropertyNameLikePosition(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindPropertyAccessExpression:
+		// `obj.name` — node is the `.name` part on the right.
+		pae := parent.AsPropertyAccessExpression()
+		return pae != nil && pae.Name() == node
+	case ast.KindQualifiedName:
+		// `Foo.Bar` in type position — node is the `.Bar` part on the right.
+		qn := parent.AsQualifiedName()
+		return qn != nil && qn.Right == node
+	case ast.KindPropertyAssignment:
+		// `{ name: value }` in object literal — node is the property key.
+		pa := parent.AsPropertyAssignment()
+		return pa != nil && pa.Name() == node
+	case ast.KindBindingElement:
+		// `const { name: alias } = obj` — node is the source property name.
+		// The destination `alias` is a declaration name (handled separately).
+		be := parent.AsBindingElement()
+		return be != nil && be.PropertyName != nil && be.PropertyName == node
+	case ast.KindImportSpecifier:
+		// `import { name as alias } from 'mod'` — node is the source export
+		// name (PropertyName), which references the module's exported binding,
+		// not any in-scope variable. When the module is unresolvable the symbol
+		// lookup fails and would otherwise pollute unresolvedRefs[name].
+		is := parent.AsImportSpecifier()
+		return is != nil && is.PropertyName != nil && is.PropertyName == node
+	case ast.KindExportSpecifier:
+		// `export { name as alias } from 'mod'` (or non-from form) — node is
+		// the source binding name on the LHS of `as`. Same rationale as
+		// ImportSpecifier above.
+		es := parent.AsExportSpecifier()
+		return es != nil && es.PropertyName != nil && es.PropertyName == node
+	case ast.KindJsxAttribute:
+		// `<X name="..." />` — node is the attribute name.
+		attr := parent.AsJsxAttribute()
+		return attr != nil && attr.Name() == node
+	case ast.KindLabeledStatement:
+		// `name: while(...)` — label declaration, not a value reference.
+		ls := parent.AsLabeledStatement()
+		return ls != nil && ls.Label == node
+	case ast.KindBreakStatement, ast.KindContinueStatement:
+		// `break name` / `continue name` — label reference (separate namespace).
+		return true
+	case ast.KindMetaProperty:
+		// `new.target` / `import.meta` — node is the keyword.name.
+		mp := parent.AsMetaProperty()
+		return mp != nil && mp.Name() == node
+	}
+	return false
+}
+
 // collectSymbolUsages walks the entire source file AST and collects:
 //   - usages: maps each symbol to its usage reference nodes (read references)
 //   - writeRefs: maps each symbol to its write-only reference nodes (assignments)
@@ -1347,9 +1410,19 @@ func collectSymbolUsages(ctx rule.RuleContext, sourceFile *ast.Node, usages map[
 				if resolved != sym {
 					usages[resolved] = append(usages[resolved], node)
 				}
-			} else {
-				// Symbol not resolved (e.g., empty namespace references).
-				// Track by name for fallback matching in processVariable.
+			} else if !isPropertyNameLikePosition(node) {
+				// TypeChecker is the source of truth; this branch is only a
+				// narrow fallback for residual cases where GetSymbolAtLocation
+				// returns nil but the identifier IS a value/type reference
+				// (e.g., empty namespaces — see TestNoUnusedVarsPatterns'
+				// `namespace _Foo {} export const x = _Foo;` invalid case,
+				// which still depends on the name-based lookup).
+				//
+				// Identifiers in pure property/label/attribute positions can
+				// never refer to a top-level declared symbol, so excluding
+				// them here prevents `obj.name` (any-typed) from polluting
+				// the lookup of an unused local `name`. See gap-rules report
+				// Cases 3/4/5.
 				idText := node.AsIdentifier().Text
 				unresolvedRefs[idText] = append(unresolvedRefs[idText], node)
 			}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_patterns_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_patterns_test.go
@@ -395,6 +395,173 @@ class Foo {
 			Code:   `const { foo, ...rest } = { foo: 1, bar: 2 }; console.log(rest);`,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 9}},
 		},
+
+		// ====================================================================
+		// Real-world regression cases from the portal lint-migration gap doc
+		// (@typescript-eslint/no-unused-vars). Each case is a minimal slice of a
+		// production file where rslint previously diverged from ESLint. They
+		// guard against:
+		//   (a) the name-fallback bucket being polluted by same-named property
+		//       accesses on `any` / unresolvable types — gap doc Cases 3/4/5;
+		//   (b) ImportSpecifier / ExportSpecifier `PropertyName` from
+		//       unresolvable modules causing the same pollution.
+		// Configs mirror what the portal subspaces actually use.
+		// ====================================================================
+
+		// Case 1 (agents-server): `_tail` is a renamed property in object
+		// destructuring with rest sibling. Under that subspace's effective
+		// config (no varsIgnorePattern), argsIgnorePattern does NOT apply to
+		// a `const` destructuring → ESLint reports `_tail`.
+		{
+			Code: `function f(params: any) {
+  if (params.head !== undefined && params.tail !== undefined) {
+    const { tail: _tail, ...rest } = params;
+    return rest;
+  }
+  return params;
+}
+export { f };`,
+			Options: map[string]interface{}{
+				"args":              "none",
+				"argsIgnorePattern": "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 19},
+			},
+		},
+
+		// Case 2 (operator-toolkit): unused type parameter `T` on an exported
+		// interface (does not match `^_|React`).
+		{
+			Code: `export interface RpcResponse<T = unknown> {
+  code?: number;
+  message?: string;
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 1, Column: 30},
+			},
+		},
+
+		// Case 3 (server/.../trigger.ts:723): object destructuring; `name` is
+		// unused, siblings are used. Includes the polluting `obj.name` accesses
+		// on an `any`-typed receiver that previously masked the report.
+		{
+			Code: `interface Trigger { id: string; projectId: string; name: string; rule: string; type: string; }
+declare const externalAny: any;
+export function pollute(triggers: Trigger[]): void {
+  console.log(externalAny.name, externalAny.name);
+  for (const trigger of triggers) {
+    const { id, projectId, name, rule, type } = trigger;
+    console.log(id, projectId, rule, type);
+  }
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 6, Column: 28},
+			},
+		},
+
+		// Case 4 (server/.../goofyDeployChannelNode.ts:92): destructured
+		// `deployConfigSource` shadowed by many polluting `obj.deployConfigSource`
+		// accesses elsewhere in the file. Same root cause as Case 3.
+		{
+			Code: `type Meta = { id: string; region: string; appName: string; vRegion: string; deployConfigSource: string };
+export function process(item: any) {
+  const getMetaInfo = (i: any): Meta => i as Meta;
+  const { id, region, appName, vRegion, deployConfigSource } = getMetaInfo(item);
+  console.log(id, region, appName, vRegion);
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 4, Column: 41},
+			},
+		},
+
+		// Case 5 (server/.../scm-params.ts:93): `const isTikTokBiz =
+		// project.features?.isTikTokBiz` — the same-named PropertyAccess on
+		// `any`-resolved features previously fell through to unresolvedRefs and
+		// falsely "used" the const.
+		{
+			Code: `declare const project: any;
+export function getCfg(): boolean {
+  const isTikTokBiz = project.features?.isTikTokBiz ?? true;
+  return true;
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Edge A: ImportSpecifier.PropertyName from an unresolvable module.
+		// The `name` on the LHS of `as` references the module's exported
+		// binding which is nil when the module cannot be resolved. It must
+		// NOT be added to unresolvedRefs to falsely "use" the local `name`.
+		{
+			Code: `import { name as alias } from './does-not-exist';
+function foo(): number {
+  const name = 1;
+  return alias as unknown as number;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Edge B: ExportSpecifier.PropertyName in a re-export from an
+		// unresolvable module. Same fallback-pollution pattern as Edge A.
+		{
+			Code: `export { name as renamed } from './does-not-exist';
+function foo(): number {
+  const name = 1;
+  return 0;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Edge C: enum member name with a same-named unused local.
+		// EnumMember.Name is a declaration name (handled by isDeclarationName);
+		// this guards against future regressions in that classification.
+		{
+			Code: `export enum E { name = 1 }
+function foo(): number {
+  const name = 1;
+  return E.name;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
 	}
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-unused-vars` was missing legitimate unused-variable reports whenever the same identifier name appeared in a syntactic position that is not a value/type reference (most commonly `obj.name` on an `any`-typed receiver). Those identifiers were being added to the name-keyed `unresolvedRefs` fallback bucket inside `collectSymbolUsages`, and a same-named local would then look up that bucket and treat them as "uses".

This PR introduces `isPropertyNameLikePosition` and uses it to gate population of `unresolvedRefs`. The TypeChecker remains the primary source for symbol resolution; the fallback is preserved for the original cases it was added for (e.g. empty namespaces — `namespace _Foo {}; export const x = _Foo;`), but it no longer accepts identifiers whose syntactic position can never reference a declared symbol:

- `PropertyAccessExpression.Name` — `obj.name`
- `QualifiedName.Right` — `Foo.Bar` in type positions
- `PropertyAssignment.Name` — `{ name: value }` keys
- `BindingElement.PropertyName` — `const { name: alias } = obj`
- `ImportSpecifier.PropertyName` — `import { name as alias } from 'mod'`
- `ExportSpecifier.PropertyName` — `export { name as alias } from 'mod'`
- `JsxAttribute.Name` — `<X name="..." />`
- `LabeledStatement.Label` / `BreakStatement.Label` / `ContinueStatement.Label`
- `MetaProperty.Name` — `new.target` / `import.meta`

8 new invalid test cases are added to `TestNoUnusedVarsPatterns` covering: the 5 real-world cases from a portal `lint-migration` gap report (one of which is a config mismatch and intentionally remains the exclusive ESLint-only report), plus the import/export specifier and enum-member edge cases.

End-to-end verified by re-running the gap comparator on the portal monorepo (with the patched binary): ESLint-only gaps for `@typescript-eslint/no-unused-vars` drop from **5 → 1**, rslint-only stays at **0**, total reports change from 267 → 271. Spot-checked on `webinfra/rsbuild` (clean → 0 reports under the project's actual config; force-enabled probe surfaces only `^_`-prefixed names already handled by the standard ignore pattern) and `webinfra/rspack` (rule disabled in project config; force-enabled probe yields only correct `^_` names plus 2 accurate `usedOnlyAsType` reports).

## Related Links

- Reproduces / closes: portal `lint-migration/gap-rules/_typescript-eslint_no-unused-vars.md`

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).