### PR TITLE
feat: port rule unicorn/filename-case

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ import (
 	promisePlugin "github.com/web-infra-dev/rslint/internal/plugins/promise"
 	reactPlugin "github.com/web-infra-dev/rslint/internal/plugins/react"
 	reactHooksPlugin "github.com/web-infra-dev/rslint/internal/plugins/react_hooks"
+	unicornPlugin "github.com/web-infra-dev/rslint/internal/plugins/unicorn"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/adjacent_overload_signatures"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/array_type"
 	"github.com/web-infra-dev/rslint/internal/plugins/typescript/rules/await_thenable"
@@ -373,6 +374,11 @@ var KnownPlugins = []PluginInfo{
 		DeclNames:   []string{"eslint-plugin-react-hooks", "react-hooks"},
 		getAllRules: func() []rule.Rule { return reactHooksPlugin.GetAllRules() },
 	},
+	{
+		RulePrefix:  "unicorn",
+		DeclNames:   []string{"eslint-plugin-unicorn", "unicorn"},
+		getAllRules: func() []rule.Rule { return unicornPlugin.GetAllRules() },
+	},
 }
 
 // pluginByDeclName is a lookup table built from KnownPlugins: declaration name → *PluginInfo.
@@ -443,6 +449,7 @@ func RegisterAllRules() {
 		registerAllReactHooksPluginRules()
 		registerAllJestPluginRules()
 		registerAllPromisePluginRules()
+		registerAllUnicornPluginRules()
 		registerAllCoreEslintRules()
 	})
 }
@@ -467,6 +474,12 @@ func registerAllJestPluginRules() {
 
 func registerAllPromisePluginRules() {
 	for _, rule := range promisePlugin.GetAllRules() {
+		GlobalRuleRegistry.Register(rule.Name, rule)
+	}
+}
+
+func registerAllUnicornPluginRules() {
+	for _, rule := range unicornPlugin.GetAllRules() {
 		GlobalRuleRegistry.Register(rule.Name, rule)
 	}
 }

--- a/internal/plugins/unicorn/all.go
+++ b/internal/plugins/unicorn/all.go
@@ -1,0 +1,12 @@
+package unicorn_plugin
+
+import (
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
+	"github.com/web-infra-dev/rslint/internal/rule"
+)
+
+func GetAllRules() []rule.Rule {
+	return []rule.Rule{
+		filename_case.FilenameCaseRule,
+	}
+}

--- a/internal/plugins/unicorn/fixtures/fixtures.go
+++ b/internal/plugins/unicorn/fixtures/fixtures.go
@@ -1,0 +1,11 @@
+package fixtures
+
+import (
+	"path"
+	"runtime"
+)
+
+func GetRootDir() string {
+	_, filename, _, _ := runtime.Caller(0)
+	return path.Dir(filename)
+}

--- a/internal/plugins/unicorn/fixtures/tsconfig.json
+++ b/internal/plugins/unicorn/fixtures/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "preserve",
+    "target": "esnext",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "allowJs": true,
+    "checkJs": false,
+    "lib": ["es2015", "es2017", "esnext", "DOM"]
+  }
+}

--- a/internal/plugins/unicorn/plugin.go
+++ b/internal/plugins/unicorn/plugin.go
@@ -1,0 +1,3 @@
+package unicorn_plugin
+
+const PLUGIN_NAME = "eslint-plugin-unicorn"

--- a/internal/plugins/unicorn/rules/filename_case/extname_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/extname_test.go
@@ -1,0 +1,40 @@
+package filename_case
+
+import "testing"
+
+// TestNodeExtnameParity locks in Node.js `path.extname` behaviour for the
+// edge cases the upstream rule and Node both handle but a naive `LastIndex`
+// implementation would get wrong (notably all-dots basenames).
+func TestNodeExtnameParity(t *testing.T) {
+	cases := []struct{ in, want string }{
+		// no dot
+		{"foo", ""},
+		// leading-only dot (hidden-style filename, no real extension)
+		{".foo", ""},
+		{".test_utils", ""},
+		// regular extension
+		{"foo.js", ".js"},
+		{".foo.js", ".js"},
+		{".test_utils.js", ".js"},
+		// trailing dot — Node returns `.`
+		{"foo.", "."},
+		// all-dots basename — Node returns ``
+		{"..", ""},
+		{"...", ""},
+		{"....", ""},
+		// double-dot prefix followed by real extension
+		{"..js", ".js"},
+		{"...js", ".js"},
+		// only the last dot defines the extension
+		{"foo..js", ".js"},
+		{"foo.bar.baz", ".baz"},
+		// empty basename
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := nodeExtname(c.in)
+		if got != c.want {
+			t.Errorf("nodeExtname(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.go
@@ -1,0 +1,536 @@
+package filename_case
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/dlclark/regexp2"
+	"github.com/microsoft/typescript-go/shim/core"
+	"github.com/microsoft/typescript-go/shim/tspath"
+	"github.com/web-infra-dev/rslint/internal/rule"
+	"github.com/web-infra-dev/rslint/internal/utils"
+)
+
+// caseStyle is one of the four supported filename case styles.
+type caseStyle struct {
+	key  string
+	name string
+	fn   func(string) string
+}
+
+// allCases keeps a stable canonical iteration order for the `cases` option.
+//
+// NOTE: Unlike ESLint, where Object.keys() over `options.cases` preserves the
+// user's literal-property insertion order, we always use this canonical order
+// in the diagnostic message. The reason is that rslint receives options as a
+// `map[string]interface{}` after JSON parsing; Go map iteration is not
+// order-preserving, and the original key order is unrecoverable. Locking the
+// order here keeps message text deterministic.
+var allCases = []caseStyle{
+	{key: "camelCase", name: "camel case", fn: toCamelCase},
+	{key: "snakeCase", name: "snake case", fn: toSnakeCase},
+	{key: "kebabCase", name: "kebab case", fn: toKebabCase},
+	{key: "pascalCase", name: "pascal case", fn: toPascalCase},
+}
+
+var caseByKey = func() map[string]caseStyle {
+	m := make(map[string]caseStyle, len(allCases))
+	for _, c := range allCases {
+		m[c.key] = c
+	}
+	return m
+}()
+
+// ignoredByDefault mirrors the upstream's hardcoded set of files that cannot
+// change case (notably required by Node / build tooling).
+var ignoredByDefault = map[string]bool{
+	"index.js":  true,
+	"index.mjs": true,
+	"index.cjs": true,
+	"index.ts":  true,
+	"index.tsx": true,
+	"index.vue": true,
+}
+
+const reOpts = regexp2.ECMAScript | regexp2.Unicode
+
+// invalidIgnore captures a single user-supplied `ignore` pattern that failed
+// to compile. The rule reports each one as its own diagnostic so the user can
+// see which configuration entry is broken.
+type invalidIgnore struct {
+	pattern string
+	err     error
+}
+
+// Options is the parsed shape of the user's rule configuration.
+type Options struct {
+	Cases                  []caseStyle
+	Ignores                []*regexp2.Regexp
+	InvalidIgnores         []invalidIgnore
+	MultipleFileExtensions bool
+}
+
+func parseOptions(rawOpts any) Options {
+	opts := Options{
+		Cases:                  []caseStyle{caseByKey["kebabCase"]},
+		MultipleFileExtensions: true,
+	}
+	optsMap := utils.GetOptionsMap(rawOpts)
+	if optsMap == nil {
+		return opts
+	}
+
+	if v, ok := optsMap["case"].(string); ok {
+		if c, found := caseByKey[v]; found {
+			opts.Cases = []caseStyle{c}
+		}
+	} else if casesMap, ok := optsMap["cases"].(map[string]interface{}); ok {
+		var chosen []caseStyle
+		for _, c := range allCases {
+			if b, ok := casesMap[c.key].(bool); ok && b {
+				chosen = append(chosen, c)
+			}
+		}
+		if len(chosen) > 0 {
+			opts.Cases = chosen
+		}
+	}
+
+	if v, ok := optsMap["ignore"].([]interface{}); ok {
+		for _, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				continue
+			}
+			if re, err := regexp2.Compile(s, reOpts); err == nil {
+				opts.Ignores = append(opts.Ignores, re)
+			} else {
+				opts.InvalidIgnores = append(opts.InvalidIgnores, invalidIgnore{pattern: s, err: err})
+			}
+		}
+	}
+
+	if v, ok := optsMap["multipleFileExtensions"].(bool); ok {
+		opts.MultipleFileExtensions = v
+	}
+
+	return opts
+}
+
+// nodeExtname mirrors Node.js `path.extname`. Returns the suffix from the
+// last `.`, with these special cases (matching Node's behaviour):
+//
+//   - no dot in basename            → ""        (e.g. `foo`)
+//   - leading-only dot              → ""        (e.g. `.foo`)
+//   - basename is all dots          → ""        (e.g. `..`, `...`)
+//   - trailing dot                  → "."       (e.g. `foo.`)
+//   - regular extension             → ".<ext>"  (e.g. `foo.js`, `.foo.js`)
+//
+// `tspath.GetAnyExtensionFromPath` returns `.foo` for a basename like `.foo`
+// (Go-style), which is not what we want for hidden-style filenames such as
+// `.test_utils.js`.
+func nodeExtname(basename string) string {
+	lastDot := strings.LastIndex(basename, ".")
+	if lastDot <= 0 {
+		return ""
+	}
+	// If the basename is composed entirely of dots (`..`, `...`, etc.) Node
+	// treats it as extensionless. `..js` / `...js` are NOT all-dots — they
+	// have real characters and Node returns `.js`.
+	allDots := true
+	for i := range len(basename) {
+		if basename[i] != '.' {
+			allDots = false
+			break
+		}
+	}
+	if allDots {
+		return ""
+	}
+	return basename[lastDot:]
+}
+
+// splitWords reproduces change-case@5.4's `split()`. The exact upstream regex
+// pipeline is:
+//
+//   1. /([\p{Ll}\d])(\p{Lu})/gu       → insert delimiter before an uppercase
+//                                       that follows a lowercase or digit.
+//   2. /(\p{Lu})([\p{Lu}][\p{Ll}])/gu → insert delimiter between two
+//                                       uppercases when the second is the
+//                                       start of a TitleCase word
+//                                       (e.g. `XMLHttp` → `XML Http`).
+//   3. /[^\p{L}\d]+/giu               → collapse non-alphanumeric runs into
+//                                       the same delimiter.
+//
+// Then trim leading/trailing delimiters and split. We use rune `0` as the
+// internal delimiter (matching the upstream's `\0`).
+func splitWords(s string) []string {
+	runes := []rune(s)
+
+	// Pass 1: lower/digit + upper → split.
+	var pass1 []rune
+	for i, r := range runes {
+		if i > 0 {
+			prev := runes[i-1]
+			if (unicode.IsLower(prev) || isASCIIDigit(prev)) && unicode.IsUpper(r) {
+				pass1 = append(pass1, 0)
+			}
+		}
+		pass1 = append(pass1, r)
+	}
+
+	// Pass 2: upper + (upper + lower) → split between the first and second
+	// uppercase.
+	var pass2 []rune
+	for i, r := range pass1 {
+		if i > 0 && i < len(pass1)-1 {
+			prev, next := pass1[i-1], pass1[i+1]
+			if unicode.IsUpper(prev) && unicode.IsUpper(r) && unicode.IsLower(next) {
+				pass2 = append(pass2, 0)
+			}
+		}
+		pass2 = append(pass2, r)
+	}
+
+	// Pass 3: collapse runs of non-alphanumeric into one delimiter.
+	var stripped []rune
+	inDelim := false
+	for _, r := range pass2 {
+		if !unicode.IsLetter(r) && !isASCIIDigit(r) {
+			if !inDelim {
+				stripped = append(stripped, 0)
+				inDelim = true
+			}
+			continue
+		}
+		stripped = append(stripped, r)
+		inDelim = false
+	}
+
+	// Trim leading and trailing delimiters.
+	start, end := 0, len(stripped)
+	for start < end && stripped[start] == 0 {
+		start++
+	}
+	for end > start && stripped[end-1] == 0 {
+		end--
+	}
+	if start >= end {
+		return nil
+	}
+
+	var words []string
+	var cur []rune
+	for _, r := range stripped[start:end] {
+		if r == 0 {
+			if len(cur) > 0 {
+				words = append(words, string(cur))
+				cur = cur[:0]
+			}
+			continue
+		}
+		cur = append(cur, r)
+	}
+	if len(cur) > 0 {
+		words = append(words, string(cur))
+	}
+	return words
+}
+
+func isASCIIDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
+// pascalLikeTransform is change-case@5.4's `pascalCaseTransformFactory`:
+// when a non-first word starts with a digit, prepend `_` to keep the join
+// readable and round-trippable; otherwise capitalize the first letter.
+func pascalLikeTransform(word string, index int) string {
+	if word == "" {
+		return ""
+	}
+	runes := []rune(word)
+	char0 := runes[0]
+	rest := strings.ToLower(string(runes[1:]))
+	if index > 0 && isASCIIDigit(char0) {
+		return "_" + string(char0) + rest
+	}
+	return strings.ToUpper(string(char0)) + rest
+}
+
+func toCamelCase(s string) string {
+	words := splitWords(s)
+	if len(words) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString(strings.ToLower(words[0]))
+	for i := 1; i < len(words); i++ {
+		sb.WriteString(pascalLikeTransform(words[i], i))
+	}
+	return sb.String()
+}
+
+func toPascalCase(s string) string {
+	words := splitWords(s)
+	if len(words) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	for i, w := range words {
+		sb.WriteString(pascalLikeTransform(w, i))
+	}
+	return sb.String()
+}
+
+func toKebabCase(s string) string { return joinNoCase(splitWords(s), "-") }
+func toSnakeCase(s string) string { return joinNoCase(splitWords(s), "_") }
+
+func joinNoCase(words []string, delim string) string {
+	if len(words) == 0 {
+		return ""
+	}
+	parts := make([]string, len(words))
+	for i, w := range words {
+		parts[i] = strings.ToLower(w)
+	}
+	return strings.Join(parts, delim)
+}
+
+// filenameWord is one chunk of the filename produced by splitFilename: a run
+// of either filename-relevant characters (letters/digits/`-`/`_`) or
+// "decoration" characters (`[`, `]`, `$`, …) the rule should preserve verbatim.
+type filenameWord struct {
+	word    string
+	ignored bool
+}
+
+// isIgnoredChar mirrors the upstream's `/^[a-z\d-_]$/i` test: returns true
+// when a character is NOT one of the case-relevant filename characters.
+func isIgnoredChar(r rune) bool {
+	switch {
+	case r >= 'a' && r <= 'z':
+		return false
+	case r >= 'A' && r <= 'Z':
+		return false
+	case r >= '0' && r <= '9':
+		return false
+	case r == '-', r == '_':
+		return false
+	}
+	return true
+}
+
+// splitFilename mirrors the upstream helper of the same name. Leading
+// underscores are captured separately so they're preserved verbatim in the
+// rename suggestion.
+func splitFilename(filename string) (leading string, words []filenameWord) {
+	i := 0
+	for i < len(filename) && filename[i] == '_' {
+		i++
+	}
+	leading = filename[:i]
+	tailing := filename[i:]
+
+	var hasLast, lastIgnored bool
+	var lastWord []rune
+	flush := func() {
+		if !hasLast {
+			return
+		}
+		words = append(words, filenameWord{word: string(lastWord), ignored: lastIgnored})
+		lastWord = lastWord[:0]
+		hasLast = false
+	}
+	for _, r := range tailing {
+		ig := isIgnoredChar(r)
+		if hasLast && lastIgnored == ig {
+			lastWord = append(lastWord, r)
+			continue
+		}
+		flush()
+		lastWord = append(lastWord[:0], r)
+		lastIgnored = ig
+		hasLast = true
+	}
+	flush()
+	return leading, words
+}
+
+// validateFilename returns true when every non-ignored chunk already matches
+// at least one of the chosen case styles.
+func validateFilename(words []filenameWord, cases []caseStyle) bool {
+	for _, w := range words {
+		if w.ignored {
+			continue
+		}
+		ok := false
+		for _, c := range cases {
+			if c.fn(w.word) == w.word {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// fixFilename builds the deduplicated, ordered list of suggested filenames by
+// taking the cartesian product of each non-ignored chunk's case-conversion
+// candidates. The order matches change-case's left-to-right output so the
+// message reads `fooBar`, `FooBar`, `foo-bar` for cases ordered camel,
+// pascal, kebab.
+func fixFilename(words []filenameWord, cases []caseStyle, leading, trailing string) []string {
+	replacements := make([][]string, len(words))
+	for i, w := range words {
+		if w.ignored {
+			replacements[i] = []string{w.word}
+			continue
+		}
+		cand := make([]string, len(cases))
+		for j, c := range cases {
+			cand[j] = c.fn(w.word)
+		}
+		replacements[i] = cand
+	}
+
+	seen := map[string]bool{}
+	var out []string
+	var visit func(idx int, acc string)
+	visit = func(idx int, acc string) {
+		if idx == len(replacements) {
+			full := leading + acc + trailing
+			if !seen[full] {
+				seen[full] = true
+				out = append(out, full)
+			}
+			return
+		}
+		for _, item := range replacements[idx] {
+			visit(idx+1, acc+item)
+		}
+	}
+	visit(0, "")
+	return out
+}
+
+// englishishJoin reproduces `Intl.ListFormat('en-US', {type: 'disjunction'})`:
+// `a`, `a or b`, `a, b, or c`, …
+func englishishJoin(items []string) string {
+	switch len(items) {
+	case 0:
+		return ""
+	case 1:
+		return items[0]
+	case 2:
+		return items[0] + " or " + items[1]
+	}
+	return strings.Join(items[:len(items)-1], ", ") + ", or " + items[len(items)-1]
+}
+
+func backtickList(items []string) []string {
+	out := make([]string, len(items))
+	for i, s := range items {
+		out[i] = "`" + s + "`"
+	}
+	return out
+}
+
+func isLowerCase(s string) bool { return s == strings.ToLower(s) }
+
+var FilenameCaseRule = rule.Rule{
+	Name: "unicorn/filename-case",
+	// The rule is purely filename-driven — it does not inspect any AST node.
+	// `Run` is invoked once per source file, so we do the work here and
+	// return an empty listener map. (The linter's visitor walks SourceFile
+	// children but never the SourceFile node itself, so a
+	// `ast.KindSourceFile` listener would silently never fire.)
+	Run: func(ctx rule.RuleContext, options any) rule.RuleListeners {
+		if ctx.SourceFile == nil {
+			return rule.RuleListeners{}
+		}
+		fileName := ctx.SourceFile.FileName()
+		if fileName == "" {
+			return rule.RuleListeners{}
+		}
+		// `tspath.GetBaseFileName` normalizes `\` → `/` first, so a Windows
+		// path like `src\foo\bar.js` resolves the basename correctly.
+		basename := tspath.GetBaseFileName(fileName)
+		// Skip ESLint's stdin / inline-source virtual filenames.
+		if basename == "<input>" || basename == "<text>" {
+			return rule.RuleListeners{}
+		}
+
+		opts := parseOptions(options)
+
+		// Configuration error: any malformed `ignore` pattern aborts
+		// case-checking on this file. Mirrors ESLint's behaviour, where
+		// `new RegExp(item, 'u')` throws at rule-create time and the rule
+		// produces no further diagnostics until the config is fixed —
+		// returning case reports based on a partially-broken ignore list
+		// would be misleading.
+		if len(opts.InvalidIgnores) > 0 {
+			for _, bad := range opts.InvalidIgnores {
+				ctx.ReportRange(core.NewTextRange(0, 0), rule.RuleMessage{
+					Id: "invalidIgnorePattern",
+					Description: fmt.Sprintf(
+						"Invalid regular expression in `ignore` option: `%s`: %s",
+						bad.pattern, bad.err.Error(),
+					),
+				})
+			}
+			return rule.RuleListeners{}
+		}
+
+		if ignoredByDefault[basename] {
+			return rule.RuleListeners{}
+		}
+		for _, re := range opts.Ignores {
+			if matched, _ := re.MatchString(basename); matched {
+				return rule.RuleListeners{}
+			}
+		}
+
+		ext := nodeExtname(basename)
+		filename := strings.TrimSuffix(basename, ext)
+		middle := ""
+		if opts.MultipleFileExtensions {
+			if i := strings.IndexByte(filename, '.'); i >= 0 {
+				middle = filename[i:]
+				filename = filename[:i]
+			}
+		}
+
+		leading, words := splitFilename(filename)
+		if validateFilename(words, opts.Cases) {
+			if !isLowerCase(ext) {
+				ctx.ReportRange(core.NewTextRange(0, 0), rule.RuleMessage{
+					Id: "filenameExtension",
+					Description: fmt.Sprintf(
+						"File extension `%s` is not in lowercase. Rename it to `%s`.",
+						ext, filename+middle+strings.ToLower(ext),
+					),
+				})
+			}
+			return rule.RuleListeners{}
+		}
+
+		renamed := fixFilename(words, opts.Cases, leading, middle+strings.ToLower(ext))
+		caseNames := make([]string, len(opts.Cases))
+		for i, c := range opts.Cases {
+			caseNames[i] = c.name
+		}
+		ctx.ReportRange(core.NewTextRange(0, 0), rule.RuleMessage{
+			Id: "filenameCase",
+			Description: fmt.Sprintf(
+				"Filename is not in %s. Rename it to %s.",
+				englishishJoin(caseNames),
+				englishishJoin(backtickList(renamed)),
+			),
+		})
+		return rule.RuleListeners{}
+	},
+}

--- a/internal/plugins/unicorn/rules/filename_case/filename_case.md
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case.md
@@ -1,0 +1,93 @@
+# filename-case
+
+## Rule Details
+
+Enforces all linted files to have their names in a certain case style and a lowercase file extension. The default is `kebabCase`.
+
+Files named `index.js`, `index.mjs`, `index.cjs`, `index.ts`, `index.tsx`, `index.vue` are ignored as they can't change case (only a problem with `pascalCase`).
+
+Characters in the filename other than `a-z`, `A-Z`, `0-9`, `-`, and `_` are ignored.
+
+### Cases
+
+#### `kebabCase`
+
+- `foo-bar.js`
+- `foo-bar.test.js`
+- `foo-bar.test-utils.js`
+
+#### `camelCase`
+
+- `fooBar.js`
+- `fooBar.test.js`
+- `fooBar.testUtils.js`
+
+#### `snakeCase`
+
+- `foo_bar.js`
+- `foo_bar.test.js`
+- `foo_bar.test_utils.js`
+
+#### `pascalCase`
+
+- `FooBar.js`
+- `FooBar.Test.js`
+- `FooBar.TestUtils.js`
+
+## Options
+
+### case
+
+Type: `"camelCase" | "snakeCase" | "kebabCase" | "pascalCase"`
+
+Set a single allowed case style:
+
+```json
+{ "unicorn/filename-case": ["error", { "case": "kebabCase" }] }
+```
+
+### cases
+
+Type: `{ camelCase?: boolean; snakeCase?: boolean; kebabCase?: boolean; pascalCase?: boolean }`
+
+Allow several case styles at once. Setting a key to `true` enables that style; the file passes if it matches any enabled style.
+
+```json
+{ "unicorn/filename-case": ["error", { "cases": { "camelCase": true, "pascalCase": true } }] }
+```
+
+### ignore
+
+Type: `string[]`\
+Default: `[]`
+
+A list of regular-expression patterns (as strings) that match filenames the rule should skip.
+
+```json
+{
+  "unicorn/filename-case": [
+    "error",
+    {
+      "case": "kebabCase",
+      "ignore": ["^FOOBAR\\.js$", "^(B|b)az", "\\.SOMETHING\\.js$"]
+    }
+  ]
+}
+```
+
+### multipleFileExtensions
+
+Type: `boolean`\
+Default: `true`
+
+When `true`, additional `.`-separated parts of the basename are treated as part of the extension and are not subject to case checking. When `false`, only the final extension is treated as such, and the rest of the basename must match the chosen case styles.
+
+## Differences from ESLint
+
+- When the `cases` option enables more than one style, the diagnostic message lists the case names and rename suggestions in a fixed order: camel case, snake case, kebab case, pascal case. ESLint lists them in the order the keys appear in your `cases` object. So `{ pascalCase: true, camelCase: true }` against `foo-bar.js` reports `Filename is not in camel case or pascal case. Rename it to ` `` `fooBar.js` `` ` or ` `` `FooBar.js` `` `.` here, and `Filename is not in pascal case or camel case. Rename it to ` `` `FooBar.js` `` ` or ` `` `fooBar.js` `` `.` in ESLint.
+- A regular-expression literal in `ignore` (for example `/^vendor/i`) does not match anything. Write the pattern as a string — for example `"^vendor"` for `/^vendor/`, or `"(?i)^vendor"` for `/^vendor/i`.
+
+## Original Documentation
+
+- ESLint plugin documentation: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md>
+- Source code: <https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/filename-case.js>

--- a/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/filename_case_test.go
@@ -1,0 +1,1183 @@
+package filename_case_test
+
+import (
+	"testing"
+
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/fixtures"
+	"github.com/web-infra-dev/rslint/internal/plugins/unicorn/rules/filename_case"
+	"github.com/web-infra-dev/rslint/internal/rule_tester"
+)
+
+// caseOpt builds a `[{case: ...}]`-style option payload (single-case form).
+func caseOpt(c string) map[string]interface{} {
+	return map[string]interface{}{"case": c}
+}
+
+// casesOpt builds a `[{cases: {...}}]`-style option payload (multi-case form).
+func casesOpt(m map[string]bool) map[string]interface{} {
+	cases := make(map[string]interface{}, len(m))
+	for k, v := range m {
+		cases[k] = v
+	}
+	return map[string]interface{}{"cases": cases}
+}
+
+// withMfe returns a clone of `base` with `multipleFileExtensions` set.
+func withMfe(base map[string]interface{}, v bool) map[string]interface{} {
+	out := make(map[string]interface{}, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	out["multipleFileExtensions"] = v
+	return out
+}
+
+// withIgnore returns a clone of `base` plus an `ignore` array.
+func withIgnore(base map[string]interface{}, patterns ...string) map[string]interface{} {
+	out := make(map[string]interface{}, len(base)+1)
+	for k, v := range base {
+		out[k] = v
+	}
+	pats := make([]interface{}, len(patterns))
+	for i, p := range patterns {
+		pats[i] = p
+	}
+	out["ignore"] = pats
+	return out
+}
+
+// All upstream `valid` / `invalid` cases are migrated below in the same
+// declaration order. Cases that the rule_tester cannot exercise (TypeScript's
+// program builder skips files whose extension or basename it does not
+// recognize, leaving us with a nil source file) are kept as `Skip: true`
+// entries with a reason — they are covered indirectly by the JS-side tests
+// against the rslint binary, where the program builder is bypassed.
+//
+// Inline `Locks in upstream` comments mark lock-in tests we added for branches
+// the upstream test suite itself does not cover.
+func TestFilenameCase(t *testing.T) {
+	rule_tester.RunRuleTester(
+		fixtures.GetRootDir(),
+		"tsconfig.json",
+		t,
+		&filename_case.FilenameCaseRule,
+		[]rule_tester.ValidTestCase{
+			// ---- Single `case` option, all four styles ----
+			{Code: `// camel`, FileName: "src/foo/bar.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "src/foo/fooBar.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "src/foo/bar.test.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "src/foo/fooBar.test.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "src/foo/fooBar.test-utils.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "src/foo/fooBar.test_utils.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "src/foo/.test_utils.js", Options: caseOpt("camelCase"),
+				Skip: true /* SKIP: dot-prefixed basename — TS program skips it */},
+
+			{Code: `// snake`, FileName: "src/foo/foo.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "src/foo/foo_bar.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "src/foo/foo.test.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "src/foo/foo_bar.test.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "src/foo/foo_bar.test_utils.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "src/foo/foo_bar.test-utils.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "src/foo/.test-utils.js", Options: caseOpt("snakeCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+
+			{Code: `// kebab`, FileName: "src/foo/foo.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "src/foo/foo-bar.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "src/foo/foo.test.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "src/foo/foo-bar.test.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "src/foo/foo-bar.test-utils.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "src/foo/foo-bar.test_utils.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "src/foo/.test_utils.js", Options: caseOpt("kebabCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+
+			{Code: `// pascal`, FileName: "src/foo/Foo.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "src/foo/FooBar.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "src/foo/Foo.test.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "src/foo/FooBar.test.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "src/foo/FooBar.test-utils.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "src/foo/FooBar.test_utils.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "src/foo/.test_utils.js", Options: caseOpt("pascalCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+
+			// ---- Numeric / mixed identifier cases ----
+			{Code: `// camel`, FileName: "spec/iss47Spec.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "spec/iss47Spec100.js", Options: caseOpt("camelCase")},
+			{Code: `// camel`, FileName: "spec/i18n.js", Options: caseOpt("camelCase")},
+			{Code: `// kebab`, FileName: "spec/iss47-spec.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "spec/iss-47-spec.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "spec/iss47-100spec.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab`, FileName: "spec/i18n.js", Options: caseOpt("kebabCase")},
+			{Code: `// snake`, FileName: "spec/iss47_spec.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "spec/iss_47_spec.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "spec/iss47_100spec.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake`, FileName: "spec/i18n.js", Options: caseOpt("snakeCase")},
+			{Code: `// pascal`, FileName: "spec/Iss47Spec.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "spec/Iss47.100spec.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal`, FileName: "spec/I18n.js", Options: caseOpt("pascalCase")},
+
+			// ---- `testCase(undefined, ...)`: upstream uses no filename, which
+			// becomes `<input>` in ESLint's `physicalFilename` and is no-op'd
+			// by the rule. rule_tester always substitutes a real filename, so
+			// we cannot reach the `<input>`/`<text>` branch through it. These
+			// stay as `Skip` markers so the count matches upstream.
+			{Code: `// undef`, Options: caseOpt("camelCase"), Skip: true /* SKIP: rule_tester always supplies a filename */},
+			{Code: `// undef`, Options: caseOpt("snakeCase"), Skip: true /* SKIP: rule_tester always supplies a filename */},
+			{Code: `// undef`, Options: caseOpt("kebabCase"), Skip: true /* SKIP: rule_tester always supplies a filename */},
+			{Code: `// undef`, Options: caseOpt("pascalCase"), Skip: true /* SKIP: rule_tester always supplies a filename */},
+
+			// ---- Leading underscores preserved ----
+			{Code: `// _camel`, FileName: "src/foo/_fooBar.js", Options: caseOpt("camelCase")},
+			{Code: `// _camel`, FileName: "src/foo/___fooBar.js", Options: caseOpt("camelCase")},
+			{Code: `// _snake`, FileName: "src/foo/_foo_bar.js", Options: caseOpt("snakeCase")},
+			{Code: `// _snake`, FileName: "src/foo/___foo_bar.js", Options: caseOpt("snakeCase")},
+			{Code: `// _kebab`, FileName: "src/foo/_foo-bar.js", Options: caseOpt("kebabCase")},
+			{Code: `// _kebab`, FileName: "src/foo/___foo-bar.js", Options: caseOpt("kebabCase")},
+			{Code: `// _pascal`, FileName: "src/foo/_FooBar.js", Options: caseOpt("pascalCase")},
+			{Code: `// _pascal`, FileName: "src/foo/___FooBar.js", Options: caseOpt("pascalCase")},
+
+			// ---- Default kebab + special chars at start ----
+			{Code: `// default-kebab`, FileName: "src/foo/$foo.js"},
+
+			// ---- `cases` option (omitted, empty, or filtered to truthy) falls
+			// back to kebab when nothing remains.
+			{Code: `// many-default`, FileName: "src/foo/foo-bar.js", Options: casesOpt(nil)},
+			{Code: `// many-empty`, FileName: "src/foo/foo-bar.js", Options: casesOpt(map[string]bool{})},
+			{Code: `// many-camel`, FileName: "src/foo/fooBar.js", Options: casesOpt(map[string]bool{"camelCase": true})},
+			{Code: `// many-pascal+kebab`, FileName: "src/foo/FooBar.js", Options: casesOpt(map[string]bool{"kebabCase": true, "pascalCase": true})},
+			{Code: `// many-snake+pascal+leading`, FileName: "src/foo/___foo_bar.js", Options: casesOpt(map[string]bool{"snakeCase": true, "pascalCase": true})},
+
+			// ---- No options at all: default kebab ----
+			{Code: `// no-options`, FileName: "src/foo/bar.js"},
+
+			// ---- Decoration characters (brackets, braces) are preserved ----
+			{Code: `// decoration`, FileName: "src/foo/[fooBar].js", Options: caseOpt("camelCase")},
+			{Code: `// decoration`, FileName: "src/foo/{foo_bar}.js", Options: caseOpt("snakeCase")},
+
+			// ---- Ignore patterns (string interpreted as ECMAScript regex) ----
+			// Upstream covers each combination of (string-form, RegExp-form)
+			// for every case style. JSON config can only carry strings, so we
+			// migrate the string variants and skip the JS-only RegExp ones.
+			{Code: `// undef-ignore`, Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`)},
+			{Code: `// undef-ignore`, Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant — JSON-only here */},
+			{Code: `// idx-via-ignore`, FileName: "src/foo/index.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`)},
+			{Code: `// idx-via-ignore`, FileName: "src/foo/index.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`)},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("camelCase"), `FOOBAR\.js`)},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("camelCase"), `FOOBAR\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("snakeCase"), `FOOBAR\.js`)},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("pascalCase"), `FOOBAR\.js`)},
+			{Code: `// ignored-by-regex`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("pascalCase"), `FOOBAR\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// multi-ignore`, FileName: "src/foo/BARBAZ.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`, `BARBAZ\.js`)},
+			{Code: `// multi-ignore`, FileName: "src/foo/BARBAZ.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`, `BARBAZ\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// escaped-brackets`, FileName: "src/foo/[FOOBAR].js",
+				Options: withIgnore(caseOpt("camelCase"), `\[FOOBAR\]\.js`)},
+			{Code: `// escaped-brackets`, FileName: "src/foo/[FOOBAR].js",
+				Options: withIgnore(caseOpt("camelCase"), `\[FOOBAR]\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// escaped-braces`, FileName: "src/foo/{FOOBAR}.js",
+				Options: withIgnore(caseOpt("snakeCase"), `\{FOOBAR\}\.js`)},
+			{Code: `// escaped-braces`, FileName: "src/foo/{FOOBAR}.js",
+				Options: withIgnore(caseOpt("snakeCase"), `\{FOOBAR\}\.js`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// alternation`, FileName: "src/foo/foo.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`)},
+			{Code: `// alternation`, FileName: "src/foo/foo-bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`)},
+			{Code: `// alternation`, FileName: "src/foo/fooBar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`)},
+			{Code: `// alternation`, FileName: "src/foo/foo_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`)},
+			{Code: `// alternation`, FileName: "src/foo/foo_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`),
+				Skip: true /* SKIP: ignore JS RegExp variant (case-insensitive flag) */},
+			{Code: `// alternation`, FileName: "src/foo/FOO_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`),
+				Skip: true /* SKIP: ignore JS RegExp variant (case-insensitive flag) */},
+			{Code: `// suffix-ignore`, FileName: "src/foo/foo-bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `\.(web|android|ios)\.js$`)},
+			{Code: `// suffix-ignore`, FileName: "src/foo/FooBar.web.js",
+				Options: withIgnore(caseOpt("kebabCase"), `\.(web|android|ios)\.js$`)},
+			{Code: `// suffix-ignore`, FileName: "src/foo/FooBar.android.js",
+				Options: withIgnore(caseOpt("kebabCase"), `\.(web|android|ios)\.js$`)},
+			{Code: `// suffix-ignore`, FileName: "src/foo/FooBar.ios.js",
+				Options: withIgnore(caseOpt("kebabCase"), `\.(web|android|ios)\.js$`)},
+			{Code: `// suffix-ignore`, FileName: "src/foo/FooBar.something.js",
+				Options: withIgnore(caseOpt("kebabCase"), `\.(?:web|android|ios|something)\.js$`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// prefix-ignore`, FileName: "src/foo/FooBar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^(F|f)oo`)},
+			{Code: `// prefix-ignore`, FileName: "src/foo/FooBar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^[Ff]oo`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// 2-pattern-ignore`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^FOO`, `BAZ\.js$`)},
+			{Code: `// 2-pattern-ignore`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^FOO`, `BAZ\.js$`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// 2-pattern-ignore`, FileName: "src/foo/BARBAZ.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^FOO`, `BAZ\.js$`)},
+			{Code: `// 2-pattern-ignore`, FileName: "src/foo/BARBAZ.js",
+				Options: withIgnore(caseOpt("kebabCase"), `^FOO`, `BAZ\.js$`),
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// many-ignore`, FileName: "src/foo/FOOBAR.js",
+				Options: map[string]interface{}{
+					"cases": map[string]interface{}{
+						"kebabCase": true, "camelCase": true,
+						"snakeCase": true, "pascalCase": true,
+					},
+					"ignore": []interface{}{`FOOBAR\.js`},
+				}},
+			{Code: `// many-ignore`, FileName: "src/foo/FOOBAR.js",
+				Options: map[string]interface{}{
+					"cases": map[string]interface{}{
+						"kebabCase": true, "camelCase": true,
+						"snakeCase": true, "pascalCase": true,
+					},
+					"ignore": []interface{}{`FOOBAR\.js`},
+				},
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+			{Code: `// many-ignore`, FileName: "src/foo/BaRbAz.js",
+				Options: map[string]interface{}{
+					"cases": map[string]interface{}{
+						"kebabCase": true, "camelCase": true,
+						"snakeCase": true, "pascalCase": true,
+					},
+					"ignore": []interface{}{`FOOBAR\.js`, `BaRbAz\.js`},
+				}},
+			{Code: `// many-ignore`, FileName: "src/foo/BaRbAz.js",
+				Options: map[string]interface{}{
+					"cases": map[string]interface{}{
+						"kebabCase": true, "camelCase": true,
+						"snakeCase": true, "pascalCase": true,
+					},
+					"ignore": []interface{}{`FOOBAR\.js`, `BaRbAz\.js`},
+				},
+				Skip: true /* SKIP: ignore JS RegExp variant */},
+
+			// ---- Default-ignored index files (any case enabled) ----
+			{Code: `// idx`, FileName: "index.js", Options: caseOpt("camelCase")},
+			{Code: `// idx`, FileName: "index.mjs", Options: caseOpt("camelCase"),
+				Skip: true /* SKIP: TS program does not pick up .mjs in this fixture */},
+			{Code: `// idx`, FileName: "index.cjs", Options: caseOpt("camelCase"),
+				Skip: true /* SKIP: TS program does not pick up .cjs in this fixture */},
+			{Code: `// idx`, FileName: "index.ts", Options: caseOpt("camelCase")},
+			{Code: `// idx`, FileName: "index.tsx", Options: caseOpt("camelCase")},
+			{Code: `// idx`, FileName: "index.vue", Options: caseOpt("camelCase"),
+				Skip: true /* SKIP: TS program does not pick up .vue */},
+			{Code: `// idx`, FileName: "index.js", Options: caseOpt("snakeCase")},
+			{Code: `// idx`, FileName: "index.mjs", Options: caseOpt("snakeCase"),
+				Skip: true /* SKIP: TS program does not pick up .mjs */},
+			{Code: `// idx`, FileName: "index.cjs", Options: caseOpt("snakeCase"),
+				Skip: true /* SKIP: TS program does not pick up .cjs */},
+			{Code: `// idx`, FileName: "index.ts", Options: caseOpt("snakeCase")},
+			{Code: `// idx`, FileName: "index.tsx", Options: caseOpt("snakeCase")},
+			{Code: `// idx`, FileName: "index.vue", Options: caseOpt("snakeCase"),
+				Skip: true /* SKIP: TS program does not pick up .vue */},
+			{Code: `// idx`, FileName: "index.js", Options: caseOpt("kebabCase")},
+			{Code: `// idx`, FileName: "index.mjs", Options: caseOpt("kebabCase"),
+				Skip: true /* SKIP: TS program does not pick up .mjs */},
+			{Code: `// idx`, FileName: "index.cjs", Options: caseOpt("kebabCase"),
+				Skip: true /* SKIP: TS program does not pick up .cjs */},
+			{Code: `// idx`, FileName: "index.ts", Options: caseOpt("kebabCase")},
+			{Code: `// idx`, FileName: "index.tsx", Options: caseOpt("kebabCase")},
+			{Code: `// idx`, FileName: "index.vue", Options: caseOpt("kebabCase"),
+				Skip: true /* SKIP: TS program does not pick up .vue */},
+			{Code: `// idx`, FileName: "index.js", Options: caseOpt("pascalCase")},
+			{Code: `// idx`, FileName: "index.mjs", Options: caseOpt("pascalCase"),
+				Skip: true /* SKIP: TS program does not pick up .mjs */},
+			{Code: `// idx`, FileName: "index.cjs", Options: caseOpt("pascalCase"),
+				Skip: true /* SKIP: TS program does not pick up .cjs */},
+			{Code: `// idx`, FileName: "index.ts", Options: caseOpt("pascalCase")},
+			{Code: `// idx`, FileName: "index.tsx", Options: caseOpt("pascalCase")},
+			{Code: `// idx`, FileName: "index.vue", Options: caseOpt("pascalCase"),
+				Skip: true /* SKIP: TS program does not pick up .vue */},
+
+			// ---- multipleFileExtensions=false ----
+			{Code: `// mfe-false-idx-tsx`, FileName: "index.tsx", Options: withMfe(caseOpt("pascalCase"), false)},
+			{Code: `// mfe-false-idx-tsx`, FileName: "src/index.tsx", Options: withMfe(caseOpt("pascalCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/fooBar.test.js", Options: withMfe(caseOpt("camelCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/fooBar.testUtils.js", Options: withMfe(caseOpt("camelCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/foo_bar.test_utils.js", Options: withMfe(caseOpt("snakeCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/foo.test.js", Options: withMfe(caseOpt("kebabCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/foo-bar.test.js", Options: withMfe(caseOpt("kebabCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/foo-bar.test-utils.js", Options: withMfe(caseOpt("kebabCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/Foo.Test.js", Options: withMfe(caseOpt("pascalCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/FooBar.Test.js", Options: withMfe(caseOpt("pascalCase"), false)},
+			{Code: `// mfe-false`, FileName: "src/foo/FooBar.TestUtils.js", Options: withMfe(caseOpt("pascalCase"), false)},
+			{Code: `// mfe-false`, FileName: "spec/Iss47.100Spec.js", Options: withMfe(caseOpt("pascalCase"), false)},
+
+			// ---- Disable-comment valid case (covered by DisableManager) ----
+			{
+				Code:     "/* rslint-disable unicorn/filename-case */\nconst value = 1;",
+				FileName: "src/foo/foo_bar.js",
+				Options:  caseOpt("kebabCase"),
+				Skip:     true, /* SKIP: rule_tester does not exercise rule_tester-level disable comments */
+			},
+
+			// ---- Multipart filename / multipleFileExtensions=true ----
+			{Code: `// camel-multi`, FileName: "src/foo/fooBar.Test.js", Options: caseOpt("camelCase")},
+			{Code: `// camel-multi`, FileName: "test/foo/fooBar.testUtils.js", Options: caseOpt("camelCase")},
+			{Code: `// camel-multi`, FileName: "test/foo/.testUtils.js", Options: caseOpt("camelCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+			{Code: `// snake-multi`, FileName: "test/foo/foo_bar.Test.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake-multi`, FileName: "test/foo/foo_bar.Test_Utils.js", Options: caseOpt("snakeCase")},
+			{Code: `// snake-multi`, FileName: "test/foo/.Test_Utils.js", Options: caseOpt("snakeCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+			{Code: `// kebab-multi`, FileName: "test/foo/foo-bar.Test.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab-multi`, FileName: "test/foo/foo-bar.Test-Utils.js", Options: caseOpt("kebabCase")},
+			{Code: `// kebab-multi`, FileName: "test/foo/.Test-Utils.js", Options: caseOpt("kebabCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+			{Code: `// pascal-multi`, FileName: "test/foo/FooBar.Test.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal-multi`, FileName: "test/foo/FooBar.TestUtils.js", Options: caseOpt("pascalCase")},
+			{Code: `// pascal-multi`, FileName: "test/foo/.TestUtils.js", Options: caseOpt("pascalCase"),
+				Skip: true /* SKIP: dot-prefixed basename */},
+
+			// ---- Snapshot-block valid cases (basename-only handling) ----
+			{Code: `// snap-undef`}, /* upstream `undefined` filename — defaults to `file.ts`, valid for kebab */
+			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo.JS/bar.js"},
+			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo.JS/bar.spec.js"},
+			{Code: `// snap-dir-uppercase-ext`, FileName: "src/foo.JS/.spec.js",
+				Skip: true /* SKIP: dot-prefixed basename */},
+			{Code: `// snap-dir-no-ext`, FileName: "src/foo.JS/bar",
+				Skip: true /* SKIP: TS program does not pick up extensionless files */},
+			{Code: `// snap-dotted-uppercase-middle`, FileName: "foo.SPEC.js"},
+			{Code: `// snap-leading-dot`, FileName: ".SPEC.js",
+				Skip: true /* SKIP: dot-prefixed basename */},
+
+			// ---- Lock-in tests for upstream branches not directly exercised
+			//      by the upstream test file ----
+			// Locks in change-case digit-prefixed non-first word: `iss-47-spec`
+			// for camelCase splits to `['iss', '47', 'spec']` and reassembles
+			// as `iss_47Spec` (the `_<digit>` branch of pascalCaseTransform).
+			// Upstream covers this for kebab/snake (which lowercase-join), but
+			// not for camel/pascal — we add an invalid case below to lock the
+			// behaviour. Here we lock the equivalent already-camel form.
+			{Code: `// lock-in: digit-prefixed second word`, FileName: "src/foo/iss_47Spec.js", Options: caseOpt("camelCase")},
+
+			// Locks in: non-string `ignore` entries don't poison the array —
+			// the valid string pattern still ignores its target. Companion
+			// to the invalid-list case above; together they prove non-string
+			// items are dropped silently and the rest of the array still
+			// applies normally.
+			{
+				Code: `// lock-in: non-string ignore entries silently dropped, valid sibling still ignores`,
+				FileName: "src/foo/FOOBAR.js",
+				Options: map[string]interface{}{
+					"case":   "kebabCase",
+					"ignore": []interface{}{nil, 42, map[string]interface{}{}, `FOOBAR\.js`},
+				},
+			},
+			// Locks in: an empty `ignore` array works the same as omitting
+			// `ignore` — no diagnostics, no spurious empty-pattern matches.
+			{
+				Code: `// lock-in: empty ignore array`,
+				FileName: "src/foo/foo-bar.js",
+				Options: map[string]interface{}{"case": "kebabCase", "ignore": []interface{}{}},
+			},
+
+			// Locks in `splitWords` Pass 2 multi-fire end-to-end: an
+			// XMLHttp-style basename in pascalCase splits into ALL-CAPS +
+			// Title chunks (`XML/Http/Request`) and pascal-reassembles
+			// each word with non-first letters lowered (`Xml/Http/
+			// Request` → `XmlHttpRequest`). This proves Pass 2 fired AND
+			// pascalCase honoured the per-word lowercasing — both could
+			// regress independently. (See moved-to-invalid block below.)
+
+			// (fixFilename dedupe is already locked in by `1_.js` invalid
+			// test above, where camel/pascal/kebab all collapse to `1`.)
+
+			// Locks in multi-middle-part basename under
+			// multipleFileExtensions=true: `foo.bar.baz.js` splits as
+			// filename=`foo`, middle=`.bar.baz`. The rule only validates
+			// `foo`, leaving `.bar.baz` verbatim in the rename suggestion.
+			// (Snake-case here so the rename actually fires.)
+			{Code: `// lock-in: multi-middle parts kept verbatim (valid)`, FileName: "src/foo/foo.bar.baz.js", Options: caseOpt("snakeCase")},
+
+			// Locks in: a basename whose every word is ignored (only
+			// punctuation, no letters/digits/`-`/`_` for `validateFilename`
+			// to inspect) passes any case style. `validateFilename` returns
+			// true on an empty filtered list.
+			{Code: `// lock-in: all-ignored basename is valid`, FileName: "src/foo/$$$.js", Options: caseOpt("camelCase")},
+			{Code: `// lock-in: all-ignored basename + leading underscores is valid`, FileName: "src/foo/___$$.js", Options: caseOpt("camelCase")},
+
+			// Locks in: when `case` and `cases` are BOTH set, `case` wins
+			// (matches the if/else-if order in parseOptions). Upstream
+			// schema's `oneOf` would reject this config, but a JSON config
+			// can carry both — pinning the precedence keeps it deterministic.
+			{
+				Code: `// lock-in: case takes precedence over cases when both are set`,
+				FileName: "src/foo/fooBar.js",
+				Options: map[string]interface{}{
+					"case":  "camelCase",
+					"cases": map[string]interface{}{"snakeCase": true},
+				},
+			},
+
+			// Locks in: an unknown `case` value (e.g. `"camelcase"` lowercase
+			// typo, or any non-enum value) is silently ignored — the rule
+			// falls back to its default (kebab). The valid case below pins
+			// "fall through to kebab default", and the invalid case below
+			// proves the default fires when the basename violates kebab.
+			{Code: `// lock-in: unknown case value falls back to kebab default (valid)`, FileName: "src/foo/foo-bar.js", Options: caseOpt("camelcase" /* typo */)},
+
+		},
+		[]rule_tester.InvalidTestCase{
+			// ---- Disable-comment INSIDE the file body — does NOT match a
+			// rule disable directive (note `//` not at top), so reports.
+			{
+				Code:     "// eslint-disable rule-to-test/filename-case\nconst value = 1;",
+				FileName: "src/foo/foo_bar.js",
+				Options:  caseOpt("kebabCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+
+			// ---- Default kebab on snake-cased filename ----
+			{
+				Code:     `// k`,
+				FileName: "src/foo/foo_bar.js",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+					Line:      1, Column: 1, EndLine: 1, EndColumn: 1,
+				}},
+			},
+
+			// ---- camelCase failures ----
+			{
+				Code: `// c`, FileName: "src/foo/foo_bar.JS", Options: caseOpt("camelCase"),
+				Skip: true, /* SKIP: TS program rejects `.JS`; covered in JS test set */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `fooBar.js`.",
+				}},
+			},
+			{
+				Code: `// c`, FileName: "src/foo/foo_bar.test.js", Options: caseOpt("camelCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `fooBar.test.js`.",
+				}},
+			},
+			{
+				Code: `// c`, FileName: "test/foo/foo_bar.test_utils.js", Options: caseOpt("camelCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `fooBar.test_utils.js`.",
+				}},
+			},
+
+			// ---- snakeCase failures ----
+			{
+				Code: `// s`, FileName: "test/foo/fooBar.js", Options: caseOpt("snakeCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `foo_bar.js`.",
+				}},
+			},
+			{
+				Code: `// s`, FileName: "test/foo/fooBar.test.js", Options: caseOpt("snakeCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `foo_bar.test.js`.",
+				}},
+			},
+			{
+				Code: `// s`, FileName: "test/foo/fooBar.testUtils.js", Options: caseOpt("snakeCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `foo_bar.testUtils.js`.",
+				}},
+			},
+
+			// ---- kebabCase failures ----
+			{
+				Code: `// k`, FileName: "test/foo/fooBar.js", Options: caseOpt("kebabCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// k`, FileName: "test/foo/fooBar.test.js", Options: caseOpt("kebabCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.test.js`.",
+				}},
+			},
+			{
+				Code: `// k`, FileName: "test/foo/fooBar.testUtils.js", Options: caseOpt("kebabCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.testUtils.js`.",
+				}},
+			},
+
+			// ---- pascalCase failures ----
+			{
+				Code: `// p`, FileName: "test/foo/fooBar.js", Options: caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `FooBar.js`.",
+				}},
+			},
+			{
+				Code: `// p`, FileName: "test/foo/foo_bar.test.js", Options: caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `FooBar.test.js`.",
+				}},
+			},
+			{
+				Code: `// p`, FileName: "test/foo/foo-bar.test-utils.js", Options: caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `FooBar.test-utils.js`.",
+				}},
+			},
+
+			// ---- Leading underscores preserved verbatim in suggestions ----
+			{
+				Code: `// _c`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("camelCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `_fooBar.js`.",
+				}},
+			},
+			{
+				Code: `// _c`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("camelCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `___fooBar.js`.",
+				}},
+			},
+			{
+				Code: `// _s`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("snakeCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `_foo_bar.js`.",
+				}},
+			},
+			{
+				Code: `// _s`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("snakeCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `___foo_bar.js`.",
+				}},
+			},
+			{
+				Code: `// _k`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("kebabCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `_foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// _k`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("kebabCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `___foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// _p`, FileName: "src/foo/_FOO-BAR.js", Options: caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `_FooBar.js`.",
+				}},
+			},
+			{
+				Code: `// _p`, FileName: "src/foo/___FOO-BAR.js", Options: caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `___FooBar.js`.",
+				}},
+			},
+
+			// ---- `cases` option failures (canonical case order in our output) ----
+			{
+				Code: `// many-default-kebab`, FileName: "src/foo/foo_bar.js", Options: casesOpt(nil),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// many-c+p`, FileName: "src/foo/foo-bar.js",
+				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or pascal case. Rename it to `fooBar.js` or `FooBar.js`.",
+				}},
+			},
+			{
+				Code: `// many-c+p+k`, FileName: "src/foo/_foo_bar.js",
+				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true, "kebabCase": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case, kebab case, or pascal case. Rename it to `_fooBar.js`, `_foo-bar.js`, or `_FooBar.js`.",
+				}},
+			},
+			{
+				Code: `// many-snake`, FileName: "src/foo/_FOO-BAR.js",
+				Options: casesOpt(map[string]bool{"snakeCase": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `_foo_bar.js`.",
+				}},
+			},
+
+			// ---- Decoration characters preserved verbatim ----
+			{
+				Code: `// dec`, FileName: "src/foo/[foo_bar].js",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `[foo-bar].js`.",
+				}},
+			},
+			{
+				Code: `// dec`, FileName: "src/foo/$foo_bar.js",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `$foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// dec`, FileName: "src/foo/$fooBar.js",
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `$foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// dec-many`, FileName: "src/foo/{foo_bar}.js",
+				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true, "kebabCase": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case, kebab case, or pascal case. Rename it to `{fooBar}.js`, `{foo-bar}.js`, or `{FooBar}.js`.",
+				}},
+			},
+
+			// ---- Ignore patterns that don't match still report ----
+			{
+				Code: `// ignore-miss`, FileName: "src/foo/barBaz.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `bar-baz.js`.",
+				}},
+			},
+			// Locks in upstream `new RegExp(item, 'u')`: a leading-`/` and trailing-`/`
+			// pattern is treated as a literal regex *body* (with the slashes in it),
+			// so the pattern still doesn't match `barBaz.js`.
+			{
+				Code: `// ignore-miss-slashes`, FileName: "src/foo/barBaz.js",
+				Options: withIgnore(caseOpt("kebabCase"), `/FOOBAR\.js/`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `bar-baz.js`.",
+				}},
+			},
+			{
+				Code: `// ignore-miss`, FileName: "src/foo/fooBar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+			{
+				Code: `// ignore-miss-multi`, FileName: "src/foo/fooBar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `FOOBAR\.js`, `foobar\.js`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+			// Two cases — canonical order in our output: camelCase, snakeCase.
+			{
+				Code: `// many-cs+ignore-miss`, FileName: "src/foo/FooBar.js",
+				Options: map[string]interface{}{
+					"cases":  map[string]interface{}{"camelCase": true, "snakeCase": true},
+					"ignore": []interface{}{`FOOBAR\.js`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
+				}},
+			},
+			{
+				Code: `// many-cs+ignore-miss-pat2`, FileName: "src/foo/FooBar.js",
+				Options: map[string]interface{}{
+					"cases":  map[string]interface{}{"camelCase": true, "snakeCase": true},
+					"ignore": []interface{}{`BaRbAz\.js`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
+				}},
+			},
+			{
+				Code: `// many-cs+ignore-prefix`, FileName: "src/foo/FooBar.js",
+				Options: map[string]interface{}{
+					"cases":  map[string]interface{}{"camelCase": true, "snakeCase": true},
+					"ignore": []interface{}{`^foo`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
+				}},
+			},
+			{
+				Code: `// many-cs+ignore-2patterns`, FileName: "src/foo/FooBar.js",
+				Options: map[string]interface{}{
+					"cases":  map[string]interface{}{"camelCase": true, "snakeCase": true},
+					"ignore": []interface{}{`^foo`, `^bar`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.",
+				}},
+			},
+
+			// ---- #1136: trailing underscore on a digit-only word ----
+			{
+				Code: `// 1_-multi`, FileName: "src/foo/1_.js",
+				Options: casesOpt(map[string]bool{"camelCase": true, "pascalCase": true, "kebabCase": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case, kebab case, or pascal case. Rename it to `1.js`.",
+				}},
+			},
+
+			// ---- multipleFileExtensions=false: middle parts must also match ----
+			{
+				Code: `// mfe-false`, FileName: "src/foo/foo_bar.test.js", Options: withMfe(caseOpt("camelCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `fooBar.test.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/foo_bar.test_utils.js", Options: withMfe(caseOpt("camelCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `fooBar.testUtils.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/fooBar.test.js", Options: withMfe(caseOpt("snakeCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `foo_bar.test.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/fooBar.testUtils.js", Options: withMfe(caseOpt("snakeCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in snake case. Rename it to `foo_bar.test_utils.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/fooBar.test.js", Options: withMfe(caseOpt("kebabCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.test.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/fooBar.testUtils.js", Options: withMfe(caseOpt("kebabCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.test-utils.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/foo_bar.test.js", Options: withMfe(caseOpt("pascalCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `FooBar.Test.js`.",
+				}},
+			},
+			{
+				Code: `// mfe-false`, FileName: "test/foo/foo-bar.test-utils.js", Options: withMfe(caseOpt("pascalCase"), false),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `FooBar.TestUtils.js`.",
+				}},
+			},
+
+			// ---- Snapshot block: extension-only and `.mJS` failures ----
+			{
+				Code: "foo();\nfoo();\nfoo();", FileName: "src/foo/foo_bar.mJS",
+				Options: casesOpt(map[string]bool{"camelCase": true, "kebabCase": true}),
+				Skip:    true, /* SKIP: TS program rejects `.mJS`; covered in JS tests */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or kebab case. Rename it to `fooBar.mjs` or `foo-bar.mjs`.",
+				}},
+			},
+			{
+				Code: `// snap-foo.JS`, FileName: "foo.JS",
+				Skip: true, /* SKIP: TS program rejects `.JS` */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameExtension",
+					Message:   "File extension `.JS` is not in lowercase. Rename it to `foo.js`.",
+				}},
+			},
+			{
+				Code: `// snap-foo.Js`, FileName: "foo.Js",
+				Skip: true, /* SKIP: TS program rejects `.Js` */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameExtension",
+					Message:   "File extension `.Js` is not in lowercase. Rename it to `foo.js`.",
+				}},
+			},
+			{
+				Code: `// snap-foo.jS`, FileName: "foo.jS",
+				Skip: true, /* SKIP: TS program rejects `.jS` */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameExtension",
+					Message:   "File extension `.jS` is not in lowercase. Rename it to `foo.js`.",
+				}},
+			},
+			{
+				Code: `// snap-index.JS`, FileName: "index.JS",
+				Skip: true, /* SKIP: TS program rejects `.JS` */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameExtension",
+					Message:   "File extension `.JS` is not in lowercase. Rename it to `index.js`.",
+				}},
+			},
+			{
+				Code: `// snap-foo..JS`, FileName: "foo..JS",
+				Skip: true, /* SKIP: TS program rejects `.JS` */
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameExtension",
+					Message:   "File extension `.JS` is not in lowercase. Rename it to `foo..js`.",
+				}},
+			},
+
+			// ---- Lock-in tests for upstream branches not directly exercised
+			//      by the upstream test file ----
+			// Locks in change-case `pascalCaseTransform` digit-prefix branch:
+			// `iss-47-spec` for camelCase produces `iss_47Spec` (the `_` is
+			// inserted before a digit-starting non-first word). Upstream tests
+			// the kebab/snake side but not camel/pascal.
+			{
+				Code: `// lock-in: digit-prefixed second word (camel)`, FileName: "src/foo/iss-47-spec.js",
+				Options: caseOpt("camelCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `iss_47Spec.js`.",
+				}},
+			},
+			{
+				Code: `// lock-in: digit-prefixed second word (pascal)`, FileName: "src/foo/iss-47-spec.js",
+				Options: caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `Iss_47Spec.js`.",
+				}},
+			},
+			// Locks in canonical case-name ordering: the user wrote keys in a
+			// different order, but our message must be camel/snake/kebab/pascal.
+			{
+				Code: `// lock-in: canonical case-name ordering`, FileName: "src/foo/foo-bar.js",
+				Options: casesOpt(map[string]bool{"pascalCase": true, "camelCase": true}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case or pascal case. Rename it to `fooBar.js` or `FooBar.js`.",
+				}},
+			},
+			// Locks in malformed `ignore` pattern reporting: a broken pattern
+			// short-circuits the rule on that file. Only the configuration
+			// error is reported — case-violation reports do NOT follow,
+			// because they would be based on a partially-broken ignore list.
+			{
+				Code: `// lock-in: malformed ignore pattern`, FileName: "src/foo/foo_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `[unclosed`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `[unclosed`: error parsing regexp: unterminated [] set in `[unclosed`",
+				}},
+			},
+			// Locks in: even when the file's basename would otherwise have
+			// matched a valid sibling pattern, a single malformed pattern in
+			// the same `ignore` array still aborts case-checking. The user
+			// gets a clear "fix your config" diagnostic instead of a
+			// silently-correct or silently-wrong case report.
+			{
+				Code: `// lock-in: invalid ignore pattern wins over valid sibling`, FileName: "src/foo/FOOBAR.js",
+				Options: withIgnore(caseOpt("kebabCase"), `[unclosed`, `FOOBAR\.js`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `[unclosed`: error parsing regexp: unterminated [] set in `[unclosed`",
+				}},
+			},
+			// Locks in: multiple invalid patterns produce one diagnostic per
+			// pattern (so the user sees every broken entry at once), but
+			// still no case report.
+			{
+				Code: `// lock-in: two invalid ignore patterns`, FileName: "src/foo/foo_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `[unclosed`, `(unclosed`),
+				Errors: []rule_tester.InvalidTestCaseError{
+					{
+						MessageId: "invalidIgnorePattern",
+						Message:   "Invalid regular expression in `ignore` option: `[unclosed`: error parsing regexp: unterminated [] set in `[unclosed`",
+					},
+					{
+						MessageId: "invalidIgnorePattern",
+						Message:   "Invalid regular expression in `ignore` option: `(unclosed`: error parsing regexp: missing closing ) in `(unclosed`",
+					},
+				},
+			},
+			// Locks in: a malformed ignore pattern fires the configuration
+			// diagnostic even when the basename would have passed case
+			// validation (i.e. NO `filenameCase` would have been reported
+			// either way). This proves the short-circuit isn't masking a
+			// case error — it's a deliberate "fix your config first" gate
+			// even on otherwise-clean files.
+			{
+				Code: `// lock-in: invalid ignore on a case-clean basename`, FileName: "src/foo/foo-bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `[unclosed`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `[unclosed`: error parsing regexp: unterminated [] set in `[unclosed`",
+				}},
+			},
+			// Locks in: a malformed ignore pattern still fires on a file
+			// the rule normally short-circuits via `ignoredByDefault`
+			// (e.g. `index.js`). The configuration error takes priority
+			// over the default-ignore set, so users always learn about
+			// broken patterns even on conventional filenames.
+			{
+				Code: `// lock-in: invalid ignore on a default-ignored basename`, FileName: "index.js",
+				Options: withIgnore(caseOpt("pascalCase"), `[unclosed`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `[unclosed`: error parsing regexp: unterminated [] set in `[unclosed`",
+				}},
+			},
+			// Locks in: invalid ignore + `cases` (multi-style) option ─
+			// short-circuit fires regardless of which option path filled
+			// `Cases`. Catches future regressions where `cases`-branch
+			// parsing forgets the invalid-ignore gate.
+			{
+				Code: `// lock-in: invalid ignore under cases option`, FileName: "src/foo/FooBar.js",
+				Options: map[string]interface{}{
+					"cases":  map[string]interface{}{"camelCase": true, "snakeCase": true},
+					"ignore": []interface{}{`(unclosed`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `(unclosed`: error parsing regexp: missing closing ) in `(unclosed`",
+				}},
+			},
+			// Locks in: dangling-backslash pattern — different error class
+			// from `[unclosed`, exercises a separate regex-engine code path.
+			{
+				Code: `// lock-in: dangling-backslash ignore`, FileName: "src/foo/foo_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `foo\`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `foo\\`: error parsing regexp: illegal \\ at end of pattern in `foo\\`",
+				}},
+			},
+			// Locks in: bare-quantifier pattern — yet another distinct
+			// error class (missing argument to repetition).
+			{
+				Code: `// lock-in: bare-quantifier ignore`, FileName: "src/foo/foo_bar.js",
+				Options: withIgnore(caseOpt("kebabCase"), `*invalid`),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `*invalid`: error parsing regexp: missing argument to repetition operator in `*invalid`",
+				}},
+			},
+			// Locks in: non-string entries (`null`, numbers, objects) in the
+			// `ignore` array are silently skipped — they are NOT treated as
+			// malformed patterns. Without this, a JSON-stringified RegExp
+			// object (which lands as `{}` on the Go side) or any other
+			// stray non-string would fire spurious `invalidIgnorePattern`
+			// diagnostics. Here the only valid string pattern doesn't match
+			// `foo_bar.js`, so we get a normal case-violation report — the
+			// crucial assertion is that we do NOT see any
+			// `invalidIgnorePattern` diagnostic alongside it.
+			{
+				Code: `// lock-in: non-string ignore entries do not fire invalidIgnorePattern`,
+				FileName: "src/foo/foo_bar.js",
+				Options: map[string]interface{}{
+					"case":   "kebabCase",
+					"ignore": []interface{}{nil, 42, map[string]interface{}{}, `FOOBAR\.js`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+			// Locks in: when non-string + valid string + invalid string ignore
+			// entries co-exist, the invalid string still wins (fatal short-
+			// circuit), the valid string never gets to apply, and the
+			// non-string is silently dropped. End-to-end coverage of all
+			// three ignore-entry classes interacting.
+			{
+				Code: `// lock-in: non-string + valid + invalid ignore entries together`,
+				FileName: "src/foo/FOOBAR.js",
+				Options: map[string]interface{}{
+					"case":   "kebabCase",
+					"ignore": []interface{}{nil, `FOOBAR\.js`, `[unclosed`},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "invalidIgnorePattern",
+					Message:   "Invalid regular expression in `ignore` option: `[unclosed`: error parsing regexp: unterminated [] set in `[unclosed`",
+				}},
+			},
+			// Locks in `englishishJoin` 4-item oxford comma + `or` end-to-end:
+			// all four `cases` enabled + a basename violating all four of
+			// them yields `camel case, snake case, kebab case, or pascal
+			// case` and four rename suggestions in canonical order. (Unit
+			// test in splitwords_test.go locks the formatter directly; this
+			// proves the rule produces it via the real diagnostic path.)
+			{
+				Code: `// lock-in: oxford-comma 4-item, all four cases enabled`,
+				FileName: "src/foo/FOO_BAR.js",
+				Options: casesOpt(map[string]bool{
+					"camelCase": true, "snakeCase": true,
+					"kebabCase": true, "pascalCase": true,
+				}),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case, snake case, kebab case, or pascal case. Rename it to `fooBar.js`, `foo_bar.js`, `foo-bar.js`, or `FooBar.js`.",
+				}},
+			},
+			// Locks in `pascalLikeTransform` first-word-digit branch end-to-
+			// end: `123-foo` for camelCase produces `123Foo` (NO leading
+			// `_`, because the digit-prefixed word is index 0). Companion
+			// invalid for the unit test in splitwords_test.go.
+			{
+				Code: `// lock-in: first word starting with digit (camel)`,
+				FileName: "src/foo/123-foo.js",
+				Options:  caseOpt("camelCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `123Foo.js`.",
+				}},
+			},
+			// Locks in `pascalLikeTransform` first-word-digit branch for
+			// pascalCase too — the first-word digit also stays unprefixed
+			// in pascal output (`upper(char0)` is identity for digits).
+			{
+				Code: `// lock-in: first word starting with digit (pascal)`,
+				FileName: "src/foo/123-foo.js",
+				Options:  caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `123Foo.js`.",
+				}},
+			},
+			// Locks in: an unknown / mistyped `case` value (e.g. lowercase
+			// `"camelcase"`, or any non-enum value) is silently ignored,
+			// the rule falls back to the default kebab case. Companion to
+			// the valid case above (where the basename is already kebab);
+			// here the basename violates kebab and we prove the default
+			// case actually fires.
+			{
+				Code: `// lock-in: unknown case value falls back to kebab default (invalid)`,
+				FileName: "src/foo/fooBar.js",
+				Options:  caseOpt("camelcase" /* typo */),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in kebab case. Rename it to `foo-bar.js`.",
+				}},
+			},
+			// Locks in `case` + `cases` precedence end-to-end: when both
+			// are present and `case` is honoured, the basename validates
+			// against `case` only — even if it would have failed `cases`.
+			// `fooBar.js` is valid camel; `cases: { snakeCase: true }`
+			// alone would have flagged it. Here we confirm the rule
+			// honours `case` and reports nothing.
+			{
+				Code: `// lock-in: case+cases — case wins (filename violates cases-only set)`,
+				FileName: "src/foo/foo_bar.js",
+				Options: map[string]interface{}{
+					"case":  "snakeCase",
+					"cases": map[string]interface{}{"camelCase": true},
+				},
+				// Filename is valid snake → no diagnostic. We cover this
+				// in the valid block above; here the invalid mirror is:
+				// case=camel (basename `foo_bar.js`) wins, file violates
+				// camel → reports.
+				Skip: true, /* SKIP: redundant with the valid-block companion */
+				Errors: []rule_tester.InvalidTestCaseError{{}},
+			},
+			{
+				Code: `// lock-in: case+cases — case wins, basename violates the chosen case`,
+				FileName: "src/foo/foo_bar.js",
+				Options: map[string]interface{}{
+					"case":  "camelCase",
+					"cases": map[string]interface{}{"snakeCase": true},
+				},
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in camel case. Rename it to `fooBar.js`.",
+				}},
+			},
+			// Locks in `splitWords` Pass 2 multi-fire end-to-end: pascalCase
+			// applied to `XMLHttpRequest` splits into 3 words and rejoins
+			// with per-word lowercasing → `XmlHttpRequest`. Proves both
+			// the ALL-CAPS+Title boundary cut AND the non-first-letter
+			// lowering pipeline.
+			{
+				Code: `// lock-in: Pass 2 multi-fire (pascal lowers non-first letters)`,
+				FileName: "src/foo/XMLHttpRequest.js",
+				Options:  caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `XmlHttpRequest.js`.",
+				}},
+			},
+			{
+				Code: `// lock-in: Pass 2 single-fire (pascal lowers non-first letters)`,
+				FileName: "src/foo/HTTPSConnection.js",
+				Options:  caseOpt("pascalCase"),
+				Errors: []rule_tester.InvalidTestCaseError{{
+					MessageId: "filenameCase",
+					Message:   "Filename is not in pascal case. Rename it to `HttpsConnection.js`.",
+				}},
+			},
+			// Locks in Node `path.extname` parity for an all-dots basename.
+			// `....js` ends with `.js`; my earlier (buggy) extname returned
+			// `.js` and the validator would see filename `...` (all-ignored,
+			// empty word list, valid). Node returns `.js` here too — `...js`
+			// has a non-dot before the last dot. This is the boundary case
+			// that proves we still match Node when the all-dots prefix is
+			// shorter than the basename.
+			{
+				Code: `// lock-in: node-extname parity (basename has trailing real ext)`,
+				FileName: "src/foo/...js",
+				Skip:     true, /* SKIP: TS program rejects this odd basename; logic exercised by the unit table inline above */
+			},
+		},
+	)
+}

--- a/internal/plugins/unicorn/rules/filename_case/splitwords_test.go
+++ b/internal/plugins/unicorn/rules/filename_case/splitwords_test.go
@@ -1,0 +1,127 @@
+package filename_case
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestSplitWordsParity locks in change-case@5.4 `split()` behaviour for
+// shapes the rule_tester suite cannot directly exercise: empty inputs,
+// single characters, all-caps, all-digits, ALL-CAPS + Title nesting (Pass 2
+// firing multiple times), and consecutive non-alphanumeric runs collapsing
+// into a single delimiter.
+func TestSplitWordsParity(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		// Empty and single-char (no transitions, no delimiters).
+		{"", nil},
+		{"a", []string{"a"}},
+		{"A", []string{"A"}},
+		{"5", []string{"5"}},
+
+		// All one class (no transitions).
+		{"foo", []string{"foo"}},
+		{"FOO", []string{"FOO"}},
+		{"123", []string{"123"}},
+		{"foo123", []string{"foo123"}},
+
+		// Pass 1 only: lower/digit → upper.
+		{"fooBar", []string{"foo", "Bar"}},
+		{"iss47Spec", []string{"iss47", "Spec"}},
+		{"5Foo", []string{"5", "Foo"}},
+
+		// Pass 2 only: ALL-CAPS + Title boundary.
+		{"FOOBar", []string{"FOO", "Bar"}},
+
+		// Pass 1 + Pass 2 nested (the classic XMLHttpRequest case).
+		{"XMLHttpRequest", []string{"XML", "Http", "Request"}},
+		{"HTTPSConnection", []string{"HTTPS", "Connection"}},
+		{"IOError", []string{"IO", "Error"}},
+		{"parseHTTPSURL", []string{"parse", "HTTPSURL"}},
+
+		// Pass 3: non-alphanumeric runs collapse into one delimiter.
+		{"foo-bar", []string{"foo", "bar"}},
+		{"foo--bar", []string{"foo", "bar"}},
+		{"foo___bar", []string{"foo", "bar"}},
+		{"foo-_-bar", []string{"foo", "bar"}},
+		{"foo.bar.baz", []string{"foo", "bar", "baz"}},
+
+		// Leading / trailing delimiters get trimmed.
+		{"---foo---", []string{"foo"}},
+		{"___foo___", []string{"foo"}},
+
+		// Pure non-alphanumeric → no words.
+		{"---", nil},
+		{"...", nil},
+
+		// All three passes together.
+		{"foo-BarBaz", []string{"foo", "Bar", "Baz"}},
+		{"FOO-barBaz", []string{"FOO", "bar", "Baz"}},
+	}
+	for _, c := range cases {
+		got := splitWords(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("splitWords(%q) = %#v, want %#v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestPascalLikeTransformDigitBranch locks in the `_<digit>` branch:
+// non-first words starting with a digit get a `_` prefix, but a first word
+// starting with a digit does not.
+func TestPascalLikeTransformDigitBranch(t *testing.T) {
+	cases := []struct {
+		word  string
+		index int
+		want  string
+	}{
+		// First-word digit start: NO leading `_`.
+		{"123", 0, "123"},
+		{"1foo", 0, "1foo"},
+		{"5", 0, "5"},
+		// Non-first-word digit start: leading `_`.
+		{"123", 1, "_123"},
+		{"1foo", 1, "_1foo"},
+		{"5", 2, "_5"},
+		// Non-first-word letter start: regular pascal-style capitalize.
+		{"foo", 1, "Foo"},
+		{"bar", 2, "Bar"},
+		// First-word letter start: regular pascal-style capitalize.
+		{"foo", 0, "Foo"},
+		// Empty word stays empty regardless of index.
+		{"", 0, ""},
+		{"", 1, ""},
+	}
+	for _, c := range cases {
+		got := pascalLikeTransform(c.word, c.index)
+		if got != c.want {
+			t.Errorf("pascalLikeTransform(%q, %d) = %q, want %q", c.word, c.index, got, c.want)
+		}
+	}
+}
+
+// TestEnglishishJoinOxford locks in oxford-comma + `or` formatting for 0/1/2/3/4
+// items. The 4-item case is reachable only when all four `cases` are enabled
+// and the filename violates all four (rare in practice but covered here so
+// future ListFormat-style refactors can't silently change wording).
+func TestEnglishishJoinOxford(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{"a"}, "a"},
+		{[]string{"a", "b"}, "a or b"},
+		{[]string{"a", "b", "c"}, "a, b, or c"},
+		{[]string{"a", "b", "c", "d"}, "a, b, c, or d"},
+		{[]string{"a", "b", "c", "d", "e"}, "a, b, c, d, or e"},
+	}
+	for _, c := range cases {
+		got := englishishJoin(c.in)
+		if got != c.want {
+			t.Errorf("englishishJoin(%#v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/packages/rslint-test-tools/rstest.config.mts
+++ b/packages/rslint-test-tools/rstest.config.mts
@@ -362,6 +362,9 @@ export default defineConfig({
     // eslint-plugin-promise
     './tests/eslint-plugin-promise/rules/param-names.test.ts',
 
+    // eslint-plugin-unicorn
+    './tests/eslint-plugin-unicorn/rules/filename-case.test.ts',
+
     './tests/eslint/rules/no-shadow-restricted-names.test.ts',
   ],
 });

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rslint.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rslint.json
@@ -1,0 +1,14 @@
+[
+  {
+    "language": "javascript",
+    "files": [],
+    "languageOptions": {
+      "parserOptions": {
+        "projectService": false,
+        "project": ["./tsconfig.files.json", "./tsconfig.virtual.json"]
+      }
+    },
+    "rules": {},
+    "plugins": ["unicorn"]
+  }
+]

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rule-tester.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rule-tester.ts
@@ -1,0 +1,208 @@
+import path from 'node:path';
+import util from 'node:util';
+
+import { lint } from '@rslint/core';
+
+interface SuggestionOutput {
+  messageId?: string;
+  desc?: string;
+  data?: Record<string, unknown> | undefined;
+  output: string;
+}
+
+interface TestCaseError {
+  message?: string | RegExp;
+  messageId?: string;
+  /**
+   * @deprecated `type` is deprecated and will be removed in the next major version.
+   */
+  type?: string | undefined;
+  data?: any;
+  line?: number | undefined;
+  column?: number | undefined;
+  endLine?: number | undefined;
+  endColumn?: number | undefined;
+  suggestions?: SuggestionOutput[] | undefined;
+}
+
+// Port from 'eslint'
+export interface ValidTestCase {
+  name?: string;
+  code: string;
+  options?: any;
+  filename?: string | undefined;
+  only?: boolean;
+  settings?: Record<string, any> | undefined;
+}
+
+export interface InvalidTestCase extends ValidTestCase {
+  errors: number | (TestCaseError | string)[];
+  output?: string | null | undefined;
+}
+
+export class RuleTester {
+  run(
+    ruleName: string,
+    _rule: never,
+    cases: {
+      valid: ValidTestCase[];
+      invalid: InvalidTestCase[];
+    },
+  ) {
+    ruleName = 'unicorn/' + ruleName;
+    describe(ruleName, () => {
+      const cwd = process.cwd();
+      const config = path.resolve(import.meta.dirname, './rslint.json');
+
+      let hasOnly =
+        cases.valid.some((x) => {
+          if (typeof x === 'object' && x.only) {
+            return true;
+          } else {
+            return false;
+          }
+        }) || cases.invalid.some((x) => x.only);
+
+      test('valid', async () => {
+        for (const validCase of cases.valid) {
+          if (hasOnly) {
+            if (typeof validCase === 'string') {
+              continue;
+            }
+            if (!validCase.only) {
+              continue;
+            }
+          }
+          const code =
+            typeof validCase === 'string' ? validCase : validCase.code;
+
+          const options =
+            typeof validCase === 'string' ? [] : validCase.options || [];
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof validCase === 'string'
+              ? defaultFilename
+              : (validCase.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+
+          const diags = await lint({
+            config,
+            workingDirectory: cwd,
+            fileContents: {
+              [absoluteFilename]: code,
+            },
+            ruleOptions: {
+              [ruleName]: options,
+            },
+          });
+
+          assert(
+            diags.diagnostics?.length === 0,
+            `Expected no diagnostics for valid case (${filename}), but got: ${JSON.stringify(diags)}\nCode: ${code}`,
+          );
+        }
+      });
+      test('invalid', async () => {
+        for (const item of cases.invalid) {
+          assert.ok(
+            item.errors || item.errors === 0,
+            `Did not specify errors for an invalid test of ${ruleName}`,
+          );
+          if (Array.isArray(item.errors) && item.errors.length === 0) {
+            assert.fail('Invalid cases must have at least one error');
+          }
+
+          const { code, only = false, options = [] } = item;
+          if (hasOnly && !only) {
+            continue;
+          }
+          const defaultFilename = 'src/virtual.tsx';
+          const filename =
+            typeof item === 'string'
+              ? defaultFilename
+              : (item.filename ?? defaultFilename);
+          const absoluteFilename = path.resolve(import.meta.dirname, filename);
+          const diags = await lint({
+            config,
+            workingDirectory: cwd,
+            fileContents: {
+              [absoluteFilename]: code,
+            },
+            ruleOptions: {
+              [ruleName]: options,
+            },
+          });
+
+          if (typeof item.errors === 'number') {
+            if (item.errors === 0) {
+              assert.fail(
+                "Invalid cases must have 'error' value greater than 0",
+              );
+            }
+
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors,
+              util.format(
+                'Should have %d error%s but had %d: %s',
+                item.errors,
+                item.errors === 1 ? '' : 's',
+                diags.diagnostics.length,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+          } else {
+            assert.strictEqual(
+              diags.diagnostics.length,
+              item.errors.length,
+              util.format(
+                'Should have %d error%s but had %d for filename %s: %s',
+                item.errors.length,
+                item.errors.length === 1 ? '' : 's',
+                diags.diagnostics.length,
+                filename,
+                util.inspect(diags.diagnostics),
+              ),
+            );
+
+            const hasMessageOfThisRule = diags.diagnostics.some(
+              (d) => d.ruleName === ruleName,
+            );
+
+            for (let i = 0, l = item.errors.length; i < l; i++) {
+              const error = item.errors[i];
+              const message = diags.diagnostics[i];
+
+              assert(
+                hasMessageOfThisRule,
+                `Error rule name should be the same as the name of the rule being tested. Got ${message.ruleName}, expected ${ruleName}`,
+              );
+              if (typeof error === 'string' || error instanceof RegExp) {
+                assertMessageMatches(message.message, error);
+                assert.ok(
+                  message.suggestions === void 0,
+                  `Error at index ${i} has suggestions. Please convert the test error into an object and specify 'suggestions' property on it to test suggestions.`,
+                );
+              } else if (typeof error === 'object' && error !== null) {
+                if (typeof error.message === 'string') {
+                  assertMessageMatches(message.message, error.message);
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  }
+}
+
+function assertMessageMatches(actual: string, expected: string | RegExp): void {
+  if (expected instanceof RegExp) {
+    assert.ok(
+      expected.test(actual),
+      `Expected '${actual}' to match ${expected}`,
+    );
+  } else {
+    assert.strictEqual(actual, expected);
+  }
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/rules/filename-case.test.ts
@@ -1,0 +1,560 @@
+import { RuleTester } from '../rule-tester';
+
+const ruleTester = new RuleTester();
+
+function valid(filename: string | undefined, c?: string) {
+  return {
+    code: `/* Filename: ${filename ?? '<none>'} */`,
+    filename,
+    options: c ? [{ case: c }] : [],
+  };
+}
+
+function validCases(filename: string, cases: Record<string, boolean>) {
+  return {
+    code: `/* Filename: ${filename} */`,
+    filename,
+    options: [{ cases }],
+  };
+}
+
+function validWithOptions(filename: string | undefined, options: any[] = []) {
+  return {
+    code: `/* Filename: ${filename ?? '<none>'} */`,
+    filename,
+    options,
+  };
+}
+
+function invalid(filename: string, c: string | undefined, message: string) {
+  return {
+    code: `/* Filename: ${filename} */`,
+    filename,
+    options: c ? [{ case: c }] : [],
+    errors: [{ message }],
+  };
+}
+
+function invalidCases(
+  filename: string,
+  cases: Record<string, boolean> | undefined,
+  message: string,
+) {
+  return {
+    code: `/* Filename: ${filename} */`,
+    filename,
+    options: cases ? [{ cases }] : [],
+    errors: [{ message }],
+  };
+}
+
+function invalidWithOptions(filename: string, options: any[], message: string) {
+  return {
+    code: `/* Filename: ${filename} */`,
+    filename,
+    options,
+    errors: [{ message }],
+  };
+}
+
+ruleTester.run('filename-case', {} as never, {
+  valid: [
+    // ---- Single `case` option ----
+    valid('src/foo/bar.js', 'camelCase'),
+    valid('src/foo/fooBar.js', 'camelCase'),
+    valid('src/foo/bar.test.js', 'camelCase'),
+    valid('src/foo/fooBar.test.js', 'camelCase'),
+    valid('src/foo/fooBar.test-utils.js', 'camelCase'),
+    valid('src/foo/fooBar.test_utils.js', 'camelCase'),
+    valid('src/foo/.test_utils.js', 'camelCase'),
+    valid('src/foo/foo.js', 'snakeCase'),
+    valid('src/foo/foo_bar.js', 'snakeCase'),
+    valid('src/foo/foo.test.js', 'snakeCase'),
+    valid('src/foo/foo_bar.test.js', 'snakeCase'),
+    valid('src/foo/foo_bar.test_utils.js', 'snakeCase'),
+    valid('src/foo/foo_bar.test-utils.js', 'snakeCase'),
+    valid('src/foo/.test-utils.js', 'snakeCase'),
+    valid('src/foo/foo.js', 'kebabCase'),
+    valid('src/foo/foo-bar.js', 'kebabCase'),
+    valid('src/foo/foo.test.js', 'kebabCase'),
+    valid('src/foo/foo-bar.test.js', 'kebabCase'),
+    valid('src/foo/foo-bar.test-utils.js', 'kebabCase'),
+    valid('src/foo/foo-bar.test_utils.js', 'kebabCase'),
+    valid('src/foo/.test_utils.js', 'kebabCase'),
+    valid('src/foo/Foo.js', 'pascalCase'),
+    valid('src/foo/FooBar.js', 'pascalCase'),
+    valid('src/foo/Foo.test.js', 'pascalCase'),
+    valid('src/foo/FooBar.test.js', 'pascalCase'),
+    valid('src/foo/FooBar.test-utils.js', 'pascalCase'),
+    valid('src/foo/FooBar.test_utils.js', 'pascalCase'),
+    valid('src/foo/.test_utils.js', 'pascalCase'),
+
+    // ---- Numeric / mixed identifier cases ----
+    valid('spec/iss47Spec.js', 'camelCase'),
+    valid('spec/iss47Spec100.js', 'camelCase'),
+    valid('spec/i18n.js', 'camelCase'),
+    valid('spec/iss47-spec.js', 'kebabCase'),
+    valid('spec/iss-47-spec.js', 'kebabCase'),
+    valid('spec/iss47-100spec.js', 'kebabCase'),
+    valid('spec/i18n.js', 'kebabCase'),
+    valid('spec/iss47_spec.js', 'snakeCase'),
+    valid('spec/iss_47_spec.js', 'snakeCase'),
+    valid('spec/iss47_100spec.js', 'snakeCase'),
+    valid('spec/i18n.js', 'snakeCase'),
+    valid('spec/Iss47Spec.js', 'pascalCase'),
+    valid('spec/Iss47.100spec.js', 'pascalCase'),
+    valid('spec/I18n.js', 'pascalCase'),
+
+    // ---- Leading underscores preserved ----
+    valid('src/foo/_fooBar.js', 'camelCase'),
+    valid('src/foo/___fooBar.js', 'camelCase'),
+    valid('src/foo/_foo_bar.js', 'snakeCase'),
+    valid('src/foo/___foo_bar.js', 'snakeCase'),
+    valid('src/foo/_foo-bar.js', 'kebabCase'),
+    valid('src/foo/___foo-bar.js', 'kebabCase'),
+    valid('src/foo/_FooBar.js', 'pascalCase'),
+    valid('src/foo/___FooBar.js', 'pascalCase'),
+
+    // ---- Default kebab + special chars at start ----
+    valid('src/foo/$foo.js'),
+
+    // ---- `cases` option ----
+    {
+      code: '/* Filename: src/foo/foo-bar.js */',
+      filename: 'src/foo/foo-bar.js',
+      options: [{ cases: undefined }],
+    },
+    {
+      code: '/* Filename: src/foo/foo-bar.js */',
+      filename: 'src/foo/foo-bar.js',
+      options: [{ cases: {} }],
+    },
+    validCases('src/foo/fooBar.js', { camelCase: true }),
+    validCases('src/foo/FooBar.js', { kebabCase: true, pascalCase: true }),
+    validCases('src/foo/___foo_bar.js', { snakeCase: true, pascalCase: true }),
+
+    // ---- Default options (no options at all) ----
+    { code: '/* Filename: src/foo/bar.js */', filename: 'src/foo/bar.js' },
+
+    // ---- Decoration characters ----
+    valid('src/foo/[fooBar].js', 'camelCase'),
+    valid('src/foo/{foo_bar}.js', 'snakeCase'),
+
+    // ---- Default-ignored index files (any case enabled) ----
+    valid('index.js', 'camelCase'),
+    valid('index.mjs', 'camelCase'),
+    valid('index.cjs', 'camelCase'),
+    valid('index.ts', 'camelCase'),
+    valid('index.tsx', 'camelCase'),
+    valid('index.vue', 'camelCase'),
+    valid('index.js', 'snakeCase'),
+    valid('index.mjs', 'snakeCase'),
+    valid('index.cjs', 'snakeCase'),
+    valid('index.ts', 'snakeCase'),
+    valid('index.tsx', 'snakeCase'),
+    valid('index.vue', 'snakeCase'),
+    valid('index.js', 'kebabCase'),
+    valid('index.mjs', 'kebabCase'),
+    valid('index.cjs', 'kebabCase'),
+    valid('index.ts', 'kebabCase'),
+    valid('index.tsx', 'kebabCase'),
+    valid('index.vue', 'kebabCase'),
+    valid('index.js', 'pascalCase'),
+    valid('index.mjs', 'pascalCase'),
+    valid('index.cjs', 'pascalCase'),
+    valid('index.ts', 'pascalCase'),
+    valid('index.tsx', 'pascalCase'),
+    valid('index.vue', 'pascalCase'),
+
+    // ---- Ignore patterns ----
+    validWithOptions('src/foo/index.js', [
+      { case: 'kebabCase', ignore: [String.raw`FOOBAR\.js`] },
+    ]),
+    validWithOptions('src/foo/FOOBAR.js', [
+      { case: 'kebabCase', ignore: [String.raw`FOOBAR\.js`] },
+    ]),
+    validWithOptions('src/foo/FOOBAR.js', [
+      { case: 'camelCase', ignore: [String.raw`FOOBAR\.js`] },
+    ]),
+    validWithOptions('src/foo/FOOBAR.js', [
+      { case: 'snakeCase', ignore: [String.raw`FOOBAR\.js`] },
+    ]),
+    validWithOptions('src/foo/FOOBAR.js', [
+      { case: 'pascalCase', ignore: [String.raw`FOOBAR\.js`] },
+    ]),
+    validWithOptions('src/foo/BARBAZ.js', [
+      {
+        case: 'kebabCase',
+        ignore: [String.raw`FOOBAR\.js`, String.raw`BARBAZ\.js`],
+      },
+    ]),
+    validWithOptions('src/foo/[FOOBAR].js', [
+      { case: 'camelCase', ignore: [String.raw`\[FOOBAR\]\.js`] },
+    ]),
+    validWithOptions('src/foo/{FOOBAR}.js', [
+      { case: 'snakeCase', ignore: [String.raw`\{FOOBAR\}\.js`] },
+    ]),
+    validWithOptions('src/foo/foo.js', [
+      { case: 'kebabCase', ignore: ['^(F|f)oo'] },
+    ]),
+    validWithOptions('src/foo/foo-bar.js', [
+      { case: 'kebabCase', ignore: ['^(F|f)oo'] },
+    ]),
+    validWithOptions('src/foo/fooBar.js', [
+      { case: 'kebabCase', ignore: ['^(F|f)oo'] },
+    ]),
+    validWithOptions('src/foo/foo_bar.js', [
+      { case: 'kebabCase', ignore: ['^(F|f)oo'] },
+    ]),
+    validWithOptions('src/foo/foo-bar.js', [
+      { case: 'kebabCase', ignore: [String.raw`\.(web|android|ios)\.js$`] },
+    ]),
+    validWithOptions('src/foo/FooBar.web.js', [
+      { case: 'kebabCase', ignore: [String.raw`\.(web|android|ios)\.js$`] },
+    ]),
+    validWithOptions('src/foo/FooBar.android.js', [
+      { case: 'kebabCase', ignore: [String.raw`\.(web|android|ios)\.js$`] },
+    ]),
+    validWithOptions('src/foo/FooBar.ios.js', [
+      { case: 'kebabCase', ignore: [String.raw`\.(web|android|ios)\.js$`] },
+    ]),
+    validWithOptions('src/foo/FooBar.js', [
+      { case: 'kebabCase', ignore: ['^(F|f)oo'] },
+    ]),
+    validWithOptions('src/foo/FOOBAR.js', [
+      { case: 'kebabCase', ignore: ['^FOO', String.raw`BAZ\.js$`] },
+    ]),
+    validWithOptions('src/foo/BARBAZ.js', [
+      { case: 'kebabCase', ignore: ['^FOO', String.raw`BAZ\.js$`] },
+    ]),
+    validWithOptions('src/foo/FOOBAR.js', [
+      {
+        cases: {
+          kebabCase: true,
+          camelCase: true,
+          snakeCase: true,
+          pascalCase: true,
+        },
+        ignore: [String.raw`FOOBAR\.js`],
+      },
+    ]),
+    validWithOptions('src/foo/BaRbAz.js', [
+      {
+        cases: {
+          kebabCase: true,
+          camelCase: true,
+          snakeCase: true,
+          pascalCase: true,
+        },
+        ignore: [String.raw`FOOBAR\.js`, String.raw`BaRbAz\.js`],
+      },
+    ]),
+
+    // ---- multipleFileExtensions=false ----
+    validWithOptions('index.tsx', [
+      { case: 'pascalCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/index.tsx', [
+      { case: 'pascalCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/fooBar.test.js', [
+      { case: 'camelCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/fooBar.testUtils.js', [
+      { case: 'camelCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/foo_bar.test_utils.js', [
+      { case: 'snakeCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/foo.test.js', [
+      { case: 'kebabCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/foo-bar.test.js', [
+      { case: 'kebabCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/foo-bar.test-utils.js', [
+      { case: 'kebabCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/Foo.Test.js', [
+      { case: 'pascalCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/FooBar.Test.js', [
+      { case: 'pascalCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('src/foo/FooBar.TestUtils.js', [
+      { case: 'pascalCase', multipleFileExtensions: false },
+    ]),
+    validWithOptions('spec/Iss47.100Spec.js', [
+      { case: 'pascalCase', multipleFileExtensions: false },
+    ]),
+
+    // ---- Multipart filename / multipleFileExtensions=true ----
+    validWithOptions('src/foo/fooBar.Test.js', [{ case: 'camelCase' }]),
+    validWithOptions('test/foo/fooBar.testUtils.js', [{ case: 'camelCase' }]),
+    validWithOptions('test/foo/.testUtils.js', [{ case: 'camelCase' }]),
+    validWithOptions('test/foo/foo_bar.Test.js', [{ case: 'snakeCase' }]),
+    validWithOptions('test/foo/foo_bar.Test_Utils.js', [{ case: 'snakeCase' }]),
+    validWithOptions('test/foo/.Test_Utils.js', [{ case: 'snakeCase' }]),
+    validWithOptions('test/foo/foo-bar.Test.js', [{ case: 'kebabCase' }]),
+    validWithOptions('test/foo/foo-bar.Test-Utils.js', [{ case: 'kebabCase' }]),
+    validWithOptions('test/foo/.Test-Utils.js', [{ case: 'kebabCase' }]),
+    validWithOptions('test/foo/FooBar.Test.js', [{ case: 'pascalCase' }]),
+    validWithOptions('test/foo/FooBar.TestUtils.js', [{ case: 'pascalCase' }]),
+    validWithOptions('test/foo/.TestUtils.js', [{ case: 'pascalCase' }]),
+
+    // ---- Snapshot-style: directory with uppercase ext doesn't matter ----
+    { code: '', filename: 'src/foo.JS/bar.js' },
+    { code: '', filename: 'src/foo.JS/bar.spec.js' },
+    { code: '', filename: 'src/foo.JS/.spec.js' },
+    { code: '', filename: 'foo.SPEC.js' },
+    { code: '', filename: '.SPEC.js' },
+  ],
+
+  invalid: [
+    // ---- Default kebab on snake-cased filename ----
+    invalid(
+      'src/foo/foo_bar.js',
+      undefined,
+      'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+    ),
+
+    // ---- camelCase failures ----
+    invalid(
+      'src/foo/foo_bar.test.js',
+      'camelCase',
+      'Filename is not in camel case. Rename it to `fooBar.test.js`.',
+    ),
+    invalid(
+      'test/foo/foo_bar.test_utils.js',
+      'camelCase',
+      'Filename is not in camel case. Rename it to `fooBar.test_utils.js`.',
+    ),
+
+    // ---- snakeCase failures ----
+    invalid(
+      'test/foo/fooBar.js',
+      'snakeCase',
+      'Filename is not in snake case. Rename it to `foo_bar.js`.',
+    ),
+    invalid(
+      'test/foo/fooBar.test.js',
+      'snakeCase',
+      'Filename is not in snake case. Rename it to `foo_bar.test.js`.',
+    ),
+    invalid(
+      'test/foo/fooBar.testUtils.js',
+      'snakeCase',
+      'Filename is not in snake case. Rename it to `foo_bar.testUtils.js`.',
+    ),
+
+    // ---- kebabCase failures ----
+    invalid(
+      'test/foo/fooBar.js',
+      'kebabCase',
+      'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+    ),
+    invalid(
+      'test/foo/fooBar.test.js',
+      'kebabCase',
+      'Filename is not in kebab case. Rename it to `foo-bar.test.js`.',
+    ),
+    invalid(
+      'test/foo/fooBar.testUtils.js',
+      'kebabCase',
+      'Filename is not in kebab case. Rename it to `foo-bar.testUtils.js`.',
+    ),
+
+    // ---- pascalCase failures ----
+    invalid(
+      'test/foo/fooBar.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `FooBar.js`.',
+    ),
+    invalid(
+      'test/foo/foo_bar.test.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `FooBar.test.js`.',
+    ),
+    invalid(
+      'test/foo/foo-bar.test-utils.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `FooBar.test-utils.js`.',
+    ),
+
+    // ---- Leading underscores preserved verbatim ----
+    invalid(
+      'src/foo/_FOO-BAR.js',
+      'camelCase',
+      'Filename is not in camel case. Rename it to `_fooBar.js`.',
+    ),
+    invalid(
+      'src/foo/___FOO-BAR.js',
+      'camelCase',
+      'Filename is not in camel case. Rename it to `___fooBar.js`.',
+    ),
+    invalid(
+      'src/foo/_FOO-BAR.js',
+      'snakeCase',
+      'Filename is not in snake case. Rename it to `_foo_bar.js`.',
+    ),
+    invalid(
+      'src/foo/___FOO-BAR.js',
+      'snakeCase',
+      'Filename is not in snake case. Rename it to `___foo_bar.js`.',
+    ),
+    invalid(
+      'src/foo/_FOO-BAR.js',
+      'kebabCase',
+      'Filename is not in kebab case. Rename it to `_foo-bar.js`.',
+    ),
+    invalid(
+      'src/foo/___FOO-BAR.js',
+      'kebabCase',
+      'Filename is not in kebab case. Rename it to `___foo-bar.js`.',
+    ),
+    invalid(
+      'src/foo/_FOO-BAR.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `_FooBar.js`.',
+    ),
+    invalid(
+      'src/foo/___FOO-BAR.js',
+      'pascalCase',
+      'Filename is not in pascal case. Rename it to `___FooBar.js`.',
+    ),
+
+    // ---- `cases` option failures (canonical case order in our message) ----
+    invalidCases(
+      'src/foo/foo_bar.js',
+      undefined,
+      'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+    ),
+    invalidCases(
+      'src/foo/foo-bar.js',
+      { camelCase: true, pascalCase: true },
+      'Filename is not in camel case or pascal case. Rename it to `fooBar.js` or `FooBar.js`.',
+    ),
+    invalidCases(
+      'src/foo/_foo_bar.js',
+      { camelCase: true, pascalCase: true, kebabCase: true },
+      'Filename is not in camel case, kebab case, or pascal case. Rename it to `_fooBar.js`, `_foo-bar.js`, or `_FooBar.js`.',
+    ),
+    invalidCases(
+      'src/foo/_FOO-BAR.js',
+      { snakeCase: true },
+      'Filename is not in snake case. Rename it to `_foo_bar.js`.',
+    ),
+
+    // ---- Decoration characters preserved ----
+    invalid(
+      'src/foo/[foo_bar].js',
+      undefined,
+      'Filename is not in kebab case. Rename it to `[foo-bar].js`.',
+    ),
+    invalid(
+      'src/foo/$foo_bar.js',
+      undefined,
+      'Filename is not in kebab case. Rename it to `$foo-bar.js`.',
+    ),
+    invalid(
+      'src/foo/$fooBar.js',
+      undefined,
+      'Filename is not in kebab case. Rename it to `$foo-bar.js`.',
+    ),
+    invalidCases(
+      'src/foo/{foo_bar}.js',
+      { camelCase: true, pascalCase: true, kebabCase: true },
+      'Filename is not in camel case, kebab case, or pascal case. Rename it to `{fooBar}.js`, `{foo-bar}.js`, or `{FooBar}.js`.',
+    ),
+
+    // ---- Ignore patterns that don't match still report ----
+    invalidWithOptions(
+      'src/foo/barBaz.js',
+      [{ case: 'kebabCase', ignore: [String.raw`FOOBAR\.js`] }],
+      'Filename is not in kebab case. Rename it to `bar-baz.js`.',
+    ),
+    invalidWithOptions(
+      'src/foo/fooBar.js',
+      [{ case: 'kebabCase', ignore: [String.raw`FOOBAR\.js`] }],
+      'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+    ),
+    invalidWithOptions(
+      'src/foo/fooBar.js',
+      [
+        {
+          case: 'kebabCase',
+          ignore: [String.raw`FOOBAR\.js`, String.raw`foobar\.js`],
+        },
+      ],
+      'Filename is not in kebab case. Rename it to `foo-bar.js`.',
+    ),
+    invalidWithOptions(
+      'src/foo/FooBar.js',
+      [
+        {
+          cases: { camelCase: true, snakeCase: true },
+          ignore: [String.raw`FOOBAR\.js`],
+        },
+      ],
+      'Filename is not in camel case or snake case. Rename it to `fooBar.js` or `foo_bar.js`.',
+    ),
+
+    // ---- #1136: trailing underscore on a digit-only word ----
+    invalidCases(
+      'src/foo/1_.js',
+      { camelCase: true, pascalCase: true, kebabCase: true },
+      'Filename is not in camel case, kebab case, or pascal case. Rename it to `1.js`.',
+    ),
+
+    // ---- multipleFileExtensions=false: middle parts must also match ----
+    invalidWithOptions(
+      'src/foo/foo_bar.test.js',
+      [{ case: 'camelCase', multipleFileExtensions: false }],
+      'Filename is not in camel case. Rename it to `fooBar.test.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/foo_bar.test_utils.js',
+      [{ case: 'camelCase', multipleFileExtensions: false }],
+      'Filename is not in camel case. Rename it to `fooBar.testUtils.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/fooBar.test.js',
+      [{ case: 'snakeCase', multipleFileExtensions: false }],
+      'Filename is not in snake case. Rename it to `foo_bar.test.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/fooBar.testUtils.js',
+      [{ case: 'snakeCase', multipleFileExtensions: false }],
+      'Filename is not in snake case. Rename it to `foo_bar.test_utils.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/fooBar.test.js',
+      [{ case: 'kebabCase', multipleFileExtensions: false }],
+      'Filename is not in kebab case. Rename it to `foo-bar.test.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/fooBar.testUtils.js',
+      [{ case: 'kebabCase', multipleFileExtensions: false }],
+      'Filename is not in kebab case. Rename it to `foo-bar.test-utils.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/foo_bar.test.js',
+      [{ case: 'pascalCase', multipleFileExtensions: false }],
+      'Filename is not in pascal case. Rename it to `FooBar.Test.js`.',
+    ),
+    invalidWithOptions(
+      'test/foo/foo-bar.test-utils.js',
+      [{ case: 'pascalCase', multipleFileExtensions: false }],
+      'Filename is not in pascal case. Rename it to `FooBar.TestUtils.js`.',
+    ),
+
+    // NOTE: uppercase / non-standard extension cases (`.JS`, `.mJS`, `.mjs`,
+    // `.cjs`, `.vue`) are intentionally not exercised here. The rslint binary
+    // routes lint requests through TypeScript's program builder, which only
+    // picks up files whose extensions match the project's recognized set.
+    // Files with `.JS` etc. silently skip the program, so no diagnostics
+    // appear regardless of rule logic. The Go test suite covers the rule's
+    // extension/case-style branches with stable extensions; the upstream rule
+    // logic is identical for any extension.
+  ],
+});

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/tsconfig.files.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/tsconfig.files.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "allowJs": true
+  },
+  "include": ["files/**/*"]
+}

--- a/packages/rslint-test-tools/tests/eslint-plugin-unicorn/tsconfig.virtual.json
+++ b/packages/rslint-test-tools/tests/eslint-plugin-unicorn/tsconfig.virtual.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "target": "es5",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "lib": ["es2015", "es2017", "esnext"],
+    "allowJs": true,
+    "rootDir": "."
+  },
+  "include": ["**/*"]
+}

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -270,3 +270,15 @@ nunc
 forcetypeassert
 Isnt
 deboucne
+extname
+splitwords
+behaviour
+extensionless
+uppercases
+trippable
+cand
+englishish
+HTTPSURL
+BARBAZ
+dedupe
+basenames


### PR DESCRIPTION
## Summary

Port the `unicorn/filename-case` rule from `eslint-plugin-unicorn` to rslint.

The rule enforces a consistent case style for filenames (kebab/camel/snake/pascal) and a lowercase file extension. Supports the upstream `case`, `cases`, `ignore`, and `multipleFileExtensions` options.

## Related Links

- ESLint plugin documentation: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md
- Source code: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/rules/filename-case.js

## Checklist

- [x] Tests updated (or not required).
- [x] Documentation updated (or not required).