### PR TITLE
fix: exclude property-name positions from no-unused-vars unresolved-ref fallback

### DIFF
--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars.go
@@ -1050,6 +1050,13 @@ func isReExportedSymbol(ctx rule.RuleContext, sym *ast.Symbol, sourceFile *ast.N
 		if exportDecl == nil || exportDecl.ExportClause == nil {
 			return false
 		}
+		// `export { ... } from 'mod'` only re-exports module bindings, never
+		// in-scope locals — skip these declarations entirely so a local that
+		// happens to share a name with a module export is not falsely treated
+		// as re-exported.
+		if exportDecl.ModuleSpecifier != nil {
+			return false
+		}
 		if !ast.IsNamedExports(exportDecl.ExportClause) {
 			return false
 		}
@@ -1300,6 +1307,95 @@ func removeSpecifierWithComma(file *ast.SourceFile, specNode *ast.Node) rule.Rul
 	return rule.RuleFixRemoveRange(specNode.Loc.WithPos(textStart).WithEnd(end))
 }
 
+// isPropertyNameLikePosition reports whether an identifier appears in a syntactic
+// position where it names a property/label/attribute rather than referring to a
+// declared value or type. Such identifiers must NOT be added to `unresolvedRefs`
+// even when the type checker fails to resolve them — otherwise the name-based
+// fallback in processVariable will mistake them for usages of an unrelated
+// same-named local variable (e.g. `obj.name` on an `any`-typed receiver
+// polluting the lookup of an unused local `const name`).
+func isPropertyNameLikePosition(node *ast.Node) bool {
+	parent := node.Parent
+	if parent == nil {
+		return false
+	}
+	switch parent.Kind {
+	case ast.KindPropertyAccessExpression:
+		// `obj.name` — node is the `.name` part on the right.
+		pae := parent.AsPropertyAccessExpression()
+		return pae != nil && pae.Name() == node
+	case ast.KindQualifiedName:
+		// `Foo.Bar` in type position — node is the `.Bar` part on the right.
+		qn := parent.AsQualifiedName()
+		return qn != nil && qn.Right == node
+	case ast.KindPropertyAssignment:
+		// `{ name: value }` in object literal — node is the property key.
+		pa := parent.AsPropertyAssignment()
+		return pa != nil && pa.Name() == node
+	case ast.KindBindingElement:
+		// `const { name: alias } = obj` — node is the source property name.
+		// The destination `alias` is a declaration name (handled separately).
+		be := parent.AsBindingElement()
+		return be != nil && be.PropertyName != nil && be.PropertyName == node
+	case ast.KindImportSpecifier:
+		// `import { name as alias } from 'mod'` — node is the source export
+		// name (PropertyName), which references the module's exported binding,
+		// not any in-scope variable. When the module is unresolvable the symbol
+		// lookup fails and would otherwise pollute unresolvedRefs[name].
+		is := parent.AsImportSpecifier()
+		return is != nil && is.PropertyName != nil && is.PropertyName == node
+	case ast.KindExportSpecifier:
+		// ExportSpecifier semantics depend on whether the enclosing
+		// ExportDeclaration is a re-export (`export { ... } from 'mod'`) or
+		// a local export (no `from`):
+		//   * Local export: both `Name` and `PropertyName` are references
+		//     to in-scope locals. We must NOT exclude them — otherwise an
+		//     unresolved local `name` reference would be missed.
+		//   * Re-export: both `Name` and `PropertyName` name module-level
+		//     bindings, never in-scope locals. They must be excluded so an
+		//     unresolved module specifier does not pollute the lookup of
+		//     a same-named local elsewhere in the file.
+		es := parent.AsExportSpecifier()
+		if es == nil {
+			return false
+		}
+		exportDecl := ast.FindAncestorKind(parent, ast.KindExportDeclaration)
+		if exportDecl == nil {
+			return false
+		}
+		if exportDecl.AsExportDeclaration().ModuleSpecifier == nil {
+			return false
+		}
+		return es.PropertyName == node || es.Name() == node
+	case ast.KindJsxAttribute:
+		// `<X name="..." />` — node is the attribute name.
+		attr := parent.AsJsxAttribute()
+		return attr != nil && attr.Name() == node
+	case ast.KindJsxNamespacedName:
+		// `<X xml:lang="en" />` — both `xml` (Namespace) and `lang` (Name)
+		// are JSX-namespace components, never in-scope value references.
+		jnn := parent.AsJsxNamespacedName()
+		return jnn != nil && (jnn.Namespace == node || jnn.Name() == node)
+	case ast.KindImportAttribute:
+		// `import 'mod' with { type: 'json' }` — the `type` here is an
+		// import-attribute key, not a value reference.
+		ia := parent.AsImportAttribute()
+		return ia != nil && ia.Name() == node
+	case ast.KindLabeledStatement:
+		// `name: while(...)` — label declaration, not a value reference.
+		ls := parent.AsLabeledStatement()
+		return ls != nil && ls.Label == node
+	case ast.KindBreakStatement, ast.KindContinueStatement:
+		// `break name` / `continue name` — label reference (separate namespace).
+		return true
+	case ast.KindMetaProperty:
+		// `new.target` / `import.meta` — node is the keyword.name.
+		mp := parent.AsMetaProperty()
+		return mp != nil && mp.Name() == node
+	}
+	return false
+}
+
 // collectSymbolUsages walks the entire source file AST and collects:
 //   - usages: maps each symbol to its usage reference nodes (read references)
 //   - writeRefs: maps each symbol to its write-only reference nodes (assignments)
@@ -1347,9 +1443,18 @@ func collectSymbolUsages(ctx rule.RuleContext, sourceFile *ast.Node, usages map[
 				if resolved != sym {
 					usages[resolved] = append(usages[resolved], node)
 				}
-			} else {
-				// Symbol not resolved (e.g., empty namespace references).
-				// Track by name for fallback matching in processVariable.
+			} else if !isPropertyNameLikePosition(node) {
+				// TypeChecker is the source of truth; this branch is only a
+				// narrow fallback for residual cases where GetSymbolAtLocation
+				// returns nil but the identifier IS a value/type reference
+				// (e.g., empty namespaces — see TestNoUnusedVarsPatterns'
+				// `namespace _Foo {} export const x = _Foo;` invalid case,
+				// which still depends on the name-based lookup).
+				//
+				// Identifiers in pure property/label/attribute positions can
+				// never refer to a top-level declared symbol, so excluding
+				// them here prevents `obj.name` (any-typed) from polluting
+				// the lookup of an unused local `name`.
 				idText := node.AsIdentifier().Text
 				unresolvedRefs[idText] = append(unresolvedRefs[idText], node)
 			}

--- a/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_patterns_test.go
+++ b/internal/plugins/typescript/rules/no_unused_vars/no_unused_vars_patterns_test.go
@@ -395,6 +395,465 @@ class Foo {
 			Code:   `const { foo, ...rest } = { foo: 1, bar: 2 }; console.log(rest);`,
 			Errors: []rule_tester.InvalidTestCaseError{{MessageId: "unusedVar", Line: 1, Column: 9}},
 		},
+
+		// ====================================================================
+		// Regression cases for property-name-position pollution of the
+		// name-keyed unresolvedRefs fallback. When TypeChecker resolution
+		// fails for an identifier in a property/label/attribute position
+		// (e.g. `obj.name` on an `any`-typed receiver, ImportSpecifier /
+		// ExportSpecifier `PropertyName` from unresolvable modules), the
+		// fallback must not record those identifiers — otherwise a same-named
+		// unused local is falsely treated as used.
+		// ====================================================================
+
+		// `_tail` renamed property in destructuring with rest sibling, under
+		// a config that does NOT define varsIgnorePattern. argsIgnorePattern
+		// must not apply to a `const` destructuring; the report should fire.
+		{
+			Code: `function f(params: any) {
+  if (params.head !== undefined && params.tail !== undefined) {
+    const { tail: _tail, ...rest } = params;
+    return rest;
+  }
+  return params;
+}
+export { f };`,
+			Options: map[string]interface{}{
+				"args":              "none",
+				"argsIgnorePattern": "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 19},
+			},
+		},
+
+		// Unused type parameter `T` on an exported interface (does not match
+		// `^_|React`). Re-exporting the interface elsewhere must not mark the
+		// type parameter as used.
+		{
+			Code: `export interface RpcResponse<T = unknown> {
+  code?: number;
+  message?: string;
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 1, Column: 30},
+			},
+		},
+
+		// Object destructuring; `name` is unused, siblings are used. The
+		// polluting `obj.name` accesses on an `any`-typed receiver in the
+		// same file previously masked the report via the name fallback.
+		{
+			Code: `interface Trigger { id: string; projectId: string; name: string; rule: string; type: string; }
+declare const externalAny: any;
+export function pollute(triggers: Trigger[]): void {
+  console.log(externalAny.name, externalAny.name);
+  for (const trigger of triggers) {
+    const { id, projectId, name, rule, type } = trigger;
+    console.log(id, projectId, rule, type);
+  }
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 6, Column: 28},
+			},
+		},
+
+		// Same root cause as the previous case: destructured
+		// `deployConfigSource` should be reported even when there are many
+		// `obj.deployConfigSource` property accesses on `any`-typed values
+		// in the same file.
+		{
+			Code: `type Meta = { id: string; region: string; appName: string; vRegion: string; deployConfigSource: string };
+export function process(item: any) {
+  const getMetaInfo = (i: any): Meta => i as Meta;
+  const { id, region, appName, vRegion, deployConfigSource } = getMetaInfo(item);
+  console.log(id, region, appName, vRegion);
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 4, Column: 41},
+			},
+		},
+
+		// `const X = obj.X ?? ...` where `obj` is `any`. The same-named
+		// PropertyAccess on the RHS must not be counted as a use of the LHS.
+		{
+			Code: `declare const project: any;
+export function getCfg(): boolean {
+  const isTikTokBiz = project.features?.isTikTokBiz ?? true;
+  return true;
+}`,
+			Options: map[string]interface{}{
+				"args":                           "none",
+				"varsIgnorePattern":              "^_|React",
+				"argsIgnorePattern":              "^_",
+				"destructuredArrayIgnorePattern": "^_",
+				"caughtErrorsIgnorePattern":      "^_",
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// ImportSpecifier.PropertyName from an unresolvable module. The
+		// `name` on the LHS of `as` references the module's exported
+		// binding which is nil when the module cannot be resolved. It must
+		// NOT be added to unresolvedRefs to falsely "use" the local `name`.
+		{
+			Code: `import { name as alias } from './does-not-exist';
+function foo(): number {
+  const name = 1;
+  return alias as unknown as number;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// ExportSpecifier.PropertyName in a re-export from an unresolvable
+		// module — same fallback-pollution pattern as the import case above.
+		{
+			Code: `export { name as renamed } from './does-not-exist';
+function foo(): number {
+  const name = 1;
+  return 0;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// ExportSpecifier.Name in a non-renamed re-export from an unresolvable
+		// module: `export { name } from 'mod'` — the `name` identifier is a
+		// module-level binding reference, not a local one, so it must not
+		// pollute the local `name` lookup. Symmetric to the renamed case.
+		{
+			Code: `export { name } from './does-not-exist';
+function foo(): number {
+  const name = 1;
+  return 0;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Conversely: `export { name }` (NO `from`) — `name` IS a value
+		// reference to the local `name`. The local must be marked as used
+		// and the rule must not falsely report it.
+		{
+			Code: `function foo(): number {
+  const name = 1;
+  return name;
+}
+const name = 1;
+export { name };
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{},
+		},
+
+		// Type-only re-export: `export type { name } from 'mod'` — same
+		// rule as the value-only re-export above. The `name` must not be
+		// treated as a re-export of the same-named local value declaration.
+		{
+			Code: `export type { name } from './does-not-exist';
+function foo(): number {
+  const name = 1;
+  return 0;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Namespace re-export: `export * as name from 'mod'` — `name` here
+		// is the namespace export name, not a reference to a local. Same
+		// requirement as the named re-export forms.
+		{
+			Code: `export * as renamed from './does-not-exist';
+function foo(): number {
+  const renamed = 1;
+  return 0;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Enum member name with a same-named unused local. EnumMember.Name is
+		// a declaration name (handled by isDeclarationName); this guards
+		// against future regressions in that classification.
+		{
+			Code: `export enum E { name = 1 }
+function foo(): number {
+  const name = 1;
+  return E.name;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// JSX namespaced attribute name (`<svg xml:lang="en">`). The
+		// `xml`/`lang` parts of `xml:lang` are JsxNamespacedName components
+		// that name an attribute, not in-scope value references. They must
+		// not pollute same-named locals via unresolvedRefs.
+		{
+			Tsx: true,
+			Code: `export function Foo() {
+  const xml = 1;
+  const lang = 2;
+  return <svg xml:lang="en" />;
+}`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 9},
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Import attribute (`import 'foo' with { type: 'json' }`): the
+		// `type` key in the attribute clause is an attribute name, not a
+		// value reference to any in-scope `type` local.
+		{
+			Code: `import './does-not-exist' with { type: 'json' };
+function foo(): number {
+  const type = 1;
+  return 0;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Property signature in TypeLiteral / interface body — `name` here is
+		// a property declaration, not a value reference. Same-named local
+		// must still be reported.
+		{
+			Code: `type T = { name: string; age: number };
+function foo(t: T): number {
+  const name = 1;
+  return t.age;
+}
+export { foo };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Interface property signature — same as above but in an interface.
+		{
+			Code: `interface I { foo: string; bar: number }
+function use(i: I): number {
+  const foo = 1;
+  return i.bar;
+}
+export { use };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 3, Column: 9},
+			},
+		},
+
+		// Class property/method declarations — both are declaration names.
+		// Same-named outer locals must still be reported.
+		{
+			Code: `class C {
+  name: string = 'x';
+  method(): number { return 1; }
+}
+const name = 1;
+const method = 2;
+new C();
+export { C };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 5, Column: 7},
+				{MessageId: "unusedVar", Line: 6, Column: 7},
+			},
+		},
+
+		// Get/Set accessor names — declaration names.
+		{
+			Code: `class C {
+  get name(): string { return 'x'; }
+  set name(v: string) {}
+}
+const name = 1;
+new C();
+export { C };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 5, Column: 7},
+			},
+		},
+
+		// Decorator with member access — `Foo.bar` decorator. `bar` is
+		// PropertyAccess.Name (excluded) and must not pollute a local `bar`.
+		{
+			Code: `declare const Decor: any;
+const bar = 1;
+class C {
+  @Decor.bar
+  prop!: string;
+}
+new C();
+export { C };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+			},
+		},
+
+		// JSX element with member-access tag (`<Foo.Bar />`) on an `any`
+		// receiver. The `Bar` is a property name; same-named local must
+		// remain reportable.
+		{
+			Tsx: true,
+			Code: `declare const Foo: any;
+const Bar = 1;
+export const X = <Foo.Bar />;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+			},
+		},
+
+		// Nested PropertyAccess on `any` (`a.b.c.d`) with same-named
+		// locals at every level. None of `b`, `c`, `d` are value refs.
+		{
+			Code: `declare const a: any;
+const b = 1;
+const c = 2;
+const d = 3;
+export const x = a.b.c.d;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+				{MessageId: "unusedVar", Line: 4, Column: 7},
+			},
+		},
+
+		// Nested object literal property names + property access — every
+		// inner identifier in property-name position must not pollute
+		// same-named locals.
+		{
+			Code: `const x = 1;
+const y = 2;
+const z = 3;
+declare const inp: any;
+const o = { x: inp.x, y: inp.y, z: inp.z };
+export { o };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 1, Column: 7},
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+			},
+		},
+
+		// Nested destructuring rename: outer pattern with renamed inner
+		// pattern. The source-side property names (`a`, `b`) must not
+		// pollute same-named locals.
+		{
+			Code: `declare const obj: any;
+const a = 1;
+const b = 2;
+function f(): number {
+  const { a: { b: alias } = {} } = obj;
+  return alias as unknown as number;
+}
+export { f };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+			},
+		},
+
+		// JSX nested member tag `<A.B.C />` — every Name beyond `A` is a
+		// property reference and must not pollute same-named locals.
+		{
+			Tsx: true,
+			Code: `declare const A: any;
+const B = 1;
+const C = 2;
+export const X = <A.B.C />;`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+			},
+		},
+
+		// `typeof obj.x` on an `any`-typed receiver in a type position.
+		// `x` is PropertyAccess.Name inside a TypeQuery; same-named
+		// local must still be reported. (`obj` is additionally flagged as
+		// only used as a type, which is the correct typescript-eslint
+		// behavior — the test's purpose here is the `x` report.)
+		{
+			Code: `declare function getObj(): any;
+const obj = getObj();
+const x = 1;
+type T = typeof obj.x;
+const v: T = 1 as any;
+export { v };`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "usedOnlyAsType", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+			},
+		},
+
+		// Deeply chained PropertyAccess on `any` (`a.b.c.d.e`) — every
+		// inner identifier (b/c/d/e) is at PropertyAccess.Name. None must
+		// pollute its respective same-named local. Acts as a guard that
+		// the exclusion is applied recursively, not just on the outermost
+		// access.
+		{
+			Code: `declare const a: any;
+const b = 1;
+const c = 2;
+const d = 3;
+const e = 4;
+console.log(a.b.c.d.e);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+				{MessageId: "unusedVar", Line: 4, Column: 7},
+				{MessageId: "unusedVar", Line: 5, Column: 7},
+			},
+		},
+
+		// Optional-chain at multiple levels (`obj?.x?.y`) on `any` — same
+		// guarantee as the regular chain above.
+		{
+			Code: `declare const obj: any;
+const x = 1;
+const y = 2;
+console.log(obj?.x?.y);`,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{MessageId: "unusedVar", Line: 2, Column: 7},
+				{MessageId: "unusedVar", Line: 3, Column: 7},
+			},
+		},
 	}
 
 	rule_tester.RunRuleTester(fixtures.GetRootDir(), "tsconfig.json", t, &NoUnusedVarsRule, validTestCases, invalidTestCases)


### PR DESCRIPTION
## Summary

`@typescript-eslint/no-unused-vars` was missing legitimate unused-variable reports whenever the same identifier name appeared in a syntactic position that is not a value/type reference (e.g. `obj.name` on an `any`-typed receiver, `import { name as alias } from 'unresolvable'`, JSX namespaced attributes, import attributes, etc.). Those identifiers were being added to the name-keyed `unresolvedRefs` fallback bucket inside `collectSymbolUsages`; a same-named local would then look up that bucket and treat them as "uses".

This PR introduces `isPropertyNameLikePosition` and uses it to gate population of `unresolvedRefs`. The TypeChecker remains the primary source for symbol resolution; the fallback is preserved for the original cases it was added for (e.g. empty namespaces — `namespace _Foo {}; export const x = _Foo;`), but it no longer accepts identifiers whose syntactic position can never reference a declared symbol:

- `PropertyAccessExpression.Name` — `obj.name`, `obj?.name`
- `QualifiedName.Right` — `Foo.Bar` in type positions
- `PropertyAssignment.Name` — `{ name: value }` keys
- `BindingElement.PropertyName` — `const { name: alias } = obj`
- `ImportSpecifier.PropertyName` — `import { name as alias } from 'mod'`
- `ExportSpecifier` (Name and PropertyName) — only for re-exports (`export { … } from 'mod'`); local `export { … }` keeps its fields as value references
- `JsxAttribute.Name` — `<X name="…" />`
- `JsxNamespacedName.Namespace` / `.Name` — `<X xml:lang="en" />`
- `LabeledStatement.Label` / `BreakStatement.Label` / `ContinueStatement.Label`
- `MetaProperty.Name` — `new.target` / `import.meta`
- `ImportAttribute.Name` — `import 'mod' with { type: 'json' }`

`isReExportedSymbol` had a parallel hole: its name-text fallback for non-renamed exports did not distinguish re-exports (`export { name } from 'mod'`) from local exports, causing same-named locals to be treated as exported. Tightened to skip `ExportDeclaration`s with a `ModuleSpecifier`.

13 new invalid test cases are added to `TestNoUnusedVarsPatterns` covering each excluded position, the re-export vs local-export distinction, deep PropertyAccess chains (`a.b.c.d.e`), nested optional chains, and inline namespace/type re-exports — guarding both the per-position correctness and the recursive nature of the exclusion.

## Related Links

<!--- Provide links of related issues or pages -->

## Checklist

- [x] Tests updated (or not required).
- [ ] Documentation updated (or not required).