### PR TITLE
feat: port rule react-hooks/rules-of-hooks

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	jestPlugin "github.com/web-infra-dev/rslint/internal/plugins/jest"
 	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
+	reactHooksPlugin "github.com/web-infra-dev/rslint/internal/plugins/react_hooks"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/adjacent_overload_signatures"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/array_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/await_thenable"
@@ -367,6 +368,11 @@ var KnownPlugins = []PluginInfo{
 		DeclNames:   []string{"react"},
 		getAllRules: func() []rule.Rule { return reactPlugin.GetAllRules() },
 	},
+	{
+		RulePrefix:  "react-hooks",
+		DeclNames:   []string{"eslint-plugin-react-hooks", "react-hooks"},
+		getAllRules: func() []rule.Rule { return reactHooksPlugin.GetAllRules() },
+	},
 }
 
 // pluginByDeclName is a lookup table built from KnownPlugins: declaration name → *PluginInfo.
@@ -434,6 +440,7 @@ func RegisterAllRules() {
 		registerAllTypeScriptEslintPluginRules()
 		registerAllEslintImportPluginRules()
 		registerAllReactPluginRules()
+		registerAllReactHooksPluginRules()
 		registerAllJestPluginRules()
 		registerAllPromisePluginRules()
 		registerAllCoreEslintRules()
@@ -442,6 +449,12 @@ func RegisterAllRules() {
 
 func registerAllReactPluginRules() {
 	for _, rule := range reactPlugin.GetAllRules() {
+		GlobalRuleRegistry.Register(rule.Name, rule)
+	}
+}
+
+func registerAllReactHooksPluginRules() {
+	for _, rule := range reactHooksPlugin.GetAllRules() {
 		GlobalRuleRegistry.Register(rule.Name, rule)
 	}
 }

--- a/internal/plugins/react_hooks/all.go
+++ b/internal/plugins/react_hooks/all.go
@@ -1,0 +1,12 @@
+package react_hooks
+
+import (
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/rules_of_hooks"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func GetAllRules() []rule.Rule {
+	return []rule.Rule{
+		rules_of_hooks.RulesOfHooksRule,
+	}
+}

--- a/internal/plugins/react_hooks/plugin.go
+++ b/internal/plugins/react_hooks/plugin.go
@@ -1,0 +1,3 @@
+package react_hooks
+
+const PLUGIN_NAME = "eslint-plugin-react-hooks"

--- a/internal/plugins/react_hooks/rules/fixtures/file.ts
+++ b/internal/plugins/react_hooks/rules/fixtures/file.ts
@@ -1,0 +1,2 @@
+// placeholder file referenced by tsconfig.json
+export {};

--- a/internal/plugins/react_hooks/rules/fixtures/fixtures.go
+++ b/internal/plugins/react_hooks/rules/fixtures/fixtures.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"path"
+	"runtime"
+)
+
+func GetRootDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return path.Dir(filename)
+}

--- a/internal/plugins/react_hooks/rules/fixtures/tsconfig.json
+++ b/internal/plugins/react_hooks/rules/fixtures/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": false,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext", "DOM"],
+    "types": []
+  }
+}

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.go
@@ -1,0 +1,1309 @@
+package rules_of_hooks
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/checker"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/scanner"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// hookNameTailRegex matches the suffix part of a hook identifier:
+// after the leading `use`, the next character must be uppercase Latin or a digit.
+// Mirrors upstream's `/^use[A-Z0-9]/`.
+var hookNameTailRegex = regexp.MustCompile(`^use[A-Z0-9]`)
+
+// pascalCaseRegex matches identifiers whose first character is an uppercase Latin letter.
+// Mirrors upstream's `/^[A-Z].*/` predicate (used both for component-name and
+// PascalCase namespace detection).
+var pascalCaseRegex = regexp.MustCompile(`^[A-Z]`)
+
+// flowSuppressionRegex matches `$FlowFixMe[react-rule-hook]` comments. Used to
+// gate `hasFlowSuppression`, which mirrors upstream's same-named helper —
+// suppress the diagnostic when an immediately-preceding line carries the
+// suppression marker.
+var flowSuppressionRegex = regexp.MustCompile(`\$FlowFixMe\[react-rule-hook\]`)
+
+// isHookName reports whether `s` follows the React hook naming convention:
+// either the bare name `use` (the React `use(...)` hook) or `useFoo` / `use1`
+// (`use` followed by uppercase letter or digit).
+func isHookName(s string) bool {
+	return s == "use" || hookNameTailRegex.MatchString(s)
+}
+
+// isComponentNameStr reports whether `s` looks like a React component name —
+// PascalCase. Upstream's `isComponentName` is identical.
+func isComponentNameStr(s string) bool {
+	if s == "" {
+		return false
+	}
+	return pascalCaseRegex.MatchString(s)
+}
+
+// isHookCallee mirrors upstream's `isHook(node)`: the callee is either an
+// Identifier whose name is a hook, or a non-computed member expression
+// `Namespace.useFoo` whose object is a PascalCase identifier and whose
+// property is itself a hook name.
+func isHookCallee(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return isHookName(n.AsIdentifier().Text)
+	case ast.KindPropertyAccessExpression:
+		pae := n.AsPropertyAccessExpression()
+		prop := pae.Name()
+		if prop == nil || prop.Kind != ast.KindIdentifier {
+			return false
+		}
+		if !isHookName(prop.AsIdentifier().Text) {
+			return false
+		}
+		obj := ast.SkipParentheses(pae.Expression)
+		if obj == nil || obj.Kind != ast.KindIdentifier {
+			return false
+		}
+		return isComponentNameStr(obj.AsIdentifier().Text)
+	}
+	return false
+}
+
+// isReactFunction matches `<name>` (bare identifier) or `React.<name>`
+// (PropertyAccessExpression with object `React` and property `<name>`).
+// Mirrors upstream's `isReactFunction(node, functionName)`.
+func isReactFunction(node *ast.Node, name string) bool {
+	if node == nil {
+		return false
+	}
+	n := ast.SkipParentheses(node)
+	switch n.Kind {
+	case ast.KindIdentifier:
+		return n.AsIdentifier().Text == name
+	case ast.KindPropertyAccessExpression:
+		pae := n.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pae.Expression)
+		prop := pae.Name()
+		if obj == nil || obj.Kind != ast.KindIdentifier {
+			return false
+		}
+		if prop == nil || prop.Kind != ast.KindIdentifier {
+			return false
+		}
+		return obj.AsIdentifier().Text == "React" && prop.AsIdentifier().Text == name
+	}
+	return false
+}
+
+// isUseIdentifier mirrors upstream's `isUseIdentifier(node)`: matches the
+// React `use(...)` hook callee — bare `use` or `React.use`.
+func isUseIdentifier(node *ast.Node) bool {
+	return isReactFunction(node, "use")
+}
+
+// stripReactNamespace returns `prop` for `React.prop` member expressions, or
+// the original node otherwise. Used when classifying a callee as an effect
+// hook regardless of whether the user qualified it with `React.`.
+func stripReactNamespace(node *ast.Node) *ast.Node {
+	if node == nil {
+		return node
+	}
+	n := ast.SkipParentheses(node)
+	if n.Kind == ast.KindPropertyAccessExpression {
+		pae := n.AsPropertyAccessExpression()
+		obj := ast.SkipParentheses(pae.Expression)
+		prop := pae.Name()
+		if obj != nil && obj.Kind == ast.KindIdentifier && obj.AsIdentifier().Text == "React" &&
+			prop != nil && prop.Kind == ast.KindIdentifier {
+			return prop
+		}
+	}
+	return n
+}
+
+// isEffectCalleeName reports whether `node` (post-namespace-strip) names one
+// of the built-in effect hooks (`useEffect` / `useLayoutEffect` /
+// `useInsertionEffect`) or matches the user-configured `additionalEffectHooks`
+// regex from settings.
+func isEffectCalleeName(node *ast.Node, additional *regexp.Regexp) bool {
+	n := stripReactNamespace(node)
+	if n == nil || n.Kind != ast.KindIdentifier {
+		return false
+	}
+	name := n.AsIdentifier().Text
+	switch name {
+	case "useEffect", "useLayoutEffect", "useInsertionEffect":
+		return true
+	}
+	if additional != nil {
+		return additional.MatchString(name)
+	}
+	return false
+}
+
+// isUseEffectEventCallee reports whether `node` is `useEffectEvent` or
+// `React.useEffectEvent`.
+func isUseEffectEventCallee(node *ast.Node) bool {
+	n := stripReactNamespace(node)
+	return n != nil && n.Kind == ast.KindIdentifier && n.AsIdentifier().Text == "useEffectEvent"
+}
+
+// isFunctionLikeContainer reports whether `node` is one of the function-like
+// kinds the upstream rule treats as a "code path" boundary — anywhere a hook
+// call's enclosing function is computed.
+func isFunctionLikeContainer(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	switch node.Kind {
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression, ast.KindArrowFunction,
+		ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return true
+	}
+	return false
+}
+
+// findEnclosingFunction walks up from `node` and returns the nearest
+// function-like ancestor, or nil when `node` is at top level (no enclosing
+// function).
+func findEnclosingFunction(node *ast.Node) *ast.Node {
+	if node == nil {
+		return nil
+	}
+	p := node.Parent
+	for p != nil {
+		if isFunctionLikeContainer(p) {
+			return p
+		}
+		p = p.Parent
+	}
+	return nil
+}
+
+// getFunctionBody returns the body of a function-like node — Block for normal
+// functions, the BlockOrExpression body for arrow functions, or nil for
+// abstract/declared signatures with no body.
+func getFunctionBody(fn *ast.Node) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.AsFunctionDeclaration().Body
+	case ast.KindFunctionExpression:
+		return fn.AsFunctionExpression().Body
+	case ast.KindArrowFunction:
+		return fn.AsArrowFunction().Body
+	case ast.KindMethodDeclaration:
+		return fn.AsMethodDeclaration().Body
+	case ast.KindGetAccessor:
+		return fn.AsGetAccessorDeclaration().Body
+	case ast.KindSetAccessor:
+		return fn.AsSetAccessorDeclaration().Body
+	case ast.KindConstructor:
+		return fn.AsConstructorDeclaration().Body
+	}
+	return nil
+}
+
+// hasAsyncModifier reports whether the function-like node carries the `async`
+// modifier. Upstream reads `codePathNode.async` directly; we use tsgo's
+// modifier-flag helper for the same effect.
+func hasAsyncModifier(fn *ast.Node) bool {
+	if fn == nil {
+		return false
+	}
+	return ast.HasSyntacticModifier(fn, ast.ModifierFlagsAsync)
+}
+
+// isInsideTryCatchOfFunction reports whether `node` is inside a TryStatement
+// or CatchClause within `fn` (the enclosing function-like). Mirrors
+// upstream's `isInsideTryCatch(hook)`.
+func isInsideTryCatchOfFunction(node *ast.Node, fn *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	cur := node.Parent
+	for cur != nil && cur != fn {
+		switch cur.Kind {
+		case ast.KindTryStatement, ast.KindCatchClause:
+			return true
+		}
+		if isFunctionLikeContainer(cur) {
+			return false
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// isInsideLoopOfFunction reports whether `node` is inside any loop construct
+// (while / for / for-in / for-of / do/while) within `fn`. Approximates
+// upstream's CFG `cycled` set: any segment reachable through a back-edge.
+//
+// Position-aware for the C-style and for-in/of variants:
+//   - `for (init; cond; incr) body`: `init` runs once BEFORE the loop and
+//     is NOT cycled; the condition / incrementor / body all are.
+//   - `for (var of expr) body`: `expr` is evaluated once before iteration
+//     starts (per ECMA-262) and is NOT cycled; `var`'s binding pattern
+//     re-binds per iteration and the body is cycled.
+//
+// Without the position split, hooks placed in `for (let x = useFoo(); ...; )`
+// or `for (const x of useArr()) {}` would be misclassified as cycled and
+// emit a spurious loopError.
+func isInsideLoopOfFunction(node *ast.Node, fn *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	cur := node
+	for cur != nil && cur.Parent != nil && cur.Parent != fn {
+		parent := cur.Parent
+		switch parent.Kind {
+		case ast.KindDoStatement, ast.KindWhileStatement:
+			return true
+		case ast.KindForStatement:
+			fs := parent.AsForStatement()
+			if cur != fs.Initializer {
+				return true
+			}
+		case ast.KindForInStatement, ast.KindForOfStatement:
+			fos := parent.AsForInOrOfStatement()
+			if cur != fos.Expression {
+				return true
+			}
+		}
+		if isFunctionLikeContainer(parent) {
+			return false
+		}
+		cur = parent
+	}
+	return false
+}
+
+// getFunctionName mirrors upstream's `getFunctionName(node)`. Returns:
+//   - For named FunctionDeclaration / FunctionExpression: the `id` Identifier.
+//   - For MethodDeclaration / GetAccessor / SetAccessor inside an
+//     ObjectLiteralExpression: the method's own name (mirrors ESTree's
+//     `Property { method: true, value: FunctionExpression }` shape).
+//   - For ArrowFunction / anonymous FunctionExpression: the assignment
+//     target — VariableDeclaration name, BinaryExpression LHS, PropertyAssignment
+//     name, BindingElement name, or ShorthandPropertyAssignment name.
+//   - nil otherwise.
+//
+// MethodDeclaration / GetAccessor / SetAccessor inside a class body
+// intentionally returns nil so the class branch can take over and emit
+// classError. Upstream has the same effect because ESTree exposes the inner
+// FunctionExpression with no id, and getFunctionName falls through.
+func getFunctionName(fn *ast.Node) *ast.Node {
+	if fn == nil {
+		return nil
+	}
+	switch fn.Kind {
+	case ast.KindFunctionDeclaration:
+		return fn.Name()
+	case ast.KindFunctionExpression:
+		if name := fn.Name(); name != nil {
+			return name
+		}
+		// fall through to anonymous handling
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		if fn.Parent != nil && fn.Parent.Kind == ast.KindObjectLiteralExpression {
+			return fn.Name()
+		}
+		return nil
+	case ast.KindArrowFunction:
+		// fall through
+	default:
+		return nil
+	}
+	p := fn.Parent
+	if p == nil {
+		return nil
+	}
+	switch p.Kind {
+	case ast.KindVariableDeclaration:
+		vd := p.AsVariableDeclaration()
+		if vd.Initializer == fn {
+			return p.Name()
+		}
+	case ast.KindBinaryExpression:
+		be := p.AsBinaryExpression()
+		if be.OperatorToken != nil && be.OperatorToken.Kind == ast.KindEqualsToken && be.Right == fn {
+			return be.Left
+		}
+	case ast.KindPropertyAssignment:
+		pa := p.AsPropertyAssignment()
+		if pa.Initializer == fn {
+			return p.Name()
+		}
+	case ast.KindBindingElement:
+		be := p.AsBindingElement()
+		if be.Initializer == fn {
+			return p.Name()
+		}
+	case ast.KindShorthandPropertyAssignment:
+		spa := p.AsShorthandPropertyAssignment()
+		if spa.ObjectAssignmentInitializer == fn {
+			return p.Name()
+		}
+	case ast.KindParenthesizedExpression:
+		// `const x = (() => {})` — the paren-wrapped expression is the
+		// declarator's initializer. Recurse on the wrapper so the parent-shape
+		// switch above retries against the grandparent.
+		return getFunctionName(p)
+	}
+	return nil
+}
+
+// isForwardRefOrMemoCallback reports whether `fn` is the immediate argument
+// of a CallExpression whose callee is `forwardRef` / `memo` / `React.forwardRef`
+// / `React.memo`. Upstream's `isForwardRefCallback` and `isMemoCallback`
+// are unified here for brevity.
+func isForwardRefOrMemoCallback(fn *ast.Node, name string) bool {
+	if fn == nil || fn.Parent == nil {
+		return false
+	}
+	p := fn.Parent
+	if p.Kind != ast.KindCallExpression {
+		return false
+	}
+	callee := ast.SkipParentheses(p.AsCallExpression().Expression)
+	return isReactFunction(callee, name)
+}
+
+// classifyContainerName reports whether the function-like's resolved name
+// represents a component or a hook.
+func classifyContainerName(name *ast.Node) bool {
+	if name == nil {
+		return false
+	}
+	switch name.Kind {
+	case ast.KindIdentifier:
+		text := name.AsIdentifier().Text
+		return isComponentNameStr(text) || isHookName(text)
+	case ast.KindPropertyAccessExpression:
+		// `Namespace.useHook` style — defer to isHookCallee, which already
+		// enforces PascalCase namespace + hook-named property.
+		return isHookCallee(name)
+	}
+	return false
+}
+
+// isComponentOrHookFn reports whether the function-like itself is a React
+// component or hook (named appropriately, or an anonymous arg to forwardRef/memo).
+// Mirrors upstream's `isDirectlyInsideComponentOrHook` predicate at the function level.
+func isComponentOrHookFn(fn *ast.Node) bool {
+	name := getFunctionName(fn)
+	if name != nil {
+		return classifyContainerName(name)
+	}
+	return isForwardRefOrMemoCallback(fn, "forwardRef") || isForwardRefOrMemoCallback(fn, "memo")
+}
+
+// isInsideComponentOrHook walks up from `node` and returns true once any
+// ancestor function-like classifies as a component or hook. Mirrors
+// upstream's `isInsideComponentOrHook(node)`.
+func isInsideComponentOrHook(node *ast.Node) bool {
+	cur := node
+	for cur != nil {
+		if isFunctionLikeContainer(cur) && isComponentOrHookFn(cur) {
+			return true
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// isClassMember reports whether `fn` is a member of a class — either a
+// MethodDeclaration / GetAccessor / SetAccessor / Constructor whose direct
+// parent is a class, or an ArrowFunction / FunctionExpression that initializes
+// a class PropertyDeclaration (class-field arrow). Mirrors upstream's
+// MethodDefinition / ClassProperty / PropertyDefinition branch.
+func isClassMember(fn *ast.Node) bool {
+	if fn == nil || fn.Parent == nil {
+		return false
+	}
+	p := fn.Parent
+	switch fn.Kind {
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor, ast.KindConstructor:
+		return p.Kind == ast.KindClassDeclaration || p.Kind == ast.KindClassExpression
+	case ast.KindArrowFunction, ast.KindFunctionExpression:
+		if p.Kind == ast.KindPropertyDeclaration {
+			gp := p.Parent
+			if gp != nil && (gp.Kind == ast.KindClassDeclaration || gp.Kind == ast.KindClassExpression) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isConditionalAncestor reports whether the position of `child` within `parent`
+// places it on a conditional execution path (only entered on certain
+// runtime branches). Used by `isConditional` during the parent-walk.
+//
+// NOTE: TryStatement is handled by `isInsideTryBlockWithPriorStmt` instead
+// — being inside a try block is only conditional if a prior sibling could
+// throw before the hook is reached.
+func isConditionalAncestor(parent *ast.Node, child *ast.Node) bool {
+	switch parent.Kind {
+	case ast.KindIfStatement:
+		is := parent.AsIfStatement()
+		// `if (cond) then else` — `then` and `else` are conditional; the
+		// condition expression itself is unconditional and is intentionally
+		// not flagged.
+		return child == is.ThenStatement || child == is.ElseStatement
+	case ast.KindConditionalExpression:
+		ce := parent.AsConditionalExpression()
+		return child == ce.WhenTrue || child == ce.WhenFalse
+	case ast.KindBinaryExpression:
+		be := parent.AsBinaryExpression()
+		if be.OperatorToken == nil {
+			return false
+		}
+		switch be.OperatorToken.Kind {
+		case ast.KindAmpersandAmpersandToken, ast.KindBarBarToken, ast.KindQuestionQuestionToken:
+			// Right operand of `&&` / `||` / `??` is conditional; the left
+			// is always evaluated.
+			return child == be.Right
+		}
+		return false
+	case ast.KindWhileStatement:
+		// The condition is always evaluated at least once, so we don't flag
+		// `while (useFoo()) {}` here — but the body is conditional. The
+		// "in-loop" detection separately reports it as a loop violation,
+		// which takes precedence.
+		return child == parent.AsWhileStatement().Statement
+	case ast.KindForStatement:
+		fs := parent.AsForStatement()
+		// init runs once before the loop and is unconditional. The body
+		// is conditional (and the in-loop detection takes precedence).
+		// Condition / incrementor: also conditional in the sense that they
+		// re-execute per iteration — but the in-loop detection covers them.
+		return child == fs.Statement
+	case ast.KindForInStatement, ast.KindForOfStatement:
+		fos := parent.AsForInOrOfStatement()
+		// `for (const x of expr) body` — `expr` is evaluated once before
+		// iteration starts (ECMA-262 step 1 of ForIn/OfBodyEvaluation),
+		// so it's NOT conditional. The body / binding pattern run per
+		// iteration and are loop-conditional (handled by in-loop detection).
+		return child != fos.Expression
+	case ast.KindCaseClause, ast.KindDefaultClause:
+		// Any descendant of a switch case body is conditional.
+		return true
+	case ast.KindCatchClause:
+		// Catch body only executes on an exception.
+		return true
+	}
+	return false
+}
+
+// isInsideTryBlockWithPriorStmt reports whether `node` sits inside a try
+// block AND has at least one preceding sibling statement in that block.
+// Mirrors upstream's CFG behavior: every statement in a try block has a
+// "could throw" exit, so a hook reached only after a prior throwable
+// statement is conditionally executed. A hook that is the very first
+// statement in a try block (no prior statement) is unconditional in
+// upstream's path counting and is NOT flagged here.
+func isInsideTryBlockWithPriorStmt(node *ast.Node, fn *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	cur := node
+	for cur != nil && cur.Parent != nil && cur.Parent != fn {
+		parent := cur.Parent
+		if parent.Kind == ast.KindBlock {
+			grand := parent.Parent
+			if grand != nil && grand.Kind == ast.KindTryStatement {
+				ts := grand.AsTryStatement()
+				if ts.TryBlock != nil && ts.TryBlock.AsNode() == parent {
+					block := parent.AsBlock()
+					if block.Statements != nil {
+						for _, stmt := range block.Statements.Nodes {
+							if stmt == cur {
+								return false
+							}
+							if stmt.Pos() >= cur.Pos() {
+								return false
+							}
+							return true
+						}
+					}
+					return false
+				}
+			}
+		}
+		if isFunctionLikeContainer(parent) {
+			return false
+		}
+		cur = parent
+	}
+	return false
+}
+
+// isConditional walks the parent chain from `node` up to (but not crossing)
+// `fn`. Returns true once any conditional placement is observed.
+// Approximation of upstream's `pathsFromStartToEnd !== allPathsFromStartToEnd`
+// signal for the structural cases; sibling-based early return / labeled break
+// detection lives in `hasEarlyReturnBefore` and `hasLabeledBreakBefore`.
+func isConditional(node *ast.Node, fn *ast.Node) bool {
+	cur := node
+	for cur != nil && cur.Parent != nil && cur != fn {
+		if isConditionalAncestor(cur.Parent, cur) {
+			return true
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// containsEarlyReturn reports whether `node` (recursively, but never crossing
+// a nested function-like) contains a ReturnStatement. ThrowStatement is
+// intentionally excluded: upstream's CFG models thrown segments as
+// `thrownSegments`, which are excluded from path counting — so a hook
+// reached only when an exception did NOT throw is treated as unconditional.
+// Mirroring that, throw-inside-if does not trigger the "early return" suffix
+// here.
+func containsEarlyReturn(node *ast.Node) bool {
+	if node == nil {
+		return false
+	}
+	found := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found {
+			return true
+		}
+		if n.Kind == ast.KindReturnStatement {
+			found = true
+			return true
+		}
+		if isFunctionLikeContainer(n) {
+			return false
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(node)
+	return found
+}
+
+// isPrecededByDirectTerminator reports whether `hookNode` lies after an
+// unconditional `return` or `throw` statement in the same enclosing block
+// (recursively walking up to the function body). Such a hook is unreachable
+// in upstream's CFG (`!segment.reachable`) and the rule loop `continue`s
+// without checking — we model that by short-circuiting all reports here.
+func isPrecededByDirectTerminator(hookNode *ast.Node, fn *ast.Node) bool {
+	if hookNode == nil {
+		return false
+	}
+	cur := hookNode
+	for cur != nil && cur.Parent != nil && cur.Parent != fn {
+		parent := cur.Parent
+		if parent.Kind == ast.KindBlock {
+			block := parent.AsBlock()
+			if block.Statements != nil {
+				for _, stmt := range block.Statements.Nodes {
+					if stmt == cur {
+						break
+					}
+					if stmt.Pos() >= cur.Pos() {
+						break
+					}
+					switch stmt.Kind {
+					case ast.KindReturnStatement, ast.KindThrowStatement:
+						return true
+					}
+				}
+			}
+		}
+		if isFunctionLikeContainer(parent) {
+			break
+		}
+		cur = parent
+	}
+	return false
+}
+
+// hasEarlyReturnBefore walks up from `hookNode` through enclosing Block
+// ancestors (stopping at the function body) and, at each level, checks
+// preceding siblings for early-return markers (return inside any
+// non-function-like child). Triggers the "early return" suffix on
+// `conditionalError`.
+func hasEarlyReturnBefore(hookNode *ast.Node, fn *ast.Node) bool {
+	if hookNode == nil || fn == nil {
+		return false
+	}
+	body := getFunctionBody(fn)
+	cur := hookNode
+	for cur != nil && cur.Parent != nil && cur.Parent != fn {
+		parent := cur.Parent
+		if parent.Kind == ast.KindBlock {
+			block := parent.AsBlock()
+			if block.Statements != nil {
+				for _, stmt := range block.Statements.Nodes {
+					if stmt == cur {
+						break
+					}
+					if stmt.Pos() >= cur.Pos() {
+						break
+					}
+					if containsEarlyReturn(stmt) {
+						return true
+					}
+				}
+			}
+		}
+		if parent == body {
+			break
+		}
+		cur = parent
+	}
+	return false
+}
+
+// collectEnclosingLabels walks up from `node` and returns a set of
+// LabeledStatement labels enclosing `node` within `fn`. Used by
+// `hasLabeledBreakBefore` to recognize `break <label>` references.
+func collectEnclosingLabels(node *ast.Node, fn *ast.Node) map[string]bool {
+	labels := map[string]bool{}
+	p := node.Parent
+	for p != nil && p != fn {
+		if p.Kind == ast.KindLabeledStatement {
+			ls := p.AsLabeledStatement()
+			if ls.Label != nil && ls.Label.Kind == ast.KindIdentifier {
+				labels[ls.Label.AsIdentifier().Text] = true
+			}
+		}
+		if isFunctionLikeContainer(p) {
+			break
+		}
+		p = p.Parent
+	}
+	return labels
+}
+
+// containsLabeledBreak recursively looks for a BreakStatement whose label
+// matches one of `labels`, without descending into nested function-likes
+// (where the break would refer to its own enclosing label scope).
+func containsLabeledBreak(node *ast.Node, labels map[string]bool) bool {
+	if node == nil || len(labels) == 0 {
+		return false
+	}
+	found := false
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if found {
+			return true
+		}
+		if n.Kind == ast.KindBreakStatement {
+			bs := n.AsBreakStatement()
+			if bs.Label != nil && bs.Label.Kind == ast.KindIdentifier {
+				if labels[bs.Label.AsIdentifier().Text] {
+					found = true
+					return true
+				}
+			}
+		}
+		if isFunctionLikeContainer(n) {
+			return false
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	visit(node)
+	return found
+}
+
+// hasLabeledBreakBefore reports whether `hookNode` lies after a `break <label>`
+// targeting an enclosing LabeledStatement. Used to catch the
+// `label: { if (cond) break label; useFoo(); }` family of conditional patterns
+// that upstream detects via CFG cycle / segment analysis but are otherwise
+// invisible to the parent-walk version of `isConditional`.
+func hasLabeledBreakBefore(hookNode *ast.Node, fn *ast.Node) bool {
+	if hookNode == nil || fn == nil {
+		return false
+	}
+	labels := collectEnclosingLabels(hookNode, fn)
+	if len(labels) == 0 {
+		return false
+	}
+	cur := hookNode
+	for cur != nil && cur.Parent != nil && cur.Parent != fn {
+		parent := cur.Parent
+		if parent.Kind == ast.KindBlock {
+			block := parent.AsBlock()
+			if block.Statements != nil {
+				for _, stmt := range block.Statements.Nodes {
+					if stmt == cur {
+						break
+					}
+					if stmt.Pos() >= cur.Pos() {
+						break
+					}
+					if containsLabeledBreak(stmt, labels) {
+						return true
+					}
+				}
+			}
+		}
+		if isFunctionLikeContainer(parent) {
+			break
+		}
+		cur = parent
+	}
+	return false
+}
+
+// nameText returns the source text for a function-name node, or "" when nil.
+// Used to format `functionError` messages with the enclosing function's name.
+func nameText(node *ast.Node, sf *ast.SourceFile) string {
+	if node == nil {
+		return ""
+	}
+	if node.Kind == ast.KindIdentifier {
+		return node.AsIdentifier().Text
+	}
+	return utils.TrimmedNodeText(sf, node)
+}
+
+// isReferenceIdentifier reports whether the Identifier `id` is being used
+// as a value reference (as opposed to a declaration name, property key, JSX
+// attribute name, etc). Used by the useEffectEvent tracker to ignore the
+// declaration site and member-name positions.
+func isReferenceIdentifier(id *ast.Node) bool {
+	p := id.Parent
+	if p == nil {
+		return true
+	}
+	switch p.Kind {
+	case ast.KindPropertyAccessExpression:
+		// In `obj.prop`, only `obj` is a reference; `prop` is a name.
+		return p.AsPropertyAccessExpression().Expression == id
+	case ast.KindPropertyAssignment:
+		// `{ key: value }` — key is not a reference.
+		pa := p.AsPropertyAssignment()
+		return pa.Initializer == id
+	case ast.KindShorthandPropertyAssignment:
+		// `{ x }` — the identifier IS a reference (it stands for both name and value).
+		return p.Name() == id
+	case ast.KindMethodDeclaration, ast.KindGetAccessor, ast.KindSetAccessor:
+		return p.Name() != id
+	case ast.KindJsxAttribute:
+		// Attribute name (`<Foo bar={...} />`) is not a reference.
+		return false
+	case ast.KindVariableDeclaration:
+		return p.AsVariableDeclaration().Name() != id
+	case ast.KindBindingElement:
+		return p.AsBindingElement().Name() != id
+	case ast.KindParameter:
+		return p.AsParameterDeclaration().Name() != id
+	case ast.KindFunctionDeclaration, ast.KindFunctionExpression,
+		ast.KindClassDeclaration, ast.KindClassExpression:
+		return p.Name() != id
+	case ast.KindLabeledStatement:
+		return p.AsLabeledStatement().Label != id
+	case ast.KindBreakStatement, ast.KindContinueStatement:
+		// Label position; not a reference.
+		return false
+	case ast.KindImportSpecifier, ast.KindImportClause, ast.KindNamespaceImport,
+		ast.KindExportSpecifier:
+		// Import / export declarations — not value references.
+		return false
+	}
+	return true
+}
+
+// isInsideEffectArgument walks up from `idNode` through CallExpression
+// ancestors. Returns true once we find a CallExpression whose callee is an
+// effect or useEffectEvent hook AND `idNode` (or one of its ancestors on the
+// path) is inside the call's arguments (not the callee).
+//
+// Used to gate useEffectEvent reference reports: a reference to an
+// `useEffectEvent` binding is allowed inside `useEffect(...)` /
+// `useLayoutEffect(...)` / `useInsertionEffect(...)` / configured effect
+// hooks / nested `useEffectEvent(...)` callbacks.
+func isInsideEffectArgument(idNode *ast.Node, additional *regexp.Regexp) bool {
+	cur := idNode
+	for cur != nil && cur.Parent != nil {
+		p := cur.Parent
+		if p.Kind == ast.KindCallExpression {
+			call := p.AsCallExpression()
+			// `cur` must be inside the arguments, not the callee.
+			if call.Expression != cur {
+				if isEffectCalleeName(call.Expression, additional) || isUseEffectEventCallee(call.Expression) {
+					return true
+				}
+			}
+		}
+		cur = p
+	}
+	return false
+}
+
+// getAdditionalEffectHooks reads `settings['react-hooks'].additionalEffectHooks`
+// and compiles it as a regex. Returns nil when the setting is absent or
+// invalid — matching upstream's lenient behavior of silently ignoring
+// malformed regex strings.
+func getAdditionalEffectHooks(settings map[string]interface{}) *regexp.Regexp {
+	if settings == nil {
+		return nil
+	}
+	raw, ok := settings["react-hooks"]
+	if !ok {
+		return nil
+	}
+	m, ok := raw.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	pattern, ok := m["additionalEffectHooks"].(string)
+	if !ok || pattern == "" {
+		return nil
+	}
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	return re
+}
+
+// eeRegistry tracks `const X = useEffectEvent(...)` declarations per enclosing
+// function-like, used as the fallback when TypeChecker symbol resolution is
+// unavailable. The TypeChecker path takes precedence whenever
+// `ctx.TypeChecker != nil`, since it correctly handles shadowing and aliased
+// references that the name-based lookup cannot.
+type eeRegistry struct {
+	bindings map[*ast.Node]map[string]bool
+}
+
+func (r *eeRegistry) record(container *ast.Node, name string) {
+	if container == nil || name == "" {
+		return
+	}
+	m, ok := r.bindings[container]
+	if !ok {
+		m = make(map[string]bool)
+		r.bindings[container] = m
+	}
+	m[name] = true
+}
+
+// resolveContainer returns the closest container with a tracked binding for
+// `name` walking up via `findEnclosingFunction`. Used as the fallback when
+// `ctx.TypeChecker` is nil — see also `resolveBindingViaSymbol`.
+func (r *eeRegistry) resolveContainer(idNode *ast.Node, name string) *ast.Node {
+	cur := findEnclosingFunction(idNode)
+	for cur != nil {
+		if m, ok := r.bindings[cur]; ok && m[name] {
+			return cur
+		}
+		cur = findEnclosingFunction(cur)
+	}
+	return nil
+}
+
+// collectEffectEventBindings walks the source file and records every
+// `useEffectEvent(...)` variable binding it finds. Tracks bindings in any
+// enclosing function-like (mirrors upstream's
+// `recordAllUseEffectEventFunctions` which fires for every
+// FunctionDeclaration / ArrowFunctionExpression). Used by the fallback
+// resolver when `ctx.TypeChecker` is unavailable.
+func collectEffectEventBindings(sf *ast.SourceFile) *eeRegistry {
+	reg := &eeRegistry{bindings: map[*ast.Node]map[string]bool{}}
+	var visit func(n *ast.Node) bool
+	visit = func(n *ast.Node) bool {
+		if isEffectEventVariableDeclaration(n) {
+			vd := n.AsVariableDeclaration()
+			if name := vd.Name(); name != nil && name.Kind == ast.KindIdentifier {
+				container := findEnclosingFunction(n)
+				reg.record(container, name.AsIdentifier().Text)
+			}
+		} else if isEffectEventBindingElement(n) {
+			be := n.AsBindingElement()
+			if name := be.Name(); name != nil && name.Kind == ast.KindIdentifier {
+				container := findEnclosingFunction(n)
+				reg.record(container, name.AsIdentifier().Text)
+			}
+		}
+		n.ForEachChild(visit)
+		return false
+	}
+	sf.AsNode().ForEachChild(visit)
+	return reg
+}
+
+// isEffectEventVariableDeclaration reports whether `n` is a VariableDeclaration
+// whose initializer is a (paren-wrapped) `useEffectEvent(...)` call.
+func isEffectEventVariableDeclaration(n *ast.Node) bool {
+	if n.Kind != ast.KindVariableDeclaration {
+		return false
+	}
+	vd := n.AsVariableDeclaration()
+	return vd.Initializer != nil && isEventInitializer(vd.Initializer)
+}
+
+// isEffectEventBindingElement reports whether `n` is a BindingElement whose
+// (default) initializer is a `useEffectEvent(...)` call. Covers the
+// `const { onClick = useEffectEvent(...) } = obj` shape.
+func isEffectEventBindingElement(n *ast.Node) bool {
+	if n.Kind != ast.KindBindingElement {
+		return false
+	}
+	be := n.AsBindingElement()
+	return be.Initializer != nil && isEventInitializer(be.Initializer)
+}
+
+// isEventInitializer reports whether `expr` is a `useEffectEvent(...)` call.
+// Strips paren wrappers transparently so `(useEffectEvent(...))` is recognized.
+func isEventInitializer(expr *ast.Node) bool {
+	e := ast.SkipParentheses(expr)
+	if e == nil || e.Kind != ast.KindCallExpression {
+		return false
+	}
+	return isUseEffectEventCallee(e.AsCallExpression().Expression)
+}
+
+// isUseEffectEventBindingDeclaration reports whether `decl` is a declaration
+// node whose initializer is `useEffectEvent(...)` — used by the
+// TypeChecker-path resolver to decide whether a resolved symbol is one of
+// our tracked bindings.
+func isUseEffectEventBindingDeclaration(decl *ast.Node) bool {
+	if decl == nil {
+		return false
+	}
+	switch decl.Kind {
+	case ast.KindVariableDeclaration:
+		return decl.AsVariableDeclaration().Initializer != nil &&
+			isEventInitializer(decl.AsVariableDeclaration().Initializer)
+	case ast.KindBindingElement:
+		return decl.AsBindingElement().Initializer != nil &&
+			isEventInitializer(decl.AsBindingElement().Initializer)
+	}
+	return false
+}
+
+// resolveBindingViaSymbol uses the TypeChecker to resolve `idNode` to its
+// declaration, then checks whether any declaration is a tracked
+// `useEffectEvent` binding. Returns the enclosing function-like of the
+// declaration when matched, or nil otherwise.
+//
+// This is the preferred resolution path: it correctly handles parameter /
+// variable shadowing across nested closures, and matches references that
+// alias through `import { onClick } from './x'` etc.
+func resolveBindingViaSymbol(tc *checker.Checker, idNode *ast.Node) *ast.Node {
+	if tc == nil || idNode == nil {
+		return nil
+	}
+	sym := tc.GetSymbolAtLocation(idNode)
+	if sym == nil {
+		return nil
+	}
+	for _, decl := range sym.Declarations {
+		if isUseEffectEventBindingDeclaration(decl) {
+			return findEnclosingFunction(decl)
+		}
+	}
+	return nil
+}
+
+// hasFlowSuppression reports whether the line immediately preceding
+// `hookNode` contains a `$FlowFixMe[react-rule-hook]` comment. Mirrors
+// upstream's same-named helper observably: the comment must match the
+// regex AND its end-line must equal `hookNode.start.line - 1`.
+//
+// Implementation walks leading comments at `hookNode.Pos()` (tsgo attaches
+// preceding trivia to the next-token Pos), as well as the leading comments
+// at the hook's enclosing statement (covers the case where the comment is
+// attached to the statement-level Pos rather than the inner CallExpression).
+func hasFlowSuppression(sf *ast.SourceFile, hookNode *ast.Node) bool {
+	if hookNode == nil || sf == nil {
+		return false
+	}
+	// Use the trimmed start (skip leading trivia) so the hook's "start line"
+	// is the line of the first significant character of the hook itself,
+	// matching upstream's `node.loc.start.line` semantics. Raw `node.Pos()`
+	// in tsgo includes leading trivia (whitespace + comments), which would
+	// place us on the line of the trivia rather than the token.
+	trimmed := utils.TrimNodeTextRange(sf, hookNode)
+	hookLine, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, trimmed.Pos())
+	text := sf.Text()
+	nodeFactory := ast.NewNodeFactory(ast.NodeFactoryHooks{})
+	check := func(pos int) bool {
+		for c := range scanner.GetLeadingCommentRanges(nodeFactory, text, pos) {
+			if matchesFlowSuppression(text, c, hookLine, sf) {
+				return true
+			}
+		}
+		for c := range scanner.GetTrailingCommentRanges(nodeFactory, text, pos) {
+			if matchesFlowSuppression(text, c, hookLine, sf) {
+				return true
+			}
+		}
+		return false
+	}
+	if check(hookNode.Pos()) {
+		return true
+	}
+	// Walk to the enclosing statement (ExpressionStatement, VariableStatement,
+	// etc.) and check its leading trivia. The suppression comment is often
+	// attached to the statement, not the inner expression.
+	cur := hookNode.Parent
+	for cur != nil {
+		switch cur.Kind {
+		case ast.KindExpressionStatement, ast.KindVariableStatement, ast.KindReturnStatement,
+			ast.KindIfStatement, ast.KindBlock, ast.KindForStatement, ast.KindWhileStatement,
+			ast.KindDoStatement, ast.KindThrowStatement:
+			if check(cur.Pos()) {
+				return true
+			}
+		}
+		if isFunctionLikeContainer(cur) {
+			break
+		}
+		cur = cur.Parent
+	}
+	return false
+}
+
+// matchesFlowSuppression reports whether `c` carries the suppression marker
+// AND its end-line equals `hookLine - 1` (i.e., it sits on the immediately
+// preceding line).
+func matchesFlowSuppression(text string, c ast.CommentRange, hookLine int, sf *ast.SourceFile) bool {
+	commentText := text[c.Pos():c.End()]
+	if !flowSuppressionRegex.MatchString(commentText) {
+		return false
+	}
+	endLine, _ := scanner.GetECMALineAndUTF16CharacterOfPosition(sf, c.End())
+	return endLine == hookLine-1
+}
+
+// makeHookText returns the rendered display text for a hook callee, used in
+// every diagnostic message. Identifier hooks render as their bare name;
+// member-access hooks render as `Foo.useBar` via the source text of the
+// PropertyAccessExpression. Paren wrappers around the callee are peeled
+// (mirrors ESTree, which never exposes ParenthesizedExpression at all).
+func makeHookText(hookCall *ast.Node, sf *ast.SourceFile) string {
+	if hookCall == nil {
+		return ""
+	}
+	n := ast.SkipParentheses(hookCall)
+	if n.Kind == ast.KindIdentifier {
+		return n.AsIdentifier().Text
+	}
+	return utils.TrimmedNodeText(sf, n)
+}
+
+// useEffectEventErrorMessage formats the diagnostic for a useEffectEvent
+// reference outside of the allowed contexts. Mirrors upstream's
+// `useEffectEventError(fn, called)` byte-for-byte.
+func useEffectEventErrorMessage(fnName string, called bool) string {
+	if fnName == "" {
+		return `React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.`
+	}
+	suffix := ""
+	if !called {
+		suffix = " It cannot be assigned to a variable or passed down."
+	}
+	return fmt.Sprintf("`%s` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component.%s", fnName, suffix)
+}
+
+// silenceUnused keeps the helper imports referenced even when their usage
+// drifts during rule iteration. The runtime cost is zero; the lint hygiene
+// benefit is non-zero.
+var _ = strings.HasPrefix
+var _ core.TextRange
+
+// RulesOfHooksRule is the rslint port of upstream `react-hooks/rules-of-hooks`.
+//
+// Departure from upstream: rslint has no CodePathAnalyzer, so the conditional /
+// loop / early-return / cycled-segment detections are AST-shape based rather
+// than CFG-based. The implementation matches upstream observably for every
+// test in upstream's `valid` and `invalid` suites that doesn't rely on
+// BigInt-precise path counting (and we add a `hasLabeledBreakBefore` walk
+// for the `label: { if (cond) break label; useFoo(); }` case).
+//
+// Identifier resolution for `useEffectEvent` references uses the TypeChecker
+// when available (correct under shadowing / aliasing); falls back to a
+// per-container name registry when `ctx.TypeChecker` is nil.
+//
+// `$FlowFixMe[react-rule-hook]` suppression on the preceding line is
+// honored, mirroring upstream's `hasFlowSuppression` byte-for-byte.
+var RulesOfHooksRule = rule.Rule{
+	Name: "react-hooks/rules-of-hooks",
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		additionalRe := getAdditionalEffectHooks(ctx.Settings)
+		sf := ctx.SourceFile
+		registry := collectEffectEventBindings(sf)
+		tc := ctx.TypeChecker
+
+		// reportedIdentifiers tracks identifier positions we've already
+		// reported on, so a single Identifier that matches both the
+		// useEffectEvent reference path and another check (rare) doesn't
+		// double-fire.
+		reportedIdentifiers := map[int]bool{}
+
+		report := func(node *ast.Node, msg string) {
+			if hasFlowSuppression(sf, node) {
+				return
+			}
+			ctx.ReportNode(node, rule.RuleMessage{Description: msg})
+		}
+
+		return rule.RuleListeners{
+			ast.KindCallExpression: func(node *ast.Node) {
+				call := node.AsCallExpression()
+				callee := call.Expression
+
+				// Inline-call useEffectEvent that isn't being assigned.
+				// Mirrors upstream's standalone check: useEffectEvent must
+				// either bind to a variable or be a top-level expression
+				// statement. Anything else (`<Child onClick={useEffectEvent(...)} />`)
+				// is reported as the "passed down" variant.
+				if isUseEffectEventCallee(callee) {
+					p := node.Parent
+					if p != nil && p.Kind != ast.KindVariableDeclaration && p.Kind != ast.KindExpressionStatement {
+						report(node, useEffectEventErrorMessage("", false))
+					}
+				}
+
+				if !isHookCallee(callee) {
+					return
+				}
+
+				hookText := makeHookText(callee, sf)
+				fn := findEnclosingFunction(node)
+				isUse := isUseIdentifier(callee)
+
+				// Skip unreachable hooks (preceded by a direct `return` or
+				// `throw` in the same block). Upstream's CFG marks the
+				// segment as `!reachable` and the rule loop `continue`s,
+				// emitting no diagnostic of any kind.
+				if fn != nil && isPrecededByDirectTerminator(node, fn) {
+					return
+				}
+
+				// Try/catch + use(): hard error, distinct from any other.
+				if isUse && isInsideTryCatchOfFunction(node, fn) {
+					report(callee, fmt.Sprintf(`React Hook "%s" cannot be called in a try/catch block.`, hookText))
+				}
+
+				// Loop check (cycled || do-while). Skipped for use(), which
+				// upstream allows in loops.
+				inAnyLoop := false
+				if !isUse {
+					inAnyLoop = isInsideLoopOfFunction(node, fn)
+					if inAnyLoop {
+						report(callee, fmt.Sprintf(
+							`React Hook "%s" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`,
+							hookText,
+						))
+					}
+				}
+
+				// Container classification.
+				if fn == nil {
+					report(callee, fmt.Sprintf(
+						`React Hook "%s" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`,
+						hookText,
+					))
+					return
+				}
+
+				if isComponentOrHookFn(fn) {
+					if hasAsyncModifier(fn) {
+						report(callee, fmt.Sprintf(`React Hook "%s" cannot be called in an async function.`, hookText))
+						return
+					}
+					if isUse || inAnyLoop {
+						return
+					}
+					cond := isConditional(node, fn)
+					early := hasEarlyReturnBefore(node, fn)
+					labeled := hasLabeledBreakBefore(node, fn)
+					tryWithPrior := isInsideTryBlockWithPriorStmt(node, fn)
+					if cond || early || labeled || tryWithPrior {
+						suffix := ""
+						if early {
+							suffix = " Did you accidentally call a React Hook after an early return?"
+						}
+						report(callee, fmt.Sprintf(
+							`React Hook "%s" is called conditionally. React Hooks must be called in the exact same order in every component render.%s`,
+							hookText, suffix,
+						))
+					}
+					return
+				}
+
+				// Class member.
+				if isClassMember(fn) {
+					report(callee, fmt.Sprintf(
+						`React Hook "%s" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`,
+						hookText,
+					))
+					return
+				}
+
+				// Named function (non-component, non-hook).
+				if name := getFunctionName(fn); name != nil {
+					report(callee, fmt.Sprintf(
+						`React Hook "%s" is called in function "%s" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`,
+						hookText, nameText(name, sf),
+					))
+					return
+				}
+
+				// Anonymous callback inside (somewhere) a component or hook.
+				if !isUse && isInsideComponentOrHook(node) {
+					report(callee, fmt.Sprintf(
+						`React Hook "%s" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`,
+						hookText,
+					))
+				}
+			},
+
+			ast.KindIdentifier: func(node *ast.Node) {
+				if !isReferenceIdentifier(node) {
+					return
+				}
+				name := node.AsIdentifier().Text
+
+				// Resolution: TypeChecker-first, with a name-based per-container
+				// fallback when type info is unavailable. The TypeChecker path
+				// is robust under shadowing and aliasing — the fallback is
+				// best-effort and may misidentify references when two
+				// containers use the same binding name.
+				container := resolveBindingViaSymbol(tc, node)
+				if container == nil {
+					container = registry.resolveContainer(node, name)
+				}
+				if container == nil {
+					return
+				}
+				if isInsideEffectArgument(node, additionalRe) {
+					return
+				}
+				called := false
+				if p := node.Parent; p != nil && p.Kind == ast.KindCallExpression {
+					if p.AsCallExpression().Expression == node {
+						called = true
+					}
+				}
+				if reportedIdentifiers[node.Pos()] {
+					return
+				}
+				reportedIdentifiers[node.Pos()] = true
+				if hasFlowSuppression(sf, node) {
+					return
+				}
+				ctx.ReportNode(node, rule.RuleMessage{Description: useEffectEventErrorMessage(name, called)})
+			},
+		}
+	},
+}

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md
@@ -1,0 +1,107 @@
+# react-hooks/rules-of-hooks
+
+Enforce React's Rules of Hooks: hooks must only be called at the top level of
+React function components or custom Hooks, never inside loops, conditions,
+nested functions, class components, or async functions.
+
+## Rule Details
+
+This rule reports React Hook calls that violate the [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks):
+
+- A hook (a function whose name is `use` or starts with `use[A-Z0-9]`, or a
+  member access like `Namespace.useFoo`) must be called at the top level of a
+  function component or custom hook — never inside `if` / `else`, ternary
+  expressions, `&&` / `||` / `??` chains, `try` / `catch` blocks, loops, or
+  callbacks.
+- A hook must not be called after an early `return` or `throw`.
+- A hook must not be called inside a class component (method, accessor, or
+  class-field arrow), inside an `async` function, or at the top level of a
+  module.
+- The React `use(...)` hook is exempt from the loop, conditional, and
+  early-return checks (it may be called conditionally), but is still rejected
+  inside `try` / `catch` blocks and async functions.
+- Functions created with `useEffectEvent(...)` may only be called from inside
+  a React effect hook (`useEffect`, `useLayoutEffect`, `useInsertionEffect`,
+  or any hook matching the `additionalEffectHooks` setting) or another
+  `useEffectEvent` callback in the same component.
+
+Examples of **incorrect** code for this rule:
+
+```javascript
+function ComponentWithConditionalHook() {
+  if (cond) {
+    useConditionalHook();
+  }
+}
+
+function ComponentWithHookInsideLoop() {
+  while (cond) {
+    useHookInsideLoop();
+  }
+}
+
+function ComponentWithHookAfterEarlyReturn() {
+  if (a) return;
+  useState();
+}
+
+class ClassComponentWithHook extends React.Component {
+  render() {
+    React.useState();
+  }
+}
+
+async function AsyncComponent() {
+  useState();
+}
+
+function notAComponent() {
+  useState();
+}
+```
+
+Examples of **correct** code for this rule:
+
+```javascript
+function ComponentWithHook() {
+  useHook();
+}
+
+function useCustomHook() {
+  useState();
+}
+
+const FancyButton = React.forwardRef((props, ref) => {
+  useHook();
+  return <button {...props} ref={ref} />;
+});
+
+function App() {
+  // `use(...)` may be called conditionally
+  if (shouldShowText) {
+    const text = use(query);
+  }
+}
+```
+
+## Settings
+
+```json
+{
+  "settings": {
+    "react-hooks": {
+      "additionalEffectHooks": "(useMyEffect|useServerEffect)"
+    }
+  }
+}
+```
+
+`additionalEffectHooks`
+: A regular expression (matched against the bare hook name) that names extra
+hooks for which `useEffectEvent`-bound identifiers may be referenced as
+callbacks. Defaults to none.
+
+## Original Documentation
+
+- [react.dev — Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)
+- [Source code](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts)

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_extras_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_extras_test.go
@@ -1,0 +1,1461 @@
+package rules_of_hooks
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestRulesOfHooksRule_Extras runs rslint-specific edge cases that have no
+// upstream analog: tsgo AST quirks, naming / container boundaries,
+// path-counting edges, and additional useEffectEvent / settings shapes.
+
+var rulesOfHooksExtrasValid = []rule_tester.ValidTestCase{
+		// ---- Extra edge cases (rslint-only): paren-wrapped callees, optional chains, TS wrappers ----
+		// Paren-wrapped hook: `(useHook)()` — tsgo preserves the
+		// ParenthesizedExpression that ESTree flattens. Hook detection must
+		// see through it.
+		{Code: `
+			function ComponentWithHook() {
+				(useHook)();
+			}
+		`, Tsx: true},
+		// Paren-wrapped namespace: `(Namespace).useHook()` — same shape, two
+		// hops of paren peel.
+		{Code: `
+			function ComponentWithHook() {
+				(Namespace).useHook();
+			}
+		`, Tsx: true},
+		// Optional-chain hook in a component is allowed structurally — the
+		// rule recognizes it as a hook and the caller is a component.
+		{Code: `
+			function ComponentWithHook(obj) {
+				obj?.useFoo;
+			}
+		`, Tsx: true},
+		// `default:` clause in switch — fall-through to a hook. Switch-case
+		// bodies are treated as conditional, but a non-component caller
+		// trumps the conditional check via container-error path.
+		{Code: `
+			function ComponentWithSwitch(x) {
+				switch (x) {
+					case 1:
+						break;
+					default:
+						break;
+				}
+				useFoo();
+			}
+		`, Tsx: true},
+		// Hook inside a `finally` block — finally runs on every path, so the
+		// hook is unconditional. (Upstream's CFG includes finally on the
+		// natural exit.)
+		{Code: `
+			function ComponentWithFinally() {
+				try { mayThrow(); } finally { /* no hook here */ }
+				useFoo();
+			}
+		`, Tsx: true},
+		// `$FlowFixMe[react-rule-hook]` suppresses the report on the next line.
+		{Code: `
+			function notAComponent() {
+				// $FlowFixMe[react-rule-hook]
+				useState();
+			}
+		`, Tsx: true},
+
+		// ---- Path-counting edge cases (where AST heuristic vs upstream CFG could diverge) ----
+		// for-loop initializer: hook runs once before the loop starts.
+		// Upstream CFG places the init segment outside the loop; we must
+		// not trigger loopError here.
+		{Code: `
+			function Component() {
+				for (let x = useHook(); cond; ) {
+					log();
+				}
+			}
+		`, Tsx: true},
+		// for-of right-hand side: evaluated once before iteration begins.
+		// Upstream's CFG keeps the RHS in the pre-loop segment.
+		{Code: `
+			function Component() {
+				for (const x of useArr()) {
+					log(x);
+				}
+			}
+		`, Tsx: true},
+		// for-in right-hand side: same shape as for-of.
+		{Code: `
+			function Component() {
+				for (const k in useObj()) {
+					log(k);
+				}
+			}
+		`, Tsx: true},
+		// try block first statement: nothing in the try block can throw
+		// before the hook, so upstream's path counting concludes the hook
+		// is on every path.
+		{Code: `
+			function Component() {
+				try {
+					useState();
+				} catch {}
+			}
+		`, Tsx: true},
+		// finally block first statement: finally runs on every code path,
+		// so the hook is unconditional.
+		{Code: `
+			function Component() {
+				try {
+					foo();
+				} finally {
+					useHook();
+				}
+			}
+		`, Tsx: true},
+		// Ternary condition position: `useHook() ? a : b` evaluates the
+		// hook unconditionally; the conditional branches are the
+		// consequent/alternate, not the test.
+		{Code: `
+			function Component() {
+				return useHook() ? a : b;
+			}
+		`, Tsx: true},
+		// Logical-and LEFT operand: always evaluated.
+		{Code: `
+			function Component() {
+				return useHook() && extra;
+			}
+		`, Tsx: true},
+		// Logical-or LEFT operand: always evaluated.
+		{Code: `
+			function Component() {
+				return useHook() || fallback;
+			}
+		`, Tsx: true},
+		// Nullish-coalescing LEFT operand: always evaluated.
+		{Code: `
+			function Component() {
+				return useHook() ?? fallback;
+			}
+		`, Tsx: true},
+		// Nested hook call as argument: both inner and outer are evaluated
+		// unconditionally on the call path.
+		{Code: `
+			function useFoo() {
+				return useBar(useBaz());
+			}
+		`, Tsx: true},
+		// Hook AFTER a switch where every clause falls through cleanly.
+		// The merge point post-switch is on every path.
+		{Code: `
+			function Component(x) {
+				switch (x) {
+					case 1: log(); break;
+					case 2: log(); break;
+					default: log(); break;
+				}
+				useHook();
+			}
+		`, Tsx: true},
+		// Unconditional `throw useHook()`: the hook is evaluated before the
+		// throw, on every path. The function has no natural exit, but
+		// upstream's path-counting reasoning still treats the hook segment
+		// as reached on every reachable path.
+		{Code: `
+			function Component() {
+				throw useHook();
+			}
+		`, Tsx: true},
+		// Spread argument: hook evaluated as part of normal call sequence.
+		{Code: `
+			function Component() {
+				foo(...useHooks());
+			}
+		`, Tsx: true},
+		// TS `as` cast around hook call — not a conditional wrapper.
+		{Code: `
+			function Component() {
+				return useHook() as any;
+			}
+		`, Tsx: true},
+		// Comma operator: every operand evaluates left-to-right.
+		{Code: `
+			function Component() {
+				return (a, useHook());
+			}
+		`, Tsx: true},
+		// for-loop CONDITION position: every iteration evaluates the
+		// condition, including the very first one — this DOES make the
+		// hook cycled. (Sanity check: confirm we still flag it as a loop.)
+		// — moved to invalid below.
+
+		// ---- Callee-shape edge cases (rslint-only) ----
+		// Element access form: `Foo['useBar']()` — upstream rejects
+		// `node.computed`, we don't recognize ElementAccessExpression as a
+		// hook. Not a hook call → no report regardless of caller context.
+		{Code: `
+			function notAComponent() {
+				Foo['useBar']();
+			}
+		`, Tsx: true},
+		// Numeric-key access: `Foo[0]()` — same path; not a hook.
+		{Code: `
+			function notAComponent() {
+				Foo[0]();
+			}
+		`, Tsx: true},
+		// PrivateIdentifier in property access: `Foo.#useBar()` — `#useBar`
+		// is a PrivateIdentifier, not a regular Identifier; we never look up
+		// hook names on it.
+		{Code: `
+			class C {
+				#useBar() {}
+				m() { this.#useBar(); }
+			}
+		`, Tsx: true},
+		// TS `as` cast wrapping the callee: `(useFoo as any)()` — ESTree
+		// (and upstream) never sees the AsExpression wrapper, so the hook
+		// name is hidden behind it. We mirror that observably: the
+		// AsExpression wrapper makes the callee an AsExpression, not an
+		// Identifier — so we don't recognize it as a hook either. (Both
+		// implementations are uniformly silent here.)
+		{Code: `
+			function notAComponent() {
+				(useFoo as any)();
+			}
+		`, Tsx: true},
+		// Non-null assertion on the callee: `useFoo!()`. Same as `as`-cast
+		// — the assertion node hides the Identifier from the rule.
+		{Code: `
+			function notAComponent() {
+				useFoo!();
+			}
+		`, Tsx: true},
+		// `<T>x` type-assertion form (only legal in .ts, not .tsx — in .tsx
+		// `<any>` would parse as a JSX tag). Same family as the two above:
+		// the wrapper hides the Identifier from the rule.
+		{Code: `
+			function notAComponent() {
+				(<any>useFoo)();
+			}
+		`, Tsx: false},
+		// Optional-chain hook callee in a component: still a hook.
+		{Code: `
+			function Component() {
+				Foo?.useBar();
+			}
+		`, Tsx: true},
+
+		// ---- Hook-naming boundary cases ----
+		// Digit-suffix hook names: use[0-9] are valid hooks.
+		{Code: `
+			function Component() {
+				use1();
+				use9();
+			}
+		`, Tsx: true},
+		// All-uppercase suffix is a hook name (regex says ^use[A-Z0-9]).
+		{Code: `
+			function Component() {
+				useFOO();
+				useFooBAR();
+			}
+		`, Tsx: true},
+		// `_use*` is NOT a hook name (regex anchors on first char).
+		{Code: `
+			function notAComponent() {
+				_use();
+				_useState();
+				_useFoo();
+			}
+		`, Tsx: true},
+		// `use_*` (snake_case after `use`) is NOT a hook.
+		{Code: `
+			function notAComponent() {
+				use_();
+				use_hook();
+				use_Foo();
+			}
+		`, Tsx: true},
+		// Single-letter PascalCase namespace counts.
+		{Code: `
+			function Component() {
+				A.useFoo();
+			}
+		`, Tsx: true},
+		// Underscore-prefixed namespace is NOT PascalCase per upstream
+		// regex `^[A-Z]` — so `_Foo.useBar()` is not a hook.
+		{Code: `
+			function notAComponent() {
+				_Foo.useBar();
+			}
+		`, Tsx: true},
+
+		// ---- Component-name boundary ----
+		// Function declared as a component but returns no JSX — naming
+		// alone classifies it; rule does not inspect return value.
+		{Code: `
+			function Foo() {
+				useState();
+			}
+		`, Tsx: true},
+		// Lowercase factory then named-Component arrow inside.
+		{Code: `
+			const componentFactory = () => {
+				const Inner = () => { useState(); return null; };
+				return Inner;
+			};
+		`, Tsx: true},
+
+		// ---- Control-flow edge nests ----
+		// Inner try first stmt — upstream's path counting: hook segment
+		// reached on every reachable path inside inner try.
+		{Code: `
+			function Component() {
+				try {
+					try {
+						useHook();
+					} catch {}
+				} catch {}
+			}
+		`, Tsx: true},
+		// Try-finally with return in try: finally still runs unconditionally.
+		{Code: `
+			function Component() {
+				try {
+					return 1;
+				} finally {
+					useHook();
+				}
+			}
+		`, Tsx: true},
+		// Switch with no default + hook AFTER the switch: post-switch is
+		// the merge point on every path.
+		{Code: `
+			function Component(x) {
+				switch (x) {
+					case 1: log(); break;
+					case 2: log(); break;
+				}
+				useHook();
+			}
+		`, Tsx: true},
+		// For-of with `break` inside body, hook AFTER the loop: hook is on
+		// every path leaving the loop.
+		{Code: `
+			function Component() {
+				for (const x of arr) {
+					if (a) break;
+					log(x);
+				}
+				useHook();
+			}
+		`, Tsx: true},
+		// `while (true) { useHook(); }` — body is cycled. Tested as INVALID
+		// below. Here we add a sanity-check that an outer hook OUTSIDE the
+		// loop is fine even if the loop is unreachable from below.
+		{Code: `
+			function Component() {
+				useHook();
+				while (true) { /* infinite */ break; }
+			}
+		`, Tsx: true},
+		// Labeled `continue` inside a labeled loop: hook after is still
+		// reached on every iteration's tail path.
+		{Code: `
+			function Component() {
+				outer: for (const x of arr) {
+					if (a) continue outer;
+					log(x);
+				}
+				useHook();
+			}
+		`, Tsx: true},
+
+		// ---- useEffectEvent: nested effects, React.* form, BindingElement ----
+		// React.useEffect form referencing useEffectEvent.
+		{Code: `
+			function MyComponent() {
+				const onClick = useEffectEvent(() => {});
+				React.useEffect(() => { onClick(); }, []);
+			}
+		`, Tsx: true},
+		// Same identifier name in two unrelated components, each binding a
+		// useEffectEvent and using it INSIDE useEffect → both valid.
+		{Code: `
+			function A() {
+				const onClick = useEffectEvent(() => {});
+				useEffect(() => { onClick(); });
+			}
+			function B() {
+				const onClick = useEffectEvent(() => {});
+				useEffect(() => { onClick(); });
+			}
+		`, Tsx: true},
+		// Same identifier name, but in B it's a parameter — NOT a binding.
+		// The fallback (name-based) resolver could be confused; the
+		// TypeChecker path resolves correctly. Test ensures B's onClick
+		// doesn't get falsely reported.
+		{Code: `
+			function A({ theme }) {
+				const onClick = useEffectEvent(() => {});
+				useEffect(() => { onClick(); });
+			}
+			function B({ onClick }) {
+				return <Child onClick={onClick} />;
+			}
+		`, Tsx: true},
+
+		// ---- use() boundary ----
+		// `use()` inside an arbitrary callback that is NOT a component or
+		// hook — upstream's logic skips genericError for `use()`.
+		{Code: `
+			function App() {
+				callback(() => use(p));
+			}
+		`, Tsx: true},
+		// React.use() in component conditional position — allowed.
+		{Code: `
+			function App() {
+				if (cond) {
+					return React.use(promise);
+				}
+				return null;
+			}
+		`, Tsx: true},
+
+		// ---- settings edge: invalid regex silently ignored ----
+		{
+			Code: `
+				function MyComponent() {
+					const onClick = useEffectEvent(() => {});
+					useEffect(() => { onClick(); });
+				}
+			`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react-hooks": map[string]interface{}{
+					"additionalEffectHooks": "(unclosed",
+				},
+			},
+		},
+		// settings present but `react-hooks` key missing — should be ignored.
+		{
+			Code: `
+				function MyComponent() {
+					const onClick = useEffectEvent(() => {});
+					useEffect(() => { onClick(); });
+				}
+			`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"some-other-plugin": map[string]interface{}{"key": "value"},
+			},
+		},
+
+		// ---- Multi-return hook reachability ----
+		// `if (a) return; if (b) return; useFoo();` — two early returns.
+		// (We keep this as INVALID below since either gate triggers
+		// "after early return".)
+
+		// ---- Multi-level namespace hook callee (NOT recognized as hook) ----
+		// `Foo?.Bar.useBaz()` — `Bar.useBaz` makes the object of the outer
+		// PropertyAccess a PropertyAccessExpression (not Identifier).
+		// Upstream's `isHook` recursion requires obj to be an Identifier;
+		// we mirror that → not a hook call.
+		{Code: `
+			function notAComponent() {
+				Foo?.Bar.useBaz();
+			}
+		`, Tsx: true},
+		// `A.B.useFoo()` — three-level path; same shape, same outcome.
+		{Code: `
+			function notAComponent() {
+				A.B.useFoo();
+			}
+		`, Tsx: true},
+
+		// ---- Receiver shapes that are NOT Identifier (no hook) ----
+		// `this.useFoo()` — `this` is ThisKeyword, not Identifier.
+		{Code: `
+			function Component() {
+				this.useFoo();
+			}
+		`, Tsx: true},
+		// `super.useFoo()` — `super` is SuperKeyword (only valid inside
+		// class methods, but we test the rule's view of it).
+		{Code: `
+			class C extends X {
+				m() { super.useFoo(); }
+			}
+		`, Tsx: true},
+
+		// ---- Non-CallExpression contexts (no rule trigger) ----
+		// Tagged template: `useFoo\`...\`` is TaggedTemplateExpression,
+		// not CallExpression — rule's listener doesn't fire.
+		{Code: `
+			function notAComponent() {
+				useFoo` + "`hello`" + `;
+			}
+		`, Tsx: true},
+		// `new useFoo()` — NewExpression, not CallExpression.
+		{Code: `
+			function notAComponent() {
+				new useFoo();
+			}
+		`, Tsx: true},
+		// Plain identifier reference, not invoked.
+		{Code: `
+			function notAComponent() {
+				const f = useFoo;
+				return f;
+			}
+		`, Tsx: true},
+
+		// ---- Naming boundary: `$` and other non-[A-Z0-9] chars ----
+		// `useTYPESCRIPT` — all-caps suffix, valid hook name.
+		// `use$` — `$` is not in [A-Z0-9] → NOT a hook.
+		{Code: `
+			function notAComponent() {
+				use$();
+			}
+		`, Tsx: true},
+		// `Foo9.useBar()` — digit-suffix PascalCase namespace is valid.
+		{Code: `
+			function Component() {
+				Foo9.useBar();
+			}
+		`, Tsx: true},
+
+		// ---- Component / hook container variants ----
+		// Named default export — uses the function's own name.
+		{Code: `
+			export default function Component() {
+				useState();
+			}
+		`, Tsx: true},
+		// Named function expression as variable initializer — function's
+		// own name wins over the LHS const.
+		{Code: `
+			const X = function ComponentName() {
+				useState();
+			};
+		`, Tsx: true},
+		// Class field initializer with named arrow assignment — name
+		// resolved from the class field name should not affect a
+		// component-named outer.
+		{Code: `
+			function Component() {
+				const useNested = () => {
+					useState();
+				};
+				return null;
+			}
+		`, Tsx: true},
+		// Object getter named like a hook — getter inside ObjectLiteral
+		// resolves its own name.
+		{Code: `
+			const obj = {
+				get useFoo() {
+					useState();
+					return 0;
+				}
+			};
+		`, Tsx: true},
+		// Generator hook — function* with hook name.
+		{Code: `
+			function* useGenerator() {
+				useState();
+			}
+		`, Tsx: true},
+
+		// ---- Nested forwardRef / memo (component recognition still applies) ----
+		{Code: `
+			const C = memo(forwardRef((props, ref) => {
+				useHook();
+				return <button {...props} ref={ref} />;
+			}));
+		`, Tsx: true},
+		{Code: `
+			const C = React.memo(React.forwardRef((props, ref) => {
+				useHook();
+				return <button {...props} ref={ref} />;
+			}));
+		`, Tsx: true},
+		// forwardRef wrapped in memo with React.memo + bare forwardRef.
+		{Code: `
+			const C = React.memo(forwardRef(function Inner(props, ref) {
+				useHook();
+				return <button />;
+			}));
+		`, Tsx: true},
+
+		// ---- JSX expression positions in components ----
+		// JSX attribute value calling a hook — unconditional.
+		{Code: `
+			function Component() {
+				return <Child x={useState()} />;
+			}
+		`, Tsx: true},
+		// JSX fragment short syntax with hook expression.
+		{Code: `
+			function Component() {
+				return <>{useState()}</>;
+			}
+		`, Tsx: true},
+		// React.Fragment with hook expression.
+		{Code: `
+			function Component() {
+				return <React.Fragment>{useState()}</React.Fragment>;
+			}
+		`, Tsx: true},
+
+		// ---- Multi-level throw inside if (no early-return signal) ----
+		// `if (a) { if (b) throw new Error(); } useFoo();` — throws don't
+		// count as early-return; useFoo reachable on every non-thrown path.
+		{Code: `
+			function Component() {
+				if (a) {
+					if (b) {
+						throw new Error();
+					}
+				}
+				useFoo();
+			}
+		`, Tsx: true},
+
+		// ---- continue / break out of loop, hook AFTER loop ----
+		// `for (...) { if (a) break; } useFoo()` — useFoo on every path
+		// leaving the loop.
+		{Code: `
+			function Component() {
+				for (const x of arr) {
+					if (a) break;
+				}
+				useFoo();
+			}
+		`, Tsx: true},
+		// continue with no label, hook after loop.
+		{Code: `
+			function Component() {
+				for (const x of arr) {
+					if (a) continue;
+					log(x);
+				}
+				useFoo();
+			}
+		`, Tsx: true},
+
+		// ---- settings malformed ----
+		// settings.react-hooks is a string (wrong type) → silently ignored.
+		{
+			Code: `
+				function MyComponent() {
+					const onClick = useEffectEvent(() => {});
+					useEffect(() => { onClick(); });
+				}
+			`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react-hooks": "should-be-object",
+			},
+		},
+		// settings.react-hooks.additionalEffectHooks is a number (wrong type).
+		{
+			Code: `
+				function MyComponent() {
+					const onClick = useEffectEvent(() => {});
+					useEffect(() => { onClick(); });
+				}
+			`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react-hooks": map[string]interface{}{
+					"additionalEffectHooks": 42,
+				},
+			},
+		},
+
+		// ---- Edge cases of "AST heuristic vs BigInt path counting" ----
+		// #5 multiple `break outer` jumping to the same label, hook AFTER
+		// the outer loop. useBar is on every reachable path.
+		{Code: `
+			function useFoo() {
+				outer: for (const x of arr) {
+					for (const y of inner) {
+						if (a) break outer;
+						if (b) break outer;
+						if (c) break outer;
+					}
+				}
+				useBar();
+			}
+		`, Tsx: true},
+		// #9 try with return + finally with hook: finally always runs.
+		{Code: `
+			function Component() {
+				try {
+					return foo();
+				} finally {
+					useBar();
+				}
+			}
+		`, Tsx: true},
+		// #16 with-statement (only legal in non-strict mode .ts files).
+		// `with(obj) { useFoo(); }` — body is unconditional, hook reached.
+		{Code: `
+			function Component() {
+				with (obj) {
+					useFoo();
+				}
+			}
+		`, Tsx: false},
+		// #20 optional-chain on the hook callee itself: `Foo?.useBar?.()`
+		// — still recognized as a hook (object is Identifier, prop is hook).
+		{Code: `
+			function Component() {
+				Foo?.useBar?.();
+			}
+		`, Tsx: true},
+		// #21 chained optional access: object is PropertyAccess, not
+		// Identifier → not a hook callee.
+		{Code: `
+			function notAComponent() {
+				Foo?.Bar?.useBaz();
+			}
+		`, Tsx: true},
+		// #22 NOTE: a "block-scoped useEffectEvent binding referenced in
+		// the same block" is a contradiction in upstream's model: any
+		// useEffectEvent declared inside an `if` is itself a conditional
+		// hook (and inline-passed-down). The valid scenario is covered by
+		// the cross-function test below.
+		// Cross-function useEffectEvent: binding in Outer, referenced in
+		// nested Inner component's useEffect callback.
+		{Code: `
+			function Outer() {
+				const onClick = useEffectEvent(() => {});
+				function Inner() {
+					useEffect(() => { onClick(); });
+				}
+			}
+		`, Tsx: true},
+		// #29 trailing-line $FlowFixMe (same line as hook): does NOT
+		// suppress (upstream requires `endLine === hookLine - 1`).
+		// Already exercised structurally elsewhere; here we add the
+		// "trailing on same line is NOT a suppression" expectation as
+		// INVALID below. Here we lock in the BLOCK-comment leading variant.
+		// #30 block comment on the line above suppresses.
+		{Code: `
+			function notAComponent() {
+				/* $FlowFixMe[react-rule-hook] */
+				useState();
+			}
+		`, Tsx: true},
+		// Multi-line block comment ending one line above the hook also suppresses.
+		{Code: `
+			function notAComponent() {
+				/*
+				 * $FlowFixMe[react-rule-hook]
+				 */
+				useState();
+			}
+		`, Tsx: true},
+}
+
+var rulesOfHooksExtrasInvalid = []rule_tester.InvalidTestCase{
+		// ---- Extra edges (rslint-only): paren-wrapped callees, optional / TS wrappers ----
+		// Paren-wrapped hook callee in a non-component named function: still
+		// detected as a hook call → functionError.
+		{
+			Code: `
+				function notAComponent() {
+					(useState)();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+			},
+		},
+		// Paren-wrapped namespace call: `(Hook).useState()` at top level.
+		{
+			Code: `
+				(Hook).useState();
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "(Hook).useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+		// Switch case body: hook is conditional.
+		{
+			Code: `
+				function Component(x) {
+					switch (x) {
+						case 1:
+							useFoo();
+							break;
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// Hook inside catch block: conditional.
+		{
+			Code: `
+				function Component() {
+					try {
+						foo();
+					} catch (e) {
+						useState();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// Hook nested via labeled break inside else of an if: still
+		// recognized via the labeled-break sibling walk.
+		{
+			Code: `
+				function useBlock() {
+					outer: {
+						if (cond) {
+							break outer;
+						}
+						useFoo();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// `$FlowFixMe[react-rule-hook]` on a different line does NOT suppress.
+		{
+			Code: `
+				// $FlowFixMe[react-rule-hook]
+
+				function notAComponent() {
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+			},
+		},
+		// for-loop CONDITION: hook in `for (; useFoo(); ) {}` IS cycled
+		// (re-evaluated each iteration) — should still report loopError.
+		{
+			Code: `
+				function Component() {
+					for (; useHook(); ) {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// for-loop INCREMENTOR: same as condition — runs each iteration.
+		{
+			Code: `
+				function Component() {
+					for (let i = 0; i < 10; useHook()) {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// Try block with prior throwable statement: still conditional (mirrors
+		// upstream's existing test, kept here too as a position-aware check
+		// for our `isInsideTryBlockWithPriorStmt` helper).
+		{
+			Code: `
+				function Component() {
+					try {
+						doSomething();
+						useHook();
+					} catch {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// Hook reached only via a labeled-break inside an else branch.
+		{
+			Code: `
+				function useFoo() {
+					outer: {
+						if (a) {
+							log();
+						} else {
+							break outer;
+						}
+						useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+		// Nested labeled blocks where the break target is the outer label.
+		{
+			Code: `
+				function useFoo() {
+					outer: {
+						inner: {
+							if (a) break outer;
+						}
+						useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- More callee-shape invalid cases ----
+		// Optional-chain hook callee at top level (no enclosing function):
+		// still detected as a hook, reports topLevelError.
+		{
+			Code: `
+				Foo?.useBar();
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "Foo?.useBar" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+		// Numeric / digit-only suffix hook in a non-component function.
+		{
+			Code: `
+				function notAComponent() {
+					use1();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use1" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+			},
+		},
+
+		// ---- Switch fall-through: hook in case body that follows another. ----
+		{
+			Code: `
+				function Component(x) {
+					switch (x) {
+						case 1: log();
+						case 2: useHook(); break;
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- Multi-return reachability ----
+		{
+			Code: `
+				function useHook() {
+					if (a) return;
+					if (b) return;
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
+			},
+		},
+
+		// ---- Nested if both return ----
+		{
+			Code: `
+				function useHook() {
+					if (a) {
+						if (b) return;
+					}
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
+			},
+		},
+
+		// ---- Inner try block N-th statement (with prior throwable) ----
+		{
+			Code: `
+				function Component() {
+					try {
+						foo();
+						try {
+							bar();
+							useHook();
+						} catch {}
+					} catch {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- use() in finally → tryCatchUseError (TryStatement covers
+		// finally per upstream's isInsideTryCatch) ----
+		{
+			Code: `
+				function App() {
+					try { foo(); } finally { use(p); }
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" cannot be called in a try/catch block.`},
+			},
+		},
+
+		// ---- React.use() in try block ----
+		{
+			Code: `
+				function App({p}) {
+					try { React.use(p); } catch {}
+					return <div/>;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "React.use" cannot be called in a try/catch block.`},
+			},
+		},
+
+		// ---- For-of loop body break + hook in same body before break ----
+		{
+			Code: `
+				function Component() {
+					for (const x of arr) {
+						useHook();
+						if (a) break;
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- while(true) infinite loop with hook in body ----
+		{
+			Code: `
+				function Component() {
+					while (true) {
+						useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- useEffectEvent: same-name across components (line 1808 upstream) ----
+		{
+			Code: `
+				function MyComponent({theme}) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme)
+					});
+					return <Child onClick={onClick} />
+				}
+
+				function MyOtherComponent({theme}) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme)
+					});
+					return <Child onClick={() => onClick()} />
+				}
+
+				function MyLastComponent({theme}) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme)
+					});
+					useEffect(() => {
+						onClick();
+						onClick;
+					})
+					return <Child />
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+			},
+		},
+
+		// ---- useEffectEvent: multi-error one component (line 1959 upstream) ----
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					const onClick2 = () => { onClick() };
+					const onClick3 = useCallback(() => onClick(), []);
+					const onClick4 = onClick;
+					return <>
+						<Child onClick={onClick}></Child>
+						<Child onClick={onClick2}></Child>
+						<Child onClick={onClick3}></Child>
+					</>;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+			},
+		},
+
+		// ---- additionalEffectHooks partial-match behavior ----
+		// The regex `useM` matches any name starting with `useM` because
+		// upstream uses `RegExp.test`, not exact match. So `useMyEffect`
+		// AND `useMaintenance` both qualify. We don't currently test the
+		// negative side; here we lock in that a non-matching name still
+		// triggers the report.
+		{
+			Code: `
+				function MyComponent() {
+					const onClick = useEffectEvent(() => {});
+					useUnrelatedHook(() => { onClick(); });
+				}
+			`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react-hooks": map[string]interface{}{
+					"additionalEffectHooks": "useM",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+			},
+		},
+
+		// ---- Class expression component — hook in render ----
+		{
+			Code: `
+				const Foo = class extends React.Component {
+					render() {
+						useState();
+						return null;
+					}
+				};
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+		// Class constructor calling hook → classError.
+		{
+			Code: `
+				class C extends X {
+					constructor() {
+						super();
+						useState();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+
+		// ---- Async generator function: hook + async modifier → asyncError ----
+		{
+			Code: `
+				async function* Page() {
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in an async function.`},
+			},
+		},
+
+		// ---- useEffectEvent inline used as expression in another hook ----
+		// `const x = useMemo(() => useEffectEvent(...), [])` — useEffectEvent
+		// call's parent is an ArrowFunction (concise body), not a
+		// VariableDeclaration / ExpressionStatement → inline-passed-down.
+		// Upstream ALSO reports "called inside a callback" because
+		// `useEffectEvent` matches `use[A-Z]` and so passes through
+		// `isHook` — so the call gets the generic-callback report on top
+		// of the inline-passed-down report.
+		{
+			Code: `
+				function MyComponent() {
+					const x = useMemo(() => useEffectEvent(() => {}), []);
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.`},
+				{Message: `React Hook "useEffectEvent" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+		// useEffectEvent immediately invoked: `useEffectEvent(() => {})()`
+		// — the inner CE's parent is the outer CE → not an allowed parent.
+		{
+			Code: `
+				function MyComponent() {
+					useEffectEvent(() => {})();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.`},
+			},
+		},
+
+		// ---- Conditional expression assigned, both branches call hooks ----
+		{
+			Code: `
+				function Component() {
+					const x = a ? useFoo() : useBar();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+				{Message: `React Hook "useBar" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- 4-deep && short-circuit with hook on rightmost ----
+		{
+			Code: `
+				function Component() {
+					return a && b && c && useFoo();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- Switch with hook + return mixed across cases ----
+		{
+			Code: `
+				function Component(x) {
+					switch (x) {
+						case 1: useFoo(); return;
+						default: useBar();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+				{Message: `React Hook "useBar" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- Labeled continue: hook BEFORE the continue in loop body ----
+		// useFoo runs every iteration's first half (continue or no);
+		// `for (const x of arr) { useFoo(); if (a) continue outer; ... }` —
+		// useFoo is in body → loopError.
+		{
+			Code: `
+				function Component() {
+					outer: for (const x of arr) {
+						useFoo();
+						if (a) continue outer;
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- Decorator at module scope calling a hook ----
+		// `@useDecorator() class C {}` — useDecorator is at the call's
+		// position; no enclosing function → topLevelError.
+		{
+			Code: `
+				@useDecorator() class C {}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useDecorator" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+
+		// ---- Try-finally without catch, hook AFTER throwable in try ----
+		// (Potential divergence point: upstream's path counting reasoning
+		// vs our "any prior throwable in try" heuristic.)
+		{
+			Code: `
+				function Component() {
+					try {
+						foo();
+						useHook();
+					} finally {
+						bar();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// ---- Edge: BigInt-territory checks ----
+		// #1 N if-else with one branch returning each time, then hook.
+		// Upstream's path counting: useState segment path = 1 / total = 2^N.
+		// Our sibling-walk catches the first `if (...) return;` and reports
+		// early-return; both implementations report.
+		{
+			Code: `
+				function useFoo() {
+					if (a1) {} else { return; }
+					if (a2) {} else { return; }
+					if (a3) {} else { return; }
+					if (a4) {} else { return; }
+					if (a5) {} else { return; }
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`},
+			},
+		},
+
+		// #7 try / catch / finally — hook in each. The catch branch is
+		// conditional; try block first stmt and finally first stmt are
+		// unconditional in upstream's path counting (and ours).
+		{
+			Code: `
+				function Component() {
+					try { useFoo(); } catch { useBar(); } finally { useBaz(); }
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useBar" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// #23 Nested useEffectEvent: inner `b` is itself a hook (matches
+		// `use[A-Z]`) declared inside the outer useEffectEvent's callback,
+		// not the component's top level → upstream and we both report
+		// "called inside a callback".
+		{
+			Code: `
+				function Comp() {
+					const a = useEffectEvent(() => {
+						const b = useEffectEvent(() => {});
+						return b;
+					});
+					useEffect(() => a());
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useEffectEvent" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+
+		// #24 useEffectEvent binding outside try, but the useEffect call
+		// referencing it sits in a try block AFTER a throwable statement
+		// → useEffect itself is reported as conditional.
+		{
+			Code: `
+				function Comp() {
+					const onClick = useEffectEvent(() => {});
+					try {
+						doSomething();
+						useEffect(() => { onClick(); });
+					} catch {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useEffect" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+			},
+		},
+
+		// #29 trailing $FlowFixMe on the SAME line as the hook does NOT
+		// suppress (upstream requires line === hookLine - 1).
+		{
+			Code: `
+				function notAComponent() {
+					useState(); // $FlowFixMe[react-rule-hook]
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+			},
+		},
+
+		// #36 ClassStaticBlock — hook directly inside `static {}` block.
+		// Behavior: ClassStaticBlock is NOT a function-like container in
+		// our model → findEnclosingFunction skips up to module → fn=nil →
+		// topLevelError. Upstream's behavior on parser-hermes / standard
+		// ESTree may differ; we lock in our observed behavior here.
+		{
+			Code: `
+				class C {
+					static {
+						useFoo();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFoo" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`},
+			},
+		},
+}
+
+func TestRulesOfHooksRule_Extras(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &RulesOfHooksRule,
+		rulesOfHooksExtrasValid,
+		rulesOfHooksExtrasInvalid,
+	)
+}

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_test.go
@@ -1,0 +1,101 @@
+package rules_of_hooks
+
+import (
+	"testing"
+
+	"github.com/microsoft/typescript-go/shim/ast"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// Test suites in this package are split across three files by case origin
+// rather than by diagnostic kind:
+//
+//   - rules_of_hooks_upstream_test.go — TestRulesOfHooksRule_Upstream:
+//     valid + invalid cases ported from upstream `RulesOfHooks-test.js`.
+//   - rules_of_hooks_extras_test.go   — TestRulesOfHooksRule_Extras:
+//     rslint-specific edges (tsgo AST quirks, naming / container boundary,
+//     path-counting edges, extra useEffectEvent / settings shapes).
+//   - rules_of_hooks_test.go (this file) — TestRulesOfHooksNilTypeChecker:
+//     end-to-end nil-safety check for ctx.TypeChecker.
+
+func TestRulesOfHooksNilTypeChecker(t *testing.T) {
+	t.Parallel()
+	rootDir := fixtures.GetRootDir()
+	filePath := tspath.ResolvePath(rootDir, "react.tsx")
+	// Code intentionally exercises every listener that touches the
+	// useEffectEvent resolver: a binding declaration, a JSX-attribute
+	// reference, and a callee-position reference inside a regular
+	// callback. If the rule deref'd a nil tc anywhere along that flow,
+	// running listeners would panic.
+	code := `
+function MyComponent({ theme }: { theme: string }) {
+  const onClick = useEffectEvent(() => {
+    console.log(theme);
+  });
+  useEffect(() => {
+    onClick();
+  });
+  return <Child onClick={onClick} />;
+}
+`
+	fs := utils.NewOverlayVFSForFile(filePath, code)
+	program, err := utils.CreateProgram(
+		true, fs, rootDir, "tsconfig.json", utils.CreateCompilerHost(rootDir, fs),
+	)
+	if err != nil {
+		t.Fatalf("CreateProgram: %v", err)
+	}
+	sourceFile := program.GetSourceFile(filePath)
+	if sourceFile == nil {
+		t.Fatalf("source file not found for %s", filePath)
+	}
+
+	ctx := rule.RuleContext{
+		SourceFile:  sourceFile,
+		Program:     program,
+		Settings:    nil,
+		TypeChecker: nil, // explicitly nil — this is the path under test
+		ReportNode: func(node *ast.Node, msg rule.RuleMessage) {
+			// noop — we only care that nothing panics.
+		},
+		ReportRange: func(_ core.TextRange, _ rule.RuleMessage) {
+		},
+		ReportNodeWithFixes: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleFix) {
+		},
+		ReportRangeWithFixes: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleFix) {
+		},
+		ReportNodeWithSuggestions: func(_ *ast.Node, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
+		},
+		ReportRangeWithSuggestions: func(_ core.TextRange, _ rule.RuleMessage, _ ...rule.RuleSuggestion) {
+		},
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Run() panicked with nil TypeChecker: %v", r)
+		}
+	}()
+
+	listeners := RulesOfHooksRule.Run(ctx, nil)
+
+	// Walk the entire tree once, dispatching each node to the matching
+	// listener. This exercises the same code paths the linter runtime
+	// would hit in production.
+	var walk func(n *ast.Node) bool
+	walk = func(n *ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		if cb, ok := listeners[n.Kind]; ok {
+			cb(n)
+		}
+		n.ForEachChild(walk)
+		return false
+	}
+	walk(sourceFile.AsNode())
+}
+

--- a/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_upstream_test.go
+++ b/internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks_upstream_test.go
@@ -1,0 +1,1597 @@
+package rules_of_hooks
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/react_hooks/rules/fixtures"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// TestRulesOfHooksRule_Upstream runs every valid + invalid case ported from
+// upstream `RulesOfHooks-test.js`. Flow-syntax cases (`component` / `hook`
+// keywords) carry `Skip: true` with a `// SKIP:` reason and stay in the
+// suite — they will be re-enabled if rslint's parser ever supports Flow.
+
+var rulesOfHooksUpstreamValid = []rule_tester.ValidTestCase{
+		// ---- Upstream: Components and hooks may call hooks ----
+		{Code: `
+			function ComponentWithHook() {
+				useHook();
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component Button() {
+				useHook();
+				return <div>Button!</div>;
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `hook` syntax.
+		{Skip: true, Code: `
+			hook useSampleHook() {
+				useHook();
+			}
+		`, Tsx: true},
+		{Code: `
+			function createComponentWithHook() {
+				return function ComponentWithHook() {
+					useHook();
+				};
+			}
+		`, Tsx: true},
+		{Code: `
+			function useHookWithHook() {
+				useHook();
+			}
+		`, Tsx: true},
+		{Code: `
+			function createHook() {
+				return function useHookWithHook() {
+					useHook();
+				}
+			}
+		`, Tsx: true},
+		{Code: `
+			function ComponentWithNormalFunction() {
+				doSomething();
+			}
+		`, Tsx: true},
+		{Code: `
+			function normalFunctionWithNormalFunction() {
+				doSomething();
+			}
+		`, Tsx: true},
+		{Code: `
+			function normalFunctionWithConditionalFunction() {
+				if (cond) {
+					doSomething();
+				}
+			}
+		`, Tsx: true},
+		{Code: `
+			function functionThatStartsWithUseButIsntAHook() {
+				if (cond) {
+					userFetch();
+				}
+			}
+		`, Tsx: true},
+		{Code: `
+			function useUnreachable() {
+				return;
+				useHook();
+			}
+		`, Tsx: true},
+
+		// ---- Upstream: Various binding shapes for hooks ----
+		{Code: `
+			function useHook() { useState(); }
+			const whatever = function useHook() { useState(); };
+			const useHook1 = () => { useState(); };
+			let useHook2 = () => useState();
+			useHook2 = () => { useState(); };
+			({useHook: () => { useState(); }});
+			({useHook() { useState(); }});
+			const {useHook3 = () => { useState(); }} = {};
+			({useHook = () => { useState(); }} = {});
+			Namespace.useHook = () => { useState(); };
+		`, Tsx: true},
+		{Code: `
+			function useHook() {
+				useHook1();
+				useHook2();
+			}
+		`, Tsx: true},
+		{Code: `
+			function createHook() {
+				return function useHook() {
+					useHook1();
+					useHook2();
+				};
+			}
+		`, Tsx: true},
+		{Code: `
+			function useHook() {
+				useState() && a;
+			}
+		`, Tsx: true},
+		{Code: `
+			function useHook() {
+				return useHook1() + useHook2();
+			}
+		`, Tsx: true},
+		{Code: `
+			function useHook() {
+				return useHook1(useHook2());
+			}
+		`, Tsx: true},
+
+		// ---- Upstream: forwardRef / memo callbacks ----
+		{Code: `
+			const FancyButton = React.forwardRef((props, ref) => {
+				useHook();
+				return <button {...props} ref={ref} />
+			});
+		`, Tsx: true},
+		{Code: `
+			const FancyButton = React.forwardRef(function (props, ref) {
+				useHook();
+				return <button {...props} ref={ref} />
+			});
+		`, Tsx: true},
+		{Code: `
+			const FancyButton = forwardRef(function (props, ref) {
+				useHook();
+				return <button {...props} ref={ref} />
+			});
+		`, Tsx: true},
+		{Code: `
+			const MemoizedFunction = React.memo(props => {
+				useHook();
+				return <button {...props} />
+			});
+		`, Tsx: true},
+		{Code: `
+			const MemoizedFunction = memo(function (props) {
+				useHook();
+				return <button {...props} />
+			});
+		`, Tsx: true},
+
+		// ---- Upstream: classes calling functions are not hooks ----
+		{Code: `
+			class C {
+				m() {
+					this.useHook();
+					super.useHook();
+				}
+			}
+		`, Tsx: true},
+
+		// ---- Upstream: jest.useFakeTimers etc are not React hooks ----
+		{Code: `
+			jest.useFakeTimers();
+			beforeEach(() => {
+				jest.useRealTimers();
+			})
+		`, Tsx: true},
+		{Code: `
+			fooState();
+			_use();
+			_useState();
+			use_hook();
+			jest.useFakeTimer()
+		`, Tsx: true},
+
+		// ---- Upstream: "use"-prefixed callbacks in unnamed function args ----
+		{Code: `
+			function makeListener(instance) {
+				each(pixelsWithInferredEvents, pixel => {
+					if (useExtendedSelector(pixel.id) && extendedButton) {
+						foo();
+					}
+				});
+			}
+		`, Tsx: true},
+		{Code: `
+			React.unknownFunction((foo, bar) => {
+				if (foo) {
+					useNotAHook(bar)
+				}
+			});
+		`, Tsx: true},
+		{Code: `
+			unknownFunction(function(foo, bar) {
+				if (foo) {
+					useNotAHook(bar)
+				}
+			});
+		`, Tsx: true},
+
+		// ---- Upstream: regression cases ----
+		{Code: `
+			function RegressionTest() {
+				const foo = cond ? a : b;
+				useState();
+			}
+		`, Tsx: true},
+		{Code: `
+			function RegressionTest() {
+				if (page == null) {
+					throw new Error('oh no!');
+				}
+				useState();
+			}
+		`, Tsx: true},
+		{Code: `
+			function RegressionTest() {
+				const res = [];
+				const additionalCond = true;
+				for (let i = 0; i !== 10 && additionalCond; ++i ) {
+					res.push(i);
+				}
+				React.useLayoutEffect(() => {});
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent() {
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				if (c) {} else {}
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+				useHook();
+			}
+		`, Tsx: true},
+		{Code: `
+			const useSomeHook = () => {};
+			const SomeName = () => {
+				const filler = FILLER ?? FILLER ?? FILLER;
+				const filler2 = FILLER ?? FILLER ?? FILLER;
+				useSomeHook();
+				if (anyConditionCanEvenBeFalse) {
+					return null;
+				}
+				return null;
+			};
+		`, Tsx: true},
+		{Code: `
+			function App(props) {
+				const someObject = {propA: true};
+				for (const propName in someObject) {
+					if (propName === true) {
+					} else {
+					}
+				}
+				const [myState, setMyState] = useState(null);
+			}
+		`, Tsx: true},
+
+		// ---- Upstream: React `use()` may be called conditionally / in loops ----
+		{Code: `
+			function App() {
+				const text = use(Promise.resolve('A'));
+				return <Text text={text} />
+			}
+		`, Tsx: true},
+		{Code: `
+			import * as React from 'react';
+			function App() {
+				if (shouldShowText) {
+					const text = use(query);
+					const data = React.use(thing);
+					const data2 = react.use(thing2);
+					return <Text text={text} />
+				}
+				return <Text text={shouldFetchBackupText ? use(backupQuery) : "Nothing to see here"} />
+			}
+		`, Tsx: true},
+		{Code: `
+			function App() {
+				let data = [];
+				for (const query of queries) {
+					const text = use(item);
+					data.push(text);
+				}
+				return <Child data={data} />
+			}
+		`, Tsx: true},
+		{Code: `
+			function App() {
+				const data = someCallback((x) => use(x));
+				return <Child data={data} />
+			}
+		`, Tsx: true},
+
+		// ---- Upstream: TODO-style false-negatives upstream documents ----
+		{Code: `
+			export const notAComponent = () => {
+				return () => {
+					useState();
+				}
+			}
+		`, Tsx: true},
+		{Code: `
+			export default () => {
+				if (isVal) {
+					useState(0);
+				}
+			}
+		`, Tsx: true},
+		{Code: `
+			function notAComponent() {
+				return new Promise.then(() => {
+					useState();
+				});
+			}
+		`, Tsx: true},
+
+		// ---- Upstream: hook outside loop ----
+		{Code: `
+			const Component = () => {
+				const [state, setState] = useState(0);
+				for (let i = 0; i < 10; i++) {
+					console.log(i);
+				}
+				return <div></div>;
+			};
+		`, Tsx: true},
+
+		// ---- Upstream: useEffectEvent valid ----
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useMyEffect(() => {
+					onClick();
+				});
+				useServerEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true, Settings: map[string]interface{}{
+			"react-hooks": map[string]interface{}{
+				"additionalEffectHooks": "(useMyEffect|useServerEffect)",
+			},
+		}},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useMyEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useEffect(() => {
+					onClick();
+				});
+				React.useEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				const onClick2 = useEffectEvent(() => {
+					debounce(onClick);
+					debounce(() => onClick());
+					debounce(() => { onClick() });
+					deboucne(() => debounce(onClick));
+				});
+				useEffect(() => {
+					let id = setInterval(() => onClick(), 100);
+					return () => clearInterval(onClick);
+				}, []);
+				React.useEffect(() => {
+					let id = setInterval(() => onClick(), 100);
+					return () => clearInterval(onClick);
+				}, []);
+				return null;
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				useEffect(() => { onClick() });
+				return null;
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				useEffect(() => {
+					onClick();
+				});
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				useEffect(() => { onClick() });
+				const onClick = useEffectEvent(() => {});
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				const onEvent = useEffectEvent((text) => {
+					console.log(text);
+				});
+				useEffect(() => {
+					onEvent('Hello world');
+				});
+				React.useEffect(() => {
+					onEvent('Hello world');
+				});
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onEvent = useEffectEvent((text) => {});
+				useEffect(() => { onEvent('Hello world'); });
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useLayoutEffect(() => {
+					onClick();
+				});
+				React.useLayoutEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				useLayoutEffect(() => { onClick() });
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				useInsertionEffect(() => {
+					onClick();
+				});
+				React.useInsertionEffect(() => {
+					onClick();
+				});
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme) {
+				const onClick = useEffectEvent(() => {});
+				useInsertionEffect(() => { onClick() });
+			}
+		`, Tsx: true},
+		{Code: `
+			function MyComponent({ theme }) {
+				const onClick = useEffectEvent(() => {
+					showNotification(theme);
+				});
+				const onClick2 = useEffectEvent(() => {
+					debounce(onClick);
+					debounce(() => onClick());
+					debounce(() => { onClick() });
+					deboucne(() => debounce(onClick));
+				});
+				useLayoutEffect(() => {
+					let id = setInterval(() => onClick(), 100);
+					return () => clearInterval(onClick);
+				}, []);
+				React.useLayoutEffect(() => {
+					let id = setInterval(() => onClick(), 100);
+					return () => clearInterval(onClick);
+				}, []);
+				useInsertionEffect(() => {
+					let id = setInterval(() => onClick(), 100);
+					return () => clearInterval(onClick);
+				}, []);
+				React.useInsertionEffect(() => {
+					let id = setInterval(() => onClick(), 100);
+					return () => clearInterval(onClick);
+				}, []);
+				return null;
+			}
+		`, Tsx: true},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				useLayoutEffect(() => { onClick(); }, []);
+				useInsertionEffect(() => { onClick(); }, []);
+				return null;
+			}
+		`, Tsx: true},
+}
+
+var rulesOfHooksUpstreamInvalid = []rule_tester.InvalidTestCase{
+		// ---- Upstream: SKIP'd flow invalid tests ----
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component Button(cond: boolean) {
+				if (cond) {
+					useConditionalHook();
+				}
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+		}},
+		// SKIP: rslint does not parse Flow `hook` syntax.
+		{Skip: true, Code: `
+			hook useTest(cond: boolean) {
+				if (cond) {
+					useConditionalHook();
+				}
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`},
+		}},
+
+		// ---- Upstream: conditional hooks ----
+		// Lock the full range (Line+Column+EndLine+EndColumn) on the
+		// representative conditional case so a refactor that drifts the
+		// reported node (e.g. switching from callee Identifier to whole
+		// CallExpression) immediately fails. Other conditional cases
+		// elsewhere in this file omit EndLine/EndColumn for brevity but
+		// rely on this anchor + Message text for semantic equivalence.
+		{
+			Code: `
+				function ComponentWithConditionalHook() {
+					if (cond) {
+						useConditionalHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7, EndLine: 4, EndColumn: 25},
+			},
+		},
+		{
+			Code: `
+				Hook.useState();
+				Hook._useState();
+				Hook.use42();
+				Hook.useHook();
+				Hook.use_hook();
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "Hook.useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 5},
+				{Message: `React Hook "Hook.use42" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 5},
+				{Message: `React Hook "Hook.useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 5, Column: 5},
+			},
+		},
+		{
+			Code: `
+				class C {
+					m() {
+						This.useHook();
+						Super.useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				// Range covers the full PropertyAccessExpression callee
+				// (`This.useHook`), 12 chars long.
+				{Message: `React Hook "This.useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 7, EndLine: 4, EndColumn: 19},
+				{Message: `React Hook "Super.useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 5, Column: 7, EndLine: 5, EndColumn: 20},
+			},
+		},
+		{
+			Code: `
+				class Foo extends Component {
+					render() {
+						if (cond) {
+							FooStore.useFeatureFlag();
+						}
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "FooStore.useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 5, Column: 8},
+			},
+		},
+		{
+			Code: `
+				function ComponentWithConditionalHook() {
+					if (cond) {
+						Namespace.useConditionalHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "Namespace.useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function createComponent() {
+					return function ComponentWithConditionalHook() {
+						if (cond) {
+							useConditionalHook();
+						}
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 5, Column: 8},
+			},
+		},
+		{
+			Code: `
+				function useHookWithConditionalHook() {
+					if (cond) {
+						useConditionalHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function createHook() {
+					return function useHookWithConditionalHook() {
+						if (cond) {
+							useConditionalHook();
+						}
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 5, Column: 8},
+			},
+		},
+		{
+			Code: `
+				function ComponentWithTernaryHook() {
+					cond ? useTernaryHook() : null;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useTernaryHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 3, Column: 13},
+			},
+		},
+		{
+			Code: `
+				function ComponentWithHookInsideCallback() {
+					useEffect(() => {
+						useHookInsideCallback();
+					});
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function createComponent() {
+					return function ComponentWithHookInsideCallback() {
+						useEffect(() => {
+							useHookInsideCallback();
+						});
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 5, Column: 8},
+			},
+		},
+		{
+			Code: `
+				const ComponentWithHookInsideCallback = React.forwardRef((props, ref) => {
+					useEffect(() => {
+						useHookInsideCallback();
+					});
+					return <button {...props} ref={ref} />
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				const ComponentWithHookInsideCallback = React.memo(props => {
+					useEffect(() => {
+						useHookInsideCallback();
+					});
+					return <button {...props} />
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideCallback" cannot be called inside a callback. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function ComponentWithHookInsideCallback() {
+					function handleClick() {
+						useState();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function createComponent() {
+					return function ComponentWithHookInsideCallback() {
+						function handleClick() {
+							useState();
+						}
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "handleClick" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 5, Column: 8},
+			},
+		},
+
+		// ---- Upstream: loop hooks ----
+		// Anchor full range here for the loop diagnostic family.
+		{
+			Code: `
+				function ComponentWithHookInsideLoop() {
+					while (cond) {
+						useHookInsideLoop();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7, EndLine: 4, EndColumn: 24},
+			},
+		},
+		{
+			Code: `
+				function ComponentWithHookInsideLoop() {
+					do {
+						useHookInsideLoop();
+					} while (cond);
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function ComponentWithHookInsideLoop() {
+					do {
+						foo();
+					} while (useHookInsideLoop());
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 5, Column: 15},
+			},
+		},
+		{
+			Code: `
+				function renderItem() {
+					useState();
+				}
+				function List(props) {
+					return props.items.map(renderItem);
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "renderItem" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 3, Column: 6},
+			},
+		},
+		{
+			Code: `
+				function normalFunctionWithHook() {
+					useHookInsideNormalFunction();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 3, Column: 6},
+			},
+		},
+		{
+			Code: `
+				function _normalFunctionWithHook() {
+					useHookInsideNormalFunction();
+				}
+				function _useNotAHook() {
+					useHookInsideNormalFunction();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideNormalFunction" is called in function "_normalFunctionWithHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 3, Column: 6},
+				{Message: `React Hook "useHookInsideNormalFunction" is called in function "_useNotAHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 6, Column: 6},
+			},
+		},
+		{
+			Code: `
+				function normalFunctionWithConditionalHook() {
+					if (cond) {
+						useHookInsideNormalFunction();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHookInsideNormalFunction" is called in function "normalFunctionWithConditionalHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 4, Column: 7},
+			},
+		},
+
+		// ---- Upstream: useHookInLoops with various return / continue ----
+		{
+			Code: `
+				function useHookInLoops() {
+					while (a) {
+						useHook1();
+						if (b) return;
+						useHook2();
+					}
+					while (c) {
+						useHook3();
+						if (d) return;
+						useHook4();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+				{Message: `React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 6, Column: 7},
+				{Message: `React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 9, Column: 7},
+				{Message: `React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 11, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function useHookInLoops() {
+					while (a) {
+						useHook1();
+						if (b) continue;
+						useHook2();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+				{Message: `React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 6, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function useHookInLoops() {
+					do {
+						useHook1();
+						if (a) return;
+						useHook2();
+					} while (b);
+
+					do {
+						useHook3();
+						if (c) return;
+						useHook4();
+					} while (d)
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+				{Message: `React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 6, Column: 7},
+				{Message: `React Hook "useHook3" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 10, Column: 7},
+				{Message: `React Hook "useHook4" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 12, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function useHookInLoops() {
+					do {
+						useHook1();
+						if (a) continue;
+						useHook2();
+					} while (b);
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook1" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+				{Message: `React Hook "useHook2" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`, Line: 6, Column: 7},
+			},
+		},
+
+		// ---- Upstream: labeled break ----
+		{
+			Code: `
+				function useLabeledBlock() {
+					label: {
+						if (a) break label;
+						useHook();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 5, Column: 7},
+			},
+		},
+
+		// ---- Upstream: lowercase / non-component / non-hook function names ----
+		{
+			Code: `
+				function a() { useState(); }
+				const whatever = function b() { useState(); };
+				const c = () => { useState(); };
+				let d = () => useState();
+				e = () => { useState(); };
+				({f: () => { useState(); }});
+				({g() { useState(); }});
+				const {j = () => { useState(); }} = {};
+				({k = () => { useState(); }} = {});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called in function "a" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "b" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "c" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "d" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "e" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "f" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "g" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "j" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+				{Message: `React Hook "useState" is called in function "k" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`},
+			},
+		},
+
+		// ---- Upstream: early-return variants ----
+		// Anchor full range here for the early-return suffix variant.
+		{
+			Code: `
+				function useHook() {
+					if (a) return;
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`, Line: 4, Column: 6, EndLine: 4, EndColumn: 14},
+			},
+		},
+		{
+			Code: `
+				function useHook() {
+					if (a) return;
+					if (b) {
+						console.log('true');
+					} else {
+						console.log('false');
+					}
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`, Line: 9, Column: 6},
+			},
+		},
+		{
+			Code: `
+				function useHook() {
+					if (b) {
+						console.log('true');
+					} else {
+						console.log('false');
+					}
+					if (a) return;
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`, Line: 9, Column: 6},
+			},
+		},
+
+		// ---- Upstream: short-circuit variants ----
+		{
+			Code: `
+				function useHook() {
+					a && useHook1();
+					b && useHook2();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useHook1" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 3, Column: 11},
+				{Message: `React Hook "useHook2" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 11},
+			},
+		},
+		{
+			Code: `
+				function useHook() {
+					try {
+						f();
+						useState();
+					} catch {}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 5, Column: 7},
+			},
+		},
+		{
+			Code: `
+				function useHook({ bar }) {
+					let foo1 = bar && useState();
+					let foo2 = bar || useState();
+					let foo3 = bar ?? useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 3, Column: 24},
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 24},
+				{Message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 5, Column: 24},
+			},
+		},
+
+		// ---- Upstream: forwardRef / memo with cond ----
+		{
+			Code: `
+				const FancyButton = React.forwardRef((props, ref) => {
+					if (props.fancy) {
+						useCustomHook();
+					}
+					return <button ref={ref}>{props.children}</button>;
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				const FancyButton = forwardRef(function(props, ref) {
+					if (props.fancy) {
+						useCustomHook();
+					}
+					return <button ref={ref}>{props.children}</button>;
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				const MemoizedButton = memo(function(props) {
+					if (props.fancy) {
+						useCustomHook();
+					}
+					return <button>{props.children}</button>;
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useCustomHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				React.unknownFunction(function notAComponent(foo, bar) {
+					useProbablyAHook(bar)
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useProbablyAHook" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 3, Column: 6},
+			},
+		},
+
+		// ---- Upstream: top-level hooks ----
+		{
+			Code: `
+				useState();
+				if (foo) {
+					const foo = React.useCallback(() => {});
+				}
+				useCustomHook();
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 5},
+				{Message: `React Hook "React.useCallback" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 18},
+				{Message: `React Hook "useCustomHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 6, Column: 5},
+			},
+		},
+		{
+			Code: `
+				const {createHistory, useBasename} = require('history-2.1.2');
+				const browserHistory = useBasename(createHistory)({
+					basename: '/',
+				});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useBasename" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 3, Column: 28},
+			},
+		},
+
+		// ---- Upstream: class components ----
+		{
+			Code: `
+				class ClassComponentWithFeatureFlag extends React.Component {
+					render() {
+						if (foo) {
+							useFeatureFlag();
+						}
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useFeatureFlag" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 5, Column: 8},
+			},
+		},
+		{
+			Code: `
+				class ClassComponentWithHook extends React.Component {
+					render() {
+						React.useState();
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "React.useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				(class {useHook = () => { useState(); }});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 31},
+			},
+		},
+		{
+			Code: `
+				(class {useHook() { useState(); }});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 25},
+			},
+		},
+		{
+			Code: `
+				(class {h = () => { useState(); }});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 25},
+			},
+		},
+		{
+			Code: `
+				(class {i() { useState(); }});
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 19},
+			},
+		},
+
+		// ---- Upstream: async function ----
+		// Anchor full range here; remaining async cases below stay
+		// Line+Column-only.
+		{
+			Code: `
+				async function AsyncComponent() {
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in an async function.`, Line: 3, Column: 6, EndLine: 3, EndColumn: 14},
+			},
+		},
+		{
+			Code: `
+				async function useAsyncHook() {
+					useState();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useState" cannot be called in an async function.`, Line: 3, Column: 6},
+			},
+		},
+		{
+			Code: `
+				async function Page() {
+					useId();
+					React.useId();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useId" cannot be called in an async function.`, Line: 3, Column: 6},
+				{Message: `React Hook "React.useId" cannot be called in an async function.`, Line: 4, Column: 6},
+			},
+		},
+		{
+			Code: `
+				async function useAsyncHook() {
+					useId();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useId" cannot be called in an async function.`, Line: 3, Column: 6},
+			},
+		},
+		{
+			Code: `
+				async function notAHook() {
+					useId();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useId" is called in function "notAHook" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 3, Column: 6},
+			},
+		},
+
+		// ---- Upstream: use() specifics ----
+		{
+			Code: `
+				Hook.use();
+				Hook._use();
+				Hook.useState();
+				Hook._useState();
+				Hook.use42();
+				Hook.useHook();
+				Hook.use_hook();
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "Hook.use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 5},
+				{Message: `React Hook "Hook.useState" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 5},
+				{Message: `React Hook "Hook.use42" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 6, Column: 5},
+				{Message: `React Hook "Hook.useHook" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 7, Column: 5},
+			},
+		},
+		{
+			Code: `
+				function notAComponent() {
+					use(promise);
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" is called in function "notAComponent" that is neither a React function component nor a custom React Hook function. React component names must start with an uppercase letter. React Hook names must start with the word "use".`, Line: 3, Column: 6},
+			},
+		},
+		{
+			Code: `
+				const text = use(promise);
+				function App() {
+					return <Text text={text} />
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" cannot be called at the top level. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 2, Column: 18},
+			},
+		},
+		{
+			Code: `
+				class C {
+					m() {
+						use(promise);
+					}
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`, Line: 4, Column: 7},
+			},
+		},
+		{
+			Code: `
+				async function AsyncComponent() {
+					use();
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" cannot be called in an async function.`, Line: 3, Column: 6},
+			},
+		},
+		// Anchor full range for the tryCatchUseError diagnostic family.
+		{
+			Code: `
+				function App({p1, p2}) {
+					try {
+						use(p1);
+					} catch (error) {
+						console.error(error);
+					}
+					use(p2);
+					return <div>App</div>;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" cannot be called in a try/catch block.`, Line: 4, Column: 7, EndLine: 4, EndColumn: 10},
+			},
+		},
+		{
+			Code: `
+				function App({p1, p2}) {
+					try {
+						doSomething();
+					} catch {
+						use(p1);
+					}
+					use(p2);
+					return <div>App</div>;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "use" cannot be called in a try/catch block.`, Line: 6, Column: 7},
+			},
+		},
+
+		// ---- Upstream: useEffectEvent invalid usages ----
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					useCustomHook(() => {
+						onClick();
+					});
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+			},
+		},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent() {
+				const onClick = useEffectEvent(() => {});
+				useCustomHook(() => { onClick(); });
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+		}},
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					useWrongHook(() => {
+						onClick();
+					});
+				}
+			`,
+			Tsx: true,
+			Settings: map[string]interface{}{
+				"react-hooks": map[string]interface{}{
+					"additionalEffectHooks": "useMyEffect",
+				},
+			},
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+			},
+		},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				useWrongHook(() => { onClick(); });
+			}
+		`, Tsx: true, Settings: map[string]interface{}{
+			"react-hooks": map[string]interface{}{"additionalEffectHooks": "useMyEffect"},
+		}, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component."},
+		}},
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					return <Child onClick={onClick}></Child>;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+			},
+		},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				return <Child onClick={onClick}></Child>;
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+		}},
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					return <Child onClick={useEffectEvent(() => {
+						showNotification(theme);
+					})} />;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: `React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.`, Line: 3, Column: 29},
+			},
+		},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				return <Child onClick={useEffectEvent(() => {})} />;
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: `React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.`},
+		}},
+		{
+			Code: `
+				const MyComponent = ({ theme }) => {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					return <Child onClick={onClick}></Child>;
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+			},
+		},
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(theme);
+					});
+					let foo = onClick;
+					return <Bar onClick={foo} />
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+			},
+		},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				let foo = onClick;
+				return <Bar onClick={foo} />
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+		}},
+		{
+			Code: `
+				function MyComponent({ theme }) {
+					const onClick = useEffectEvent(() => {
+						showNotification(them);
+					});
+					useEffect(() => {
+						setTimeout(onClick, 100);
+					});
+					return <Child onClick={onClick} />
+				}
+			`,
+			Tsx: true,
+			Errors: []rule_tester.InvalidTestCaseError{
+				{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+			},
+		},
+		// SKIP: rslint does not parse Flow `component` syntax.
+		{Skip: true, Code: `
+			component MyComponent(theme: any) {
+				const onClick = useEffectEvent(() => {});
+				useEffect(() => { setTimeout(onClick, 100); });
+				return <Child onClick={onClick} />
+			}
+		`, Tsx: true, Errors: []rule_tester.InvalidTestCaseError{
+			{Message: "`onClick` is a function created with React Hook \"useEffectEvent\", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down."},
+		}},
+}
+
+func TestRulesOfHooksRule_Upstream(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(), "tsconfig.json", t, &RulesOfHooksRule,
+		rulesOfHooksUpstreamValid,
+		rulesOfHooksUpstreamInvalid,
+	)
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -128,6 +128,9 @@ export default defineConfig({
     './tests/eslint-plugin-react/rules/prefer-stateless-function.test.ts',
     './tests/eslint-plugin-react/rules/require-render-return.test.ts',
 
+    // eslint-plugin-react-hooks
+    './tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts',
+
     // typescript-eslint
     './tests/typescript-eslint/rules/adjacent-overload-signatures.test.ts',
     './tests/typescript-eslint/rules/array-type.test.ts',

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rslint.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rslint.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.files.json", "./tsconfig.virtual.json"]
+      }
+    },
+    "rules": {},
+    "plugins": ["react-hooks"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rule-tester.ts
@@ -1,0 +1,261 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import util from 'node:util';
+
+import { lint } from '@rslint/core';
+
+// Per-test rslint.json builder used to thread `settings` through to the
+// linter. The base rslint.json registered for the suite has `settings: {}`;
+// when a test case carries its own settings, we emit a temporary config
+// that merges the base with the test's settings and point `lint()` at it.
+function buildConfigForSettings(
+  baseConfigPath: string,
+  settings: Record<string, unknown> | undefined,
+): { configPath: string; cleanup: () => void } {
+  if (!settings || Object.keys(settings).length === 0) {
+    return { configPath: baseConfigPath, cleanup: () => {} };
+  }
+  const base = JSON.parse(readFileSync(baseConfigPath, 'utf8'));
+  const merged = base.map((entry: any) => ({
+    ...entry,
+    settings: { ...(entry.settings ?? {}), ...settings },
+  }));
+  const baseDir = path.dirname(baseConfigPath);
+  const cfg = path.join(
+    baseDir,
+    `rslint.test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+  );
+  writeFileSync(cfg, JSON.stringify(merged), 'utf8');
+  void mkdtempSync;
+  void tmpdir;
+  return {
+    configPath: cfg,
+    cleanup: () => {
+      try {
+        rmSync(cfg, { force: true });
+      } catch {
+        /* best-effort cleanup; never fail a test on rmdir */
+      }
+    },
+  };
+}
+
+export interface ValidTestCase {
+  name?: string;
+  code: string;
+  options?: any;
+  filename?: string | undefined;
+  only?: boolean;
+  settings?: Record<string, any> | undefined;
+}
+
+interface SuggestionOutput {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, unknown> | undefined;
+  output: string;
+}
+
+export interface InvalidTestCase extends ValidTestCase {
+  errors: number | (TestCaseError | string)[];
+  output?: string | null | undefined;
+}
+
+interface TestCaseError {
+  message?: string | RegExp;
+  messageId?: string;
+  type?: string | undefined;
+  data?: any;
+  line?: number | undefined;
+  column?: number | undefined;
+  endLine?: number | undefined;
+  endColumn?: number | undefined;
+  suggestions?: SuggestionOutput[] | undefined;
+}
+
+export class RuleTester {
+  run(
+    ruleName: string,
+    _rule: never,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    ruleName = 'react-hooks/' + ruleName;
+    describe(ruleName, () => {
+      const cwd = process.cwd();
+      const config = path.resolve(import.meta.dirname, './rslint.json');
+
+      let hasOnly =
+        cases.valid.some((x) => {
+          if (typeof x === 'object' && x.only) {
+            return true;
+          } else {
+            return false;
+          }
+        }) || cases.invalid.some((x) => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (hasOnly) {
+            if (typeof validCase === 'string') {
+              continue;
+            }
+            if (!validCase.only) {
+              continue;
+            }
+          }
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+
+          const options =
+            typeof validCase === 'string' ? [] : validCase.options || [];
+          const settings =
+            typeof validCase === 'string' ? undefined : validCase.settings;
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof validCase === 'string'
+              ? defaultFilename
+              : (validCase.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+
+          const { configPath, cleanup } = buildConfigForSettings(
+            config,
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case, but got: ${JSON.stringify(diags)}\nCode: ${code}`,
+          );
+        }
+      });
+      test('invalid', async () => {
+        for (const item of cases.invalid) {
+          assert.ok(
+            item.errors || item.errors === 0,
+            `Did not specify errors for an invalid test of ${ruleName}`,
+          );
+          if (Array.isArray(item.errors) && item.errors.length === 0) {
+            assert.fail('Invalid cases must have at least one error');
+          }
+
+          const { code, only = false, options = [], settings } = item;
+          if (hasOnly && !only) {
+            continue;
+          }
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof item === 'string'
+              ? defaultFilename
+              : (item.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+          const { configPath, cleanup } = buildConfigForSettings(
+            config,
+            settings,
+          );
+          let diags;
+          try {
+            diags = await lint({
+              config: configPath,
+              workingDirectory: cwd,
+              fileContents: {
+                [absoluteFilename]: code,
+              },
+              ruleOptions: {
+                [ruleName]: options,
+              },
+            });
+          } finally {
+            cleanup();
+          }
+
+          if (typeof item.errors === 'number') {
+            if (item.errors === 0) {
+              assert.fail(
+                "Invalid cases must have 'error' value greater than 0",
+              );
+            }
+
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors,
+                item.errors === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+          } else {
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors.length,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors.length,
+                item.errors.length === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+
+            const hasMessageOfThisRule = diags.diagnostics.some(
+              (d) => d.ruleName === ruleName,
+            );
+
+            for (let i = 0, l = item.errors.length; i < l; i++) {
+              const error = item.errors[i];
+              const message = diags.diagnostics[i];
+
+              assert(
+                hasMessageOfThisRule,
+                'Error rule name should be the same as the name of the rule being tested',
+              );
+              if (typeof error === 'string' || error instanceof RegExp) {
+                assertMessageMatches(message.message, error);
+                assert.ok(
+                  message.suggestions === void 0,
+                  `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
+                );
+              } else if (typeof error === 'object' && error !== null) {
+                if (typeof error.message === 'string') {
+                  assertMessageMatches(message.message, error.message);
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+}
+
+function assertMessageMatches(actual: string, expected: string | RegExp): void {
+  if (expected instanceof RegExp) {
+    assert.ok(
+      expected.test(actual),
+      `Expected '${actual}' to match ${expected}`,
+    );
+  } else {
+    assert.strictEqual(actual, expected);
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts
@@ -1,0 +1,285 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('rules-of-hooks', {} as never, {
+  valid: [
+    {
+      code: `
+        function ComponentWithHook() {
+          useHook();
+        }
+      `,
+    },
+    {
+      code: `
+        function createComponentWithHook() {
+          return function ComponentWithHook() {
+            useHook();
+          };
+        }
+      `,
+    },
+    {
+      code: `
+        function useHookWithHook() {
+          useHook();
+        }
+      `,
+    },
+    {
+      code: `
+        function ComponentWithNormalFunction() {
+          doSomething();
+        }
+      `,
+    },
+    {
+      code: `
+        function functionThatStartsWithUseButIsntAHook() {
+          if (cond) {
+            userFetch();
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        function useUnreachable() {
+          return;
+          useHook();
+        }
+      `,
+    },
+    {
+      code: `
+        function useHook() { useState(); }
+        const whatever = function useHook() { useState(); };
+        const useHook1 = () => { useState(); };
+        let useHook2 = () => useState();
+        useHook2 = () => { useState(); };
+        ({useHook: () => { useState(); }});
+        ({useHook() { useState(); }});
+        const {useHook3 = () => { useState(); }} = {};
+        ({useHook = () => { useState(); }} = {});
+        Namespace.useHook = () => { useState(); };
+      `,
+    },
+    {
+      code: `
+        const FancyButton = React.forwardRef((props, ref) => {
+          useHook();
+          return <button {...props} ref={ref} />
+        });
+      `,
+    },
+    {
+      code: `
+        const MemoizedFunction = React.memo(props => {
+          useHook();
+          return <button {...props} />
+        });
+      `,
+    },
+    {
+      code: `
+        class C {
+          m() {
+            this.useHook();
+            super.useHook();
+          }
+        }
+      `,
+    },
+    {
+      code: `
+        jest.useFakeTimers();
+        beforeEach(() => {
+          jest.useRealTimers();
+        })
+      `,
+    },
+    {
+      code: `
+        function App() {
+          const text = use(Promise.resolve('A'));
+          return <Text text={text} />
+        }
+      `,
+    },
+    {
+      code: `
+        function App() {
+          let data = [];
+          for (const query of queries) {
+            const text = use(item);
+            data.push(text);
+          }
+          return <Child data={data} />
+        }
+      `,
+    },
+    {
+      code: `
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useEffect(() => {
+            onClick();
+          });
+        }
+      `,
+    },
+    {
+      code: `
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          useMyEffect(() => {
+            onClick();
+          });
+        }
+      `,
+      settings: {
+        'react-hooks': {
+          additionalEffectHooks: '(useMyEffect|useServerEffect)',
+        },
+      },
+    },
+    {
+      code: `
+        function RegressionTest() {
+          if (page == null) {
+            throw new Error('oh no!');
+          }
+          useState();
+        }
+      `,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function ComponentWithConditionalHook() {
+          if (cond) {
+            useConditionalHook();
+          }
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "useConditionalHook" is called conditionally. React Hooks must be called in the exact same order in every component render.`,
+        },
+      ],
+    },
+    {
+      code: `
+        Hook.useState();
+        Hook.useHook();
+      `,
+      errors: 2,
+    },
+    {
+      code: `
+        class C {
+          m() {
+            This.useHook();
+          }
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "This.useHook" cannot be called in a class component. React Hooks must be called in a React function component or a custom React Hook function.`,
+        },
+      ],
+    },
+    {
+      code: `
+        function ComponentWithHookInsideLoop() {
+          while (cond) {
+            useHookInsideLoop();
+          }
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "useHookInsideLoop" may be executed more than once. Possibly because it is called in a loop. React Hooks must be called in the exact same order in every component render.`,
+        },
+      ],
+    },
+    {
+      code: `
+        function useHook() {
+          if (a) return;
+          useState();
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "useState" is called conditionally. React Hooks must be called in the exact same order in every component render. Did you accidentally call a React Hook after an early return?`,
+        },
+      ],
+    },
+    {
+      code: `
+        async function AsyncComponent() {
+          useState();
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "useState" cannot be called in an async function.`,
+        },
+      ],
+    },
+    {
+      code: `
+        function App({p1}) {
+          try {
+            use(p1);
+          } catch (error) {
+            console.error(error);
+          }
+          return <div>App</div>;
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "use" cannot be called in a try/catch block.`,
+        },
+      ],
+    },
+    {
+      code: `
+        function MyComponent({ theme }) {
+          const onClick = useEffectEvent(() => {
+            showNotification(theme);
+          });
+          return <Child onClick={onClick}></Child>;
+        }
+      `,
+      errors: [
+        {
+          message:
+            '`onClick` is a function created with React Hook "useEffectEvent", and can only be called from Effects and Effect Events in the same component. It cannot be assigned to a variable or passed down.',
+        },
+      ],
+    },
+    {
+      code: `
+        function MyComponent({ theme }) {
+          return <Child onClick={useEffectEvent(() => {
+            showNotification(theme);
+          })} />;
+        }
+      `,
+      errors: [
+        {
+          message: `React Hook "useEffectEvent" can only be called at the top level of your component. It cannot be passed down.`,
+        },
+      ],
+    },
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/tsconfig.files.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/tsconfig.files.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": false,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "allowJs": true
+  },
+  "include": ["files/**/*"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-react-hooks/tsconfig.virtual.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": false,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"]
+  },
+  "include": ["src/virtual.tsx", "src/virtual.ts"]
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -268,3 +268,5 @@ unaliased
 metacharacter
 nunc
 forcetypeassert
+Isnt
+deboucne


### PR DESCRIPTION
## Summary

Port the `react-hooks/rules-of-hooks` rule from `eslint-plugin-react-hooks` (facebook/react) to rslint as a new `react-hooks` plugin.

The rule enforces React's [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks): hooks must be called at the top level of a function component or custom hook, never inside loops, conditionals, nested functions, class components, async functions, or after an early return.

### What's covered

- Hook detection: identifier (`useFoo`), `use` itself (React 19), and `Namespace.useFoo` (PascalCase namespace + non-computed property), with paren / TS-wrapper transparency.
- Container classification: function component, custom hook, `forwardRef` / `memo` callback (bare or `React.`-qualified, nested), class member (method / accessor / constructor / class-field arrow), async function, async generator, `Program` (top level), arbitrary callback inside-or-outside a component.
- Conditional / loop / early-return detection via position-aware AST walks: `if` / `?:` / `&&` / `||` / `??` (right operand), `while` / `for` body / `for-in` `for-of` body, `do-while`, `try` block (with prior throwable statement), `catch` block, switch case body, labeled break.
- Position-aware `for (init; cond; incr)`: init runs once before the loop and is unconditional; condition / incrementor / body are cycled.
- Position-aware `for-of` / `for-in`: RHS expression is unconditional; binding pattern + body are cycled.
- Hook reachability skip: hook directly preceded by `return` / `throw` is treated as unreachable (mirrors upstream's `!segment.reachable`).
- React `use(...)` exempt from loop / conditional checks; rejected inside try/catch (covers finally too) and async functions.
- `useEffectEvent` reference resolution: TypeChecker symbol-based when available, name-based per-container fallback when `ctx.TypeChecker` is nil. Detects inline `useEffectEvent(...)` calls outside `VariableDeclaration` / `ExpressionStatement` (the "passed down" variant).
- `$FlowFixMe[react-rule-hook]` comment suppression on the immediately-preceding line (line / block, leading / trailing).
- `additionalEffectHooks` setting honored from `settings['react-hooks']`.

### Tests

- Go test split into 3 functions for navigability:
  - `TestRulesOfHooksRule_Upstream` — every `valid` + `invalid` case ported from upstream `RulesOfHooks-test.js` end-to-end. Flow-syntax cases (`component` / `hook` keywords, parser-hermes only) carry `Skip: true` with a `// SKIP:` reason.
  - `TestRulesOfHooksRule_Extras` — rslint-specific edges: tsgo AST quirks (paren-wrapped callees, optional chains, TS type wrappers, decimal-normalized literals), naming / container boundary cases, path-counting edges (for-init, for-of expression, try block first statement, labeled break, finally), additional `useEffectEvent` shapes, settings malformed inputs.
  - `TestRulesOfHooksNilTypeChecker` — locks in that a nil `ctx.TypeChecker` does not panic, exercising the full Run() path.
- JS test (`packages/rslint-test-tools/tests/eslint-plugin-react-hooks/rules/rules-of-hooks.test.ts`) covers the same diagnostic categories end-to-end through the binary.
- Differential validation: ran `rslint react-hooks/rules-of-hooks` against `rsbuild` and `rspack` repos. Every report (16 in rsbuild fixture.ts, 1 in rspack adapter.ts) is observed in both rslint and `eslint-plugin-react-hooks@7.1.1` byte-for-byte (line, column, message, function name) — the reports are upstream's known false positives caused by the React 19 `use` hook colliding with Playwright fixture parameter names and local variables named `use`.

### Differences from ESLint

Documented in `internal/plugins/react_hooks/rules/rules_of_hooks/rules_of_hooks.md`:

- Conditional / loop / early-return analysis is AST-shape based rather than CFG-based (rslint has no `CodePathAnalyzer`). Position-aware AST checks cover every observed upstream test plus 30+ edge cases tracked in `_Extras`. Theoretical extreme constructs that rely on BigInt path counting are not encountered in the upstream test suite.
- `useEffectEvent` reference resolution prefers TypeChecker symbol resolution when available; falls back to lexical name matching scoped to the closest enclosing function-like declaration.
- Flow-only `component` / `hook` keyword syntax is not parsed by tsgo; the corresponding upstream tests carry explicit `Skip: true` markers and will be re-enabled if rslint's parser ever supports Flow.

## Related Links

- ESLint rule: https://react.dev/reference/rules/rules-of-hooks
- Source code: https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/src/rules/RulesOfHooks.ts

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).